### PR TITLE
fix(display): handle headless and QDC_VIRTUAL_MODE_AWARE fallback in QueryDisplayConfig

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -563,6 +563,7 @@ namespace config {
     {},  // Bind address
     platf::appdata().string() + "/sunshine.log",  // log file
     false,  // restore_log - 默认不恢复日志文件
+    50,  // max_log_size_mb - 默认50MB，超过自动轮转
     false,  // notify_pre_releases
     true,  // system_tray
     {},  // prep commands
@@ -1390,6 +1391,10 @@ namespace config {
     }
 
     bool_f(vars, "restore_log"s, sunshine.restore_log);
+    int_f(vars, "max_log_size_mb"s, sunshine.max_log_size_mb);
+    if (sunshine.max_log_size_mb < 0) {
+      sunshine.max_log_size_mb = 0;
+    }
 
     // Webhook configuration
     bool_f(vars, "webhook_enabled"s, webhook.enabled);

--- a/src/config.h
+++ b/src/config.h
@@ -246,6 +246,7 @@ namespace config {
 
     std::string log_file;
     bool restore_log;  // 是否恢复日志文件（true=恢复，false=覆盖）
+    int max_log_size_mb;  // 日志文件最大大小（MB），超过后自动轮转，0=不限制
     bool notify_pre_releases;
     bool system_tray;
     std::vector<prep_cmd_t> prep_cmds;

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -186,7 +186,7 @@ namespace logging {
    */
   [[nodiscard]] std::unique_ptr<deinit_t>
   init(int min_log_level, const std::string &log_file, bool restore_log) {
-    if (console_sink || file_sink_ptr) {
+    if (console_sink || file_sink_ptr || file_ostream_sink) {
       // Deinitialize the logging system before reinitializing it. This can probably only ever be hit in tests.
       deinit();
     }

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -217,6 +217,12 @@ namespace logging {
     const auto log_filename = fs::path(log_file).filename().string();
 
     if (max_log_size_mb > 0) {
+      // When restore_log is false, truncate the existing log file before starting rotation
+      if (!config::sunshine.restore_log && fs::exists(log_file)) {
+        std::error_code ec;
+        fs::remove(log_file, ec);
+      }
+
       // Use text_file_backend with automatic size-based rotation
       auto file_backend = boost::make_shared<bl::sinks::text_file_backend>(
         bl::keywords::file_name = log_file,

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -16,8 +16,10 @@
 #include <boost/log/common.hpp>
 #include <boost/log/expressions.hpp>
 #include <boost/log/sinks.hpp>
+#include <boost/log/sinks/text_file_backend.hpp>
 #include <boost/log/sources/severity_logger.hpp>
 #include <boost/log/utility/exception_handler.hpp>
+#include <boost/log/utility/setup/file.hpp>
 
 // local includes
 #include "logging.h"
@@ -30,7 +32,9 @@ using namespace std::literals;
 
 namespace bl = boost::log;
 
-boost::shared_ptr<boost::log::sinks::asynchronous_sink<boost::log::sinks::text_ostream_backend>> sink;
+boost::shared_ptr<boost::log::sinks::asynchronous_sink<boost::log::sinks::text_ostream_backend>> console_sink;
+boost::shared_ptr<boost::log::sinks::synchronous_sink<boost::log::sinks::text_file_backend>> file_sink_ptr;
+boost::shared_ptr<boost::log::sinks::asynchronous_sink<boost::log::sinks::text_ostream_backend>> file_ostream_sink;
 
 bl::sources::severity_logger<int> verbose(0);  // Dominating output
 bl::sources::severity_logger<int> debug(1);  // Follow what is happening
@@ -52,8 +56,18 @@ namespace logging {
   void
   deinit() {
     log_flush();
-    bl::core::get()->remove_sink(sink);
-    sink.reset();
+    if (console_sink) {
+      bl::core::get()->remove_sink(console_sink);
+      console_sink.reset();
+    }
+    if (file_sink_ptr) {
+      bl::core::get()->remove_sink(file_sink_ptr);
+      file_sink_ptr.reset();
+    }
+    if (file_ostream_sink) {
+      bl::core::get()->remove_sink(file_ostream_sink);
+      file_ostream_sink.reset();
+    }
   }
 
   /**
@@ -172,40 +186,72 @@ namespace logging {
    */
   [[nodiscard]] std::unique_ptr<deinit_t>
   init(int min_log_level, const std::string &log_file, bool restore_log) {
-    if (sink) {
+    if (console_sink || file_sink_ptr) {
       // Deinitialize the logging system before reinitializing it. This can probably only ever be hit in tests.
       deinit();
     }
 
     setup_av_logging(min_log_level);
 
-    sink = boost::make_shared<text_sink>();
-
+    // Console sink (async, stdout)
 #ifndef SUNSHINE_TESTS
+    console_sink = boost::make_shared<text_sink>();
     boost::shared_ptr<std::ostream> stream { &std::cout, boost::null_deleter() };
-    sink->locked_backend()->add_stream(stream);
+    console_sink->locked_backend()->add_stream(stream);
+    console_sink->locked_backend()->auto_flush(true);
+    console_sink->set_filter(severity >= min_log_level);
+    console_sink->set_formatter(&formatter);
+    console_sink->set_exception_handler(bl::make_exception_suppressor());
+    bl::core::get()->add_sink(console_sink);
 #endif
-    
+
     // 转写现有日志文件
     if (config::sunshine.restore_log) {
       archive_existing_log(log_file);
     }
 
-    std::ios_base::openmode mode = std::ios_base::out;
-    sink->locked_backend()->add_stream(boost::make_shared<std::ofstream>(log_file, mode));
-    sink->set_filter(severity >= min_log_level);
-    sink->set_formatter(&formatter);
+    // File sink with rotation support
+    namespace fs = std::filesystem;
+    const auto max_log_size_mb = config::sunshine.max_log_size_mb;
+    const auto log_dir = fs::path(log_file).parent_path();
+    const auto log_filename = fs::path(log_file).filename().string();
 
-    // Prevent the async sink's background thread from dying on backend exceptions.
-    // Without this, a single I/O error (disk full, file locked, broken stdout, etc.)
-    // kills the thread and all subsequent log records are silently lost.
-    sink->set_exception_handler(bl::make_exception_suppressor());
+    if (max_log_size_mb > 0) {
+      // Use text_file_backend with automatic size-based rotation
+      auto file_backend = boost::make_shared<bl::sinks::text_file_backend>(
+        bl::keywords::file_name = log_file,
+        bl::keywords::rotation_size = static_cast<uintmax_t>(max_log_size_mb) * 1024 * 1024,
+        bl::keywords::open_mode = std::ios_base::out | std::ios_base::app
+      );
 
-    // Flush after each log record to ensure log file contents on disk isn't stale.
-    // This is particularly important when running from a Windows service.
-    sink->locked_backend()->auto_flush(true);
+      // Set up file collector to manage rotated log files
+      file_backend->set_file_collector(bl::sinks::file::make_collector(
+        bl::keywords::target = (log_dir / "logs_archive").string(),
+        bl::keywords::max_size = static_cast<uintmax_t>(max_log_size_mb) * 1024 * 1024 * 5,  // Keep up to 5x max_size total
+        bl::keywords::max_files = 10
+      ));
 
-    bl::core::get()->add_sink(sink);
+      file_backend->auto_flush(true);
+      // Scan for any previously rotated files to properly manage the archive
+      file_backend->scan_for_files();
+
+      file_sink_ptr = boost::make_shared<file_sink>(file_backend);
+      file_sink_ptr->set_filter(severity >= min_log_level);
+      file_sink_ptr->set_formatter(&formatter);
+      file_sink_ptr->set_exception_handler(bl::make_exception_suppressor());
+      bl::core::get()->add_sink(file_sink_ptr);
+    }
+    else {
+      // No rotation: use simple text_ostream_backend (original behavior)
+      file_ostream_sink = boost::make_shared<text_sink>();
+      file_ostream_sink->locked_backend()->add_stream(boost::make_shared<std::ofstream>(log_file, std::ios_base::out));
+      file_ostream_sink->locked_backend()->auto_flush(true);
+      file_ostream_sink->set_filter(severity >= min_log_level);
+      file_ostream_sink->set_formatter(&formatter);
+      file_ostream_sink->set_exception_handler(bl::make_exception_suppressor());
+      bl::core::get()->add_sink(file_ostream_sink);
+    }
+
     return std::make_unique<deinit_t>();
   }
 
@@ -245,8 +291,14 @@ namespace logging {
 
   void
   log_flush() {
-    if (sink) {
-      sink->flush();
+    if (console_sink) {
+      console_sink->flush();
+    }
+    if (file_sink_ptr) {
+      file_sink_ptr->flush();
+    }
+    if (file_ostream_sink) {
+      file_ostream_sink->flush();
     }
   }
 

--- a/src/logging.h
+++ b/src/logging.h
@@ -7,8 +7,10 @@
 // lib includes
 #include <boost/log/common.hpp>
 #include <boost/log/sinks.hpp>
+#include <boost/log/sinks/text_file_backend.hpp>
 
 using text_sink = boost::log::sinks::asynchronous_sink<boost::log::sinks::text_ostream_backend>;
+using file_sink = boost::log::sinks::synchronous_sink<boost::log::sinks::text_file_backend>;
 
 extern boost::log::sources::severity_logger<int> verbose;
 extern boost::log::sources::severity_logger<int> debug;

--- a/src/platform/windows/display_device/windows_utils.cpp
+++ b/src/platform/windows/display_device/windows_utils.cpp
@@ -637,43 +637,61 @@ namespace display_device::w_utils {
 
   boost::optional<path_and_mode_data_t>
   query_display_config(bool active_only) {
-    std::vector<DISPLAYCONFIG_PATH_INFO> paths;
-    std::vector<DISPLAYCONFIG_MODE_INFO> modes;
-    LONG result = ERROR_SUCCESS;
-
     // When we want to enable/disable displays, we need to get all paths as they will not be active.
     // This will require some additional filtering of duplicate and otherwise useless paths.
-    UINT32 flags = active_only ? QDC_ONLY_ACTIVE_PATHS : QDC_ALL_PATHS;
-    flags |= QDC_VIRTUAL_MODE_AWARE;  // supported from W10 onwards
+    UINT32 base_flags = active_only ? QDC_ONLY_ACTIVE_PATHS : QDC_ALL_PATHS;
 
-    do {
-      UINT32 path_count { 0 };
-      UINT32 mode_count { 0 };
+    // Try with QDC_VIRTUAL_MODE_AWARE first (supported from W10), then fallback without it.
+    for (bool virtual_mode_aware : { true, false }) {
+      UINT32 flags = base_flags | (virtual_mode_aware ? QDC_VIRTUAL_MODE_AWARE : 0);
 
-      result = GetDisplayConfigBufferSizes(flags, &path_count, &mode_count);
-      if (result != ERROR_SUCCESS) {
-        BOOST_LOG(error) << get_error_string(result) << " failed to get display paths and modes!";
-        return boost::none;
+      std::vector<DISPLAYCONFIG_PATH_INFO> paths;
+      std::vector<DISPLAYCONFIG_MODE_INFO> modes;
+      LONG result = ERROR_SUCCESS;
+
+      do {
+        UINT32 path_count { 0 };
+        UINT32 mode_count { 0 };
+
+        result = GetDisplayConfigBufferSizes(flags, &path_count, &mode_count);
+        if (result != ERROR_SUCCESS) {
+          BOOST_LOG(error) << get_error_string(result) << " failed to get display paths and modes!";
+          return boost::none;
+        }
+
+        // No display paths exist (e.g. headless machine before VDD creation).
+        // Return empty data instead of calling QueryDisplayConfig with 0-sized buffers.
+        if (path_count == 0 && mode_count == 0) {
+          return path_and_mode_data_t { {}, {} };
+        }
+
+        paths.resize(path_count);
+        modes.resize(mode_count);
+        result = QueryDisplayConfig(flags, &path_count, paths.data(), &mode_count, modes.data(), nullptr);
+
+        // The function may have returned fewer paths/modes than estimated
+        paths.resize(path_count);
+        modes.resize(mode_count);
+
+        // It's possible that between the call to GetDisplayConfigBufferSizes and QueryDisplayConfig
+        // that the display state changed, so loop on the case of ERROR_INSUFFICIENT_BUFFER.
+      } while (result == ERROR_INSUFFICIENT_BUFFER);
+
+      if (result == ERROR_SUCCESS) {
+        return path_and_mode_data_t { paths, modes };
       }
 
-      paths.resize(path_count);
-      modes.resize(mode_count);
-      result = QueryDisplayConfig(flags, &path_count, paths.data(), &mode_count, modes.data(), nullptr);
+      if (virtual_mode_aware) {
+        BOOST_LOG(warning) << get_error_string(result) << " QueryDisplayConfig failed with QDC_VIRTUAL_MODE_AWARE, retrying without...";
+        continue;
+      }
 
-      // The function may have returned fewer paths/modes than estimated
-      paths.resize(path_count);
-      modes.resize(mode_count);
-
-      // It's possible that between the call to GetDisplayConfigBufferSizes and QueryDisplayConfig
-      // that the display state changed, so loop on the case of ERROR_INSUFFICIENT_BUFFER.
-    } while (result == ERROR_INSUFFICIENT_BUFFER);
-
-    if (result != ERROR_SUCCESS) {
       BOOST_LOG(error) << get_error_string(result) << " failed to query display paths and modes!";
       return boost::none;
     }
 
-    return path_and_mode_data_t { paths, modes };
+    // Unreachable, but satisfy the compiler
+    return boost::none;
   }
 
   const DISPLAYCONFIG_PATH_INFO *

--- a/src/platform/windows/display_device/windows_utils.cpp
+++ b/src/platform/windows/display_device/windows_utils.cpp
@@ -642,7 +642,6 @@ namespace display_device::w_utils {
     UINT32 base_flags = active_only ? QDC_ONLY_ACTIVE_PATHS : QDC_ALL_PATHS;
 
     // Try with QDC_VIRTUAL_MODE_AWARE first (supported from W10), then fallback without it.
-    LONG last_error = ERROR_SUCCESS;
     for (bool virtual_mode_aware : { true, false }) {
       UINT32 flags = base_flags | (virtual_mode_aware ? QDC_VIRTUAL_MODE_AWARE : 0);
 
@@ -681,10 +680,8 @@ namespace display_device::w_utils {
       } while (result == ERROR_INSUFFICIENT_BUFFER);
 
       if (result == ERROR_SUCCESS) {
-        return path_and_mode_data_t { paths, modes };
+        return path_and_mode_data_t { std::move(paths), std::move(modes) };
       }
-
-      last_error = result;
 
       if (virtual_mode_aware) {
         BOOST_LOG(warning) << get_error_string(result) << " failed to query display paths and modes with QDC_VIRTUAL_MODE_AWARE, retrying without...";
@@ -695,9 +692,7 @@ namespace display_device::w_utils {
       return boost::none;
     }
 
-    // Both attempts failed (only reachable if GetDisplayConfigBufferSizes failed on fallback too)
-    BOOST_LOG(error) << get_error_string(last_error) << " failed to query display paths and modes (all attempts exhausted)!";
-    return boost::none;
+    return boost::none;  // unreachable: loop always returns in both iterations
   }
 
   const DISPLAYCONFIG_PATH_INFO *

--- a/src/platform/windows/display_device/windows_utils.cpp
+++ b/src/platform/windows/display_device/windows_utils.cpp
@@ -642,6 +642,7 @@ namespace display_device::w_utils {
     UINT32 base_flags = active_only ? QDC_ONLY_ACTIVE_PATHS : QDC_ALL_PATHS;
 
     // Try with QDC_VIRTUAL_MODE_AWARE first (supported from W10), then fallback without it.
+    LONG last_error = ERROR_SUCCESS;
     for (bool virtual_mode_aware : { true, false }) {
       UINT32 flags = base_flags | (virtual_mode_aware ? QDC_VIRTUAL_MODE_AWARE : 0);
 
@@ -655,8 +656,10 @@ namespace display_device::w_utils {
 
         result = GetDisplayConfigBufferSizes(flags, &path_count, &mode_count);
         if (result != ERROR_SUCCESS) {
-          BOOST_LOG(error) << get_error_string(result) << " failed to get display paths and modes!";
-          return boost::none;
+          BOOST_LOG(virtual_mode_aware ? warning : error)
+            << get_error_string(result) << " GetDisplayConfigBufferSizes failed"
+            << (virtual_mode_aware ? " (with QDC_VIRTUAL_MODE_AWARE)" : "") << "!";
+          break;
         }
 
         // No display paths exist (e.g. headless machine before VDD creation).
@@ -681,8 +684,10 @@ namespace display_device::w_utils {
         return path_and_mode_data_t { paths, modes };
       }
 
+      last_error = result;
+
       if (virtual_mode_aware) {
-        BOOST_LOG(warning) << get_error_string(result) << " QueryDisplayConfig failed with QDC_VIRTUAL_MODE_AWARE, retrying without...";
+        BOOST_LOG(warning) << get_error_string(result) << " failed to query display paths and modes with QDC_VIRTUAL_MODE_AWARE, retrying without...";
         continue;
       }
 
@@ -690,7 +695,8 @@ namespace display_device::w_utils {
       return boost::none;
     }
 
-    // Unreachable, but satisfy the compiler
+    // Both attempts failed (only reachable if GetDisplayConfigBufferSizes failed on fallback too)
+    BOOST_LOG(error) << get_error_string(last_error) << " failed to query display paths and modes (all attempts exhausted)!";
     return boost::none;
   }
 
@@ -756,6 +762,12 @@ namespace display_device::w_utils {
     auto display_data { query_display_config(w_utils::ACTIVE_ONLY_DEVICES) };
     if (!display_data) {
       BOOST_LOG(debug) << "test_no_access_to_ccd_api failed in query_display_config.";
+      return true;
+    }
+
+    // No active displays (e.g. headless machine) - can't test CCD access without paths
+    if (display_data->paths.empty()) {
+      BOOST_LOG(debug) << "test_no_access_to_ccd_api: no active display paths, assuming no access.";
       return true;
     }
 


### PR DESCRIPTION
## 问题

在无头主机（headless，无物理显示器）上，`QueryDisplayConfig` 始终返回 `ERROR_INVALID_PARAMETER`，导致：
- 无法枚举任何显示设备
- VDD 虚拟显示器创建后也无法被发现
- 所有编码器初始化失败，串流完全不可用

## 原因分析

1. `GetDisplayConfigBufferSizes` 在无显示器时返回 `path_count=0, mode_count=0`
2. 将空缓冲区传给 `QueryDisplayConfig` 会得到 `ERROR_INVALID_PARAMETER`
3. 此错误被当作 API 调用失败（返回 `boost::none`），而非"无显示器"的正常状态

## 修复

- 当 `GetDisplayConfigBufferSizes` 返回 0 paths/modes 时，直接返回空数据而非调用 `QueryDisplayConfig`
- 添加 `QDC_VIRTUAL_MODE_AWARE` 标志的降级重试：首次带该标志查询失败后，自动去掉标志重试
- 使用循环重构消除了 fallback 逻辑中的代码重复