### PR TITLE
feat: add HDR luminance analysis toggle switch

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -447,6 +447,7 @@ namespace config {
     false,  // variable_refresh_rate
     0,  // minimum_fps_target (0 = auto, about half the stream FPS)
     "balanced"s,  // downscaling_quality (default: bicubic for best quality/performance balance)
+    false,  // hdr_luminance_analysis (disabled by default to avoid GPU overhead)
   };
 
   audio_t audio {
@@ -1203,6 +1204,7 @@ namespace config {
     int_f(vars, "max_bitrate", video.max_bitrate);
     bool_f(vars, "variable_refresh_rate", video.variable_refresh_rate);
     int_between_f(vars, "minimum_fps_target", video.minimum_fps_target, { 0, 1000 });
+    bool_f(vars, "hdr_luminance_analysis", video.hdr_luminance_analysis);
     bool_f(vars, "vdd_keep_enabled", video.vdd_keep_enabled);
     bool_f(vars, "vdd_headless_create", video.vdd_headless_create_enabled);
     bool_f(vars, "vdd_reuse", video.vdd_reuse);

--- a/src/config.h
+++ b/src/config.h
@@ -110,6 +110,7 @@ namespace config {
     bool variable_refresh_rate;  // Allow video stream framerate to match render framerate for VRR support
     int minimum_fps_target;  // Minimum FPS target (0 = auto, 1-1000 = minimum FPS to maintain)
     std::string downscaling_quality;  // Downscaling quality: "fast" (bilinear+8pt), "balanced" (bicubic), "high_quality" (future: lanczos)
+    bool hdr_luminance_analysis;  // Enable per-frame HDR luminance analysis for dynamic metadata
   };
 
   struct audio_t {

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -968,7 +968,8 @@ namespace platf::dxgi {
 
       // Initialize HDR luminance analyzer for HDR formats (P010, Y410, R16_UINT)
       // The analyzer is optional — if it fails, HDR will still work with static metadata only
-      if (format == DXGI_FORMAT_P010 || format == DXGI_FORMAT_Y410 || format == DXGI_FORMAT_R16_UINT) {
+      if (config::video.hdr_luminance_analysis &&
+          (format == DXGI_FORMAT_P010 || format == DXGI_FORMAT_Y410 || format == DXGI_FORMAT_R16_UINT)) {
         if (init_hdr_luminance_analyzer() != 0) {
           BOOST_LOG(warning) << "HDR luminance analyzer init failed, dynamic metadata will use defaults";
         }

--- a/src_assets/common/assets/web/configs/tabs/audiovideo/DisplayDeviceOptions.vue
+++ b/src_assets/common/assets/web/configs/tabs/audiovideo/DisplayDeviceOptions.vue
@@ -153,6 +153,17 @@ function addRemapping(type) {
                   <option value="automatic">{{ $tp('config.hdr_prep_automatic') }}</option>
                 </select>
               </div>
+
+              <!-- HDR Luminance Analysis -->
+              <div class="mb-3">
+                <div class="form-check form-switch">
+                  <input class="form-check-input" type="checkbox" id="hdr_luminance_analysis" v-model="config.hdr_luminance_analysis" true-value="enabled" false-value="disabled" />
+                  <label class="form-check-label" for="hdr_luminance_analysis">
+                    {{ $tp('config.hdr_luminance_analysis') }}
+                  </label>
+                </div>
+                <div class="form-text">{{ $tp('config.hdr_luminance_analysis_desc') }}</div>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 问题

Commit `1934b2d2` 修复了 `hdr_luminance_reduce_cs.hlsl` 中未初始化变量导致的着色器编译错误后，HDR 亮度分析功能被意外启用。这导致每帧额外增加 ~0.5-1.5ms GPU 开销（高分辨率下 21,600+ 线程组调度 + staging buffer 拷贝），造成 AMD 和 NVIDIA GPU 的 HDR 捕获帧率回归。

v2026.217 版本正常是因为着色器编译失败 → `hdr_analysis_enabled = false` → 无每帧开销。

## 修改内容

添加 `hdr_luminance_analysis` 配置开关（默认：禁用），允许用户控制是否运行 HDR 亮度分析。

- **config.h**: 在 video_t 中添加 `hdr_luminance_analysis` 字段
- **config.cpp**: 默认值 false，添加 bool_f 加载器
- **display_vram.cpp**: `init_hdr_luminance_analyzer()` 调用前增加配置条件
- **WebUI**: 在显示设备选项中添加开关（英文/中文翻译）

禁用时 HDR 串流使用静态元数据，无每帧 GPU 开销。