### PR TITLE
fix(vite): move multi-page HTML inputs to rolldownOptions.input

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -48,9 +48,9 @@ export default defineConfig({
     outDir: resolve(assetsDstPath),
     emptyOutDir: true,
     chunkSizeWarningLimit: 1000,
-    // 在 Vite 7 中，同时配置 rollupOptions 和 rolldownOptions
-    // rollupOptions 用于 HTML 文件生成，rolldownOptions 用于打包优化
-    rollupOptions: {
+    // Vite 8 使用 rolldown 内核：多入口 HTML 必须放在 rolldownOptions.input
+    // 放到 rollupOptions.input 会被忽略，导致除 index.html 外其它页面 404
+    rolldownOptions: {
       input: {
         apps: resolve(assetsSrcPath, 'apps.html'),
         config: resolve(assetsSrcPath, 'config.html'),
@@ -60,8 +60,6 @@ export default defineConfig({
         troubleshooting: resolve(assetsSrcPath, 'troubleshooting.html'),
         welcome: resolve(assetsSrcPath, 'welcome.html'),
       },
-    },
-    rolldownOptions: {
       output: {
         // 优化chunk命名
         chunkFileNames: 'assets/[name]-[hash].js',


### PR DESCRIPTION
## 问题

升级 vite 到 ^8.0.8 (`a32655c03`) 后，安装的 Sunshine 打开 WebUI 出现以下症状：

- 页面空白
- 浏览器控制台报 `Failed to load resource: net::ERR_RESPONSE_HEADERS_TRUNCATED`
- 直接访问 `/apps`、`/config`、`/pin`、`/troubleshooting` 等页面 404

## 根因

Vite 8 内核已切换到 [Rolldown](https://rolldown.rs/)。多入口 HTML 必须配置在 **`build.rolldownOptions.input`**；放在 `build.rollupOptions.input` 的入口会被静默忽略。

参考 [Vite 官方文档 · Multi-Page App](https://vite.dev/guide/build.html#multi-page-app)：
> During build, all you need to do is to specify multiple `.html` files as entry points:
> ```js
> rolldownOptions: { input: { ... } }
> ```

当前 [vite.config.js](vite.config.js) 仍在使用 `rollupOptions.input` 列出 7 个 HTML 入口。结果只有根目录的 `index.html` 被默认入口处理，其它 6 个 HTML 全部没产出：

```
build/assets/web/
├── assets/
├── images/
└── index.html        ← 只有这一个
```

缺失的页面：`apps.html`、`config.html`、`password.html`、`pin.html`、`troubleshooting.html`、`welcome.html`。

`ERR_RESPONSE_HEADERS_TRUNCATED` 是 Sunshine HTTP server 处理 web 静态资源 404 时的副作用。

## 验证

`vite.dev.config.js` 中的 dev server 配置（同样在 vite 8 升级时改过）已经正确使用 `rolldownOptions.input`，只有 `vite.config.js` 漏改：

```js
// vite.dev.config.js（已正确）
build: {
  rolldownOptions: {
    input: htmlPages.reduce((acc, name) => { ... }, {}),
    ...
  },
}
```

## 修复

把 7 个 HTML 入口从 `rollupOptions.input` 整体挪进 `rolldownOptions.input`，与已有的 output 配置放在一起。`rollupOptions` 块整个移除（vite 8 下没有 fallback 行为）。

```js
rolldownOptions: {
  input: {
    apps: resolve(assetsSrcPath, 'apps.html'),
    config: resolve(assetsSrcPath, 'config.html'),
    index: resolve(assetsSrcPath, 'index.html'),
    password: resolve(assetsSrcPath, 'password.html'),
    pin: resolve(assetsSrcPath, 'pin.html'),
    troubleshooting: resolve(assetsSrcPath, 'troubleshooting.html'),
    welcome: resolve(assetsSrcPath, 'welcome.html'),
  },
  output: { ... },  // 原有 chunk/asset 命名配置
},
```

## 测试

- [x] 配置变更与 [vite.dev.config.js](vite.dev.config.js) 已验证可用的写法保持一致
- [x] 与 [Vite 8 官方多页 App 文档](https://vite.dev/guide/build.html#multi-page-app) 完全对齐
- [ ] 待 CI 构建产物验证 `build/assets/web/` 下出现全部 7 个 HTML

## 影响

- 修复后 WebUI 全部页面恢复可访问
- 修复历史 commit `a32655c03 chore: remove unused cross-env dep, upgrade vite to v8` 漏改的部分
