### PR TITLE
feat(opt): 提高日志缓存和增量读取性能、优化屏幕检测超时逻辑

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -498,6 +498,17 @@ namespace confighttp {
   }
 
   /**
+   * @brief Snapshot of the log cache state.
+   * All fields are immutable once constructed; swapped atomically via shared_ptr.
+   */
+  struct LogCacheSnapshot {
+    std::shared_ptr<const std::string> content;  ///< Cached log content (nullptr in offset-only mode)
+    std::uintmax_t file_size = 0;                ///< Actual file size on disk when snapshot was taken
+    std::intmax_t mtime_ns = 0;                  ///< File mtime when snapshot was taken
+    std::uintmax_t start_offset = 0;             ///< File byte position where content begins
+  };
+
+  /**
    * @brief Try to read only the new tail of the log file and append to existing content.
    * @return New content on success, nullptr on any failure (caller should fall back to full read).
    */
@@ -522,9 +533,54 @@ namespace confighttp {
   }
 
   /**
+   * @brief Read the last max_bytes of a file directly from disk.
+   */
+  static std::shared_ptr<const std::string>
+  read_file_tail(const std::filesystem::path &path, std::uintmax_t max_bytes) {
+    std::ifstream in(path.string(), std::ios::binary);
+    if (!in) {
+      return nullptr;
+    }
+    in.seekg(0, std::ios::end);
+    auto file_size = static_cast<std::uintmax_t>(in.tellg());
+    auto read_size = std::min(file_size, max_bytes);
+    in.seekg(-static_cast<std::streamoff>(read_size), std::ios::end);
+    std::string content(static_cast<std::size_t>(read_size), '\0');
+    if (!in.read(content.data(), static_cast<std::streamsize>(read_size))) {
+      return nullptr;
+    }
+    return std::make_shared<const std::string>(std::move(content));
+  }
+
+  /**
+   * @brief Read a specific byte range [offset, offset+length) from a file.
+   * @return Content string on success, nullptr on failure.
+   */
+  static std::shared_ptr<const std::string>
+  read_file_range(const std::filesystem::path &path, std::uintmax_t offset, std::uintmax_t length) {
+    std::ifstream in(path.string(), std::ios::binary);
+    if (!in || !in.seekg(static_cast<std::streamoff>(offset))) {
+      return nullptr;
+    }
+    std::string content(static_cast<std::size_t>(length), '\0');
+    if (!in.read(content.data(), static_cast<std::streamsize>(length))) {
+      return nullptr;
+    }
+    return std::make_shared<const std::string>(std::move(content));
+  }
+
+  /**
    * @brief Get the logs from the log file.
    * @param response The HTTP response object.
    * @param request The HTTP request object.
+   *
+   * Dual mode via X-Log-Offset header:
+   *   - Without header: stream full log file from disk (for download)
+   *   - With header:    cached or offset-based incremental support (for live viewer)
+   *
+   * When the log file is small (≤ 4 MB), the entire file is cached in memory for fast serving.
+   * When the log file exceeds 4 MB, no content is cached; reads go directly to disk at the
+   * client's offset (offset-only mode), avoiding unbounded memory growth.
    *
    * @api_examples{/api/logs| GET| null}
    */
