### PR TITLE
fix: 修复退出串流后客户端显示主机离线的问题

### DIFF
--- a/src/platform/windows/display_device/settings.cpp
+++ b/src/platform/windows/display_device/settings.cpp
@@ -794,6 +794,15 @@ namespace display_device {
         // 这里不修改拓扑，分辨率、刷新率、HDR 等设置仍然会应用
         BOOST_LOG(info) << "VDD mode: topology controlled by vdd_prep in prepare_vdd, only getting current topology metadata";
         topology_result = get_current_topology_metadata(config.device_id);
+
+        // 如果有预保存的初始拓扑（在 VDD 创建前保存的物理显示器拓扑），
+        // 用它替换 get_current_topology_metadata 返回的初始拓扑。
+        // 否则恢复时 remove_vdd_from_topology 会将初始拓扑清空，
+        // 导致物理显示器无法被重新启用。
+        if (topology_result && pre_saved_initial_topology && !pre_saved_initial_topology->empty()) {
+          BOOST_LOG(info) << "VDD mode: using pre-saved initial topology (physical displays) instead of current VDD-only topology";
+          topology_result->pair.initial = *pre_saved_initial_topology;
+        }
       }
       else {
         // 普通模式：device_prep 控制拓扑

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -3052,6 +3052,13 @@ namespace stream {
 
     bool
     change_dynamic_param_for_client(const std::string &client_name, const video::dynamic_param_t &param) {
+      // 先检查是否有活动的广播引用，避免在无活跃session时
+      // 触发start_broadcast/end_broadcast循环（"僵尸广播"），
+      // 这可能阻塞HTTPS服务器线程导致客户端显示主机离线
+      if (!broadcast_shared.has_ref()) {
+        return false;
+      }
+
       auto broadcast_ref = broadcast_shared.ref();
       if (!broadcast_ref) {
         BOOST_LOG(warning) << "No broadcast context available when changing dynamic parameter for client";


### PR DESCRIPTION
根因分析：
1. 僵尸广播(zombie broadcast)：延迟到达的 ABR HTTP 请求在 session 结束后 触发 change_dynamic_param_for_client()，该函数调用 broadcast_shared.ref() 创建了一个临时的广播上下文，随后 end_broadcast() 中的 control_thread.join() 阻塞了 HTTPS handler 线程，导致 HTTPS 服务器 无法接受新连接，客户端显示主机离线。

2. VDD 模式下初始拓扑错误：apply_config 在 VDD 模式下调用 get_current_topology_metadata() 获取的是 VDD 启用后的当前拓扑 （只有 VDD 设备），忽略了 pre_saved_initial_topology（物理显示器拓扑）。 恢复时 remove_vdd_from_topology() 将初始拓扑清空，物理显示器无法 被重新启用。

修复：
- stream.cpp: 在 change_dynamic_param_for_client 中添加 has_ref() 前置 检查，无活跃 session 时不触发僵尸广播
- settings.cpp: VDD 模式下使用 pre_saved_initial_topology 替换 get_current_topology_metadata 返回的 VDD-only 初始拓扑