### PR TITLE
fix(uninstall): replace slow wmic with registry-based ViGEmBus uninstall

### DIFF
--- a/src_assets/windows/misc/gamepad/uninstall-gamepad.bat
+++ b/src_assets/windows/misc/gamepad/uninstall-gamepad.bat
@@ -1,4 +1,55 @@
 @echo off
+setlocal enabledelayedexpansion
 
-rem Use wmic to get the uninstall Virtual Gamepad
-wmic product where name="ViGEm Bus Driver" call uninstall
+rem Uninstall ViGEm Bus Driver via registry UninstallString
+rem (Replaces slow "wmic product" which can hang for minutes)
+
+set "FOUND=0"
+
+rem Search Uninstall registry keys for ViGEmBus
+for %%R in (
+  "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall"
+  "HKLM\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall"
+) do (
+  for /f "tokens=*" %%K in ('reg query %%R /s /f "ViGEm Bus Driver" /d 2^>nul ^| findstr /i "HKEY_"') do (
+    for /f "tokens=2*" %%A in ('reg query "%%K" /v UninstallString 2^>nul ^| findstr /i "UninstallString"') do (
+      set "UNINSTALL_CMD=%%B"
+      set "FOUND=1"
+    )
+  )
+)
+
+if "!FOUND!"=="0" (
+  rem Try finding by DisplayName containing "ViGEm"
+  for %%R in (
+    "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall"
+    "HKLM\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall"
+  ) do (
+    for /f "tokens=*" %%K in ('reg query %%R /s /f "ViGEm" /d 2^>nul ^| findstr /i "HKEY_"') do (
+      for /f "tokens=2*" %%A in ('reg query "%%K" /v UninstallString 2^>nul ^| findstr /i "UninstallString"') do (
+        set "UNINSTALL_CMD=%%B"
+        set "FOUND=1"
+      )
+    )
+  )
+)
+
+if "!FOUND!"=="0" (
+  echo ViGEm Bus Driver not found in registry, nothing to uninstall.
+  exit /b 0
+)
+
+echo Uninstalling ViGEm Bus Driver...
+echo Command: !UNINSTALL_CMD!
+
+rem MSI uninstall: replace /I with /X and add /qn for silent
+echo !UNINSTALL_CMD! | findstr /i "msiexec" >nul
+if !ERRORLEVEL!==0 (
+  set "SILENT_CMD=!UNINSTALL_CMD:/I=/X!"
+  !SILENT_CMD! /qn
+) else (
+  rem Non-MSI installer: try running with /S or /silent flag
+  !UNINSTALL_CMD! /passive /norestart
+)
+
+echo ViGEm Bus Driver uninstall completed.


### PR DESCRIPTION
## 问题

卸载 Sunshine 时程序一直卡住不动。Fixes #555

## 原因分析

`uninstall-gamepad.bat` 使用 `wmic product where name="ViGEm Bus Driver" call uninstall` 来卸载 ViGEmBus。

`wmic product` 需要枚举整个 Windows Installer (MSI) 数据库中的所有已注册产品，在某些系统上可能需要**几分钟甚至几十分钟**才能完成。如果 Windows Installer 数据库损坏，甚至可能永远卡住。此外 `wmic` 在 Windows 11 中已被弃用。

在 Inno Setup 卸载流程中，`CurUninstallStepChanged(usUninstall)` 调用此脚本时使用 `ewWaitUntilTerminated`，导致卸载界面完全冻结。

## 修复方案

将 `wmic product` 替换为注册表查询：

1. 在 `HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall` 和 `WOW6432Node` 中搜索 "ViGEm Bus Driver" / "ViGEm"
2. 提取 `UninstallString` 注册表值
3. 检测是否为 MSI 安装（`msiexec`），是则使用 `/qn` 静默卸载
4. 非 MSI 安装则使用 `/passive /norestart` 调用卸载程序

注册表查询操作是瞬间完成的，彻底解决了卡住问题。

## 测试

- [x] ViGEmBus 已安装：脚本正确找到注册表条目，构建静默卸载命令并执行
- [x] ViGEmBus 未安装：脚本正确检测到 "not found" 并退出