### PR TITLE
fix: config from_view converters handle numeric string values

### DIFF
--- a/src/display_device/parsed_config.cpp
+++ b/src/display_device/parsed_config.cpp
@@ -1,6 +1,7 @@
 // lib includes
 #include <boost/algorithm/string.hpp>
 #include <boost/regex.hpp>
+#include <charconv>
 #include <cmath>
 
 // local includes
@@ -487,6 +488,25 @@ namespace display_device {
           return boost::none;
       }
     }
+    /**
+     * @brief Parse a numeric string as an enum index with range validation.
+     * @param value String to parse (e.g. "1", "2").
+     * @param max_val Maximum valid enum value (inclusive).
+     * @param default_val Value to return on parse failure or out-of-range.
+     * @returns Parsed integer if valid and in [0, max_val], otherwise default_val.
+     *
+     * Used as fallback when config stores enum values as numeric strings
+     * instead of named strings (e.g. "1" instead of "automatic").
+     */
+    int
+    numeric_enum_fallback(std::string_view value, int max_val, int default_val) {
+      int n = 0;
+      auto [ptr, ec] = std::from_chars(value.data(), value.data() + value.size(), n);
+      if (ec == std::errc{} && ptr == value.data() + value.size() && n >= 0 && n <= max_val) {
+        return n;
+      }
+      return default_val;
+    }
   }  // namespace
 
   int
@@ -500,7 +520,7 @@ namespace display_device {
     _CONVERT_(ensure_only_display);
     _CONVERT_(ensure_secondary);
 #undef _CONVERT_
-    return static_cast<int>(parsed_config_t::device_prep_e::no_operation);
+    return numeric_enum_fallback(value, 4, static_cast<int>(parsed_config_t::device_prep_e::no_operation));
   }
 
   int
@@ -512,7 +532,7 @@ namespace display_device {
     _CONVERT_(automatic);
     _CONVERT_(manual);
 #undef _CONVERT_
-    return static_cast<int>(parsed_config_t::resolution_change_e::no_operation);
+    return numeric_enum_fallback(value, 2, static_cast<int>(parsed_config_t::resolution_change_e::no_operation));
   }
 
   int
@@ -524,7 +544,7 @@ namespace display_device {
     _CONVERT_(automatic);
     _CONVERT_(manual);
 #undef _CONVERT_
-    return static_cast<int>(parsed_config_t::refresh_rate_change_e::no_operation);
+    return numeric_enum_fallback(value, 2, static_cast<int>(parsed_config_t::refresh_rate_change_e::no_operation));
   }
 
   int
@@ -535,7 +555,7 @@ namespace display_device {
     _CONVERT_(no_operation);
     _CONVERT_(automatic);
 #undef _CONVERT_
-    return static_cast<int>(parsed_config_t::hdr_prep_e::no_operation);
+    return numeric_enum_fallback(value, 1, static_cast<int>(parsed_config_t::hdr_prep_e::no_operation));
   }
 
   int
@@ -548,7 +568,7 @@ namespace display_device {
     _CONVERT_(vdd_as_secondary);
     _CONVERT_(display_off);
 #undef _CONVERT_
-    return static_cast<int>(parsed_config_t::vdd_prep_e::no_operation);
+    return numeric_enum_fallback(value, 3, static_cast<int>(parsed_config_t::vdd_prep_e::no_operation));
   }
 
   parsed_config_t::vdd_prep_e


### PR DESCRIPTION
## 问题

当配置文件中的枚举值以数字字符串形式存储（如 `resolution_change = 1` 而非 `resolution_change = automatic`）时，`from_view` 转换器无法匹配任何命名字符串，默认回退到 `no_operation`(0)，导致 VDD 分辨率和刷新率切换被静默禁用。

### 日志表现

```
解析后的显示设备配置:
设备ID: ZakoHDR
分辨率: 不变    ← 应该是客户端请求的分辨率
刷新率: 不变    ← 应该是客户端请求的刷新率
```

### 根本原因

`int_f(vars, "resolution_change", ..., resolution_change_from_view)` 中，`resolution_change_from_view("1")` 只尝试匹配字符串名称 (`"automatic"`, `"manual"`, `"no_operation"`)，数字字符串 `"1"` 不匹配任何一项，返回默认值 `no_operation`(0)。

## 修复

为所有 5 个 `from_view` 转换器增加数字字符串回退解析：
- `device_prep_from_view` (0-4)
- `resolution_change_from_view` (0-2)
- `refresh_rate_change_from_view` (0-2)
- `hdr_prep_from_view` (0-1)
- `vdd_prep_from_view` (0-3)

命名字符串匹配优先；数字解析仅作为回退，带范围验证。