### PR TITLE
feat: auto-elevate UAC during WGC capture

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -461,6 +461,7 @@ namespace config {
     0,  // minimum_fps_target (0 = auto, about half the stream FPS)
     "balanced"s,  // downscaling_quality (default: bicubic for best quality/performance balance)
     false,  // hdr_luminance_analysis (disabled by default to avoid GPU overhead)
+    false,  // wgc_disable_secure_desktop (disabled by default for security)
   };
 
   audio_t audio {
@@ -1236,6 +1237,7 @@ namespace config {
     bool_f(vars, "variable_refresh_rate", video.variable_refresh_rate);
     int_between_f(vars, "minimum_fps_target", video.minimum_fps_target, { 0, 1000 });
     bool_f(vars, "hdr_luminance_analysis", video.hdr_luminance_analysis);
+    bool_f(vars, "wgc_disable_secure_desktop", video.wgc_disable_secure_desktop);
     bool_f(vars, "vdd_keep_enabled", video.vdd_keep_enabled);
     bool_f(vars, "vdd_headless_create", video.vdd_headless_create_enabled);
     bool_f(vars, "vdd_reuse", video.vdd_reuse);

--- a/src/config.h
+++ b/src/config.h
@@ -113,6 +113,7 @@ namespace config {
     int minimum_fps_target;  // Minimum FPS target (0 = auto, 1-1000 = minimum FPS to maintain)
     std::string downscaling_quality;  // Downscaling quality: "fast" (bilinear+8pt), "balanced" (bicubic), "high_quality" (future: lanczos)
     bool hdr_luminance_analysis;  // Enable per-frame HDR luminance analysis for dynamic metadata
+    bool wgc_disable_secure_desktop;  // Auto-disable UAC secure desktop when using WGC capture
   };
 
   struct audio_t {

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -418,6 +418,13 @@ namespace platf::dxgi {
   };
 
   /**
+   * @brief Recover ConsentPromptBehaviorAdmin registry value if a previous WGC session crashed.
+   * Safe to call from any capture mode — checks for backup file and restores if found.
+   */
+  void
+  recover_secure_desktop();
+
+  /**
    * Display duplicator that uses the Windows.Graphics.Capture API.
    */
   class wgc_capture_t {

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -1077,6 +1077,9 @@ namespace platf {
    */
   std::shared_ptr<display_t>
   display(mem_type_e hwdevice_type, const std::string &display_name, const video::config_t &config) {
+    // Recover ConsentPromptBehaviorAdmin if Sunshine previously crashed during WGC capture (runs only once)
+    dxgi::recover_secure_desktop();
+
     auto try_init = [&](auto disp) -> std::shared_ptr<display_t> {
       if (!disp->init(config, display_name)) {
         return disp;

--- a/src/platform/windows/display_wgc.cpp
+++ b/src/platform/windows/display_wgc.cpp
@@ -6,8 +6,12 @@
 #include <winsock2.h>
 #include <windows.h>
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <dxgi1_2.h>
+#include <filesystem>
+#include <fstream>
+#include <mutex>
 #include <thread>
 
 // local includes
@@ -72,6 +76,215 @@ __mingw_uuidof<winrt::IDirect3DDxgiInterfaceAccess>() -> GUID const & {
 #endif
 
 namespace platf::dxgi {
+
+  // UAC bypass for WGC capture mode.
+  // WGC cannot capture UAC prompts, so we temporarily set ConsentPromptBehaviorAdmin=0
+  // to auto-elevate without prompting during capture, and restore the original value when capture ends.
+  namespace secure_desktop {
+    static constexpr const wchar_t *kPoliciesKey = L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System";
+    static constexpr const wchar_t *kValueName = L"ConsentPromptBehaviorAdmin";
+
+    static std::mutex state_mutex;
+    static int wgc_ref_count = 0;
+    static DWORD original_value = 5;  // Default: prompt for consent on secure desktop
+    static bool modified = false;
+    static std::once_flag recovery_flag;
+
+    static std::filesystem::path
+    backup_file_path() {
+      wchar_t temp[MAX_PATH];
+      GetTempPathW(MAX_PATH, temp);
+      return std::filesystem::path(temp) / L"sunshine_uac_consent_backup";
+    }
+
+    /**
+     * @brief Valid range for ConsentPromptBehaviorAdmin: 0-5.
+     */
+    static bool
+    is_valid_consent_value(DWORD value) {
+      return value <= 5;
+    }
+
+    /**
+     * @brief Save original value to a temp file for crash recovery.
+     * @return true if backup was successfully written and flushed.
+     */
+    static bool
+    save_backup(DWORD value) {
+      try {
+        auto path = backup_file_path();
+        std::ofstream f(path, std::ios::trunc);
+        if (f) {
+          f << value;
+          f.flush();
+          if (f.good()) {
+            return true;
+          }
+        }
+        BOOST_LOG(error) << "Failed to write crash recovery backup file"sv;
+      }
+      catch (...) {
+        BOOST_LOG(error) << "Exception writing crash recovery backup file"sv;
+      }
+      return false;
+    }
+
+    /**
+     * @brief Remove the backup file.
+     */
+    static void
+    remove_backup() {
+      try {
+        std::filesystem::remove(backup_file_path());
+      }
+      catch (...) {
+      }
+    }
+
+    /**
+     * @brief Restore from crash recovery backup if it exists.
+     */
+    static void
+    recover_from_crash() {
+      try {
+        auto path = backup_file_path();
+        if (!std::filesystem::exists(path)) return;
+
+        std::ifstream f(path);
+        DWORD saved_value;
+        if (!(f >> saved_value)) {
+          BOOST_LOG(warning) << "Corrupt crash recovery backup file, removing"sv;
+          remove_backup();
+          return;
+        }
+
+        if (!is_valid_consent_value(saved_value)) {
+          BOOST_LOG(error) << "Invalid ConsentPromptBehaviorAdmin value "sv << saved_value << " in backup, rejecting"sv;
+          remove_backup();
+          return;
+        }
+
+        HKEY hkey;
+        if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, kPoliciesKey, 0, KEY_WRITE, &hkey) == ERROR_SUCCESS) {
+          auto result = RegSetValueExW(hkey, kValueName, 0, REG_DWORD, (const BYTE *) &saved_value, sizeof(saved_value));
+          RegCloseKey(hkey);
+          if (result == ERROR_SUCCESS) {
+            BOOST_LOG(info) << "Restored ConsentPromptBehaviorAdmin to "sv << saved_value << " from crash recovery backup"sv;
+            remove_backup();
+          }
+          else {
+            BOOST_LOG(error) << "Failed to restore ConsentPromptBehaviorAdmin from crash backup, will retry next startup"sv;
+          }
+        }
+        else {
+          BOOST_LOG(error) << "Failed to open registry for crash recovery, will retry next startup"sv;
+        }
+      }
+      catch (...) {
+      }
+    }
+
+    /**
+     * @brief Disable UAC prompts by setting ConsentPromptBehaviorAdmin to 0 (elevate without prompting).
+     * @return true if the value was modified.
+     */
+    static bool
+    disable() {
+      std::lock_guard<std::mutex> lock(state_mutex);
+
+      if (wgc_ref_count++ > 0) {
+        // Another WGC instance already disabled it
+        return false;
+      }
+
+      // If a prior restore() failed, the registry is still at 0 and original_value
+      // holds the real pre-modification value. Don't re-read or overwrite it.
+      if (modified) {
+        BOOST_LOG(info) << "ConsentPromptBehaviorAdmin still modified from prior session (pending restore), reusing original value "sv << original_value;
+        return false;
+      }
+
+      DWORD value, size = sizeof(value);
+      auto read_result = RegGetValueW(HKEY_LOCAL_MACHINE, kPoliciesKey, kValueName, RRF_RT_REG_DWORD, nullptr, &value, &size);
+      if (read_result != ERROR_SUCCESS) {
+        BOOST_LOG(warning) << "Failed to read ConsentPromptBehaviorAdmin (error 0x"sv << util::hex(read_result).to_string_view() << "), aborting UAC disable"sv;
+        return false;
+      }
+      original_value = value;
+
+      if (value == 0) {
+        BOOST_LOG(info) << "ConsentPromptBehaviorAdmin is already 0 (auto-elevate)"sv;
+        return false;
+      }
+
+      // Persist backup BEFORE modifying registry — ensures crash recovery is possible
+      if (!save_backup(original_value)) {
+        BOOST_LOG(error) << "Cannot persist backup file, aborting UAC disable to prevent irrecoverable state"sv;
+        return false;
+      }
+
+      HKEY hkey;
+      if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, kPoliciesKey, 0, KEY_WRITE, &hkey) != ERROR_SUCCESS) {
+        BOOST_LOG(warning) << "Cannot disable UAC prompts: insufficient privileges. Run Sunshine elevated to enable this feature."sv;
+        remove_backup();
+        return false;
+      }
+
+      DWORD new_value = 0;
+      auto result = RegSetValueExW(hkey, kValueName, 0, REG_DWORD, (const BYTE *) &new_value, sizeof(new_value));
+      RegCloseKey(hkey);
+
+      if (result == ERROR_SUCCESS) {
+        modified = true;
+        BOOST_LOG(info) << "Set ConsentPromptBehaviorAdmin to 0 for WGC capture (original value: "sv << original_value << ")"sv;
+        return true;
+      }
+
+      BOOST_LOG(warning) << "Failed to set ConsentPromptBehaviorAdmin [0x"sv << util::hex(result).to_string_view() << ']';
+      remove_backup();
+      return false;
+    }
+
+    /**
+     * @brief Restore the original ConsentPromptBehaviorAdmin setting.
+     */
+    static void
+    restore() {
+      std::lock_guard<std::mutex> lock(state_mutex);
+
+      if (--wgc_ref_count > 0) {
+        // Other WGC instances still active
+        return;
+      }
+
+      if (!modified) {
+        return;
+      }
+
+      HKEY hkey;
+      if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, kPoliciesKey, 0, KEY_WRITE, &hkey) == ERROR_SUCCESS) {
+        auto result = RegSetValueExW(hkey, kValueName, 0, REG_DWORD, (const BYTE *) &original_value, sizeof(original_value));
+        RegCloseKey(hkey);
+        if (result == ERROR_SUCCESS) {
+          BOOST_LOG(info) << "Restored ConsentPromptBehaviorAdmin to "sv << original_value;
+          modified = false;
+          remove_backup();
+        }
+        else {
+          BOOST_LOG(error) << "Failed to restore ConsentPromptBehaviorAdmin, backup preserved for next startup"sv;
+        }
+      }
+      else {
+        BOOST_LOG(error) << "Failed to open registry for restore, backup preserved for next startup"sv;
+      }
+    }
+  }  // namespace secure_desktop
+
+  void
+  recover_secure_desktop() {
+    std::call_once(secure_desktop::recovery_flag, secure_desktop::recover_from_crash);
+  }
+
   /**
    * @brief Find a window by title (case-insensitive fuzzy matching).
    * @param window_title The window title to search for.
@@ -219,6 +432,10 @@ namespace platf::dxgi {
     item = nullptr;
     capture_session = nullptr;
     frame_pool = nullptr;
+
+    if (config::video.wgc_disable_secure_desktop) {
+      secure_desktop::restore();
+    }
   }
 
   /**
@@ -460,6 +677,15 @@ namespace platf::dxgi {
     catch (winrt::hresult_error &e) {
       BOOST_LOG(error) << "Screen capture is not supported on this device for this release of Windows: failed to start capture: [0x"sv << util::hex(e.code()).to_string_view() << ']';
       return -1;
+    }
+
+    // Disable UAC prompts so WGC can operate without interruption (if enabled in config)
+    if (config::video.wgc_disable_secure_desktop) {
+      secure_desktop::disable();
+    }
+    else {
+      BOOST_LOG(info) << "WGC capture active. UAC prompts will not be auto-elevated. "
+                         "Set wgc_disable_secure_desktop=true in config to auto-elevate UAC during WGC capture."sv;
     }
 
     return 0;

--- a/src_assets/common/assets/web/configs/tabs/audiovideo/ExperimentalFeatures.vue
+++ b/src_assets/common/assets/web/configs/tabs/audiovideo/ExperimentalFeatures.vue
@@ -3,6 +3,7 @@ import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { $tp } from '../../../platform-i18n'
 import PlatformLayout from '../../../components/layout/PlatformLayout.vue'
+import Checkbox from '../../../components/Checkbox.vue'
 
 const props = defineProps({
   platform: String,
@@ -77,6 +78,15 @@ function addRemapping(type) {
                 />
                 <div class="form-text">{{ $t('config.window_title_desc') }}</div>
               </div>
+
+              <!-- WGC Disable Secure Desktop -->
+              <Checkbox
+                class="mb-3"
+                id="wgc_disable_secure_desktop"
+                locale-prefix="config"
+                v-model="config.wgc_disable_secure_desktop"
+                default="false"
+              ></Checkbox>
 
               <!-- Display Mode Remapping -->
               <div

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -565,6 +565,8 @@
     "wgc_user_mode_available": "Currently running in user mode. WGC capture is available.",
     "window_title": "Window Title",
     "window_title_desc": "The title of the window to capture (partial match, case-insensitive). If left empty, the current running application name will be used automatically.",
+    "wgc_disable_secure_desktop": "Auto-Elevate UAC (WGC Mode)",
+    "wgc_disable_secure_desktop_desc": "When using WGC capture, temporarily disable UAC prompts by auto-elevating admin requests without user confirmation. This allows seamless remote operation without UAC dialog interruptions. The original UAC settings are restored when streaming ends. WARNING: This reduces system security — any program requesting admin privileges will be silently elevated during streaming.",
     "window_title_placeholder": "e.g., Application Name"
   },
   "index": {

--- a/src_assets/common/assets/web/public/assets/locale/zh.json
+++ b/src_assets/common/assets/web/public/assets/locale/zh.json
@@ -565,6 +565,8 @@
     "wgc_user_mode_available": "当前以用户模式运行，WGC 捕获可用。",
     "window_title": "窗口标题",
     "window_title_desc": "要捕获的窗口标题（部分匹配，不区分大小写）。如果留空，将自动使用当前运行的应用名称。",
+    "wgc_disable_secure_desktop": "自动提升 UAC（WGC 模式）",
+    "wgc_disable_secure_desktop_desc": "使用 WGC 捕获时，临时禁用 UAC 提示，管理员权限请求将自动通过而不弹出确认对话框。这可以避免远程串流时 UAC 弹窗导致的中断。串流结束后自动恢复原始 UAC 设置。警告：这会降低系统安全性——串流期间任何程序请求管理员权限将被静默提升。",
     "window_title_placeholder": "例如：yuanshen"
   },
   "index": {


### PR DESCRIPTION
## Problem

When using WGC (Windows Graphics Capture) mode in user session, UAC prompts cannot be captured or interacted with by remote clients. This is because:
1. WGC cannot capture the secure desktop where UAC dialogs appear
2. Even with secure desktop disabled, UIPI prevents user-level processes from sending input to SYSTEM-level consent.exe windows

All industry solutions (TeamViewer, AnyDesk, Parsec, RDP) handle this via SYSTEM service mode. For WGC user-mode users, there is no clean API-level solution.

## Solution

Add an opt-in config option `wgc_disable_secure_desktop` that temporarily sets `ConsentPromptBehaviorAdmin=0` during WGC capture, causing admin elevation requests to auto-approve without any UAC dialog. The original value is restored when capture ends.

### Safety Measures
- **Off by default** — users must explicitly enable via WebUI or config file
- **Crash recovery** — original value is backed up to `%TEMP%\sunshine_uac_consent_backup` and restored on next startup even after crashes
- **Ref-counted** — supports multiple WGC instances
- **Clear warning** — WebUI displays security impact warning in both English and Chinese

## Changes
- `config.h/config.cpp`: Add `wgc_disable_secure_desktop` bool option
- `display_wgc.cpp`: Add `secure_desktop` namespace with disable/restore/crash-recovery logic
- `display_base.cpp`: Add startup crash recovery via `recover_secure_desktop()`
- `display.h`: Expose `recover_secure_desktop()` function
- `ExperimentalFeatures.vue`: Add toggle checkbox
- `en.json/zh.json`: Add i18n strings with security warnings