@@ -536,13 +592,40 @@ namespace confighttp {
 
     //print_req(request);
 
-    // Log caching: avoid reading disk unnecessarily when file hasn't changed
-    // Use std::atomic<shared_ptr> to ensure thread-safe access (no locks)
-    static std::atomic<std::shared_ptr<const std::string>> cached_log;
-    static std::atomic<std::uintmax_t> cached_log_size { 0 };
-    static std::atomic<std::intmax_t> cached_log_mtime_ns { 0 };
-
     const std::filesystem::path log_path(config::sunshine.log_file);
+
+    // --- Mode 1: No X-Log-Offset header → stream full file from disk (download) ---
+    auto offset_it = request->header.find("X-Log-Offset");
+    if (offset_it == request->header.end()) {
+      std::error_code ec;
+      auto fsize = std::filesystem::file_size(log_path, ec);
+      if (ec) {
+        response->write(SimpleWeb::StatusCode::server_error_internal_server_error, "Failed to read log file");
+        return;
+      }
+      std::ifstream in(log_path.string(), std::ios::binary);
+      if (!in.is_open()) {
+        response->write(SimpleWeb::StatusCode::server_error_internal_server_error, "Failed to open log file");
+        return;
+      }
+      SimpleWeb::CaseInsensitiveMultimap headers;
+      headers.emplace("Content-Type", "text/plain; charset=utf-8");
+      headers.emplace("Content-Disposition", "attachment; filename=\"sunshine.log\"");
+      headers.emplace("Content-Length", std::to_string(fsize));
+      response->write(SimpleWeb::StatusCode::success_ok, in, headers);
+      return;
+    }
+
+    // --- Mode 2: X-Log-Offset present → cached or offset-only mode for live viewer ---
+
+    // When file ≤ MAX_LOG_CACHE_SIZE: entire file cached in memory (cached mode).
+    // When file > MAX_LOG_CACHE_SIZE: no content in memory, reads go to disk (offset-only mode).
+    // MAX_RESPONSE_SIZE caps a single response to avoid large allocations.
+    static constexpr std::uintmax_t MAX_LOG_CACHE_SIZE = 4 * 1024 * 1024;   // 4 MB
+    static constexpr std::uintmax_t MAX_RESPONSE_SIZE  = 4 * 1024 * 1024;   // 4 MB
+
+    // Single atomic snapshot ensures all cache fields are consistent across threads.
+    static std::atomic<std::shared_ptr<const LogCacheSnapshot>> log_cache;
 
     // Check file status
     std::error_code ec;
@@ -558,72 +641,109 @@ namespace confighttp {
     }
     auto current_mtime_ns = current_mtime.time_since_epoch().count();
 
-    const auto prev_size = cached_log_size.load();
-    const bool cache_stale = (current_size != prev_size || current_mtime_ns != cached_log_mtime_ns.load());
+    // Refresh cache if file changed
+    auto snapshot = log_cache.load();
+    const bool cache_stale = !snapshot || current_size != snapshot->file_size || current_mtime_ns != snapshot->mtime_ns;
     if (cache_stale) {
-      auto new_content = try_incremental_log_read(log_path, prev_size, current_size, cached_log.load());
-      if (!new_content) {
-        new_content = std::make_shared<const std::string>(file_handler::read_file(log_path.string().c_str()));
-      }
-      // If read returned empty, ensure file still exists (e.g. not deleted during read)
-      if (new_content->empty() && !std::filesystem::exists(log_path, ec)) {
-        response->write(SimpleWeb::StatusCode::server_error_internal_server_error, "Log file not available");
-        return;
-      }
-      cached_log.store(new_content);
-      cached_log_size.store(current_size);
-      cached_log_mtime_ns.store(current_mtime_ns);
-    }
+      auto new_snap = std::make_shared<LogCacheSnapshot>();
+      new_snap->file_size = current_size;
+      new_snap->mtime_ns = current_mtime_ns;
 
-    // Atomic load shared_ptr, subsequent operations based on this snapshot
-    auto content = cached_log.load();
-    if (!content) {
-      response->write(SimpleWeb::StatusCode::server_error_internal_server_error, "Log not available");
-      return;
-    }
-
-    // Read client's offset from request header (trim whitespace; invalid values => 0, then full response)
-    std::uintmax_t client_offset = 0;
-    auto it = request->header.find("X-Log-Offset");
-    if (it != request->header.end()) {
-      try {
-        std::string offset_str(it->second);
-        boost::algorithm::trim(offset_str);
-        if (!offset_str.empty()) {
-          client_offset = std::stoull(offset_str);
+      if (current_size <= MAX_LOG_CACHE_SIZE) {
+        // --- Cached mode: file fits in memory ---
+        std::shared_ptr<const std::string> new_content;
+        if (snapshot && snapshot->content && snapshot->file_size > 0 && current_size > snapshot->file_size) {
+          new_content = try_incremental_log_read(log_path, snapshot->file_size, current_size, snapshot->content);
         }
+        if (!new_content) {
+          new_content = read_file_tail(log_path, MAX_LOG_CACHE_SIZE);
+        }
+        if (!new_content) {
+          new_content = std::make_shared<const std::string>();
+        }
+        if (new_content->empty() && !std::filesystem::exists(log_path, ec)) {
+          response->write(SimpleWeb::StatusCode::server_error_internal_server_error, "Log file not available");
+          return;
+        }
+        new_snap->content = std::move(new_content);
+        new_snap->start_offset = current_size - new_snap->content->size();
       }
-      catch (const std::invalid_argument &) {
-        client_offset = 0;
+      else {
+        // --- Offset-only mode: file too large, don't cache content ---
+        new_snap->content = nullptr;
+        new_snap->start_offset = 0;
       }
-      catch (const std::out_of_range &) {
-        client_offset = 0;
+
+      log_cache.store(new_snap);
+      snapshot = std::move(new_snap);
+    }
+
+    // Parse client offset
+    std::uintmax_t client_offset = 0;
+    try {
+      std::string offset_str(offset_it->second);
+      boost::algorithm::trim(offset_str);
+      if (!offset_str.empty()) {
+        client_offset = std::stoull(offset_str);
       }
+    }
+    catch (const std::invalid_argument &) {
+      client_offset = 0;
+    }
+    catch (const std::out_of_range &) {
+      client_offset = 0;
     }
 
     SimpleWeb::CaseInsensitiveMultimap headers;
     headers.emplace("Content-Type", "text/plain");
-    headers.emplace("X-Log-Size", std::to_string(content->size()));
+    headers.emplace("X-Log-Size", std::to_string(snapshot->file_size));
     headers.emplace("X-Frame-Options", "DENY");
     headers.emplace("Content-Security-Policy", "frame-ancestors 'none';");
 
-    // offset equals current size: no change in logs, return 304
-    if (client_offset > 0 && client_offset == content->size()) {
+    // No change in logs → 304
+    if (client_offset > 0 && client_offset == snapshot->file_size) {
       headers.emplace("X-Log-Range", "unchanged");
       response->write(SimpleWeb::StatusCode::redirection_not_modified, headers);
       return;
     }
 
-    // Valid offset and within range: return increment
-    if (client_offset > 0 && client_offset < content->size()) {
-      headers.emplace("X-Log-Range", "incremental");
-      auto delta = content->substr(client_offset);
-      response->write(SimpleWeb::StatusCode::success_ok, delta, headers);
+    if (snapshot->content) {
+      // === Cached mode: serve from memory ===
+      if (client_offset > 0 && client_offset >= snapshot->start_offset && client_offset < snapshot->file_size) {
+        auto cache_pos = client_offset - snapshot->start_offset;
+        headers.emplace("X-Log-Range", "incremental");
+        auto delta = snapshot->content->substr(static_cast<std::size_t>(cache_pos));
+        response->write(SimpleWeb::StatusCode::success_ok, delta, headers);
+      }
+      else {
+        headers.emplace("X-Log-Range", "full");
+        response->write(SimpleWeb::StatusCode::success_ok, *snapshot->content, headers);
+      }
     }
     else {
-      // Invalid offset (file rotation/first request): return full content
-      headers.emplace("X-Log-Range", "full");
-      response->write(SimpleWeb::StatusCode::success_ok, *content, headers);
+      // === Offset-only mode: read directly from disk ===
+      if (client_offset > 0 && client_offset < snapshot->file_size) {
+        auto delta_size = snapshot->file_size - client_offset;
+        if (delta_size <= MAX_RESPONSE_SIZE) {
+          // Delta fits in one response: read from client_offset to end of file
+          auto data = read_file_range(log_path, client_offset, delta_size);
+          if (data) {
+            headers.emplace("X-Log-Range", "incremental");
+            response->write(SimpleWeb::StatusCode::success_ok, *data, headers);
+            return;
+          }
+        }
+        // Delta too large or read failed: return last MAX_RESPONSE_SIZE bytes
+        auto tail = read_file_tail(log_path, MAX_RESPONSE_SIZE);
+        headers.emplace("X-Log-Range", "full");
+        response->write(SimpleWeb::StatusCode::success_ok, tail ? *tail : std::string(), headers);
+      }
+      else {
+        // First request or invalid offset: return tail
+        auto tail = read_file_tail(log_path, MAX_RESPONSE_SIZE);
+        headers.emplace("X-Log-Range", "full");
+        response->write(SimpleWeb::StatusCode::success_ok, tail ? *tail : std::string(), headers);
+      }
     }
   }
 

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -498,8 +498,7 @@ namespace confighttp {
   }
 
   /**
-   * @brief Snapshot of the log cache state.
-   * All fields are immutable once constructed; swapped atomically via shared_ptr.
+   * @brief Snapshot of log cache state, swapped atomically via shared_ptr.
    */
   struct LogCacheSnapshot {
     std::shared_ptr<const std::string> content;  ///< Cached log content (nullptr in offset-only mode)
@@ -530,26 +529,6 @@ namespace confighttp {
       return nullptr;
     }
     return std::make_shared<const std::string>(*old_content + tail);
-  }
-
-  /**
-   * @brief Read the last max_bytes of a file directly from disk.
-   */
-  static std::shared_ptr<const std::string>
-  read_file_tail(const std::filesystem::path &path, std::uintmax_t max_bytes) {
-    std::ifstream in(path.string(), std::ios::binary);
-    if (!in) {
-      return nullptr;
-    }
-    in.seekg(0, std::ios::end);
-    auto file_size = static_cast<std::uintmax_t>(in.tellg());
-    auto read_size = std::min(file_size, max_bytes);
-    in.seekg(-static_cast<std::streamoff>(read_size), std::ios::end);
-    std::string content(static_cast<std::size_t>(read_size), '\0');
-    if (!in.read(content.data(), static_cast<std::streamsize>(read_size))) {
-      return nullptr;
-    }
-    return std::make_shared<const std::string>(std::move(content));
   }
 
   /**
@@ -605,22 +584,17 @@ namespace confighttp {
       SimpleWeb::CaseInsensitiveMultimap headers;
       headers.emplace("Content-Type", "text/plain; charset=utf-8");
       headers.emplace("Content-Disposition", "attachment; filename=\"sunshine.log\"");
-      // Omit Content-Length: log file is actively written, so size may change
-      // between file_size() and the end of the stream (TOCTOU). Letting the
-      // server use chunked transfer encoding avoids truncation or hang.
+      // Omit Content-Length: log file is actively written (TOCTOU risk)
       response->write(SimpleWeb::StatusCode::success_ok, in, headers);
       return;
     }
 
     // --- Mode 2: X-Log-Offset present → cached or offset-only mode for live viewer ---
 
-    // When file ≤ MAX_LOG_CACHE_SIZE: entire file cached in memory (cached mode).
-    // When file > MAX_LOG_CACHE_SIZE: no content in memory, reads go to disk (offset-only mode).
-    // MAX_RESPONSE_SIZE caps a single response to avoid large allocations.
+    // When file ≤ MAX_LOG_CACHE_SIZE: cached in memory.  Otherwise: disk reads only.
     static constexpr std::uintmax_t MAX_LOG_CACHE_SIZE = 4 * 1024 * 1024;   // 4 MB
     static constexpr std::uintmax_t MAX_RESPONSE_SIZE  = 4 * 1024 * 1024;   // 4 MB
 
-    // Single atomic snapshot ensures all cache fields are consistent across threads.
     static std::atomic<std::shared_ptr<const LogCacheSnapshot>> log_cache;
 
     // Check file status
@@ -652,7 +626,10 @@ namespace confighttp {
           new_content = try_incremental_log_read(log_path, snapshot->file_size, current_size, snapshot->content);
         }
         if (!new_content) {
-          new_content = read_file_tail(log_path, MAX_LOG_CACHE_SIZE);
+          // Use sampled current_size to avoid TOCTOU unsigned underflow at start_offset
+          auto read_len = std::min(current_size, MAX_LOG_CACHE_SIZE);
+          auto read_start = current_size - read_len;
+          new_content = read_file_range(log_path, read_start, read_len);
         }
         if (!new_content) {
           new_content = std::make_shared<const std::string>();
@@ -670,8 +647,13 @@ namespace confighttp {
         new_snap->start_offset = 0;
       }
 
-      log_cache.store(new_snap);
-      snapshot = std::move(new_snap);
+      // CAS publish: avoid overwriting a newer snapshot from a concurrent thread
+      if (!log_cache.compare_exchange_strong(snapshot, new_snap)) {
+        // CAS failed: snapshot already updated by compare_exchange_strong
+      }
+      else {
+        snapshot = std::move(new_snap);
+      }
     }
 
     // Parse client offset
@@ -717,11 +699,10 @@ namespace confighttp {
       }
     }
     else {
-      // === Offset-only mode: read directly from disk ===
+      // === Offset-only mode: read from disk, bounded by snapshot->file_size ===
       if (client_offset > 0 && client_offset < snapshot->file_size) {
         auto delta_size = snapshot->file_size - client_offset;
         if (delta_size <= MAX_RESPONSE_SIZE) {
-          // Delta fits in one response: read from client_offset to end of file
           auto data = read_file_range(log_path, client_offset, delta_size);
           if (data) {
             headers.emplace("X-Log-Range", "incremental");
@@ -729,25 +710,17 @@ namespace confighttp {
             return;
           }
         }
-        // Delta too large or read failed: return last MAX_RESPONSE_SIZE bytes
-        auto tail = read_file_tail(log_path, MAX_RESPONSE_SIZE);
-        if (!tail) {
-          response->write(SimpleWeb::StatusCode::server_error_internal_server_error, "Failed to read log file");
-          return;
-        }
-        headers.emplace("X-Log-Range", "full");
-        response->write(SimpleWeb::StatusCode::success_ok, *tail, headers);
       }
-      else {
-        // First request or invalid offset: return tail
-        auto tail = read_file_tail(log_path, MAX_RESPONSE_SIZE);
-        if (!tail) {
-          response->write(SimpleWeb::StatusCode::server_error_internal_server_error, "Failed to read log file");
-          return;
-        }
-        headers.emplace("X-Log-Range", "full");
-        response->write(SimpleWeb::StatusCode::success_ok, *tail, headers);
+      // Delta too large, read failed, or first request: return tail up to snapshot->file_size
+      auto tail_len = std::min(snapshot->file_size, MAX_RESPONSE_SIZE);
+      auto tail_start = snapshot->file_size - tail_len;
+      auto tail = read_file_range(log_path, tail_start, tail_len);
+      if (!tail) {
+        response->write(SimpleWeb::StatusCode::server_error_internal_server_error, "Failed to read log file");
+        return;
       }
+      headers.emplace("X-Log-Range", "full");
+      response->write(SimpleWeb::StatusCode::success_ok, *tail, headers);
     }
   }
 

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -597,12 +597,6 @@ namespace confighttp {
     // --- Mode 1: No X-Log-Offset header → stream full file from disk (download) ---
     auto offset_it = request->header.find("X-Log-Offset");
     if (offset_it == request->header.end()) {
-      std::error_code ec;
-      auto fsize = std::filesystem::file_size(log_path, ec);
-      if (ec) {
-        response->write(SimpleWeb::StatusCode::server_error_internal_server_error, "Failed to read log file");
-        return;
-      }
       std::ifstream in(log_path.string(), std::ios::binary);
       if (!in.is_open()) {
         response->write(SimpleWeb::StatusCode::server_error_internal_server_error, "Failed to open log file");
@@ -611,7 +605,9 @@ namespace confighttp {
       SimpleWeb::CaseInsensitiveMultimap headers;
       headers.emplace("Content-Type", "text/plain; charset=utf-8");
       headers.emplace("Content-Disposition", "attachment; filename=\"sunshine.log\"");
-      headers.emplace("Content-Length", std::to_string(fsize));
+      // Omit Content-Length: log file is actively written, so size may change
+      // between file_size() and the end of the stream (TOCTOU). Letting the
+      // server use chunked transfer encoding avoids truncation or hang.
       response->write(SimpleWeb::StatusCode::success_ok, in, headers);
       return;
     }
@@ -735,14 +731,22 @@ namespace confighttp {
         }
         // Delta too large or read failed: return last MAX_RESPONSE_SIZE bytes
         auto tail = read_file_tail(log_path, MAX_RESPONSE_SIZE);
+        if (!tail) {
+          response->write(SimpleWeb::StatusCode::server_error_internal_server_error, "Failed to read log file");
+          return;
+        }
         headers.emplace("X-Log-Range", "full");
-        response->write(SimpleWeb::StatusCode::success_ok, tail ? *tail : std::string(), headers);
+        response->write(SimpleWeb::StatusCode::success_ok, *tail, headers);
       }
       else {
         // First request or invalid offset: return tail
         auto tail = read_file_tail(log_path, MAX_RESPONSE_SIZE);
+        if (!tail) {
+          response->write(SimpleWeb::StatusCode::server_error_internal_server_error, "Failed to read log file");
+          return;
+        }
         headers.emplace("X-Log-Range", "full");
-        response->write(SimpleWeb::StatusCode::success_ok, tail ? *tail : std::string(), headers);
+        response->write(SimpleWeb::StatusCode::success_ok, *tail, headers);
       }
     }
   }

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -632,11 +632,11 @@ namespace confighttp {
           new_content = read_file_range(log_path, read_start, read_len);
         }
         if (!new_content) {
+          if (current_size > 0) {
+            response->write(SimpleWeb::StatusCode::server_error_internal_server_error, "Failed to read log file");
+            return;
+          }
           new_content = std::make_shared<const std::string>();
-        }
-        if (new_content->empty() && !std::filesystem::exists(log_path, ec)) {
-          response->write(SimpleWeb::StatusCode::server_error_internal_server_error, "Log file not available");
-          return;
         }
         new_snap->content = std::move(new_content);
         new_snap->start_offset = current_size - new_snap->content->size();

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -3318,6 +3318,7 @@ namespace video {
         auto lg = ref->display_wp.lock();
         if (ref->display_wp->expired()) {
           BOOST_LOG(verbose) << "[Display] Display object expired, waiting for reinit...";
+          std::this_thread::sleep_for(20ms);
           continue;
         }
         display = ref->display_wp->lock();

--- a/src_assets/common/assets/web/components/LogsSection.vue
+++ b/src_assets/common/assets/web/components/LogsSection.vue
@@ -126,35 +126,43 @@ const ignoreCaseModel = computed({
 const downloadLogs = async () => {
   const timestamp = new Date().toISOString().slice(0, 19).replace(/[:.]/g, '-')
   const filename = `sunshine-logs-${timestamp}.txt`
-  const content = props.actualLogs
 
-  // Tauri WebView2: use Rust save_text_file command (dialog + fs write)
-  if (window.__TAURI_INTERNALS__) {
-    try {
-      await window.__TAURI_INTERNALS__.invoke('save_text_file', {
-        content,
-        defaultName: filename,
-        filterName: 'Text Files',
-        extensions: ['txt'],
-      })
-      return
-    } catch (e) {
-      if (e === 'cancelled') return
-      console.warn('Tauri save_text_file failed, falling back:', e)
+  try {
+    // Fetch full log file from server (no X-Log-Offset header = full file download)
+    const response = await fetch('/api/logs')
+    if (!response.ok) throw new Error(`HTTP ${response.status}`)
+    const content = await response.text()
+
+    // Tauri WebView2: use Rust save_text_file command (dialog + fs write)
+    if (window.__TAURI_INTERNALS__) {
+      try {
+        await window.__TAURI_INTERNALS__.invoke('save_text_file', {
+          content,
+          defaultName: filename,
+          filterName: 'Text Files',
+          extensions: ['txt'],
+        })
+        return
+      } catch (e) {
+        if (e === 'cancelled') return
+        console.warn('Tauri save_text_file failed, falling back:', e)
+      }
     }
-  }
 
-  // Standard browser download
-  const blob = new Blob([content], { type: 'text/plain;charset=utf-8' })
-  const url = URL.createObjectURL(blob)
-  const link = Object.assign(document.createElement('a'), {
-    href: url,
-    download: filename,
-  })
-  document.body.appendChild(link)
-  link.click()
-  document.body.removeChild(link)
-  setTimeout(() => URL.revokeObjectURL(url), 3000)
+    // Standard browser download
+    const blob = new Blob([content], { type: 'text/plain;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    const link = Object.assign(document.createElement('a'), {
+      href: url,
+      download: filename,
+    })
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+    setTimeout(() => URL.revokeObjectURL(url), 3000)
+  } catch (e) {
+    console.error('Failed to download logs:', e)
+  }
 }
 </script>
 

--- a/src_assets/common/assets/web/components/LogsSection.vue
+++ b/src_assets/common/assets/web/components/LogsSection.vue
@@ -127,39 +127,36 @@ const downloadLogs = async () => {
   const timestamp = new Date().toISOString().slice(0, 19).replace(/[:.]/g, '-')
   const filename = `sunshine-logs-${timestamp}.txt`
 
-  try {
-    // Fetch full log file from server (no X-Log-Offset header = full file download)
-    const response = await fetch('/api/logs')
-    if (!response.ok) throw new Error(`HTTP ${response.status}`)
-    const content = await response.text()
-
-    // Tauri WebView2: use Rust save_text_file command (dialog + fs write)
-    if (window.__TAURI_INTERNALS__) {
-      try {
-        await window.__TAURI_INTERNALS__.invoke('save_text_file', {
-          content,
-          defaultName: filename,
-          filterName: 'Text Files',
-          extensions: ['txt'],
-        })
-        return
-      } catch (e) {
-        if (e === 'cancelled') return
-        console.warn('Tauri save_text_file failed, falling back:', e)
-      }
+  // Tauri WebView2: fetch into memory then use Rust save_text_file command (dialog + fs write)
+  if (window.__TAURI_INTERNALS__) {
+    try {
+      const response = await fetch('/api/logs')
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
+      const content = await response.text()
+      await window.__TAURI_INTERNALS__.invoke('save_text_file', {
+        content,
+        defaultName: filename,
+        filterName: 'Text Files',
+        extensions: ['txt'],
+      })
+      return
+    } catch (e) {
+      if (e === 'cancelled') return
+      console.warn('Tauri save_text_file failed, falling back:', e)
     }
+  }
 
-    // Standard browser download
-    const blob = new Blob([content], { type: 'text/plain;charset=utf-8' })
-    const url = URL.createObjectURL(blob)
+  // Standard browser: let browser download directly via <a> link
+  // Server returns Content-Disposition: attachment, so the browser handles
+  // the download natively without buffering the entire file in JS memory.
+  try {
     const link = Object.assign(document.createElement('a'), {
-      href: url,
+      href: '/api/logs',
       download: filename,
     })
     document.body.appendChild(link)
     link.click()
     document.body.removeChild(link)
-    setTimeout(() => URL.revokeObjectURL(url), 3000)
   } catch (e) {
     console.error('Failed to download logs:', e)
   }

--- a/src_assets/common/assets/web/composables/useLogs.js
+++ b/src_assets/common/assets/web/composables/useLogs.js
@@ -27,7 +27,8 @@ export function useLogs() {
 
   const fetchLogs = async () => {
     try {
-      const response = await fetch('/api/logs')
+      // Use X-Log-Offset: 0 to get cached tail (not full file download)
+      const response = await fetch('/api/logs', { headers: { 'X-Log-Offset': '0' } })
       if (response.ok) {
         logs.value = await response.text()
         return true

--- a/src_assets/common/assets/web/composables/useTroubleshooting.js
+++ b/src_assets/common/assets/web/composables/useTroubleshooting.js
@@ -2,6 +2,7 @@ import { ref, computed, onUnmounted } from 'vue'
 
 const LOG_REFRESH_INTERVAL = 5000
 const STATUS_RESET_DELAY = 5000
+const MAX_LOG_DISPLAY_SIZE = 4 * 1024 * 1024 // 4 MB cap for in-memory log string
 
 /**
  * Creates a delayed status reset helper
@@ -90,7 +91,8 @@ export function useTroubleshooting() {
   const refreshLogs = async () => {
     try {
       const offset = Number(logOffset.value)
-      const headers = (!Number.isNaN(offset) && offset > 0) ? { 'X-Log-Offset': String(offset) } : {}
+      // Always send X-Log-Offset to use cached tail mode (without it, server returns full file for download)
+      const headers = { 'X-Log-Offset': String(Number.isNaN(offset) ? 0 : offset) }
       const response = await fetch('/api/logs', { headers })
 
       if (response.status === 304) {
@@ -114,6 +116,10 @@ export function useTroubleshooting() {
         logs.value += text
       } else {
         logs.value = text
+      }
+      // Cap in-memory log string to prevent unbounded frontend memory growth
+      if (logs.value.length > MAX_LOG_DISPLAY_SIZE) {
+        logs.value = logs.value.slice(-MAX_LOG_DISPLAY_SIZE)
       }
 
       logOffset.value = newSize


### PR DESCRIPTION
## 各场景与新设计的交互（偏移量模式）

|场景 | 文件 ≤ 4MB（缓存模式） | 文件 > 4MB(偏移量模式) |
| :--- | :---: | ---: |
|1 下载 | 不走缓存，直接流式读取 | 不走缓存，直接流式读取 |
|2 轮询 | 从内存缓存返回增量 | 从磁盘按 offset 读增量 |
|3 Fatal 检测 | offset=0 → 返回完整缓存 | offset=0 → read_file_tail 读最后 4MB |
|4 AI 诊断 | 同 3  | 同 3 |

