### PR TITLE
fix: YUV420(NV12/P010)偶数对齐

### DIFF
--- a/src/nvenc/common_impl/nvenc_base.cpp
+++ b/src/nvenc/common_impl/nvenc_base.cpp
@@ -109,6 +109,13 @@ namespace nvenc {
     encoder_params.width = client_config.width;
     encoder_params.height = client_config.height;
     encoder_params.buffer_format = buffer_format;
+
+    // YUV 4:2:0 formats (NV12/P010) require even dimensions because
+    // the chroma plane is half the size of the luma plane in both dimensions.
+    if (buffer_format == NV_ENC_BUFFER_FORMAT_NV12 || buffer_format == NV_ENC_BUFFER_FORMAT_YUV420_10BIT) {
+      encoder_params.width = (encoder_params.width + 1) & ~1;
+      encoder_params.height = (encoder_params.height + 1) & ~1;
+    }
     encoder_params.rfi = true;
 
     NV_ENC_OPEN_ENCODE_SESSION_EX_PARAMS session_params = { NV_ENC_OPEN_ENCODE_SESSION_EX_PARAMS_VER };


### PR DESCRIPTION
DXGI_FORMAT_NV12 是 YUV 4:2:0 格式，要求宽度和高度必须是偶数（因为色度平面的尺寸是亮度平面的一半）。
如果视频的长或宽是奇数，那么会导致后续创建编码器时，CreateTexture2D 直接失败。其他格式不需要偶数对齐。原因在于色度子采样方式不同：

| 格式                              | DXGI 格式            | 子采样 | 偶数要求             |
| :-------------------------------- | :------------------- | :----- | :------------------- |
| NV_ENC_BUFFER_FORMAT_NV12         | DXGI_FORMAT_NV12     | 4:2:0  | 需要，宽高都必须偶数 |
| NV_ENC_BUFFER_FORMAT_YUV420_10BIT | DXGI_FORMAT_P010     | 4:2:0  | 需要，宽高都必须偶数 |
| NV_ENC_BUFFER_FORMAT_AYUV         | DXGI_FORMAT_AYUV     | 4:4:4  | 不需要               |
| NV_ENC_BUFFER_FORMAT_YUV444_10BIT | DXGI_FORMAT_R16_UINT | 4:4:4  | 不需要               |

4:2:0 格式的色度（U/V）平面尺寸是亮度（Y）平面的一半（宽高各除以 2），所以宽高必须是偶数才能整除。

4:4:4 格式每个像素都有完整的 YUV 三个分量，不存在下采样，所以对奇偶没有要求。