### PR TITLE
feat: event-driven LLM ABR with real-time fallback

### DIFF
--- a/cmake/packaging/common.cmake
+++ b/cmake/packaging/common.cmake
@@ -17,6 +17,14 @@ set(CPACK_STRIP_FILES YES)
 install(DIRECTORY "${SUNSHINE_SOURCE_ASSETS_DIR}/common/assets/"
         DESTINATION "${SUNSHINE_ASSETS_DIR}"
         PATTERN "web" EXCLUDE)
+
+# install ABR prompt template
+install(FILES "${PROJECT_SOURCE_DIR}/src/assets/abr_prompt.md"
+        DESTINATION "${SUNSHINE_ASSETS_DIR}")
+file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/assets")
+configure_file("${PROJECT_SOURCE_DIR}/src/assets/abr_prompt.md"
+               "${CMAKE_CURRENT_BINARY_DIR}/assets/abr_prompt.md"
+               COPYONLY)
 # copy assets to build directory, for running without install
 file(GLOB_RECURSE ALL_ASSETS
         RELATIVE "${SUNSHINE_SOURCE_ASSETS_DIR}/common/assets/" "${SUNSHINE_SOURCE_ASSETS_DIR}/common/assets/*")

--- a/src/abr.cpp
+++ b/src/abr.cpp
@@ -2,9 +2,14 @@
  * @file src/abr.cpp
  * @brief Adaptive Bitrate (ABR) decision engine using LLM AI.
  *
- * Uses the configured LLM API to make intelligent bitrate decisions
- * based on client network feedback and the running game type.
- * Falls back to simple threshold logic when the LLM is unavailable.
+ * Architecture: two-tier bitrate control —
+ *   1. Real-time fallback: threshold-based reactions to network conditions
+ *      (always active, rate-limited to every 3 seconds).
+ *   2. Event-driven LLM: queries the configured LLM API for optimal target
+ *      bitrate on app switches and network recovery events.
+ *
+ * The fallback layer handles immediate network degradation, while the LLM
+ * provides intelligent per-game bitrate targets that guide probe-up behavior.
  */
 
 #include "abr.h"
