### PR TITLE
feat: 消除TLS队列开销、优化托盘状态显示、修复屏幕快捷键切换、修复副屏设置 (#546)

### DIFF
--- a/src/display_device/session.cpp
+++ b/src/display_device/session.cpp
@@ -435,7 +435,7 @@ namespace display_device {
 
     BOOST_LOG(info) << "重新加载VDD驱动...";
     vdd_utils::reload_driver();
-    std::this_thread::sleep_for(1500ms);
+    std::this_thread::sleep_for(1200ms);
   }
 
   void
@@ -445,6 +445,10 @@ namespace display_device {
     const vdd_utils::physical_size_t physical_size = vdd_utils::get_client_physical_size(session.client_name);
 
     auto device_zako = display_device::find_device_by_friendlyname(ZAKO_NAME);
+
+    // pre_vdd_devices: 在 VDD 创建前一刻保存的物理显示器快照
+    // 延迟到 VDD 创建前才捕获，确保无论是新建还是重建都能拿到正确状态
+    device_info_map_t pre_vdd_devices;
 
     // Rebuild VDD device on client switch
     if (!device_zako.empty() && !current_vdd_client_id.empty() &&
@@ -492,13 +496,18 @@ namespace display_device {
 
     // Create VDD device if not present
     if (device_zako.empty()) {
+      // 在创建 VDD 之前捕获物理显示器快照
+      // 此时无 VDD 存在（新建 or 重建后已销毁），物理屏应处于正常状态
+      pre_vdd_devices = display_device::enum_available_devices();
+      BOOST_LOG(info) << "已保存pre-VDD设备列表: " << display_device::to_string(pre_vdd_devices);
+
       BOOST_LOG(info) << "创建虚拟显示器...";
       // 复用模式使用固定标识符，否则使用客户端ID生成唯一GUID
       const std::string vdd_identifier = config::video.vdd_reuse
         ? "shared_vdd"  // 固定标识符，所有客户端共用同一GUID
         : current_client_id;  // 为每个客户端生成不同GUID
       vdd_utils::create_vdd_monitor(vdd_identifier, hdr_brightness, physical_size);
-      std::this_thread::sleep_for(500ms);
+      std::this_thread::sleep_for(200ms);
     }
 
     // Wait for device to be ready
@@ -542,9 +551,9 @@ namespace display_device {
     // VDD模式下的拓扑控制与普通模式分开处理
     if (config.vdd_prep != parsed_config_t::vdd_prep_e::no_operation) {
       // User has specified a display configuration, apply it
-      if (vdd_utils::apply_vdd_prep(device_zako, config.vdd_prep)) {
+      if (vdd_utils::apply_vdd_prep(device_zako, config.vdd_prep, pre_vdd_devices)) {
         BOOST_LOG(info) << "已应用VDD屏幕布局设置";
-        std::this_thread::sleep_for(500ms);
+        std::this_thread::sleep_for(200ms);
       }
     }
     else {

--- a/src/display_device/vdd_utils.cpp
+++ b/src/display_device/vdd_utils.cpp
@@ -33,7 +33,7 @@ namespace display_device {
   namespace vdd_utils {
 
     const wchar_t *kVddPipeName = L"\\\\.\\pipe\\ZakoVDDPipe";
-    const DWORD kPipeTimeoutMs = 5000;
+    const DWORD kPipeTimeoutMs = 3000;
     const DWORD kPipeBufferSize = 4096;
     const std::chrono::milliseconds kDefaultDebounceInterval { 2000 };
 
@@ -141,7 +141,7 @@ namespace display_device {
     }
 
     bool
-    execute_pipe_command(const wchar_t *pipe_name, const wchar_t *command, std::string *response) {
+    execute_pipe_command(const wchar_t *pipe_name, const wchar_t *command, std::string *response, bool *timed_out) {
       auto hPipe = connect_to_pipe_with_retry(pipe_name);
       if (hPipe == INVALID_HANDLE_VALUE) {
         BOOST_LOG(error) << "连接MTT虚拟显示管道失败，已重试多次";
@@ -180,10 +180,11 @@ namespace display_device {
       }
 
       // 读取响应
+      bool read_timed_out = false;
       if (response) {
         char buffer[kPipeBufferSize];
-        DWORD bytesRead;
-        if (!ReadFile(hPipe, buffer, sizeof(buffer), &bytesRead, &overlapped)) {
+        DWORD bytesRead = 0;
+        if (!ReadFile(hPipe, buffer, sizeof(buffer) - 1, &bytesRead, &overlapped)) {
           if (GetLastError() != ERROR_IO_PENDING) {
             BOOST_LOG(warning) << "读取响应失败，错误代码: " << GetLastError();
             return false;
@@ -194,9 +195,21 @@ namespace display_device {
             buffer[bytesRead] = '\0';
             *response = std::string(buffer, bytesRead);
           }
+          else {
+            read_timed_out = true;
+            CancelIo(hPipe);
+          }
+        }
+        else {
+          // ReadFile completed synchronously
+          buffer[bytesRead] = '\0';
+          *response = std::string(buffer, bytesRead);
         }
       }
 
+      if (timed_out) {
+        *timed_out = read_timed_out;
+      }
       return true;
     }
 
@@ -309,12 +322,14 @@ namespace display_device {
       }
 
       // 尝试发送命令（带GUID或不带GUID）
-      bool success = execute_pipe_command(kVddPipeName, command.c_str(), &response);
+      bool read_timed_out = false;
+      bool success = execute_pipe_command(kVddPipeName, command.c_str(), &response, &read_timed_out);
 
       // 如果带GUID的命令失败，降级为不带GUID的命令（兼容旧版驱动）
       if (!success && !guid_str.empty()) {
         BOOST_LOG(warning) << "带GUID的命令失败，尝试降级为不带GUID的命令";
-        success = execute_pipe_command(kVddPipeName, L"CREATEMONITOR", &response);
+        read_timed_out = false;
+        success = execute_pipe_command(kVddPipeName, L"CREATEMONITOR", &response, &read_timed_out);
       }
 
       if (!success) {
@@ -325,7 +340,7 @@ namespace display_device {
 #if defined SUNSHINE_TRAY && SUNSHINE_TRAY >= 1
       system_tray::update_vdd_menu();
 #endif
-      BOOST_LOG(info) << "创建虚拟显示器完成，响应: " << response;
+      BOOST_LOG(info) << "创建虚拟显示器完成，响应: " << response << " [return=" << (read_timed_out ? 1 : 0) << "]";
       return true;
     }
 
@@ -627,7 +642,7 @@ namespace display_device {
     set_hdr_state(bool enable_hdr) {
       auto vdd_device_id = find_device_by_friendlyname(ZAKO_NAME);
       if (vdd_device_id.empty()) {
-        BOOST_LOG(debug) << "未找到虚拟显示器设备，跳过HDR状态设置";
+        BOOST_LOG(info) << "未找到虚拟显示器设备，跳过HDR状态设置";
         return true;
       }
 
@@ -636,13 +651,13 @@ namespace display_device {
 
       auto hdr_state_it = current_hdr_states.find(vdd_device_id);
       if (hdr_state_it == current_hdr_states.end()) {
-        BOOST_LOG(debug) << "虚拟显示器不支持HDR或状态未知";
+        BOOST_LOG(info) << "虚拟显示器不支持HDR或状态未知";
         return true;
       }
 
       hdr_state_e target_state = enable_hdr ? hdr_state_e::enabled : hdr_state_e::disabled;
       if (hdr_state_it->second == target_state) {
-        BOOST_LOG(debug) << "虚拟显示器HDR状态已是目标状态";
+        BOOST_LOG(info) << "虚拟显示器HDR状态已是目标状态";
         return true;
       }
 
@@ -662,30 +677,55 @@ namespace display_device {
     }
 
     bool
-    apply_vdd_prep(const std::string &vdd_device_id, parsed_config_t::vdd_prep_e vdd_prep) {
+    apply_vdd_prep(const std::string &vdd_device_id, parsed_config_t::vdd_prep_e vdd_prep,
+      const device_info_map_t &pre_vdd_devices) {
       if (vdd_device_id.empty()) {
-        BOOST_LOG(debug) << "VDD设备ID为空，跳过vdd_prep处理";
+        BOOST_LOG(info) << "VDD设备ID为空，跳过vdd_prep处理";
         return true;
       }
 
       if (vdd_prep == parsed_config_t::vdd_prep_e::no_operation) {
-        BOOST_LOG(debug) << "vdd_prep设置为无操作，跳过物理显示器处理";
+        BOOST_LOG(info) << "vdd_prep设置为无操作，跳过物理显示器处理";
         return true;
       }
 
-      auto current_topology = get_current_topology();
-      if (current_topology.empty()) {
-        BOOST_LOG(warning) << "无法获取当前显示器拓扑";
-        return false;
+      // 从 pre_vdd_devices（VDD创建前保存的设备列表）中获取物理显示器，
+      // 确保即使 VDD 创建后物理屏变 inactive 也能正确识别
+      std::vector<std::string> physical_devices;
+      std::string original_primary_id;
+
+      if (!pre_vdd_devices.empty()) {
+        // 使用 VDD 创建前保存的设备信息（可靠）
+        for (const auto &[device_id, info] : pre_vdd_devices) {
+          if (info.friendly_name != ZAKO_NAME) {
+            physical_devices.push_back(device_id);
+            if (info.device_state == device_state_e::primary) {
+              original_primary_id = device_id;
+            }
+          }
+        }
+        BOOST_LOG(info) << "使用pre-VDD设备列表: " << physical_devices.size() << "个物理显示器"
+                        << (original_primary_id.empty() ? "" : ", 原主屏: " + original_primary_id);
+      }
+      else {
+        // 回退：从当前设备枚举中获取（VDD创建前未保存时的兜底逻辑）
+        BOOST_LOG(warning) << "未提供pre-VDD设备列表，从当前设备枚举中查找物理显示器";
+        const auto all_devices = enum_available_devices();
+        for (const auto &[device_id, info] : all_devices) {
+          if (device_id != vdd_device_id && info.friendly_name != ZAKO_NAME) {
+            physical_devices.push_back(device_id);
+            if (info.device_state == device_state_e::primary) {
+              original_primary_id = device_id;
+            }
+          }
+        }
       }
 
-      // 找出所有物理显示器（非VDD设备）
-      std::vector<std::string> physical_devices;
-      for (const auto &group : current_topology) {
-        for (const auto &id : group) {
-          if (id != vdd_device_id) {
-            physical_devices.push_back(id);
-          }
+      // 确保原主屏在列表最前面（set_topology 中第一组拥有主屏优先权）
+      if (!original_primary_id.empty()) {
+        auto it = std::find(physical_devices.begin(), physical_devices.end(), original_primary_id);
+        if (it != physical_devices.begin() && it != physical_devices.end()) {
+          std::rotate(physical_devices.begin(), it, it + 1);
         }
       }
 

--- a/src/display_device/vdd_utils.h
+++ b/src/display_device/vdd_utils.h
@@ -19,7 +19,7 @@ namespace display_device::vdd_utils {
   // 常量定义
   inline constexpr int kMaxRetryCount = 3;
   inline constexpr auto kInitialRetryDelay = 500ms;
-  inline constexpr auto kMaxRetryDelay = 5000ms;
+  inline constexpr auto kMaxRetryDelay = 3000ms;
 
   extern const wchar_t *kVddPipeName;
   extern const DWORD kPipeTimeoutMs;
@@ -67,7 +67,7 @@ namespace display_device::vdd_utils {
   connect_to_pipe_with_retry(const wchar_t *pipe_name, int max_retries = 3);
 
   bool
-  execute_pipe_command(const wchar_t *pipe_name, const wchar_t *command, std::string *response = nullptr);
+  execute_pipe_command(const wchar_t *pipe_name, const wchar_t *command, std::string *response = nullptr, bool *timed_out = nullptr);
 
   // 驱动重载函数
   bool
@@ -134,12 +134,16 @@ namespace display_device::vdd_utils {
    * @brief Apply VDD prep settings to handle physical displays.
    * @param vdd_device_id The VDD device ID.
    * @param vdd_prep The vdd_prep_e value specifying how to handle physical displays.
+   * @param pre_vdd_devices Physical device info captured BEFORE VDD creation.
+   *        Used to reliably identify physical displays even if VDD creation
+   *        caused them to become inactive. If empty, falls back to current device enumeration.
    * @returns True if the operation succeeded.
    * @note This operation modifies topology without saving/restoring state,
    *       as Windows automatically handles topology memory when displays change.
    */
   bool
-  apply_vdd_prep(const std::string &vdd_device_id, parsed_config_t::vdd_prep_e vdd_prep);
+  apply_vdd_prep(const std::string &vdd_device_id, parsed_config_t::vdd_prep_e vdd_prep,
+    const device_info_map_t &pre_vdd_devices = {});
 
   VddSettings
   prepare_vdd_settings(const parsed_config_t &config);

--- a/src/entry_handler.cpp
+++ b/src/entry_handler.cpp
@@ -88,8 +88,7 @@ namespace lifetime {
     int zero = 0;
     desired_exit_code.compare_exchange_strong(zero, exit_code);
 
-    // Raise SIGINT to start termination
-    std::raise(SIGINT);
+    mail::man->event<bool>(mail::shutdown)->raise(true);
 
     // Termination will happen asynchronously, but the caller may
     // have wanted synchronous behavior.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -306,7 +306,7 @@ main(int argc, char *argv[]) {
 
   // Create signal handler after logging has been initialized
   auto shutdown_event = mail::man->event<bool>(mail::shutdown);
-  on_signal(SIGINT, [&force_shutdown, &display_device_deinit_guard, shutdown_event]() {
+  on_signal(SIGINT, [&force_shutdown, shutdown_event]() {
     BOOST_LOG(info) << "Interrupt handler called"sv;
 
     auto task = []() {
@@ -316,19 +316,10 @@ main(int argc, char *argv[]) {
     };
     force_shutdown = task_pool.pushDelayed(task, 10s).task_id;
 
-    // Break out of the main loop
     shutdown_event->raise(true);
-    system_tray::end_tray();
-    try {
-      display_device::session_t::get().restore_state();
-    }
-    catch (...) {
-    }
-
-    display_device_deinit_guard = nullptr;
   });
 
-  on_signal(SIGTERM, [&force_shutdown, &display_device_deinit_guard, shutdown_event]() {
+  on_signal(SIGTERM, [&force_shutdown, shutdown_event]() {
     BOOST_LOG(info) << "Terminate handler called"sv;
 
     auto task = []() {
@@ -338,16 +329,7 @@ main(int argc, char *argv[]) {
     };
     force_shutdown = task_pool.pushDelayed(task, 10s).task_id;
 
-    // Break out of the main loop
     shutdown_event->raise(true);
-    system_tray::end_tray();
-    try {
-      display_device::session_t::get().restore_state();
-    }
-    catch (...) {
-    }
-
-    display_device_deinit_guard = nullptr;
   });
 
 #ifdef _WIN32
@@ -440,6 +422,14 @@ main(int argc, char *argv[]) {
   }
 
   mainThreadLoop(shutdown_event);
+
+  system_tray::end_tray();
+  try {
+    display_device::session_t::get().restore_state();
+  }
+  catch (...) {
+  }
+  display_device_deinit_guard = nullptr;
 
   httpThread.join();
   configThread.join();

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -11,6 +11,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <shared_mutex>
 #include <sstream>
 #include <string>
 #include <unordered_map>
@@ -68,7 +69,7 @@ namespace nvhttp {
   };
 
   crypto::cert_chain_t cert_chain;
-  std::mutex cert_chain_mutex;
+  std::shared_mutex cert_chain_mutex;
 
   struct named_cert_t {
     std::string name;
@@ -403,7 +404,7 @@ namespace nvhttp {
 
     // Empty certificate chain and import certs from file
     {
-      std::lock_guard<std::mutex> lg(cert_chain_mutex);
+      std::unique_lock<std::shared_mutex> ul(cert_chain_mutex);
       cert_chain.clear();
       for (auto &named_cert : client.named_devices) {
         cert_chain.add(crypto::x509(named_cert.cert));
@@ -640,7 +641,7 @@ namespace nvhttp {
   }
 
   void
-  clientpairingsecret(pair_session_t &sess, std::shared_ptr<safe::queue_t<crypto::x509_t>> &add_cert, pt::ptree &tree, const std::string &client_pairing_secret) {
+  clientpairingsecret(pair_session_t &sess, pt::ptree &tree, const std::string &client_pairing_secret) {
     if (sess.last_phase != PAIR_PHASE::SERVERCHALLENGERESP) {
       fail_pair(sess, tree, "Out of order call to clientpairingsecret");
       return;
@@ -678,7 +679,12 @@ namespace nvhttp {
     auto verify = crypto::verify256(crypto::x509(client.cert), secret, sign);
     if (same_hash && verify) {
       tree.put("root.paired", 1);
-      add_cert->raise(crypto::x509(client.cert));
+
+      // Add cert to chain directly under exclusive lock
+      {
+        std::unique_lock<std::shared_mutex> ul(cert_chain_mutex);
+        cert_chain.add(crypto::x509(client.cert));
+      }
 
       // The client is now successfully paired and will be authorized to connect
       add_authorized_client(client.name, std::move(client.cert));
@@ -786,7 +792,7 @@ namespace nvhttp {
 
   template <class T>
   void
-  pair(std::shared_ptr<safe::queue_t<crypto::x509_t>> &add_cert, std::shared_ptr<typename SimpleWeb::ServerBase<T>::Response> response, std::shared_ptr<typename SimpleWeb::ServerBase<T>::Request> request) {
+  pair(std::shared_ptr<typename SimpleWeb::ServerBase<T>::Response> response, std::shared_ptr<typename SimpleWeb::ServerBase<T>::Request> request) {
     print_req<T>(request);
 
     // Rate limit pairing attempts per IP
@@ -896,7 +902,7 @@ namespace nvhttp {
     }
     else if (it = args.find("clientpairingsecret"); it != std::end(args)) {
       auto pairingsecret = util::from_hex_vec(it->second, true);
-      clientpairingsecret(sess_it->second, add_cert, tree, pairingsecret);
+      clientpairingsecret(sess_it->second, tree, pairingsecret);
     }
     else {
       tree.put("root.<xmlattr>.status_code", 404);
@@ -2016,8 +2022,6 @@ namespace nvhttp {
     auto cert = file_handler::read_file(config::nvhttp.cert.c_str());
     setup(pkey, cert);
 
-    auto add_cert = std::make_shared<safe::queue_t<crypto::x509_t>>(30);
-
     // resume doesn't always get the parameter "localAudioPlayMode"
     // launch will store it in host_audio
     bool host_audio {};
@@ -2026,7 +2030,7 @@ namespace nvhttp {
     http_server_t http_server;
 
     // Verify certificates after establishing connection
-    https_server.verify = [add_cert, close_verify_safe](SSL *ssl) {
+    https_server.verify = [close_verify_safe](SSL *ssl) {
       crypto::x509_t x509 {
 #if OPENSSL_VERSION_MAJOR >= 3
         SSL_get1_peer_certificate(ssl)
@@ -2049,26 +2053,12 @@ namespace nvhttp {
         BOOST_LOG(debug) << subject_name << " -- "sv << (verified ? "verified"sv : "denied"sv);
       });
 
-      // Use non-blocking pop with 0ms timeout to avoid TOCTOU race between peek() and pop().
-      // peek() is lockless, so a concurrent verify callback could drain the queue after peek()
-      // returns true, causing the blocking pop() to wait forever and deadlock the HTTPS server.
-      {
-        std::lock_guard<std::mutex> lg(cert_chain_mutex);
-        while (true) {
-          auto cert = add_cert->pop(std::chrono::milliseconds(0));
-          if (!cert) break;
-
-          char subject_name[256];
-          X509_NAME_oneline(X509_get_subject_name(cert.get()), subject_name, sizeof(subject_name));
-
-          BOOST_LOG(debug) << "Added cert ["sv << subject_name << ']';
-          cert_chain.add(std::move(cert));
-        }
-      }
-
+      // Verify the client certificate under shared lock.
+      // New certs are added directly in clientpairingsecret() under exclusive lock,
+      // so the verify callback is read-only and can run concurrently.
       const char *err_str;
       {
-        std::lock_guard<std::mutex> lg(cert_chain_mutex);
+        std::shared_lock<std::shared_mutex> sl(cert_chain_mutex);
         if (!close_verify_safe) {
           err_str = cert_chain.verify_safe(x509.get());  // default
         }
@@ -2104,7 +2094,7 @@ namespace nvhttp {
 
     https_server.default_resource["GET"] = not_found<SunshineHTTPS>;
     https_server.resource["^/serverinfo$"]["GET"] = serverinfo<SunshineHTTPS>;
-    https_server.resource["^/pair$"]["GET"] = [&add_cert](auto resp, auto req) { pair<SunshineHTTPS>(add_cert, resp, req); };
+    https_server.resource["^/pair$"]["GET"] = [](auto resp, auto req) { pair<SunshineHTTPS>(resp, req); };
     https_server.resource["^/applist$"]["GET"] = applist;
     https_server.resource["^/appasset$"]["GET"] = appasset;
     https_server.resource["^/displays$"]["GET"] = get_displays;
@@ -2124,7 +2114,7 @@ namespace nvhttp {
 
     http_server.default_resource["GET"] = not_found<SimpleWeb::HTTP>;
     http_server.resource["^/serverinfo$"]["GET"] = serverinfo<SimpleWeb::HTTP>;
-    http_server.resource["^/pair$"]["GET"] = [&add_cert](auto resp, auto req) { pair<SimpleWeb::HTTP>(add_cert, resp, req); };
+    http_server.resource["^/pair$"]["GET"] = [](auto resp, auto req) { pair<SimpleWeb::HTTP>(resp, req); };
 
     http_server.config.reuse_address = true;
     http_server.config.address = net::get_bind_address(address_family);
@@ -2180,7 +2170,7 @@ namespace nvhttp {
     client_t client;
     client_root = client;
     {
-      std::lock_guard<std::mutex> lg(cert_chain_mutex);
+      std::unique_lock<std::shared_mutex> ul(cert_chain_mutex);
       cert_chain.clear();
     }
     save_state();

--- a/src/platform/windows/display_device/settings_topology.cpp
+++ b/src/platform/windows/display_device/settings_topology.cpp
@@ -1,3 +1,6 @@
+// standard includes
+#include <thread>
+
 // local includes
 #include "settings_topology.h"
 #include "src/display_device/to_string.h"
@@ -442,14 +445,37 @@ namespace display_device {
       return boost::none;
     }
 
-    const auto current_topology { get_current_topology() };
-    if (!is_topology_valid(current_topology)) {
-      BOOST_LOG(error) << "Display topology is invalid!";
-      return boost::none;
+    // 获取活跃拓扑并检查设备是否可用，带重试以应对 HDR/拓扑变更后的短暂不稳定
+    active_topology_t current_topology;
+    bool device_active = false;
+    constexpr int max_retries = 3;
+    constexpr auto retry_delay = std::chrono::milliseconds(500);
+
+    for (int attempt = 0; attempt < max_retries; ++attempt) {
+      current_topology = get_current_topology();
+      if (!is_topology_valid(current_topology)) {
+        BOOST_LOG(warning) << "Display topology is invalid (attempt " << (attempt + 1) << "/" << max_retries << ")";
+        if (attempt + 1 < max_retries) {
+          std::this_thread::sleep_for(retry_delay);
+          continue;
+        }
+        BOOST_LOG(error) << "Display topology is invalid after all retries!";
+        return boost::none;
+      }
+
+      if (is_device_found_in_active_topology(requested_device_id, current_topology)) {
+        device_active = true;
+        break;
+      }
+
+      BOOST_LOG(warning) << "Device " << requested_device_id << " is not active (attempt " << (attempt + 1) << "/" << max_retries << "), waiting for display to stabilize...";
+      if (attempt + 1 < max_retries) {
+        std::this_thread::sleep_for(retry_delay);
+      }
     }
 
-    if (!is_device_found_in_active_topology(requested_device_id, current_topology)) {
-      BOOST_LOG(error) << "Device " << requested_device_id << " is not active!";
+    if (!device_active) {
+      BOOST_LOG(error) << "Device " << requested_device_id << " is not active after " << max_retries << " retries!";
       return boost::none;
     }
 

--- a/src/system_tray.cpp
+++ b/src/system_tray.cpp
@@ -127,6 +127,13 @@ namespace system_tray {
     vdd_submenu[3].text = s_vdd_headless_create.c_str();
   }
 
+  static void clear_tray_notification() {
+    tray.notification_title = NULL;
+    tray.notification_text = NULL;
+    tray.notification_icon = NULL;
+    tray.notification_cb = NULL;
+  }
+
   // 更新访问项目地址子菜单项的文本
   static void tray_visit_project_submenu_text() {
     visit_project_submenu[0].text = s_visit_project_sunshine.c_str();
@@ -1236,10 +1243,7 @@ namespace system_tray {
       return;
     }
 
-    tray.notification_title = NULL;
-    tray.notification_text = NULL;
-    tray.notification_cb = NULL;
-    tray.notification_icon = NULL;
+    clear_tray_notification();
     tray.icon = TRAY_ICON_PLAYING;
     tray_update(&tray);
     tray.icon = TRAY_ICON_PLAYING;
@@ -1260,6 +1264,8 @@ namespace system_tray {
     tray.tooltip = msg.c_str();
     tray.notification_icon = TRAY_ICON_PLAYING;
     tray_update(&tray);
+
+    clear_tray_notification();
   }
 
   void
@@ -1268,10 +1274,7 @@ namespace system_tray {
       return;
     }
 
-    tray.notification_title = NULL;
-    tray.notification_text = NULL;
-    tray.notification_cb = NULL;
-    tray.notification_icon = NULL;
+    clear_tray_notification();
     tray.icon = TRAY_ICON_PAUSING;
     tray_update(&tray);
 
@@ -1292,6 +1295,8 @@ namespace system_tray {
     tray.tooltip = msg.c_str();
     tray.notification_icon = TRAY_ICON_PAUSING;
     tray_update(&tray);
+
+    clear_tray_notification();
   }
 
   void
@@ -1300,10 +1305,7 @@ namespace system_tray {
       return;
     }
 
-    tray.notification_title = NULL;
-    tray.notification_text = NULL;
-    tray.notification_cb = NULL;
-    tray.notification_icon = NULL;
+    clear_tray_notification();
     tray.icon = TRAY_ICON;
     tray_update(&tray);
 
@@ -1324,6 +1326,8 @@ namespace system_tray {
     tray.notification_text = msg.c_str();
     tray.tooltip = PROJECT_NAME;
     tray_update(&tray);
+
+    clear_tray_notification();
   }
 
   void
@@ -1332,10 +1336,7 @@ namespace system_tray {
       return;
     }
 
-    tray.notification_title = NULL;
-    tray.notification_text = NULL;
-    tray.notification_cb = NULL;
-    tray.notification_icon = NULL;
+    clear_tray_notification();
     tray.icon = TRAY_ICON;
     tray_update(&tray);
     tray.icon = TRAY_ICON;
@@ -1359,6 +1360,8 @@ namespace system_tray {
       launch_ui_with_path("/pin");
     };
     tray_update(&tray);
+
+    clear_tray_notification();
   }
  
   void

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1628,14 +1628,16 @@ namespace video {
             refresh_displays(encoder.platform_formats->dev_type, display_names, display_p);
 
             // Process any pending display switch with the new list of displays
+            bool user_switched = false;
             if (switch_display_event->peek()) {
               display_p = std::clamp(*switch_display_event->pop(), 0, (int) display_names.size() - 1);
+              user_switched = true;
             }
 
-            // Use client-specified display_name if provided
+            // Use client-specified display_name if provided (only for auto-reinit, not manual switch)
             const auto &config = capture_ctxs.front().config;
             std::string target_display_name = display_names[display_p];
-            if (!config.display_name.empty()) {
+            if (!user_switched && !config.display_name.empty()) {
               // config.display_name may be a device ID - convert to display name
               std::string resolved_display_name = display_device::get_display_name(config.display_name);
               if (resolved_display_name.empty()) {
@@ -2897,14 +2899,16 @@ namespace video {
       refresh_displays(encoder.platform_formats->dev_type, display_names, display_p);
 
       // Process any pending display switch with the new list of displays
+      bool user_switched = false;
       if (switch_display_event->peek()) {
         display_p = std::clamp(*switch_display_event->pop(), 0, (int) display_names.size() - 1);
+        user_switched = true;
       }
 
-      // Use client-specified display_name if provided
+      // Use client-specified display_name if provided (only for auto-reinit, not manual switch)
       const auto &config = synced_session_ctxs.front()->config;
       std::string target_display_name = display_names[display_p];
-      if (!config.display_name.empty()) {
+      if (!user_switched && !config.display_name.empty()) {
         // config.display_name may be a device ID - convert to display name
         std::string resolved_display_name = display_device::get_display_name(config.display_name);
         if (resolved_display_name.empty()) {


### PR DESCRIPTION
* refactor(nvhttp):消除队列开销，用 shared_mutex 替换 mutex 以实现证书链管理

* feat: 优化托盘状态显示

* feat: 安全退出程序

* feat: 调整VDD设备创建和拓扑检查逻辑，优化延迟和超时设置

* fix: 修复屏幕快捷键切换

* fix: 修复ReadFile调用中的缓冲区处理，确保正确读取响应