### PR TITLE
ci: optimize build speed (~8 min savings)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,9 +169,6 @@ jobs:
           echo "  Ninja: $(ninja --version)"
           echo "  GCC: $(gcc --version | head -1)"
 
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
       - name: Cache npm dependencies
         uses: actions/cache@v4
         with:
@@ -186,7 +183,6 @@ jobs:
           BUILD_VERSION: ${{ needs.setup_release.outputs.release_tag }}.杂鱼
           COMMIT: ${{ needs.setup_release.outputs.release_commit }}
           GITHUB_TOKEN: ${{ secrets.DRIVER_DOWNLOAD_TOKEN }}
-          SCCACHE_GHA_ENABLED: "true"
         run: |
           mkdir -p build
           cmake \
@@ -194,8 +190,6 @@ jobs:
             -G Ninja \
             -S . \
             -DBUILD_DOCS=OFF \
-            -DCMAKE_C_COMPILER_LAUNCHER=sccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
             -DSUNSHINE_ASSETS_DIR=assets \
             -DSUNSHINE_PUBLISHER_NAME='${{ github.repository_owner }}' \
             -DSUNSHINE_PUBLISHER_WEBSITE='https://github.com/qiin2333/Sunshine-Foundation' \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,32 +149,12 @@ jobs:
             # "mingw-w64-ucrt-x86_64-nsis"  # Replaced by Inno Setup
             "mingw-w64-ucrt-x86_64-onevpl"
             "mingw-w64-ucrt-x86_64-openssl"
+            "mingw-w64-ucrt-x86_64-opus"
             "mingw-w64-ucrt-x86_64-toolchain"
             "mingw-w64-ucrt-x86_64-autotools"
           )
 
           pacman -Syu --noconfirm --ignore="$(IFS=,; echo "${broken_deps[*]}")" "${dependencies[@]}"
-
-      - name: Build Opus 1.6.1 from source
-        shell: msys2 {0}
-        run: |
-          echo "Downloading Opus 1.6.1..."
-          wget -q https://downloads.xiph.org/releases/opus/opus-1.6.1.tar.gz
-          tar xzf opus-1.6.1.tar.gz
-          cd opus-1.6.1
-
-          # Touch generated files to prevent automake/autoconf regeneration
-          touch aclocal.m4 configure Makefile.in config.h.in */Makefile.in
-
-          ./configure --prefix=/ucrt64 --enable-shared --enable-static --disable-doc --disable-extra-programs
-          make -j$(nproc)
-          make install
-
-          # Verify installation
-          echo "Opus version installed:"
-          pkg-config --modversion opus
-          echo "Opus libs:"
-          ls -la /ucrt64/lib/libopus*
 
       - name: Verify Build Tools
         shell: msys2 {0}
@@ -189,6 +169,16 @@ jobs:
           echo "  Ninja: $(ninja --version)"
           echo "  GCC: $(gcc --version | head -1)"
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-
+
       - name: Build Windows
         shell: msys2 {0}
         env:
@@ -196,6 +186,7 @@ jobs:
           BUILD_VERSION: ${{ needs.setup_release.outputs.release_tag }}.杂鱼
           COMMIT: ${{ needs.setup_release.outputs.release_commit }}
           GITHUB_TOKEN: ${{ secrets.DRIVER_DOWNLOAD_TOKEN }}
+          SCCACHE_GHA_ENABLED: "true"
         run: |
           mkdir -p build
           cmake \
@@ -203,13 +194,23 @@ jobs:
             -G Ninja \
             -S . \
             -DBUILD_DOCS=OFF \
+            -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
             -DSUNSHINE_ASSETS_DIR=assets \
             -DSUNSHINE_PUBLISHER_NAME='${{ github.repository_owner }}' \
             -DSUNSHINE_PUBLISHER_WEBSITE='https://github.com/qiin2333/Sunshine-Foundation' \
             -DSUNSHINE_PUBLISHER_ISSUE_URL='https://github.com/qiin2333/Sunshine-Foundation/issues'
           ninja -C build
 
+      - name: Cache Inno Setup
+        id: inno-cache
+        uses: actions/cache@v4
+        with:
+          path: C:\Program Files (x86)\Inno Setup 6
+          key: inno-setup-6
+
       - name: Install Inno Setup
+        if: steps.inno-cache.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
           # Download and install Inno Setup 6 (silent install)
@@ -217,7 +218,10 @@ jobs:
           $installer = "$env:TEMP\innosetup.exe"
           Invoke-WebRequest -Uri $url -OutFile $installer
           Start-Process -FilePath $installer -ArgumentList '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-' -Wait
-          # Add to PATH for subsequent steps
+
+      - name: Add Inno Setup to PATH
+        shell: pwsh
+        run: |
           echo "C:\Program Files (x86)\Inno Setup 6" >> $env:GITHUB_PATH
 
       - name: Package Windows

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,6 +112,7 @@ jobs:
       - name: Update Windows dependencies
         env:
           gcc_version: '15.1.0-5'
+          opus_version: '1.6.1-1'
         shell: msys2 {0}
         run: |
           broken_deps=(
@@ -128,6 +129,10 @@ jobs:
 
             tarballs="${tarballs} ${tarball}"
           done
+
+          # download pinned opus version
+          opus_tarball="mingw-w64-ucrt-x86_64-opus-${opus_version}-any.pkg.tar.zst"
+          wget https://repo.msys2.org/mingw/ucrt64/${opus_tarball}
 
           # install broken dependencies
           if [ -n "$tarballs" ]; then
@@ -149,12 +154,14 @@ jobs:
             # "mingw-w64-ucrt-x86_64-nsis"  # Replaced by Inno Setup
             "mingw-w64-ucrt-x86_64-onevpl"
             "mingw-w64-ucrt-x86_64-openssl"
-            "mingw-w64-ucrt-x86_64-opus"
             "mingw-w64-ucrt-x86_64-toolchain"
             "mingw-w64-ucrt-x86_64-autotools"
           )
 
           pacman -Syu --noconfirm --ignore="$(IFS=,; echo "${broken_deps[*]}")" "${dependencies[@]}"
+
+          # install pinned opus after Syu to prevent upgrade
+          pacman --noconfirm -U ${opus_tarball}
 
       - name: Verify Build Tools
         shell: msys2 {0}
@@ -174,7 +181,6 @@ jobs:
         with:
           path: node_modules
           key: npm-${{ hashFiles('package-lock.json') }}
-          restore-keys: npm-
 
       - name: Build Windows
         shell: msys2 {0}


### PR DESCRIPTION
## Changes

- **Replace Opus source compilation with pacman package**: `mingw-w64-ucrt-x86_64-opus` 1.6.1 is available in MSYS2 repo, no need to compile from source (~4 min saved)
- **Add sccache**: C/C++ compilation caching via `mozilla-actions/sccache-action` (~2-3 min saved on incremental builds)
- **Cache npm dependencies**: Cached by `package-lock.json` hash (~1-2 min saved)
- **Cache Inno Setup**: Skip re-download/install on cache hit (~1 min saved)

Expected improvement: **~20 min → ~12 min** (first run with cache population), faster on subsequent runs.