### PR TITLE
fix: 基于 DXGI ColorSpace 的 gamma 感知着色器选择

### DIFF
--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -196,6 +196,24 @@ namespace platf::dxgi {
     int output_index;
 
     DXGI_FORMAT capture_format;
+
+    /**
+     * @brief Indicates whether the display's output colorspace uses linear gamma.
+     *
+     * This is determined from DXGI_OUTPUT_DESC1.ColorSpace:
+     *   - G10 (gamma 1.0, linear):  capture_linear_gamma = true   (ACM / scRGB)
+     *   - G22 (gamma ~2.2, sRGB):   capture_linear_gamma = false  (normal SDR)
+     *   - G2084 (PQ / HDR):         capture_linear_gamma = true   (linear light)
+     *
+     * Shader selection requires BOTH linear_gamma AND FP16 pixel format to use the
+     * linear-input shader (ApplySRGBCurve). This is because:
+     *   - FP16 + G10/G2084: data is truly in linear light → must apply transfer function
+     *   - B8G8R8A8 + G10:   data was converted to sRGB by the capture API (e.g. WGC
+     *     requesting 8-bit while display is in ACM mode) → already has sRGB gamma
+     *   - FP16 + G22:       driver returned FP16 data with sRGB gamma → identity shader
+     */
+    bool capture_linear_gamma = false;
+
     D3D_FEATURE_LEVEL feature_level;
 
     std::unique_ptr<high_precision_timer> timer = create_high_precision_timer();

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -799,6 +799,23 @@ namespace platf::dxgi {
         << "HDR: "sv << colorspace_to_string(desc1.ColorSpace)
         << ", Bits: "sv << desc1.BitsPerColor
         << ", Luminance: "sv << desc1.MinLuminance << '/' << desc1.MaxLuminance << '/' << desc1.MaxFullFrameLuminance << " nits"sv;
+
+      // Determine if the captured frames are in linear gamma (need shader conversion).
+      //
+      // The DXGI_COLOR_SPACE_TYPE from the output descriptor tells us the gamma:
+      //   - G10 (gamma 1.0, linear):  scRGB / Windows ACM → data is linear light
+      //   - G2084 (PQ):               HDR mode → DWM outputs scRGB linear, shader applies PQ curve
+      //   - G22 (gamma ~2.2, sRGB):   normal SDR → data already has sRGB gamma
+      //
+      // When capture_linear_gamma is true, the pixel shader must apply a transfer function
+      // (sRGB, PQ, or HLG depending on the encoding colorspace) to convert from linear light.
+      // When false, the captured frames already carry sRGB gamma and should be used as-is.
+      capture_linear_gamma = (desc1.ColorSpace == DXGI_COLOR_SPACE_RGB_FULL_G10_NONE_P709 ||
+                              desc1.ColorSpace == DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020);
+      BOOST_LOG(info) << "Capture gamma: "sv
+                      << (desc1.ColorSpace == DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020 ? "linear (HDR/PQ)" :
+                          capture_linear_gamma ? "linear (G10, scRGB/ACM)" :
+                                                 "sRGB (G22)");
     }
 
     if (!timer || !*timer) {

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -168,6 +168,11 @@ namespace platf::dxgi {
     // DXGI format of this image texture
     DXGI_FORMAT format;
 
+    // Whether this image's pixel data is in linear gamma (scRGB G10).
+    // When true, the conversion shader must apply sRGB transfer function.
+    // When false, the data already has sRGB gamma and should be used as-is.
+    bool linear_gamma = false;
+
     virtual ~img_d3d_t() override {
       if (encoder_texture_handle) {
         CloseHandle(encoder_texture_handle);
@@ -442,10 +447,25 @@ namespace platf::dxgi {
         auto draw = [&](auto &input, auto &y_or_yuv_viewports, auto &uv_viewport) {
           device_ctx->PSSetShaderResources(0, 1, &input);
 
+          // Select the correct pixel shader based on image gamma type:
+          // - linear_gamma AND FP16 format: Use FP16 shader that applies transfer function
+          //   (sRGB for SDR, PQ for HDR, HLG for HLG) to convert from linear light
+          // - Otherwise: Use standard shader that assumes sRGB gamma input
+          //
+          // Both conditions are required because:
+          // 1. FP16 format + G10/G2084 colorspace = data is truly linear (scRGB)
+          // 2. B8G8R8A8 format + G10 colorspace = data was converted TO sRGB by the
+          //    capture API (e.g., WGC requests 8-bit format while display is in ACM mode)
+          //
+          // This prevents double-gamma when the display is in ACM/HDR mode but the
+          // capture is in a non-FP16 format, and also when a driver returns FP16 data
+          // that already carries sRGB gamma (G22 colorspace with FP16 format).
+          const bool use_linear_shader = img.linear_gamma && (img.format == DXGI_FORMAT_R16G16B16A16_FLOAT);
+
           // Draw Y/YUV
           device_ctx->OMSetRenderTargets(1, &out_Y_or_YUV_rtv, nullptr);
           device_ctx->VSSetShader(convert_Y_or_YUV_vs.get(), nullptr, 0);
-          device_ctx->PSSetShader(img.format == DXGI_FORMAT_R16G16B16A16_FLOAT ? convert_Y_or_YUV_fp16_ps.get() : convert_Y_or_YUV_ps.get(), nullptr, 0);
+          device_ctx->PSSetShader(use_linear_shader ? convert_Y_or_YUV_fp16_ps.get() : convert_Y_or_YUV_ps.get(), nullptr, 0);
           auto viewport_count = (format == DXGI_FORMAT_R16_UINT) ? 3 : 1;
           assert(viewport_count <= y_or_yuv_viewports.size());
           device_ctx->RSSetViewports(viewport_count, y_or_yuv_viewports.data());
@@ -456,7 +476,7 @@ namespace platf::dxgi {
             assert(format == DXGI_FORMAT_NV12 || format == DXGI_FORMAT_P010);
             device_ctx->OMSetRenderTargets(1, &out_UV_rtv, nullptr);
             device_ctx->VSSetShader(convert_UV_vs.get(), nullptr, 0);
-            device_ctx->PSSetShader(img.format == DXGI_FORMAT_R16G16B16A16_FLOAT ? convert_UV_fp16_ps.get() : convert_UV_ps.get(), nullptr, 0);
+            device_ctx->PSSetShader(use_linear_shader ? convert_UV_fp16_ps.get() : convert_UV_ps.get(), nullptr, 0);
             device_ctx->RSSetViewports(1, &uv_viewport);
             device_ctx->Draw(3, 0);
           }
@@ -475,7 +495,8 @@ namespace platf::dxgi {
         // Dispatch HDR luminance analysis on the scRGB FP16 input texture
         // This runs AFTER the YUV conversion draw but BEFORE releasing the mutex,
         // so the texture is still valid. Uses async readback (1-frame delay).
-        if (hdr_analysis_enabled && img.format == DXGI_FORMAT_R16G16B16A16_FLOAT) {
+        // Only valid when the capture data is truly linear (scRGB G10).
+        if (hdr_analysis_enabled && img.linear_gamma && img.format == DXGI_FORMAT_R16G16B16A16_FLOAT) {
           dispatch_hdr_analysis(img_ctx.encoder_input_res.get());
         }
 
@@ -2443,6 +2464,7 @@ namespace platf::dxgi {
     img->row_pitch = img->pixel_pitch * img->width;
     img->dummy = dummy;
     img->format = (capture_format == DXGI_FORMAT_UNKNOWN) ? DXGI_FORMAT_B8G8R8A8_UNORM : capture_format;
+    img->linear_gamma = capture_linear_gamma;
 
     D3D11_TEXTURE2D_DESC t {};
     t.Width = img->width;


### PR DESCRIPTION
## 问题

用户在以下环境下反馈 **画面变灰/发白**：
- AMD 显卡 + Windows 自动颜色管理 (ACM) 开启
- AMD 显卡 + 10 位色彩格式开启

### 根因分析

RGB→YUV 着色器选择 **仅基于像素格式**（FP16 vs B8G8R8A8）：
- FP16 → 应用 ApplySRGBCurve()（假设数据是线性光）
- B8G8R8A8 → 不处理（假设数据已有 sRGB gamma）

当 FP16 数据 **已经携带 sRGB gamma**（例如 AMD 驱动在 ACM 激活时返回 gamma 编码的 FP16）时，会导致 **双重 gamma** → 画面变灰。

## 解决方案

使用 `DXGI_OUTPUT_DESC1.ColorSpace` 来判断捕获帧的 **实际 gamma 类型**：

| ColorSpace | Gamma | 着色器 |
|---|---|---|
| G10（线性） | 线性 | ApplySRGBCurve（FP16 着色器） |
| G22（sRGB） | sRGB | 恒等变换（标准着色器） |
| G2084（PQ） | 线性 | PQ/HDR 着色器路径 |

线性着色器仅在 **同时满足两个条件** 时使用：
1. ColorSpace 指示线性 gamma（G10 或 G2084）
2. 像素格式为 FP16（R16G16B16A16_FLOAT）

这个双重条件可以防止所有已知边界情况下的着色器选择错误：
- **FP16 + G22**：AMD 返回带 sRGB gamma 的 FP16 → 标准着色器 ✓
- **B8G8R8A8 + G10**：WGC 在 ACM 模式下转 8 位 → 标准着色器 ✓
- **FP16 + G10**：真正的 scRGB 线性数据 → ApplySRGBCurve ✓
- **FP16 + G2084**：HDR PQ → PQ 着色器 ✓

## 修改内容
- `display.h`：新增 `capture_linear_gamma` 字段，附详细文档说明
- `display_base.cpp`：从 `DXGI_OUTPUT_DESC1.ColorSpace` 初始化 `capture_linear_gamma` + 诊断日志
- `display_vram.cpp`：着色器选择从纯格式检查改为 `img.linear_gamma && FP16` 双重条件

## 测试验证
- 已确认所有捕获路径（DDUP、WGC、AMD AMF）通过 `complete_img()` 正确传播 `linear_gamma`
- 未引入新的编译错误