### PR TITLE
fix(vdd): 修复切换设备串流时 VDD 黑屏及优化 VDD 生命周期管理

### DIFF
--- a/src/display_device/session.cpp
+++ b/src/display_device/session.cpp
@@ -158,7 +158,6 @@ namespace display_device {
 
   void
   session_t::clear_vdd_state() {
-    current_vdd_client_id.clear();
     last_vdd_setting.clear();
     current_device_prep.reset();
     current_vdd_prep.reset();
@@ -287,6 +286,9 @@ namespace display_device {
         !current_vdd_client_id.empty() && !new_client_id.empty() &&
         current_vdd_client_id != new_client_id) {
         BOOST_LOG(info) << "New session detected with different client ID, cleaning up VDD state";
+        // Cancel any pending restore from the old session before it can interfere
+        pending_restore_ = false;
+        SessionEventListener::clear_unlock_task();
         stop_timer_and_clear_vdd_state();
       }
     }
@@ -401,6 +403,7 @@ namespace display_device {
 
   bool
   session_t::destroy_vdd_monitor() {
+    current_vdd_client_id.clear();
     return vdd_utils::destroy_vdd_monitor();
   }
 
@@ -467,7 +470,7 @@ namespace display_device {
         BOOST_LOG(info) << "独立VDD模式，重建VDD设备（客户端: " << current_vdd_client_id << " -> " << current_client_id << "）";
         
         const auto old_vdd_id = device_zako;
-        vdd_utils::destroy_vdd_monitor();
+        destroy_vdd_monitor();
         clear_vdd_state();
         device_zako.clear();
         
@@ -582,7 +585,10 @@ namespace display_device {
   session_t::reset_persistence() {
     std::lock_guard lock { mutex };
     settings.reset_persistence();
+    pending_restore_ = false;
+    SessionEventListener::clear_unlock_task();
     stop_timer_and_clear_vdd_state();
+    current_vdd_client_id.clear();
   }
 
   void
@@ -679,7 +685,18 @@ namespace display_device {
         BOOST_LOG(info) << "apply_config 未执行（无persistent_data），销毁VDD并跳过拓扑恢复";
         should_destroy = true;
       }
-      
+
+      // 无头主机保护：如果销毁后会变成无头（VDD 是唯一显示设备），跳过销毁
+      // 这避免了无意义的销毁+重建循环（device ID 变化导致 persistent_data 失效）
+      if (should_destroy && config::video.vdd_headless_create_enabled) {
+        auto devices = display_device::enum_available_devices();
+        bool only_vdd = (devices.size() == 1 && devices.count(vdd_id));
+        if (only_vdd || devices.empty()) {
+          BOOST_LOG(info) << "无头主机检测：VDD 是唯一显示设备，跳过销毁";
+          should_destroy = false;
+        }
+      }
+
       if (should_destroy) {
         destroy_vdd_monitor();
         std::this_thread::sleep_for(1000ms);
@@ -691,20 +708,6 @@ namespace display_device {
       BOOST_LOG(info) << "apply_config 从未执行成功，跳过拓扑恢复";
       stop_timer_and_clear_vdd_state();
       return;
-    }
-
-    // 无头主机自动创建检查（在 VDD 清理之后、拓扑恢复之前执行）
-    if (reason == revert_reason_e::stream_ended && config::video.vdd_headless_create_enabled) {
-      auto devices = display_device::enum_available_devices();
-      if (devices.empty()) {
-        BOOST_LOG(info) << "无头主机检测：未找到显示设备，自动创建基地显示器";
-        create_vdd_monitor("");
-        constexpr int max_attempts = 5;
-        constexpr auto wait_time = std::chrono::milliseconds(233);
-        for (int i = 0; i < max_attempts && !is_display_on(); ++i) {
-          std::this_thread::sleep_for(wait_time);
-        }
-      }
     }
 
     // 无操作模式：跳过拓扑恢复（因为拓扑从未被修改过）

--- a/src/platform/windows/display_device/settings.cpp
+++ b/src/platform/windows/display_device/settings.cpp
@@ -201,9 +201,25 @@ namespace display_device {
      */
     boost::optional<device_display_mode_map_t>
     handle_display_mode_configuration(const boost::optional<resolution_t> &resolution, const boost::optional<refresh_rate_t> &refresh_rate, const device_display_mode_map_t &previous_display_modes, const topology_metadata_t &metadata) {
+      // Build a set of device IDs present in current topology to filter out stale entries
+      // (e.g. old VDD device IDs lingering in persistent_data after a client switch).
+      const auto valid_device_ids { get_device_ids_from_topology(metadata.current_topology) };
+      const std::unordered_set<std::string> valid_ids_set(valid_device_ids.begin(), valid_device_ids.end());
+
       if (resolution || refresh_rate) {
-        const auto original_display_modes { previous_display_modes.empty() ? get_current_display_modes(get_device_ids_from_topology(metadata.current_topology)) : previous_display_modes };
-        const auto new_display_modes { determine_new_display_modes(resolution, refresh_rate, original_display_modes, metadata) };
+        const auto original_display_modes { previous_display_modes.empty() ? get_current_display_modes(valid_device_ids) : previous_display_modes };
+        auto new_display_modes { determine_new_display_modes(resolution, refresh_rate, original_display_modes, metadata) };
+
+        // Filter out stale device IDs not in current topology
+        for (auto it = new_display_modes.begin(); it != new_display_modes.end();) {
+          if (valid_ids_set.find(it->first) == valid_ids_set.end()) {
+            BOOST_LOG(warning) << "Removing stale device from display modes: " << it->first;
+            it = new_display_modes.erase(it);
+          }
+          else {
+            ++it;
+          }
+        }
 
         BOOST_LOG(info) << "Changing display modes to: " << to_string(new_display_modes);
         if (!set_display_modes(new_display_modes)) {
@@ -216,10 +232,24 @@ namespace display_device {
       }
 
       if (!previous_display_modes.empty()) {
-        BOOST_LOG(info) << "Changing display modes back to: " << to_string(previous_display_modes);
-        if (!set_display_modes(previous_display_modes)) {
-          // Error already logged
-          return boost::none;
+        // Filter out stale device IDs before reverting
+        device_display_mode_map_t filtered_modes { previous_display_modes };
+        for (auto it = filtered_modes.begin(); it != filtered_modes.end();) {
+          if (valid_ids_set.find(it->first) == valid_ids_set.end()) {
+            BOOST_LOG(warning) << "Removing stale device from rollback display modes: " << it->first;
+            it = filtered_modes.erase(it);
+          }
+          else {
+            ++it;
+          }
+        }
+
+        if (!filtered_modes.empty()) {
+          BOOST_LOG(info) << "Changing display modes back to: " << to_string(filtered_modes);
+          if (!set_display_modes(filtered_modes)) {
+            // Error already logged
+            return boost::none;
+          }
         }
       }
 


### PR DESCRIPTION
问题：
configure_display() 检测到新客户端时，stop_timer_and_clear_vdd_state()
会提前清空 current_vdd_client_id，导致 prepare_vdd() 中客户端切换的
VDD 重建逻辑被跳过（该逻辑自 d6e3f1e6 引入以来一直是死代码）。

后果链：
1. VDD 重建被跳过 → 旧 VDD 被 reload_driver() 意外销毁
2. recovery 创建新 VDD，但 persistent_data 中残留旧 device ID
3. set_display_modes 尝试配置已不存在的设备 → 整体失败 → 黑屏

修复：
- 将 current_vdd_client_id 的生命周期与 VDD 设备绑定，
  仅在 destroy_vdd_monitor() 中清除，不再随 clear_vdd_state() 清理
- 客户端切换时取消旧会话的待恢复任务（pending_restore_ + unlock task），
  防止旧 restore 干扰新会话
- settings.cpp: 在 set_display_modes 前过滤 stale device ID（正常/回滚分支）
- 无头主机优化：VDD 是唯一显示设备时跳过销毁，避免无意义的
  销毁→重建循环（device ID 变化导致 persistent_data 失效）

触发条件：无头主机 + 多客户端轮流连接（VDD 跨会话存活时切换客户端）