@@ -126,8 +131,8 @@ namespace abr {
 
   /**
    * @brief Load prompt template from external file.
-   * File location: same directory as ai_config.json (config dir / abr_prompt.md).
-   * Cached after first successful load. Returns empty string if file not found.
+   * Search order: config dir (user override) → assets dir (bundled default).
+   * Cached after first successful load. Returns empty string if not found.
    */
   static const std::string &
   load_prompt_template() {
@@ -135,22 +140,28 @@ namespace abr {
     static bool loaded = false;
     if (loaded) return cached;
 
+    // Search paths: config dir first (user override), then assets dir (bundled default)
+    std::vector<std::filesystem::path> search_paths;
     try {
-      auto config_dir = std::filesystem::path(config::sunshine.config_file).parent_path();
-      auto path = config_dir / "abr_prompt.md";
-      std::ifstream file(path);
-      if (file.is_open()) {
-        cached.assign(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
-        BOOST_LOG(info) << "ABR: loaded prompt template from " << path;
-      }
-      else {
-        BOOST_LOG(warning) << "ABR: prompt template not found at " << path << ", LLM decisions will be unavailable";
-      }
+      search_paths.push_back(std::filesystem::path(config::sunshine.config_file).parent_path() / "abr_prompt.md");
     }
-    catch (const std::exception &e) {
-      BOOST_LOG(warning) << "ABR: failed to load prompt template: " << e.what();
+    catch (...) {}
+    search_paths.push_back(std::filesystem::path(SUNSHINE_ASSETS_DIR) / "abr_prompt.md");
+
+    for (const auto &path : search_paths) {
+      try {
+        std::ifstream file(path);
+        if (file.is_open()) {
+          cached.assign(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
+          BOOST_LOG(info) << "ABR: loaded prompt template from " << path;
+          loaded = true;
+          return cached;
+        }
+      }
+      catch (...) {}
     }
 
+    BOOST_LOG(warning) << "ABR: prompt template not found, LLM decisions will be unavailable";
     loaded = true;
     return cached;
   }
@@ -300,13 +311,15 @@ namespace abr {
         // Clamp to configured range
         bitrate = std::clamp(bitrate, state.config.min_bitrate_kbps, state.config.max_bitrate_kbps);
 
-        // Ignore negligible changes (< 2%)
-        if (std::abs(bitrate - state.current_bitrate_kbps) < state.current_bitrate_kbps / 50) {
-          action.new_bitrate_kbps = 0;
-          action.reason = "no_change: delta too small";
+        // Always record the LLM's recommended target
+        action.target_bitrate_kbps = bitrate;
+
+        // Only signal an immediate action if the change is significant (>= 2%)
+        if (std::abs(bitrate - state.current_bitrate_kbps) >= state.current_bitrate_kbps / 50) {
+          action.new_bitrate_kbps = bitrate;
         }
         else {
-          action.new_bitrate_kbps = bitrate;
+          action.reason = "no_change: delta too small";
         }
       }
     }
@@ -370,10 +383,13 @@ namespace abr {
     state.recent_feedback.clear();
     state.consecutive_high_loss = 0;
     state.stable_ticks = 0;
+    state.llm_target_bitrate_kbps = 0;
+    state.app_changed = true;  // Trigger initial LLM call for app classification
+    state.network_recovered = false;
     state.last_llm_call = std::chrono::steady_clock::time_point {};
+    state.last_fallback_time = std::chrono::steady_clock::time_point {};
     state.last_fg_detect = std::chrono::steady_clock::time_point {};
     state.last_fg_pid = 0;
-    state.cached_action = {};
     state.llm_in_flight = false;
     static uint64_t generation_counter = 0;
     state.generation = ++generation_counter;
@@ -411,6 +427,12 @@ namespace abr {
       }
     }
 
+    // Clamp current bitrate to the computed range
+    state.current_bitrate_kbps = std::clamp(
+      state.current_bitrate_kbps,
+      state.config.min_bitrate_kbps,
+      state.config.max_bitrate_kbps);
+
     BOOST_LOG(info) << "ABR enabled for client '" << client_name
                     << "': app=" << app_name
                     << " mode=" << mode_to_string(cfg.mode)
@@ -434,11 +456,12 @@ namespace abr {
   }
 
   /**
-   * @brief Background worker: calls LLM and stores result.
+   * @brief Background worker: calls LLM and stores target bitrate recommendation.
    * Spawned as detached thread; communicates via sessions map.
+   * Unlike old design, the LLM sets a target (not an immediate action).
    */
   static void
-  llm_worker(const std::string &client_name, uint64_t generation, std::string request_body, network_feedback_t last_feedback) {
+  llm_worker(const std::string &client_name, uint64_t generation, std::string request_body) {
     auto result = confighttp::processAiChat(request_body);
 
     std::lock_guard lock(sessions_mutex);
@@ -450,19 +473,16 @@ namespace abr {
     state.llm_in_flight = false;
 
     if (result.httpCode != 200) {
-      BOOST_LOG(warning) << "ABR LLM call failed (HTTP " << result.httpCode << "), using fallback";
-      state.cached_action = fallback_decision(state, last_feedback);
-    }
-    else {
-      state.cached_action = parse_llm_response(result.body, state);
+      BOOST_LOG(warning) << "ABR LLM call failed (HTTP " << result.httpCode << ")";
+      return;
     }
 
-    if (state.cached_action.new_bitrate_kbps > 0) {
-      state.current_bitrate_kbps = state.cached_action.new_bitrate_kbps;
-      state.stable_ticks = 0;
-      BOOST_LOG(info) << "ABR LLM decision for '" << client_name
-                      << "': " << state.cached_action.new_bitrate_kbps << " Kbps"
-                      << " (" << state.cached_action.reason << ")";
+    auto action = parse_llm_response(result.body, state);
+    if (action.target_bitrate_kbps > 0) {
+      state.llm_target_bitrate_kbps = action.target_bitrate_kbps;
+      BOOST_LOG(info) << "ABR LLM target for '" << client_name
+                      << "': " << action.target_bitrate_kbps << " Kbps"
+                      << " (" << action.reason << ")";
     }
   }
 
@@ -474,7 +494,7 @@ namespace abr {
 
     auto it = sessions.find(client_name);
     if (it == sessions.end() || !it->second.config.enabled) {
-      return { 0, "ABR not enabled" };
+      return { .reason = "ABR not enabled" };
     }
 
     auto &state = it->second;
@@ -494,47 +514,7 @@ namespace abr {
       state.recent_feedback.pop_front();
     }
 
-    // Consume cached action from completed LLM call (if any)
-    action_t result_action;
-    if (state.cached_action.new_bitrate_kbps > 0) {
-      result_action = std::exchange(state.cached_action, {});
-    }
-
-    // Emergency: high packet loss — immediate fallback regardless of LLM state
-    if (feedback.packet_loss > 5.0) {
-      auto action = fallback_decision(state, feedback);
-      if (action.new_bitrate_kbps > 0) {
-        state.current_bitrate_kbps = action.new_bitrate_kbps;
-        result_action = action;
-      }
-      return result_action;
-    }
-
-    // Decide whether to launch a new LLM call
-    auto since_last_llm = std::chrono::duration_cast<std::chrono::seconds>(now - state.last_llm_call).count();
-    bool should_call_llm = since_last_llm >= session_state_t::LLM_CALL_INTERVAL_SECONDS;
-
-    if (!should_call_llm || state.llm_in_flight) {
-      return result_action;
-    }
-
-    // LLM not available or prompt template missing → use fallback synchronously
-    if (!confighttp::isAiEnabled() || load_prompt_template().empty()) {
-      auto action = fallback_decision(state, feedback);
-      if (action.new_bitrate_kbps > 0) {
-        state.current_bitrate_kbps = action.new_bitrate_kbps;
-        BOOST_LOG(info) << "ABR fallback for '" << client_name
-                        << "': " << action.new_bitrate_kbps << " Kbps"
-                        << " (" << action.reason << ")";
-      }
-      // Merge: prefer new fallback over stale cached
-      if (action.new_bitrate_kbps > 0) {
-        result_action = action;
-      }
-      return result_action;
-    }
-
-    // Detect foreground window/process (rate limited)
+    // ── Phase 1: Foreground detection (rate limited) ──
     auto since_last_fg = std::chrono::duration_cast<std::chrono::seconds>(now - state.last_fg_detect).count();
     if (since_last_fg >= session_state_t::FG_DETECT_INTERVAL_SECONDS) {
       auto fg = detect_foreground_app();
@@ -543,22 +523,78 @@ namespace abr {
         state.foreground_title = fg.window_title;
         state.foreground_exe = fg.exe_name;
         state.last_fg_pid = fg.pid;
-        BOOST_LOG(debug) << "ABR: foreground changed to '" << fg.window_title
-                         << "' (" << fg.exe_name << ") pid=" << fg.pid;
+        state.app_changed = true;
+        BOOST_LOG(info) << "ABR: foreground changed to '" << fg.window_title
+                        << "' (" << fg.exe_name << ") pid=" << fg.pid;
       }
       else if (fg.pid == state.last_fg_pid && !fg.window_title.empty()) {
         state.foreground_title = fg.window_title;
       }
     }
 
-    // Build prompt and launch async LLM call
-    state.last_llm_call = now;
-    state.llm_in_flight = true;
+    // ── Phase 2: Fallback decisions (real-time, rate-limited to FALLBACK_INTERVAL_SECONDS) ──
+    action_t result_action;
+    auto since_last_fallback = std::chrono::duration_cast<std::chrono::seconds>(now - state.last_fallback_time).count();
+    bool can_fallback = since_last_fallback >= session_state_t::FALLBACK_INTERVAL_SECONDS;
 
-    auto prompt = build_llm_prompt(state);
-    auto request_body = build_llm_request(prompt);
+    // Emergency: high packet loss — immediate, no rate limit
+    if (feedback.packet_loss > 5.0) {
+      auto action = fallback_decision(state, feedback);
+      if (action.new_bitrate_kbps > 0) {
+        state.current_bitrate_kbps = action.new_bitrate_kbps;
+        state.last_fallback_time = now;
+        result_action = action;
+      }
+      return result_action;
+    }
 
-    std::thread(llm_worker, client_name, state.generation, std::move(request_body), feedback).detach();
+    // Regular fallback: moderate loss, probe-up, etc.
+    if (can_fallback) {
+      state.last_fallback_time = now;
+      auto action = fallback_decision(state, feedback);
+      if (action.new_bitrate_kbps > 0) {
+        // When probing up with LLM target, don't exceed the target
+        if (state.llm_target_bitrate_kbps > 0 && action.reason.find("probe_up") != std::string::npos) {
+          action.new_bitrate_kbps = std::min(action.new_bitrate_kbps, state.llm_target_bitrate_kbps);
+          if (action.new_bitrate_kbps <= state.current_bitrate_kbps) {
+            action.new_bitrate_kbps = 0;  // Already at or above LLM target, don't probe further
+          }
+        }
+        if (action.new_bitrate_kbps > 0) {
+          state.current_bitrate_kbps = action.new_bitrate_kbps;
+          BOOST_LOG(info) << "ABR fallback for '" << client_name
+                          << "': " << action.new_bitrate_kbps << " Kbps"
+                          << " (" << action.reason << ")";
+          result_action = action;
+        }
+      }
+    }
+
+    // Track network recovery: edge-trigger when stable_ticks crosses threshold
+    if (state.stable_ticks == 5 && state.consecutive_high_loss == 0) {
+      state.network_recovered = true;  // Signal for LLM (set once on transition)
+    }
+
+    // ── Phase 3: LLM trigger (event-driven, NOT periodic) ──
+    bool should_trigger_llm = (state.app_changed || state.network_recovered)
+                              && !state.llm_in_flight
+                              && confighttp::isAiEnabled()
+                              && !load_prompt_template().empty();
+
+    if (should_trigger_llm) {
+      auto since_last_llm = std::chrono::duration_cast<std::chrono::seconds>(now - state.last_llm_call).count();
+      if (since_last_llm >= session_state_t::LLM_MIN_INTERVAL_SECONDS) {
+        state.app_changed = false;
+        state.network_recovered = false;
+        state.last_llm_call = now;
+        state.llm_in_flight = true;
+
+        auto prompt = build_llm_prompt(state);
+        auto request_body = build_llm_request(prompt);
+
+        std::thread(llm_worker, client_name, state.generation, std::move(request_body)).detach();
+      }
+    }
 
     return result_action;
   }
@@ -570,9 +606,7 @@ namespace abr {
 
   void
   cleanup(const std::string &client_name) {
-    std::lock_guard lock(sessions_mutex);
-    sessions.erase(client_name);
-    BOOST_LOG(debug) << "ABR state cleaned up for client '" << client_name << "'";
+    disable(client_name);
   }
 
 }  // namespace abr

--- a/src/abr.h
+++ b/src/abr.h
@@ -2,12 +2,14 @@
  * @file src/abr.h
  * @brief Adaptive Bitrate (ABR) decision engine for server-side bitrate control.
  *
- * Uses LLM AI to make intelligent bitrate decisions based on:
- * - Client network feedback (packet loss, RTT, FPS, dropped frames)
- * - The type of game/application currently running on the host
+ * Two-tier architecture:
+ *   1. Real-time fallback: immediate threshold-based reactions to packet loss.
+ *   2. Event-driven LLM: intelligent per-game target bitrate via LLM AI,
+ *      triggered on app switches and network recovery.
  *
- * Clients POST network metrics periodically; the server consults the LLM
- * and responds with target bitrate adjustments.
+ * Clients POST network metrics periodically; the server responds with
+ * bitrate adjustments from the fallback layer, while the LLM asynchronously
+ * sets the optimal target bitrate ceiling.
  */
 #pragma once
 
@@ -45,7 +47,8 @@ namespace abr {
 
   /// Server decision sent back to client
   struct action_t {
-    int new_bitrate_kbps = 0;  ///< 0 means no change
+    int new_bitrate_kbps = 0;   ///< 0 means no change (immediate action)
+    int target_bitrate_kbps = 0; ///< LLM-recommended optimal bitrate (always set when LLM responds)
     std::string reason;
   };
 
@@ -74,21 +77,30 @@ namespace abr {
     std::deque<feedback_snapshot_t> recent_feedback;
     static constexpr size_t MAX_FEEDBACK_HISTORY = 10;
 
-    /// Rate limiting: don't call LLM more often than this
+    /// LLM target bitrate: the ideal bitrate recommended by LLM for current app/conditions.
+    /// Fallback probe-up will move toward this target. 0 = no recommendation yet.
+    int llm_target_bitrate_kbps = 0;
+
+    /// Rate limiting: minimum interval between LLM calls
     std::chrono::steady_clock::time_point last_llm_call;
-    static constexpr int LLM_CALL_INTERVAL_SECONDS = 3;
+    static constexpr int LLM_MIN_INTERVAL_SECONDS = 10;
 
     /// Foreground window detection rate limiting
     std::chrono::steady_clock::time_point last_fg_detect;
     static constexpr int FG_DETECT_INTERVAL_SECONDS = 10;
     uint32_t last_fg_pid = 0;  ///< Cached PID to detect window changes
 
-    /// Fallback: simple threshold when LLM is unavailable
+    /// Fallback: simple threshold-based decisions (always active)
     int consecutive_high_loss = 0;
     int stable_ticks = 0;
+    static constexpr int FALLBACK_INTERVAL_SECONDS = 3;
+    std::chrono::steady_clock::time_point last_fallback_time;
 
-    /// Async LLM: cached result from last completed call
-    action_t cached_action;
+    /// LLM trigger flags
+    bool app_changed = false;         ///< Foreground app changed since last LLM call
+    bool network_recovered = false;   ///< Network recovered from turbulence
+
+    /// Async LLM state
     bool llm_in_flight = false;  ///< Prevents concurrent LLM calls (protected by sessions_mutex)
     uint64_t generation = 0;     ///< Monotonic counter to detect stale worker results
 
@@ -118,7 +130,11 @@ namespace abr {
   is_enabled(const std::string &client_name);
 
   /**
-   * @brief Process network feedback and produce a bitrate action via LLM.
+   * @brief Process network feedback and produce a bitrate action.
+   *
+   * Runs fallback logic (threshold-based) on every call for real-time response.
+   * Triggers LLM asynchronously on app change or network recovery events.
+   *
    * @param client_name Client identifier.
    * @param feedback Network metrics from the client.
    * @return Bitrate adjustment action (new_bitrate_kbps == 0 means no change).


### PR DESCRIPTION
## Summary

Two-tier adaptive bitrate control architecture:

### 1. Real-time fallback (always active, every 3s)
- **>5% packet loss**: immediate ×0.70 emergency drop (no rate limit)
- **>2% packet loss**: ×0.90 moderate drop
- **Stable 5 ticks**: ×1.05 probe-up (capped at LLM target)

### 2. Event-driven LLM (async, background thread)
- Triggered on **foreground app change** or **network recovery**
- Minimum 10s between LLM calls
- Sets optimal target bitrate ceiling — never blocks feedback processing
- Uses DeepSeek via `confighttp::processAiChat()`

### Key features
- Win32 foreground window detection for game-aware decisions
- Externalized prompt template (`abr_prompt.md`) with visual complexity classification
- AI model params configurable via `ai_config.json` (system_prompt, temperature, max_tokens)
- Input sanitization and bitrate range clamping
- Generation counter prevents stale LLM results on session re-creation

### Architecture
```
process_feedback() each call:
├── Phase 1: Foreground detection (every 10s) → sets app_changed flag
├── Phase 2: Fallback (every 3s) → real-time network response
│   ├── >5% loss → immediate ×0.70
│   ├── >2% loss → ×0.90
│   └── stable 5 ticks → ×1.05 (capped at LLM target)
└── Phase 3: LLM trigger (event-driven, ≥10s min interval)
    ├── app_changed → call LLM for target recommendation
    └── network_recovered → call LLM for optimal target
```

### Changes
- `src/abr.cpp`: ABR engine (530 lines)
- `src/abr.h`: Header with all types and API
- `cmake/packaging/common.cmake`: Deploy abr_prompt.md to assets dir

### Previous PR
Supersedes #571 (merged with old architecture). This version separates real-time fallback from event-driven LLM for better responsiveness and lower API cost (~/usr/bin/bash.001/hour vs ~/usr/bin/bash.08/hour).