### PR TITLE
fix: 程序又被强制拉起问题

### DIFF
--- a/src/display_device/session.cpp
+++ b/src/display_device/session.cpp
@@ -128,9 +128,9 @@ namespace display_device {
   };
 
   session_t::deinit_t::~deinit_t() {
-    // Stop vdd timer before destruction
-    // session_t::get().vdd_timer->setup_timer(nullptr);
-    session_t::get().restore_state();
+    // 不在析构函数中调用 restore_state()
+    // 原因：析构函数在程序退出时被调用，此时 boost::log、timer 等资源可能已被销毁
+    // 解决方案：在 main.cpp 的信号处理程序中显式调用 restore_state()
   }
 
   session_t &

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -304,6 +304,11 @@ main(int argc, char *argv[]) {
     // Break out of the main loop
     shutdown_event->raise(true);
     system_tray::end_tray();
+    try {
+      display_device::session_t::get().restore_state();
+    }
+    catch (...) {
+    }
 
     display_device_deinit_guard = nullptr;
   });
@@ -321,6 +326,11 @@ main(int argc, char *argv[]) {
     // Break out of the main loop
     shutdown_event->raise(true);
     system_tray::end_tray();
+    try {
+      display_device::session_t::get().restore_state();
+    }
+    catch (...) {
+    }
 
     display_device_deinit_guard = nullptr;
   });

--- a/src/platform/windows/audio.cpp
+++ b/src/platform/windows/audio.cpp
@@ -208,11 +208,6 @@ namespace {
 using namespace std::literals;
 
 namespace platf::audio {
-  template <class T>
-  void
-  Release(T *p) {
-    p->Release();
-  }
 
   template <class T>
   void

--- a/src/platform/windows/mic_write.h
+++ b/src/platform/windows/mic_write.h
@@ -19,6 +19,16 @@
 struct OpusDecoder;
 
 namespace platf::audio {
+  
+  // COM interface Release helper for safe_ptr
+  template<typename T>
+  inline void Release(T *p) {
+    if (p) p->Release();
+  }
+  
+  // COM interface smart pointer types
+  using device_enum_t = util::safe_ptr<IMMDeviceEnumerator, Release<IMMDeviceEnumerator>>;
+  using audio_client_t = util::safe_ptr<IAudioClient, Release<IAudioClient>>;
 
   // Forward declarations for types used in mic_write_wasapi_t
   enum class match_field_e {
@@ -172,8 +182,8 @@ namespace platf::audio {
     restore_original_input_device();
 
     // Member variables
-    std::unique_ptr<IMMDeviceEnumerator> device_enum;
-    std::unique_ptr<IAudioClient> audio_client;
+    device_enum_t device_enum;
+    audio_client_t audio_client;
     IAudioRenderClient *audio_render = nullptr;
     OpusDecoder *opus_decoder = nullptr;
     HANDLE mmcss_task_handle = nullptr;


### PR DESCRIPTION
修复1
问题：程序退出时堆损坏，发生在 display_device::session_t::deinit_t 析构函数中。
原因：析构函数调用 restore_state()，在程序退出时访问了已销毁的资源（boost::log、timer 等），导致堆损坏。
解决方案：
session.cpp：移除析构函数中的 restore_state() 调用，避免在退出时访问已销毁资源。
main.cpp：在销毁 display_device_deinit_guard 之前显式调用 restore_state()，确保显示设置被恢复，同时避免堆损坏。
这样既保证显示设置会被恢复，又避免了堆损坏崩溃。

业务影响分析
restore_state() 的作用是恢复显示设置（例如：分辨率、刷新率等）到串流前的状态。

调用场景覆盖情况：
串流期间：显示设置由 stream.cpp 和 nvhttp.cpp 管理
正常退出：我们在 main.cpp 的 SIGINT/SIGTERM 处理中已添加显式调用
异常退出：session_t::init() 会在下次启动时恢复

修复2
问题：程序退出时堆损坏，发生在线程退出时调用 audio::release_mic_redirect_device()
原因： mic_write.h 中 device_enum 和 audio_client 被定义为 std::unique_ptr<IMMDeviceEnumerator> 和 std::unique_ptr<IAudioClient>
std::unique_ptr 默认使用 delete 来释放对象，但 COM 接口需要用 Release() 方法来释放
这导致了堆损坏（因为 delete 一个 COM 对象是未定义行为）
解决：
mic_write.h：添加 inline Release<T> 模板函数、使用 safe_ptr 类型定义
mic_write.cpp：移除重复的 Release 定义、在 cleanup() 中正确释放 audio_render、显式调用 audio_client.reset() 和 device_enum.reset() 确保正确的 COM 释放顺序、添加缓冲区清空超时（最多 500ms）