### PR TITLE
fix(web): await confirm in Tauri WebView to prevent deletion on cancel

### DIFF
--- a/src_assets/common/assets/web/apps.html
+++ b/src_assets/common/assets/web/apps.html
@@ -467,8 +467,8 @@
       /**
        * 显示删除确认
        */
-      showDeleteForm(index) {
-        const confirmed = confirm(
+      async showDeleteForm(index) {
+        const confirmed = await confirm(
           `确定要删除应用 "${this.apps[index].name}" 吗？`
         );
         


### PR DESCRIPTION
原因: 在 Tauri WebView 中 window.confirm 可能返回 Promise，旧实现将 Promise 当作真值导致点击取消也会删除。\n方案: 将 showDeleteForm 改为 async，并对 confirm 使用 await，兼容同步/异步实现。\n影响范围: 仅删除确认逻辑，无后端改动。\n风险: 极低；浏览器环境依旧正常。