### PR TITLE
fix: prevent microphone write errors when audio context is not active

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,6 @@ jobs:
       - name: Debug GitHub Event
         run: |
           echo "GitHub Event Name: ${{ github.event_name }}"
-          echo 'GitHub Event JSON: ${{ toJson(github.event) }}'
           echo "Has commits field: ${{ contains(toJson(github.event), 'commits') }}"
 
       - name: Setup Release (Auto)


### PR DESCRIPTION
- Change microphone data write failure log from error to debug level when audio context is not active (this is a normal condition)
- Only start receiving microphone data after device initialization succeeds
- Simplify microphone receive thread logic and error handling
- Fixes issue where 'Failed to write microphone data to stream' errors were logged when audio capture thread hadn't started yet

This fixes the error introduced in commit ac9d1ce3 where microphone receive thread could start receiving data before audio context was active, causing unnecessary error logs.