### PR TITLE
fix(vdd): 修复切换设备串流时 VDD 重建失败导致黑屏

### DIFF
--- a/src/display_device/session.cpp
+++ b/src/display_device/session.cpp
@@ -287,7 +287,13 @@ namespace display_device {
         !current_vdd_client_id.empty() && !new_client_id.empty() &&
         current_vdd_client_id != new_client_id) {
         BOOST_LOG(info) << "New session detected with different client ID, cleaning up VDD state";
-        stop_timer_and_clear_vdd_state();
+        // Only cancel timer and pending restore from the old session.
+        // Keep current_vdd_client_id intact so prepare_vdd() can detect the client
+        // switch and properly rebuild VDD (destroy old, create new, clean up stale
+        // persistent data with old device IDs).
+        timer->setup_timer(nullptr);
+        pending_restore_ = false;
+        SessionEventListener::clear_unlock_task();
       }
     }
 

--- a/src/platform/windows/display_device/settings.cpp
+++ b/src/platform/windows/display_device/settings.cpp
@@ -201,9 +201,25 @@ namespace display_device {
      */
     boost::optional<device_display_mode_map_t>
     handle_display_mode_configuration(const boost::optional<resolution_t> &resolution, const boost::optional<refresh_rate_t> &refresh_rate, const device_display_mode_map_t &previous_display_modes, const topology_metadata_t &metadata) {
+      // Collect valid device IDs from the current topology for filtering stale entries
+      const auto valid_device_ids { get_device_ids_from_topology(metadata.current_topology) };
+      const std::unordered_set<std::string> valid_ids_set(valid_device_ids.begin(), valid_device_ids.end());
+
       if (resolution || refresh_rate) {
-        const auto original_display_modes { previous_display_modes.empty() ? get_current_display_modes(get_device_ids_from_topology(metadata.current_topology)) : previous_display_modes };
-        const auto new_display_modes { determine_new_display_modes(resolution, refresh_rate, original_display_modes, metadata) };
+        const auto original_display_modes { previous_display_modes.empty() ? get_current_display_modes(valid_device_ids) : previous_display_modes };
+        auto new_display_modes { determine_new_display_modes(resolution, refresh_rate, original_display_modes, metadata) };
+
+        // Remove stale device IDs that no longer exist in the current topology
+        // (e.g. old VDD device IDs left in persistent_data after client switch)
+        for (auto it = new_display_modes.begin(); it != new_display_modes.end();) {
+          if (valid_ids_set.find(it->first) == valid_ids_set.end()) {
+            BOOST_LOG(warning) << "Removing stale device from display modes: " << it->first;
+            it = new_display_modes.erase(it);
+          }
+          else {
+            ++it;
+          }
+        }
 
         BOOST_LOG(info) << "Changing display modes to: " << to_string(new_display_modes);
         if (!set_display_modes(new_display_modes)) {


### PR DESCRIPTION
configure_display() 中检测到新客户端时调用 stop_timer_and_clear_vdd_state() 会提前清空 current_vdd_client_id，导致 prepare_vdd() 中的客户端切换 重建逻辑（依赖 current_vdd_client_id 非空）被跳过。

后果链：
1. VDD 重建被跳过 → 旧 VDD 被 reload_driver() 意外销毁
2. recovery 创建新 VDD，但 persistent_data 中残留旧 device ID
3. set_display_modes 尝试配置已不存在的旧设备 → 失败
4. VDD 被销毁 → 黑屏

修复：
- session.cpp: 客户端切换时只取消定时器和待恢复任务， 保留 current_vdd_client_id 让 prepare_vdd() 正常检测并走 完整的 VDD 重建路径（销毁旧 VDD → 清理 persistent_data 中的旧 ID → 创建新 VDD）
- settings.cpp: 在 set_display_modes 前过滤不在当前拓扑中的 stale device ID，作为防御层避免类似问题

此 bug 自 d6e3f1e6 (#327) 引入以来一直存在，仅在无头主机 + 多客户端轮流连接的场景下触发。