### PR TITLE
fix(nvenc): derive factory priority key from SDK headers

### DIFF
--- a/src/nvenc/win/impl/nvenc_dynamic_factory_blueprint.h
+++ b/src/nvenc/win/impl/nvenc_dynamic_factory_blueprint.h
@@ -26,6 +26,11 @@ namespace nvenc {
       return std::make_shared<NVENC_FACTORY_CLASS>(dll);
     }
 
+    /// SDK version (major*100 + minor) this factory was compiled against.
+    /// Defined in the corresponding _XXXX.cpp where the SDK headers are included,
+    /// so the value is always derived from the actual SDK headers in use.
+    static const int sdk_version;
+
     std::unique_ptr<nvenc_d3d11>
     create_nvenc_d3d11_native(ID3D11Device *d3d_device) override;
 
@@ -47,6 +52,15 @@ namespace NVENC_NAMESPACE {
   #include NVENC_FACTORY_INCLUDE(dynlink_cuda.h)
   #include NVENC_FACTORY_INCLUDE(nvEncodeAPI.h)
 }  // namespace NVENC_NAMESPACE
+
+// Derive the SDK version automatically from the headers we just included,
+// so the priority key in nvenc_dynamic_factory.cpp can never go out of sync
+// with the actual SDK this factory is built against (e.g. when the `1202`
+// submodule tracks master and bumps from SDK 12.2 to 13.0 to 14.0...).
+namespace nvenc {
+  const int NVENC_FACTORY_CLASS::sdk_version =
+    NVENCAPI_MAJOR_VERSION * 100 + NVENCAPI_MINOR_VERSION;
+}
 
 using namespace nvenc;
 

--- a/src/nvenc/win/nvenc_dynamic_factory.cpp
+++ b/src/nvenc/win/nvenc_dynamic_factory.cpp
@@ -23,10 +23,14 @@ NvEncodeAPIGetMaxSupportedVersion(uint32_t *version);
 namespace {
   using namespace nvenc;
 
-  constexpr std::array factory_priorities = {
-    std::tuple(&nvenc_dynamic_factory_1202::get, 1202),
-    std::tuple(&nvenc_dynamic_factory_1200::get, 1200),
-    std::tuple(&nvenc_dynamic_factory_1100::get, 1100),
+  // Priority key is taken from each factory's compile-time-derived sdk_version
+  // (defined in nvenc_dynamic_factory_blueprint.h via the SDK headers it includes),
+  // so submodules like `1202` can keep tracking master indefinitely without the
+  // priority key ever going stale. Order: highest-versioned factory first.
+  const std::array factory_priorities = {
+    std::tuple(&nvenc_dynamic_factory_1202::get, nvenc_dynamic_factory_1202::sdk_version),
+    std::tuple(&nvenc_dynamic_factory_1200::get, nvenc_dynamic_factory_1200::sdk_version),
+    std::tuple(&nvenc_dynamic_factory_1100::get, nvenc_dynamic_factory_1100::sdk_version),
   };
   constexpr auto min_driver_version = "456.71";
 


### PR DESCRIPTION
## 问题

部分用户反馈在某些 NVIDIA 驱动版本（约 R555 ~ R569，2024-05 至 2025-01）下，Sunshine 的 NVENC 编码器（HEVC / H.264 / AV1）全部不可用，自动回退到软件编码。

## 根因

`src/nvenc/win/nvenc_dynamic_factory.cpp` 中的 `factory_priorities` 表把每个 NVENC factory 的优先级 key 硬编码成了字面量：

```cpp
constexpr std::array factory_priorities = {
  std::tuple(&nvenc_dynamic_factory_1202::get, 1202),
  std::tuple(&nvenc_dynamic_factory_1200::get, 1200),
  std::tuple(&nvenc_dynamic_factory_1100::get, 1100),
};
```

而 `third-party/nvenc-headers/1202` 子模块跟随 `FFmpeg/nv-codec-headers` 的 `master` 分支，目前已经升到 **SDK 13.0**（`NVENCAPI_MAJOR_VERSION = 13`，`NVENCAPI_MINOR_VERSION = 0`），与字面量 `1202` 已完全脱节。

调度逻辑：
```cpp
for (const auto &[factory_init, version] : factory_priorities) {
  if (max_version >= version) return factory_init(dll);  // 命中即返回
}
```

驱动通过 `NvEncodeAPIGetMaxSupportedVersion()` 报告的 `max_version` 行为：

| 驱动 | max_version | 命中 factory | 实际 apiVersion | 结果 |
|---|---|---|---|---|
| R525 (2022) | 1200 | factory_1200 | 12.0 | ✅ |
| **R555 ~ R569** | **1202** | **factory_1202（SDK 13.0!）** | **13.0** | ❌ `NV_ENC_ERR_INVALID_VERSION` |
| R570+ (2025) | 1300 | factory_1202 (SDK 13.0) | 13.0 | ✅ |

R555 ~ R569 区间用户的 `nvEncOpenEncodeSessionEx()` 直接被驱动拒绝 → NVENC probe 失败 → fallback 到软编。

## 修复

让优先级 key **自动从对应 factory 编译时实际包含的 SDK 头文件派生**，永远不会脱节。

1. `nvenc_dynamic_factory_blueprint.h` 中给 factory 类增加：
   ```cpp
   static const int sdk_version;
   ```
   定义在该 TU 中 SDK 头被 `#include` 之后：
   ```cpp
   const int NVENC_FACTORY_CLASS::sdk_version =
     NVENCAPI_MAJOR_VERSION * 100 + NVENCAPI_MINOR_VERSION;
   ```

2. `nvenc_dynamic_factory.cpp` 改用这些自动派生的常量：
   ```cpp
   const std::array factory_priorities = {
     std::tuple(&nvenc_dynamic_factory_1202::get, nvenc_dynamic_factory_1202::sdk_version),
     std::tuple(&nvenc_dynamic_factory_1200::get, nvenc_dynamic_factory_1200::sdk_version),
     std::tuple(&nvenc_dynamic_factory_1100::get, nvenc_dynamic_factory_1100::sdk_version),
   };
   ```

## 修复后的行为

| 驱动 | max_version | 命中 factory | 结果 |
|---|---|---|---|
| R525 ~ R554 | 1200 ~ 1201 | factory_1200 (SDK 12.0) | ✅ |
| **R555 ~ R569** | **1202** | **factory_1200 (SDK 12.0)**（不命中 1300） | **✅ HEVC/H.264/AV1 恢复** |
| R570+ | ≥1300 | factory_1202 (SDK 13.0) | ✅ 全部新特性 |

## 长期收益

- `1202/` 子模块继续跟随 `master` 升级到 SDK 14、15……，**无需任何代码改动**，优先级 key 自动跟进
- 命名虽然历史遗留（`1202` 实际是"追新档"），但语义上不再有 footgun
- 老驱动用户始终走得到匹配的 factory，最大化可用特性

## 测试

- [x] 本地 `ucrt64` 编译通过
- [ ] 待真机验证（需要 R555 ~ R569 区间驱动用户回归）
