### PR TITLE
fix(directx): resolve uninitialized 'result' in hdr_luminance_reduce cs.hlsl

### DIFF
--- a/src_assets/windows/assets/shaders/directx/hdr_luminance_reduce_cs.hlsl
+++ b/src_assets/windows/assets/shaders/directx/hdr_luminance_reduce_cs.hlsl
@@ -113,16 +113,12 @@ void main_cs(uint GIndex : SV_GroupIndex)
         GroupMemoryBarrierWithGroupSync();
     }
 
-    // Thread 0 writes final merged result
+    // Thread 0 writes final merged result (scalars only; histogram written below by 128 threads)
     if (GIndex == 0) {
-        FinalResult result;
-        result.minMaxRGB = gs_min[0];
-        result.maxMaxRGB = gs_max[0];
-        result.sumMaxRGB = gs_sum[0];
-        result.pixelCount = gs_count[0];
-
-        // histogram is written below by multiple threads
-        finalResult[0] = result;
+        finalResult[0].minMaxRGB = gs_min[0];
+        finalResult[0].maxMaxRGB = gs_max[0];
+        finalResult[0].sumMaxRGB = gs_sum[0];
+        finalResult[0].pixelCount = gs_count[0];
     }
 
     GroupMemoryBarrierWithGroupSync();


### PR DESCRIPTION
FinalResult was partially written (min/max/sum/count) then assigned to finalResult[0], leaving histogram[] uninitialized. Some HLSL compilers (DXC/strict) treat this as error X4000 and fail compilation.

Write the four scalar fields directly to finalResult[0]; histogram is already filled by the following 128-thread block.