### PR TITLE
cherry-pick: 上游 bugfix 与 feature 同步 (#4340, #4407, #4261, #4890)

### DIFF
--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -605,6 +605,11 @@ namespace audio {
     return control_shared.has_ref();
   }
 
+  // 单步原子获取已存在的引用，避免 has_audio_ctx_ref + get_audio_ctx_ref 之间的 TOCTOU
+  audio_ctx_ref_t try_get_audio_ctx_ref() {
+    return control_shared.try_ref();
+  }
+
   bool is_audio_ctx_sink_available(const audio_ctx_t &ctx) {
     if (!ctx.control) {
       return false;
@@ -694,15 +699,13 @@ namespace audio {
   }
 
   int init_mic_redirect_device() {
-    // 关键修复：先检查是否有活动的引用，避免触发 start_audio_control
-    // 如果没有活动的引用，说明音频上下文没有启动，不应该初始化麦克风设备
-    if (!has_audio_ctx_ref()) {
+    // 单步原子获取：仅当音频上下文已存在时使用，绝不重新触发 start_audio_control。
+    auto ref = try_get_audio_ctx_ref();
+    if (!ref) {
       BOOST_LOG(debug) << "Audio context not active, skipping microphone device initialization";
       return -1;
     }
-    
-    auto ref = get_audio_ctx_ref();
-    if (!ref || !ref->control) {
+    if (!ref->control) {
       BOOST_LOG(error) << "Audio context not available for microphone data writing";
       return -1;
     }
@@ -710,15 +713,13 @@ namespace audio {
   }
 
   void release_mic_redirect_device() {
-    // 关键修复：先检查是否有活动的引用，避免触发 start_audio_control
-    // 如果没有活动的引用，说明音频上下文没有启动，不需要释放
-    if (!has_audio_ctx_ref()) {
+    // 单步原子获取：仅当音频上下文已存在时释放设备，避免在已停止后再创建上下文。
+    auto ref = try_get_audio_ctx_ref();
+    if (!ref) {
       BOOST_LOG(debug) << "Audio context not active, skipping microphone device release";
       return;
     }
-    
-    auto ref = get_audio_ctx_ref();
-    if (!ref || !ref->control) {
+    if (!ref->control) {
       BOOST_LOG(warning) << "Audio context not available for microphone device release";
       return;
     }
@@ -726,17 +727,15 @@ namespace audio {
   }
 
   int write_mic_data(const std::uint8_t *data, size_t size, uint16_t seq) {
-    // 先检查是否有活动引用，避免不必要地触发 start_audio_control
-    // 如果音频捕获线程正在运行，它会持有引用，这里会返回 true
-    if (!has_audio_ctx_ref()) {
+    // 单步原子获取：避免对已经释放的音频上下文做 check-then-act。
+    auto ref = try_get_audio_ctx_ref();
+    if (!ref) {
       BOOST_LOG(debug) << "Audio context not active, skipping microphone data write";
       // 注意：这不是错误，而是正常情况
       // 可能音频捕获还没有启动，或者已经停止
       return -1;
     }
-    
-    auto ref = get_audio_ctx_ref();
-    if (!ref || !ref->control) {
+    if (!ref->control) {
       BOOST_LOG(warning) << "Audio context reference invalid for microphone data writing";
       return -1;
     }

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -535,7 +535,8 @@ namespace audio {
     }
 
     auto frame_size = config.packetDuration * stream.sampleRate / 1000;
-    auto mic = control->microphone(stream.mapping, stream.channelCount, stream.sampleRate, frame_size);
+    bool continuous_audio = config.flags[config_t::CONTINUOUS_AUDIO];
+    auto mic = control->microphone(stream.mapping, stream.channelCount, stream.sampleRate, frame_size, continuous_audio);
     if (!mic) {
       BOOST_LOG(error) << "Audio capture: failed to initialize microphone";
       return;
@@ -574,7 +575,7 @@ namespace audio {
           BOOST_LOG(info) << "Reinitializing audio capture"sv;
           mic.reset();
           do {
-            mic = control->microphone(stream.mapping, stream.channelCount, stream.sampleRate, frame_size);
+            mic = control->microphone(stream.mapping, stream.channelCount, stream.sampleRate, frame_size, continuous_audio);
             if (!mic) {
               BOOST_LOG(warning) << "Couldn't re-initialize audio input"sv;
             }

--- a/src/audio.h
+++ b/src/audio.h
@@ -120,6 +120,18 @@ namespace audio {
   has_audio_ctx_ref();
 
   /**
+   * @brief Atomically acquire an audio context reference only if one already exists.
+   * @returns A live audio_ctx_ref_t when a context is already alive, an empty one otherwise.
+   * @note Unlike get_audio_ctx_ref() this never (re-)constructs the audio context, which
+   *       makes it safe for fire-and-forget probes such as microphone redirection that
+   *       must not resurrect a context after the audio capture loop has stopped.
+   *       Prefer this over the has_audio_ctx_ref() + get_audio_ctx_ref() pair to avoid
+   *       a TOCTOU race that could otherwise re-trigger start_audio_control().
+   */
+  audio_ctx_ref_t
+  try_get_audio_ctx_ref();
+
+  /**
    * @brief Check if the audio sink held by audio context is available.
    * @returns True if available (and can probably be restored), false otherwise.
    * @note Useful for delaying the release of audio context shared pointer (which

--- a/src/audio.h
+++ b/src/audio.h
@@ -57,6 +57,7 @@ namespace audio {
       HIGH_QUALITY,  ///< High quality audio
       HOST_AUDIO,  ///< Host audio
       CUSTOM_SURROUND_PARAMS,  ///< Custom surround parameters
+      CONTINUOUS_AUDIO,  ///< Continuous audio
       MAX_FLAGS  ///< Maximum number of flags
     };
 

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -1586,7 +1586,12 @@ namespace confighttp {
         return;
       }
 
-      outputTree.put("status", nvhttp::unpair_client(uuid));
+      const bool removed = nvhttp::unpair_client(uuid);
+      outputTree.put("status", removed);
+
+      if (removed && nvhttp::get_all_clients().empty()) {
+        proc::proc.terminate();
+      }
     }
     catch (std::exception &e) {
       BOOST_LOG(warning) << "Unpair: "sv << e.what();

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -495,6 +495,7 @@ namespace nvhttp {
     launch_session->enable_sops = util::from_view(get_arg(args, "sops", "0"));
     launch_session->surround_info = util::from_view(get_arg(args, "surroundAudioInfo", "196610"));
     launch_session->surround_params = (get_arg(args, "surroundParams", ""));
+    launch_session->continuous_audio = util::from_view(get_arg(args, "continuousAudio", "0"));
     launch_session->gcmap = util::from_view(get_arg(args, "gcmap", "0"));
     launch_session->enable_hdr = util::from_view(get_arg(args, "hdrMode", "0"));
     launch_session->use_vdd = util::from_view(get_arg(args, "useVdd", "0"));

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -641,7 +641,7 @@ namespace platf {
     set_sink(const std::string &sink) = 0;
 
     virtual std::unique_ptr<mic_t>
-    microphone(const std::uint8_t *mapping, int channels, std::uint32_t sample_rate, std::uint32_t frame_size) = 0;
+    microphone(const std::uint8_t *mapping, int channels, std::uint32_t sample_rate, std::uint32_t frame_size, bool continuous) = 0;
 
     /**
      * @brief Check if the audio sink is available in the system.

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -733,6 +733,9 @@ namespace platf {
   void
   adjust_thread_priority(thread_priority_e priority);
 
+  void
+  enable_mouse_keys();
+
   // Allow OS-specific actions to be taken to prepare for streaming
   void
   streaming_will_start();

--- a/src/platform/linux/audio.cpp
+++ b/src/platform/linux/audio.cpp
@@ -485,7 +485,7 @@ namespace platf {
       }
 
       std::unique_ptr<mic_t>
-      microphone(const std::uint8_t *mapping, int channels, std::uint32_t sample_rate, std::uint32_t frame_size) override {
+      microphone(const std::uint8_t *mapping, int channels, std::uint32_t sample_rate, std::uint32_t frame_size, bool continuous_audio) override {
         // Sink choice priority:
         // 1. Config sink
         // 2. Last sink swapped to (Usually virtual in this case)

--- a/src/platform/linux/audio.cpp
+++ b/src/platform/linux/audio.cpp
@@ -540,6 +540,26 @@ namespace platf {
         return 0;
       }
 
+      int
+      write_mic_data(const char *data, size_t size, uint16_t seq = 0) override {
+        // Microphone redirect to the host is not implemented on Linux yet.
+        (void) data;
+        (void) size;
+        (void) seq;
+        return -1;
+      }
+
+      int
+      init_mic_redirect_device() override {
+        // No host-side virtual mic on Linux.
+        return -1;
+      }
+
+      void
+      release_mic_redirect_device() override {
+        // Nothing to release.
+      }
+
       ~server_t() override {
         unload_null(index.stereo);
         unload_null(index.surround51);

--- a/src/platform/linux/misc.cpp
+++ b/src/platform/linux/misc.cpp
@@ -301,6 +301,11 @@ namespace platf {
   }
 
   void
+  enable_mouse_keys() {
+    // Unimplemented
+  }
+
+  void
   streaming_will_start() {
     // Nothing to do
   }

--- a/src/platform/macos/microphone.mm
+++ b/src/platform/macos/microphone.mm
@@ -52,7 +52,7 @@ namespace platf {
     }
 
     std::unique_ptr<mic_t>
-    microphone(const std::uint8_t *mapping, int channels, std::uint32_t sample_rate, std::uint32_t frame_size) override {
+    microphone(const std::uint8_t *mapping, int channels, std::uint32_t sample_rate, std::uint32_t frame_size, bool continuous_audio) override {
       auto mic = std::make_unique<av_mic_t>();
       const char *audio_sink = "";
 

--- a/src/platform/macos/microphone.mm
+++ b/src/platform/macos/microphone.mm
@@ -87,6 +87,32 @@ namespace platf {
 
       return sink;
     }
+
+    bool
+    is_sink_available(const std::string &sink) override {
+      BOOST_LOG(warning) << "audio_control_t::is_sink_available() unimplemented: "sv << sink;
+      return true;
+    }
+
+    int
+    write_mic_data(const char *data, size_t size, uint16_t seq = 0) override {
+      // Microphone redirect to the host is not implemented on macOS yet.
+      (void) data;
+      (void) size;
+      (void) seq;
+      return -1;
+    }
+
+    int
+    init_mic_redirect_device() override {
+      // No host-side virtual mic on macOS.
+      return -1;
+    }
+
+    void
+    release_mic_redirect_device() override {
+      // Nothing to release.
+    }
   };
 
   std::unique_ptr<audio_control_t>

--- a/src/platform/macos/misc.mm
+++ b/src/platform/macos/misc.mm
@@ -229,6 +229,11 @@ namespace platf {
   }
 
   void
+  enable_mouse_keys() {
+    // Unimplemented
+  }
+
+  void
   streaming_will_start() {
     // Nothing to do
   }

--- a/src/platform/windows/audio.cpp
+++ b/src/platform/windows/audio.cpp
@@ -470,7 +470,15 @@ namespace platf::audio {
       // Refill the sample buffer if needed
       while (sample_buf_pos - std::begin(sample_buf) < sample_size) {
         auto capture_result = _fill_buffer();
-        if (capture_result != capture_e::ok) {
+        if (capture_result == capture_e::timeout && continuous_audio) {
+          // Pad with silence only up to the requested frame boundary so any
+          // partial samples that _fill_buffer() managed to write before the
+          // timeout are preserved instead of being shifted into the next
+          // frame, which would cause a cumulative timing drift.
+          const auto remaining = sample_size - (sample_buf_pos - std::begin(sample_buf));
+          std::fill_n(sample_buf_pos, remaining, 0.0f);
+          sample_buf_pos += remaining;
+        } else if (capture_result != capture_e::ok) {
           return capture_result;
         }
       }
@@ -486,7 +494,7 @@ namespace platf::audio {
     }
 
     int
-    init(std::uint32_t sample_rate, std::uint32_t frame_size, std::uint32_t channels_out) {
+    init(std::uint32_t sample_rate, std::uint32_t frame_size, std::uint32_t channels_out, bool continuous) {
       audio_event.reset(CreateEventA(nullptr, FALSE, FALSE, nullptr));
       if (!audio_event) {
         BOOST_LOG(error) << "Couldn't create Event handle"sv;
@@ -546,6 +554,7 @@ namespace platf::audio {
       REFERENCE_TIME default_latency;
       audio_client->GetDevicePeriod(&default_latency, nullptr);
       default_latency_ms = default_latency / 1000;
+      continuous_audio = continuous;
 
       std::uint32_t frames;
       status = audio_client->GetBufferSize(&frames);
@@ -716,6 +725,7 @@ namespace platf::audio {
     util::buffer_t<float> sample_buf;
     float *sample_buf_pos;
     int channels;
+    bool continuous_audio;
 
     HANDLE mmcss_task_handle = NULL;
   };
@@ -808,10 +818,10 @@ namespace platf::audio {
     }
 
     std::unique_ptr<mic_t>
-    microphone(const std::uint8_t *mapping, int channels, std::uint32_t sample_rate, std::uint32_t frame_size) override {
+    microphone(const std::uint8_t *mapping, int channels, std::uint32_t sample_rate, std::uint32_t frame_size, bool continuous_audio) override {
       auto mic = std::make_unique<mic_wasapi_t>();
 
-      if (mic->init(sample_rate, frame_size, channels)) {
+      if (mic->init(sample_rate, frame_size, channels, continuous_audio)) {
         return nullptr;
       }
 

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -1180,8 +1180,9 @@ namespace platf {
       return {};
     }
 
-    dxgi::adapter_t adapter;
-    for (int x = 0; factory->EnumAdapters1(x, &adapter) != DXGI_ERROR_NOT_FOUND; ++x) {
+    dxgi::adapter_t::pointer adapter_p;
+    for (int x = 0; factory->EnumAdapters1(x, &adapter_p) != DXGI_ERROR_NOT_FOUND; ++x) {
+      dxgi::adapter_t adapter { adapter_p };
       DXGI_ADAPTER_DESC1 adapter_desc;
       adapter->GetDesc1(&adapter_desc);
 
@@ -1262,8 +1263,9 @@ namespace platf {
       return {};
     }
 
-    dxgi::adapter_t adapter;
-    for (int x = 0; factory->EnumAdapters1(x, &adapter) != DXGI_ERROR_NOT_FOUND; ++x) {
+    dxgi::adapter_t::pointer adapter_p;
+    for (int x = 0; factory->EnumAdapters1(x, &adapter_p) != DXGI_ERROR_NOT_FOUND; ++x) {
+      dxgi::adapter_t adapter { adapter_p };
       DXGI_ADAPTER_DESC1 adapter_desc;
       adapter->GetDesc1(&adapter_desc);
 

--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -1324,13 +1324,29 @@ namespace platf {
       }
     }
 
+    enable_mouse_keys();
+  }
+
+  void
+  enable_mouse_keys() {
     // If there is no mouse connected, enable Mouse Keys to force the cursor to appear
     if (!GetSystemMetrics(SM_MOUSEPRESENT)) {
-      BOOST_LOG(info) << "A mouse was not detected. Sunshine will enable Mouse Keys while streaming to force the mouse cursor to appear.";
+      // This function is invoked periodically (per encoded frame) so we must guard
+      // against re-reading SPI_GETMOUSEKEYS after we've already enabled it; otherwise
+      // the snapshot saved in previous_mouse_keys_state would be overwritten with
+      // our own enabled state and streaming_will_stop() would fail to restore the
+      // user's original Mouse Keys configuration.
+      if (!enabled_mouse_keys) {
+        BOOST_LOG(info) << "A mouse was not detected. Sunshine will enable Mouse Keys while streaming to force the mouse cursor to appear.";
 
-      // Get the current state of Mouse Keys so we can restore it when streaming is over
-      previous_mouse_keys_state.cbSize = sizeof(previous_mouse_keys_state);
-      if (SystemParametersInfoW(SPI_GETMOUSEKEYS, 0, &previous_mouse_keys_state, 0)) {
+        // Get the current state of Mouse Keys so we can restore it when streaming is over
+        previous_mouse_keys_state.cbSize = sizeof(previous_mouse_keys_state);
+        if (!SystemParametersInfoW(SPI_GETMOUSEKEYS, 0, &previous_mouse_keys_state, 0)) {
+          auto winerr = GetLastError();
+          BOOST_LOG(warning) << "Unable to get current state of Mouse Keys: "sv << winerr;
+          return;
+        }
+
         MOUSEKEYS new_mouse_keys_state = {};
 
         // Enable Mouse Keys
@@ -1346,10 +1362,6 @@ namespace platf {
           auto winerr = GetLastError();
           BOOST_LOG(warning) << "Unable to enable Mouse Keys: "sv << winerr;
         }
-      }
-      else {
-        auto winerr = GetLastError();
-        BOOST_LOG(warning) << "Unable to get current state of Mouse Keys: "sv << winerr;
       }
     }
   }

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -1341,6 +1341,10 @@ namespace rtsp_stream {
       std::copy_n(std::begin(platf::speaker::map_surround714), 12, std::begin(config.audio.customStreamParams.mapping));
       config.audio.flags[audio::config_t::CUSTOM_SURROUND_PARAMS] = true;
     }
+    if (session.continuous_audio) {
+      BOOST_LOG(info) << "Client requested continuous audio"sv;
+      config.audio.flags[audio::config_t::CONTINUOUS_AUDIO] = true;
+    }
 
     // If the client sent a configured bitrate, we will choose the actual bitrate ourselves
     // by using FEC percentage and audio quality settings. If the calculated bitrate ends up

--- a/src/rtsp.h
+++ b/src/rtsp.h
@@ -35,6 +35,7 @@ namespace rtsp_stream {
     int appid;
     int surround_info;
     std::string surround_params;
+    bool continuous_audio;
     bool enable_hdr;
     bool enable_sops;
     bool enable_mic;

--- a/src/thread_safe.h
+++ b/src/thread_safe.h
@@ -475,6 +475,23 @@ namespace safe {
       return _count > 0;
     }
 
+    /**
+     * @brief Atomically acquire a reference only if one already exists.
+     *        Unlike ref(), this never invokes the construct callback, which makes
+     *        it safe to use from code paths that must not (re-)start the underlying
+     *        resource (e.g. probing whether a long-running context is still alive).
+     * @return A live ptr_t when there is an existing reference, an empty one otherwise.
+     */
+    [[nodiscard]] ptr_t
+    try_ref() {
+      std::lock_guard lg { _lock };
+      if (!_count) {
+        return ptr_t { nullptr };
+      }
+      ++_count;
+      return ptr_t { this };
+    }
+
   private:
     construct_f _construct;
     destruct_f _destruct;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -2917,6 +2917,11 @@ namespace video {
         }
       }
 
+      // While streaming check to see if the mouse is present and enable Mouse Keys to force the cursor to appear.
+      // Run this BEFORE the VRR early-continue so a KVM switch on a static screen still recovers the cursor
+      // even when no new frame would be encoded.
+      platf::enable_mouse_keys();
+
       // If variable refresh rate is enabled, skip encoding when no new frame is available
       // This allows the stream framerate to match the render framerate for VRR support
       // However, if minimum_fps_target is set, we still encode to maintain minimum FPS

--- a/tests/unit/test_audio.cpp
+++ b/tests/unit/test_audio.cpp
@@ -20,7 +20,7 @@ struct AudioTest: PlatformTestSuite, testing::WithParamInterface<std::tuple<std:
 };
 
 constexpr std::bitset<config_t::MAX_FLAGS> config_flags(const int flag = -1) {
-  std::bitset<3> result = std::bitset<config_t::MAX_FLAGS>();
+  auto result = std::bitset<config_t::MAX_FLAGS>();
   if (flag >= 0) {
     result.set(flag);
   }


### PR DESCRIPTION
从上游 LizardByte/Sunshine 同步以下修复和功能：

## Bug Fixes

- **DXGI EnumAdapters1 内存泄漏** (upstream [`d3af56d6f`](https://github.com/LizardByte/Sunshine/commit/d3af56d6f), [#4340](https://github.com/LizardByte/Sunshine/pull/4340))
  - `display_base.cpp` 中 `EnumAdapters1` 返回的 adapter 指针直接赋值给 `ComPtr` 导致引用计数错误，改为通过原始指针接收后再包装

- **KVM 切换后光标消失** (upstream [`fd2bfaac7`](https://github.com/LizardByte/Sunshine/commit/fd2bfaac7), [#4407](https://github.com/LizardByte/Sunshine/pull/4407))
  - Windows Mouse Keys 辅助功能在 KVM 切换后被系统重置，导致光标不可见。提取 `enable_mouse_keys()` 并在视频帧循环中周期性调用以保持状态

- **取消配对最后一个客户端时清除托盘图标** (upstream [`d6bc76e3d`](https://github.com/LizardByte/Sunshine/commit/d6bc76e3d), [#4890](https://github.com/LizardByte/Sunshine/pull/4890))
  - unpair 最后一个客户端后调用 `proc::proc.terminate()` 以更新托盘图标状态

## Features

- **持续音频 (Continuous Audio)** (upstream [`fbcf2116c`](https://github.com/LizardByte/Sunshine/commit/fbcf2116c), [#4261](https://github.com/LizardByte/Sunshine/pull/4261))
  - 客户端可请求持续音频流，当无音频捕获时自动填充静音数据而非断流。涉及新增 `CONTINUOUS_AUDIO` flag、RTSP/NVHTTP 参数解析、WASAPI timeout 时静音填充

## 已评估跳过的上游 PR

| PR | 说明 | 原因 |
|-----|------|------|
| #4095 | 设备名特殊字符崩溃 | 我们已有相同的 to_utf8/from_utf8 实现，上游仅为代码重构 |
| #4387 | 统一颜色转换矩阵 | 已有 color_vectors_from_colorspace(colorspace, unorm_output) |
| #4051 | 非串流时省电 | 已有 iterate() 事件驱动模式 |
| #4889 | CSRF 错误提示 | 本地无 CSRF 基础设施 |
| #4625 | ViGEmBus 管理 API | 已有独立 NSIS 安装方案，架构差异大 |