### PR TITLE
feat: 添加屏幕旋转接口和优化分辨率处理

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ project(Sunshine VERSION 0.0.0
 
 set(PROJECT_LICENSE "GPL-3.0-only")
 
-set(PROJECT_FQDN "dev.lizardbyte.app.Sunshine")
+set(PROJECT_FQDN "sunshine.alkaidLab.io")
 
 set(PROJECT_BRIEF_DESCRIPTION "GameStream host for Moonlight")  # must be <= 35 characters
 

--- a/src/nvhttp.h
+++ b/src/nvhttp.h
@@ -15,6 +15,7 @@
 // local includes
 #include "crypto.h"
 #include "thread_safe.h"
+#include "version.h"
 
 /**
  * @brief Contains all the functions and variables related to the nvhttp (GameStream) server.
@@ -32,6 +33,11 @@ namespace nvhttp {
    * @brief The GFE version we are replicating.
    */
   constexpr auto GFE_VERSION = "3.23.0.74";
+
+  /**
+   * @brief The Sunshine version we are replicating.
+   */
+  constexpr auto SUNSHINE_VERSION = PROJECT_NAME " " PROJECT_VER;
 
   /**
    * @brief The HTTP port, as a difference from the config port.

--- a/src/platform/windows/display_device/windows_utils.h
+++ b/src/platform/windows/display_device/windows_utils.h
@@ -505,4 +505,19 @@ namespace display_device::w_utils {
    */
   bool
   is_any_rdp_session_active();
+
+  /**
+   * @brief Rotate the display to the specified angle.
+   * @param angle Rotation angle in degrees. Must be 0, 90, 180, or 270.
+   * @param display_name Optional display name. If empty, rotates the primary display.
+   * @returns True if rotation was successful, false otherwise.
+   *
+   * EXAMPLES:
+   * ```cpp
+   * const bool success = rotate_display(90, "");
+   * const bool success2 = rotate_display(180, "\\\\.\\DISPLAY1");
+   * ```
+   */
+  bool
+  rotate_display(int angle, const std::string &display_name);
 }  // namespace display_device::w_utils


### PR DESCRIPTION
主要更改：
1. 添加屏幕旋转API接口 (/rotate-display)
   - 支持通过HTTP API旋转屏幕（0/90/180/270度）
   - Windows平台使用ChangeDisplaySettingsEx实现
   - 未指定显示器时自动使用当前捕获的显示器

2. 改进分辨率处理逻辑
   - 初始化时通知客户端编码分辨率
   - 检测显示器方向与客户端请求不匹配的情况
   - 当方向不匹配时，使用实际屏幕分辨率编码并通知客户端
   - 避免画面变形，确保编码分辨率与实际屏幕方向一致