### PR TITLE
fix(windows): handle D3D11 device-lost (TDR) in AMD capture and encoding pipeline

### DIFF
--- a/src/amf/amf_d3d11.cpp
+++ b/src/amf/amf_d3d11.cpp
@@ -17,6 +17,7 @@
 
 #include "src/config.h"
 #include "src/logging.h"
+#include "src/utility.h"
 
 namespace amf {
 
@@ -604,6 +605,13 @@ namespace amf {
     auto res = context->CreateSurfaceFromDX11Native(input_texture, &surface, nullptr);
     if (res != AMF_OK || !surface) {
       BOOST_LOG(error) << "AMF: CreateSurfaceFromDX11Native failed, error: " << res;
+      // Check if the D3D11 device is lost (TDR, driver crash, etc.)
+      if (device) {
+        auto removed_reason = device->GetDeviceRemovedReason();
+        if (removed_reason != S_OK) {
+          BOOST_LOG(error) << "AMF: D3D11 device lost, reason: 0x" << util::hex(removed_reason).to_string_view();
+        }
+      }
       return result;
     }
 
@@ -702,6 +710,13 @@ namespace amf {
     }
     if (res != AMF_OK) {
       BOOST_LOG(error) << "AMF: SubmitInput failed, error: " << res;
+      // Check if the D3D11 device is lost (TDR, driver crash, etc.)
+      if (device) {
+        auto removed_reason = device->GetDeviceRemovedReason();
+        if (removed_reason != S_OK) {
+          BOOST_LOG(error) << "AMF: D3D11 device lost after SubmitInput, reason: 0x" << util::hex(removed_reason).to_string_view();
+        }
+      }
       return result;
     }
 

--- a/src/platform/windows/display_amd.cpp
+++ b/src/platform/windows/display_amd.cpp
@@ -77,6 +77,18 @@ namespace platf::dxgi {
     } while (result == AMF_REPEAT);
 
     if (result != AMF_OK) {
+      // Check if the underlying D3D11 device is lost (TDR, driver crash, etc.)
+      if (context) {
+        auto *d3d_device = static_cast<ID3D11Device *>(context->GetDX11Device(amf::AMF_DX11_1));
+        if (d3d_device) {
+          auto removed_reason = d3d_device->GetDeviceRemovedReason();
+          if (removed_reason != S_OK) {
+            BOOST_LOG(error) << "AMD DirectCapture: D3D11 device lost, reason: 0x"sv << util::hex(removed_reason).to_string_view() << ", requesting reinit"sv;
+            return capture_e::reinit;
+          }
+        }
+      }
+      BOOST_LOG(warning) << "AMD DirectCapture: QueryOutput failed with result: "sv << result;
       return capture_e::timeout;
     }
     return capture_e::ok;

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -154,6 +154,10 @@ namespace platf::dxgi {
       case DXGI_ERROR_ACCESS_LOST:
       case DXGI_ERROR_ACCESS_DENIED:
         return capture_e::reinit;
+      case DXGI_ERROR_DEVICE_REMOVED:
+      case DXGI_ERROR_DEVICE_RESET:
+        BOOST_LOG(error) << "D3D11 device lost during AcquireNextFrame [0x"sv << util::hex(status).to_string_view() << "], requesting reinit"sv;
+        return capture_e::reinit;
       default:
         BOOST_LOG(error) << "Couldn't acquire next frame [0x"sv << util::hex(status).to_string_view();
         return capture_e::error;
@@ -186,6 +190,11 @@ namespace platf::dxgi {
         return capture_e::ok;
 
       case DXGI_ERROR_ACCESS_LOST:
+        return capture_e::reinit;
+
+      case DXGI_ERROR_DEVICE_REMOVED:
+      case DXGI_ERROR_DEVICE_RESET:
+        BOOST_LOG(error) << "D3D11 device lost during ReleaseFrame [0x"sv << util::hex(status).to_string_view() << "], requesting reinit"sv;
         return capture_e::reinit;
 
       default:

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -448,6 +448,13 @@ namespace platf::dxgi {
         auto status = img_ctx.encoder_mutex->AcquireSync(0, INFINITE);
         if (status != S_OK) {
           BOOST_LOG(error) << "Failed to acquire encoder mutex [0x"sv << util::hex(status).to_string_view() << ']';
+          // Check if the D3D11 device is lost (TDR, driver crash, etc.)
+          if (device.get()) {
+            auto removed_reason = device->GetDeviceRemovedReason();
+            if (removed_reason != S_OK) {
+              BOOST_LOG(error) << "D3D11 device lost during convert, reason: 0x"sv << util::hex(removed_reason).to_string_view();
+            }
+          }
           return -1;
         }
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -2884,7 +2884,8 @@ namespace video {
           frame_timestamp = img->frame_timestamp;
           if (session->convert(*img)) {
             BOOST_LOG(error) << "Could not convert image"sv;
-            return;
+            // Don't exit permanently — break to let the outer reinit loop handle recovery
+            break;
           }
           has_new_frame = true;
         }
@@ -2906,7 +2907,8 @@ namespace video {
 
       if (encode(frame_nr++, *session, packets, channel_data, frame_timestamp)) {
         BOOST_LOG(error) << "Could not encode video packet"sv;
-        return;
+        // Don't exit permanently — break to let the outer reinit loop handle recovery
+        break;
       }
 
       session->request_normal_frame();


### PR DESCRIPTION
## Problem

When a GPU TDR (Timeout Detection and Recovery) occurs during AMD DirectCapture streaming, the capture pipeline would either hang indefinitely or crash. Users experience: streaming freezes, can switch to desktop but wallpaper turns black.

## Root Cause

5 locations in the capture/encoding pipeline failed to properly detect and propagate D3D11 device-lost errors:

1. **DXGI Desktop Duplication** returned `capture_e::error` (fatal) instead of `capture_e::reinit` (recoverable) on device removal
2. **Encoding thread** called `return` (permanent exit) on convert/encode failure instead of `break` (allow reinit)
3. **AMF encoder** didn't check device state after surface creation/submission failures
4. **AMD DirectCapture** masked device-lost as `capture_e::timeout`, causing infinite retry on dead device
5. **VRAM convert** keyed mutex failure didn't log device removal reason

## Changes

| File | Change | Impact |
|------|--------|--------|
| `display_base.cpp` | Handle DXGI_ERROR_DEVICE_REMOVED/RESET → return `reinit` | All capture backends (DXGI) |
| `video.cpp` | convert/encode failure: `return` → `break` | All encoders |
| `amf_d3d11.cpp` | Log device-lost after AMF failures | AMD only (diagnostic) |
| `display_amd.cpp` | Detect device-lost in QueryOutput → return `reinit` | AMD DirectCapture |
| `display_vram.cpp` | Log GetDeviceRemovedReason on AcquireSync failure | All GPU encode (diagnostic) |

## Impact Analysis

- **NVIDIA/Intel**: Benefit from Fix 1 (DXGI reinit) and Fix 2 (encode resilience). No regressions.
- **AMD**: Full TDR recovery chain - capture detects device-lost → signals reinit → encoding breaks inner loop → outer loop rebuilds pipeline → streaming resumes.
- **Infinite loop risk**: Low. Multiple circuit breakers present (`reinit_event` + sleep, `display_wp` expiry check, `shutdown_event`).
- **Thread safety**: All cross-thread communication uses existing `safe::signal_t` and `sync_util::sync_t`.

## Testing

Requires AMD GPU with DirectCapture enabled. Simulate TDR by triggering GPU timeout during gameplay.