### PR TITLE
fix(vmouse): 修复驱动卸载无法清理所有设备实例的问题

### DIFF
--- a/src_assets/windows/misc/vmouse/install-vmouse.bat
+++ b/src_assets/windows/misc/vmouse/install-vmouse.bat
@@ -55,11 +55,22 @@ rem ============================================================================
 echo Cleaning up existing Virtual Mouse driver...
 
 rem Remove ALL existing device nodes (loop until none remain)
+set "CLEANUP_COUNT=0"
 :remove_loop
 "%NEFCON%" --remove-device-node --hardware-id Root\ZakoVirtualMouse --class-guid 745a17a0-74d3-11d0-b6fe-00a0c90f57da
 if not errorlevel 1 (
+    set /a CLEANUP_COUNT+=1
     echo Removed a device node, checking for more...
+    timeout /t 1 /nobreak >nul
     goto remove_loop
+)
+echo Removed !CLEANUP_COUNT! device node(s) via nefcon.
+
+rem Fallback: use pnputil to remove any remaining device instances
+for /f "tokens=*" %%d in ('powershell -NoProfile -Command ^
+    "Get-PnpDevice -InstanceId 'ROOT\ZAKOVIRTUALMOUSE\*' -ErrorAction SilentlyContinue | ForEach-Object { $_.InstanceId }"') do (
+    echo Removing remaining device: %%d
+    pnputil /remove-device "%%d" >nul 2>&1
 )
 echo All existing device nodes removed.
 
@@ -96,6 +107,8 @@ if not errorlevel 1 (
     echo Virtual Mouse driver installation completed successfully!
 ) else (
     echo Virtual Mouse driver installation failed with error !ERRORLEVEL!
+    echo Rolling back: removing device node...
+    "%NEFCON%" --remove-device-node --hardware-id Root\ZakoVirtualMouse --class-guid 745a17a0-74d3-11d0-b6fe-00a0c90f57da
 )
 
 rem ============================================================================

--- a/src_assets/windows/misc/vmouse/uninstall-vmouse.bat
+++ b/src_assets/windows/misc/vmouse/uninstall-vmouse.bat
@@ -29,16 +29,45 @@ if not errorlevel 1 (
     echo Sunshine service not running, OK.
 )
 
-if not exist "%NEFCON%" goto skip_uninstall
+if not exist "%NEFCON%" goto skip_nefcon_uninstall
 
-echo Removing all Virtual Mouse devices...
+echo Removing all Virtual Mouse devices via nefcon...
+set "NEFCON_REMOVED=0"
 :uninstall_remove_loop
 "%NEFCON%" --remove-device-node --hardware-id Root\ZakoVirtualMouse --class-guid 745a17a0-74d3-11d0-b6fe-00a0c90f57da
-if not errorlevel 1 goto uninstall_remove_loop
+if not errorlevel 1 (
+    set /a NEFCON_REMOVED+=1
+    timeout /t 1 /nobreak >nul
+    goto uninstall_remove_loop
+)
+echo Removed !NEFCON_REMOVED! device node(s) via nefcon.
 
 echo Uninstalling Virtual Mouse driver...
 "%NEFCON%" --uninstall-driver --inf-path "%DIST_DIR%\ZakoVirtualMouse.inf"
-:skip_uninstall
+:skip_nefcon_uninstall
+
+rem Fallback: use pnputil to remove any remaining device instances
+rem This catches ghost devices that nefcon may fail to handle
+echo Checking for remaining Virtual Mouse devices...
+set "PNPUTIL_REMOVED=0"
+for /f "tokens=*" %%d in ('powershell -NoProfile -Command ^
+    "Get-PnpDevice -InstanceId 'ROOT\ZAKOVIRTUALMOUSE\*' -ErrorAction SilentlyContinue | ForEach-Object { $_.InstanceId }"') do (
+    echo Removing remaining device: %%d
+    pnputil /remove-device "%%d" >nul 2>&1
+    set /a PNPUTIL_REMOVED+=1
+)
+if !PNPUTIL_REMOVED! GTR 0 (
+    echo Removed !PNPUTIL_REMOVED! remaining device(s) via pnputil.
+) else (
+    echo No remaining devices found.
+)
+
+rem Clean up driver package from DriverStore (locale-independent)
+for /f "tokens=*" %%p in ('powershell -NoProfile -Command ^
+    "Get-ChildItem \"$env:SystemRoot\INF\oem*.inf\" -ErrorAction SilentlyContinue | Where-Object { Select-String -Path $_.FullName -Pattern 'ZakoVirtualMouse' -Quiet } | ForEach-Object { $_.Name }"') do (
+    echo Removing driver package: %%p
+    pnputil /delete-driver "%%p" /force >nul 2>&1
+)
 
 rem Clean up files
 if exist "%DIST_DIR%" (


### PR DESCRIPTION
## 问题

修复 #564

鼠标驱动因证书错误导致安装失败时，`--create-device-node` 已执行成功但 `--install-driver` 失败，留下幽灵设备节点。多次重试后积累多个残留设备。卸载时 nefcon 对异常状态设备可能返回非零错误码，导致循环提前退出，仅移除一个设备。

## 修复内容

### uninstall-vmouse.bat
- nefcon 移除循环中增加 1 秒延迟，等待 Windows 完成设备状态变更
- 新增 **pnputil 兜底机制**：nefcon 循环后通过 `Get-PnpDevice` 枚举所有 `ROOT\ZAKOVIRTUALMOUSE\*` 实例，逐一调用 `pnputil /remove-device` 清理残留
- 新增 DriverStore 清理：通过 `pnputil /enum-drivers` + `/delete-driver` 清理驱动包

### install-vmouse.bat
- 安装前清理同样增加延迟和 pnputil 兜底
- **安装失败回滚**：`--install-driver` 失败时立即调用 `--remove-device-node` 移除刚创建的设备节点，防止幽灵设备积累