### PR TITLE
fix: add amd_ltr_frames config option for PS Vita compatibility

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1178,6 +1178,7 @@ namespace config {
     bool_f(vars, "amd_vbaq", (bool &) video.amd.amd_vbaq);
     bool_f(vars, "amd_enforce_hrd", (bool &) video.amd.amd_enforce_hrd);
     int_between_f(vars, "amd_qvbr_quality", video.amd.amd_qvbr_quality, { 1, 51 });
+    int_between_f(vars, "amd_ltr_frames", video.amd.amd_ltr_frames, { 0, 4 });
 
     int_f(vars, "vt_coder", video.vt.vt_coder, vt::coder_from_view);
     int_f(vars, "vt_software", video.vt.vt_allow_sw, vt::allow_software_from_view);

--- a/src/config.h
+++ b/src/config.h
@@ -73,6 +73,7 @@ namespace config {
       std::optional<int> amd_vbaq;
       int amd_coder;
       int amd_qvbr_quality = 23;  // QVBR quality level 1-51 (lower=better, default=23)
+      int amd_ltr_frames = 1;  // LTR frames for RFI (0=disabled, default=1)
     } amd;
 
     struct {

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -1696,7 +1696,7 @@ namespace platf::dxgi {
       amf_cfg.vbaq = config::video.amd.amd_vbaq;
       amf_cfg.enforce_hrd = config::video.amd.amd_enforce_hrd;
       amf_cfg.h264_cabac = (config::video.amd.amd_coder != 2);  // 2 = CAVLC
-      amf_cfg.max_ltr_frames = 1;  // Enable RFI
+      amf_cfg.max_ltr_frames = config::video.amd.amd_ltr_frames;
       amf_cfg.qvbr_quality_level = config::video.amd.amd_qvbr_quality;
 
       // Pre-Analysis sub-system defaults: enable PAQ + TAQ for better quality at same bitrate


### PR DESCRIPTION
## Summary

Add a configurable `amd_ltr_frames` option for the standalone AMF encoder to fix PS Vita Moonlight stream freezes.

## Problem

PS Vita's Moonlight client freezes immediately on connect (static image, 0/60fps) because our fork's standalone AMF encoder enables LTR (Long Term Reference) frames by default (`max_ltr_frames = 1`). The PS Vita's old H.264 decoder doesn't support LTR frames.

Official Sunshine works because it uses FFmpeg's AMF wrapper which doesn't enable LTR.

## Solution

- New config option: `amd_ltr_frames` (range: 0-4, default: 1)
- Setting `amd_ltr_frames = 0` in `sunshine.conf` disables LTR/RFI
- Default remains 1 (enabled) — LTR is beneficial for modern clients

## Files Changed

- `src/config.h` — added field to AMD config struct
- `src/config.cpp` — added config parsing
- `src/platform/windows/display_vram.cpp` — use config value instead of hardcoded 1

Fixes #569