### PR TITLE
fix: 修复rollup构建问题

### DIFF
--- a/vite-plugin-ejs-v7.js
+++ b/vite-plugin-ejs-v7.js
@@ -1,5 +1,4 @@
 import ejs from 'ejs'
-import fs from 'fs'
 
 /**
  * Vite EJS Plugin for Vite 7
@@ -16,55 +15,6 @@ export function ViteEjsPlugin(data = {}, options = {}) {
     // Get Resolved config
     configResolved(resolvedConfig) {
       config = resolvedConfig
-    },
-    // Use load hook to preprocess HTML files before they're parsed
-    load(id) {
-      // Only process HTML files
-      if (id.endsWith('.html')) {
-        try {
-          const html = fs.readFileSync(id, 'utf-8')
-          
-          // Resolve data if it's a function
-          const resolvedData = typeof data === 'function' ? data(config) : data
-          
-          // Resolve EJS options if it's a function
-          let ejsOptions = options && options.ejs ? options.ejs : {}
-          if (typeof ejsOptions === 'function') {
-            ejsOptions = ejsOptions(config)
-          }
-          
-          // Render EJS template with data
-          const rendered = ejs.render(
-            html,
-            Object.assign(
-              {
-                NODE_ENV: config.mode,
-                isDev: config.mode === 'development',
-              },
-              resolvedData
-            ),
-            Object.assign(
-              {
-                // Setting views enables includes support
-                views: [config.root],
-              },
-              ejsOptions,
-              {
-                async: false, // Force sync
-              }
-            )
-          )
-          
-          return {
-            code: rendered,
-            map: null,
-          }
-        } catch (error) {
-          // If there's an error, let Vite handle it normally
-          return null
-        }
-      }
-      return null
     },
     transformIndexHtml: {
       // Use 'pre' order to ensure EJS is processed before other HTML transformations


### PR DESCRIPTION
Rollup 的模块管道处理入口文件时，会按插件顺序调用 `load` 钩子。谁先返回非 `null` 值，就用谁的结果。

**旧版 Rollup（之前能跑）**：

- Vite 内部的 vite:build-html 插件的 `load` 钩子排在你的插件**前面**
- 它先拦截了 HTML 入口，提取出 `<script>` 标签转换成 JS 模块代码
- 你的插件 `load` 钩子**压根没被调用**（被 Vite 内部插件抢先了）

**新版 Rollup（现在报错）**：

- 插件 `load` 钩子的执行顺序或调度逻辑变了
- 你的插件 `load` 钩子**先于** Vite 内部 HTML 插件被调用
- 返回了原始 HTML → Rollup 当 JS 解析 → `parseAsync` 报错

所以不是"新版用到了"，而是**新版改变了 `load` 钩子的调用顺序**，让原本被跳过的代码突然被执行了。它从来就不该返回 HTML 给 Rollup，只是之前运气好没被调到。

-----

理论上可以通过给 `load` 加 `enforce: 'post'` 让它排在 Vite 内部插件之后，这样 vite:build-html先拿走 HTML，你的 `load` 就不会被调到。

**但这不是好的修复方式**：

- 依赖插件执行顺序是脆弱的，下次 Rollup/Vite 更新又可能变
- `load` 钩子返回的内容 Rollup **一定会**当 JS 模块解析，返回 HTML 永远是错的
- [transformIndexHtml] 才是 Vite 处理 HTML 的正式 API，功能完全覆盖

删除 `load` 钩子是正解——不依赖顺序，不存在被意外调用的风险，功能零影响。