### PR TITLE
feat(capture): add ZakoVDD direct shared-texture capture backend

### DIFF
--- a/cmake/compile_definitions/windows.cmake
+++ b/cmake/compile_definitions/windows.cmake
@@ -85,6 +85,7 @@ set(PLATFORM_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/platform/windows/display_ram.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/windows/display_wgc.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/windows/display_amd.cpp"
+        "${CMAKE_SOURCE_DIR}/src/platform/windows/display_vdd.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/windows/audio.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/windows/mic_write.cpp"
         "${CMAKE_SOURCE_DIR}/src/platform/windows/display_device/device_hdr_states.cpp"

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -632,6 +632,14 @@ namespace platf::dxgi {
     snapshot(const pull_free_image_cb_t &pull_free_image_cb, std::shared_ptr<platf::img_t> &img_out, std::chrono::milliseconds timeout, bool cursor_visible) override;
     capture_e
     release_snapshot() override;
+
+    // Override HDR queries to use producer-reported metadata from
+    // SharedFrameMetadata, instead of querying DXGI on the virtual output
+    // (which may not propagate the producer's static HDR meta correctly).
+    bool
+    is_hdr() override;
+    bool
+    get_hdr_metadata(SS_HDR_METADATA &metadata) override;
   };
 
 }  // namespace platf::dxgi

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -546,4 +546,92 @@ namespace platf::dxgi {
     release_snapshot() override;
   };
 
+  /**
+   * VDD direct-capture: opens the named D3D11 shared texture exported by
+   * the ZakoVDD driver (SharedFrameExporter). This bypasses DXGI Desktop
+   * Duplication / WGC and works in SYSTEM service context, before user logon,
+   * across session switch, and with full HDR — at the cost of only being able
+   * to capture VDD virtual monitors (not physical displays).
+   */
+  class vdd_capture_t {
+  public:
+    vdd_capture_t();
+    ~vdd_capture_t();
+
+    /**
+     * @brief Open the named shared texture / event / metadata for the given
+     *        VDD monitor index. Must be called from the same D3D11 device
+     *        that will be used for downstream encoding.
+     * @param d3d_device  D3D11 device on the same adapter LUID as VDD's RenderAdapter.
+     * @param monitor_idx VDD-internal monitor index (0..N-1).
+     */
+    int
+    init(ID3D11Device *d3d_device, unsigned int monitor_idx);
+
+    /**
+     * @brief Wait for the next frame (event-driven, no polling).
+     * @param timeout         Maximum time to wait.
+     * @param out             Receives a Texture2D reference holding the new frame.
+     *                        The caller MUST call release_frame() before next_frame()
+     *                        to release the keyed mutex.
+     * @param out_frame_qpc   QPC value at producer-side push (for latency tracing).
+     */
+    capture_e
+    next_frame(std::chrono::milliseconds timeout, ID3D11Texture2D **out, uint64_t &out_frame_qpc);
+
+    /**
+     * @brief Release the current keyed-mutex hold so the producer can write again.
+     */
+    capture_e
+    release_frame();
+
+    /**
+     * @brief Reported producer-side dimensions / format / HDR metadata.
+     */
+    UINT  width()      const { return m_width; }
+    UINT  height()     const { return m_height; }
+    DXGI_FORMAT format() const { return m_format; }
+    bool  is_hdr()     const { return m_is_hdr; }
+    float max_nits()   const { return m_max_nits; }
+    float min_nits()   const { return m_min_nits; }
+    float max_fall()   const { return m_max_fall; }
+
+  private:
+    void close();
+
+    HANDLE m_hMeta = nullptr;
+    void  *m_pMeta = nullptr;
+    HANDLE m_hEvent = nullptr;
+    texture2d_t m_sharedTex;
+    keyed_mutex_t m_keyedMutex;
+    bool m_holdsKey = false;
+
+    UINT m_width = 0;
+    UINT m_height = 0;
+    DXGI_FORMAT m_format = DXGI_FORMAT_UNKNOWN;
+    bool  m_is_hdr = false;
+    float m_max_nits = 0.0f;
+    float m_min_nits = 0.0f;
+    float m_max_fall = 0.0f;
+    UINT64 m_lastFrameCounter = 0;
+  };
+
+  /**
+   * Display backend that consumes frames from the ZakoVDD virtual display
+   * driver via vdd_capture_t. Mirrors display_amd_vram_t / display_wgc_vram_t.
+   */
+  class display_vdd_vram_t: public display_vram_t {
+    vdd_capture_t dup;
+    unsigned int monitor_idx = 0;
+    ID3D11Texture2D *current_frame = nullptr;  // Borrowed ref from dup.next_frame, released in release_snapshot
+
+  public:
+    int
+    init(const ::video::config_t &config, const std::string &display_name);
+    capture_e
+    snapshot(const pull_free_image_cb_t &pull_free_image_cb, std::shared_ptr<platf::img_t> &img_out, std::chrono::milliseconds timeout, bool cursor_visible) override;
+    capture_e
+    release_snapshot() override;
+  };
+
 }  // namespace platf::dxgi

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -623,7 +623,7 @@ namespace platf::dxgi {
   class display_vdd_vram_t: public display_vram_t {
     vdd_capture_t dup;
     unsigned int monitor_idx = 0;
-    ID3D11Texture2D *current_frame = nullptr;  // Borrowed ref from dup.next_frame, released in release_snapshot
+    ID3D11Texture2D *current_frame = nullptr;  // Owned ref from dup.next_frame (via AddRef), released in release_snapshot
 
   public:
     int

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -1099,7 +1099,9 @@ namespace platf {
     // Build list of capture methods to try
     std::vector<std::string> try_types;
 
-    if (config::video.capture.empty()) {
+    const auto capture_backend = config.capture_backend_override.empty() ? config::video.capture : config.capture_backend_override;
+
+    if (capture_backend.empty()) {
       if (is_running_as_system_user) {
         // WGC is not available in service mode
         try_types = { "ddx" };
@@ -1109,13 +1111,13 @@ namespace platf {
         try_types = { "ddx", "wgc" };
       }
     }
-    else if (config::video.capture == "wgc" && is_running_as_system_user) {
+    else if (capture_backend == "wgc" && is_running_as_system_user) {
       // WGC explicitly requested but unavailable in service mode
       BOOST_LOG(warning) << "WGC capture is not available in service mode. Automatically switching to DDX capture."sv;
       try_types = { "ddx" };
     }
     else {
-      try_types = { config::video.capture };
+      try_types = { capture_backend };
     }
 
     for (const auto &type : try_types) {

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -1124,6 +1124,12 @@ namespace platf {
       if (type == "amd" && hwdevice_type == mem_type_e::dxgi) {
         ret = try_init(std::make_shared<dxgi::display_amd_vram_t>());
       }
+      else if (type == "vdd" && hwdevice_type == mem_type_e::dxgi) {
+        // ZakoVDD direct shared-texture capture. Works in SYSTEM context and
+        // before user logon. Only valid when the selected display is a VDD
+        // virtual monitor.
+        ret = try_init(std::make_shared<dxgi::display_vdd_vram_t>());
+      }
       else if (type == "ddx") {
         if (hwdevice_type == mem_type_e::dxgi) {
           ret = try_init(std::make_shared<dxgi::display_ddup_vram_t>());

--- a/src/platform/windows/display_vdd.cpp
+++ b/src/platform/windows/display_vdd.cpp
@@ -19,7 +19,9 @@
 
 #include <d3d11_1.h>
 #include <sddl.h>
+#include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <string>
 #include <thread>
 
@@ -355,6 +357,7 @@ namespace platf::dxgi {
     // Use producer-reported format as our capture format. complete_img() / image
     // pool will be created against this format.
     capture_format = dup.format();
+    capture_linear_gamma = capture_format == DXGI_FORMAT_R16G16B16A16_FLOAT;
 
     // Validate the producer-reported format against the formats display_vram_t
     // can actually consume (RTV creation, shaders, color conversion). Anything
@@ -377,7 +380,8 @@ namespace platf::dxgi {
     BOOST_LOG(info) << "[vdd] backend ready: monitor="sv << monitor_idx
                     << " "sv << dup.width() << "x"sv << dup.height()
                     << " fmt="sv << dxgi_format_to_string(capture_format)
-                    << " hdr="sv << dup.is_hdr();
+                    << " hdr="sv << dup.is_hdr()
+                    << " linear_gamma="sv << capture_linear_gamma;
     return 0;
   }
 
@@ -411,9 +415,16 @@ namespace platf::dxgi {
     //   maxDisplayLuminance      : nits
     //   minDisplayLuminance      : units of 0.0001 nits
     //   maxFullFrameLuminance    : nits
-    metadata.maxDisplayLuminance = static_cast<uint16_t>(dup.max_nits());
-    metadata.minDisplayLuminance = static_cast<uint32_t>(dup.min_nits() * 10000.0f);
-    metadata.maxFullFrameLuminance = static_cast<uint16_t>(dup.max_fall());
+    auto finite_clamped = [](float value, float min_value, float max_value) {
+      if (!std::isfinite(value)) {
+        return min_value;
+      }
+      return std::clamp(value, min_value, max_value);
+    };
+
+    metadata.maxDisplayLuminance = static_cast<uint16_t>(finite_clamped(dup.max_nits(), 0.0f, 65535.0f));
+    metadata.minDisplayLuminance = static_cast<uint32_t>(finite_clamped(dup.min_nits(), 0.0f, 429496.7295f) * 10000.0f);
+    metadata.maxFullFrameLuminance = static_cast<uint16_t>(finite_clamped(dup.max_fall(), 0.0f, 65535.0f));
 
     // Producer doesn't currently track per-frame content light levels.
     metadata.maxContentLightLevel = 0;

--- a/src/platform/windows/display_vdd.cpp
+++ b/src/platform/windows/display_vdd.cpp
@@ -342,11 +342,70 @@ namespace platf::dxgi {
     // Use producer-reported format as our capture format. complete_img() / image
     // pool will be created against this format.
     capture_format = dup.format();
+
+    // Validate the producer-reported format against the formats display_vram_t
+    // can actually consume (RTV creation, shaders, color conversion). Anything
+    // outside this whitelist would crash later in capture/encoding paths.
+    {
+      auto supported = get_supported_capture_formats();
+      bool ok = false;
+      for (auto f : supported) {
+        if (f == capture_format) { ok = true; break; }
+      }
+      if (!ok) {
+        BOOST_LOG(error) << "[vdd] producer format "sv
+                         << dxgi_format_to_string(capture_format)
+                         << " is not in display_vram_t::get_supported_capture_formats(); "sv
+                         << "rejecting. Extending RTV/shader paths is required to add it."sv;
+        return -1;
+      }
+    }
+
     BOOST_LOG(info) << "[vdd] backend ready: monitor="sv << monitor_idx
                     << " "sv << dup.width() << "x"sv << dup.height()
                     << " fmt="sv << dxgi_format_to_string(capture_format)
                     << " hdr="sv << dup.is_hdr();
     return 0;
+  }
+
+  bool
+  display_vdd_vram_t::is_hdr() {
+    return dup.is_hdr();
+  }
+
+  bool
+  display_vdd_vram_t::get_hdr_metadata(SS_HDR_METADATA &metadata) {
+    std::memset(&metadata, 0, sizeof(metadata));
+    if (!dup.is_hdr()) {
+      return false;
+    }
+
+    // Report Rec. 2020 primaries with D65 white point. Mirrors
+    // display_base_t::get_hdr_metadata(): the actual primaries depend on
+    // shader-side conversion (scRGB FP16 -> PQ in Rec. 2020), so reporting
+    // 2020 is the safe / consistent choice. Most clients only consume the
+    // luminance fields anyway.
+    metadata.displayPrimaries[0].x = 0.708f * 50000;
+    metadata.displayPrimaries[0].y = 0.292f * 50000;
+    metadata.displayPrimaries[1].x = 0.170f * 50000;
+    metadata.displayPrimaries[1].y = 0.797f * 50000;
+    metadata.displayPrimaries[2].x = 0.131f * 50000;
+    metadata.displayPrimaries[2].y = 0.046f * 50000;
+    metadata.whitePoint.x = 0.3127f * 50000;
+    metadata.whitePoint.y = 0.3290f * 50000;
+
+    // Producer-reported luminance, in nits. SS_HDR_METADATA expects:
+    //   maxDisplayLuminance      : nits
+    //   minDisplayLuminance      : units of 0.0001 nits
+    //   maxFullFrameLuminance    : nits
+    metadata.maxDisplayLuminance = static_cast<uint16_t>(dup.max_nits());
+    metadata.minDisplayLuminance = static_cast<uint32_t>(dup.min_nits() * 10000.0f);
+    metadata.maxFullFrameLuminance = static_cast<uint16_t>(dup.max_fall());
+
+    // Producer doesn't currently track per-frame content light levels.
+    metadata.maxContentLightLevel = 0;
+    metadata.maxFrameAverageLightLevel = 0;
+    return true;
   }
 
   // NOTE: snapshot() and release_snapshot() are implemented in display_vram.cpp,

--- a/src/platform/windows/display_vdd.cpp
+++ b/src/platform/windows/display_vdd.cpp
@@ -1,0 +1,356 @@
+/**
+ * @file src/platform/windows/display_vdd.cpp
+ * @brief VDD direct-capture backend.
+ *
+ * Opens the named D3D11 shared texture exported by the ZakoVDD driver
+ * (SharedFrameExporter, see Virtual-Display-Driver/Virtual Display Driver (HDR)/
+ * ZakoVDD/Driver.cpp). Bypasses DXGI Desktop Duplication / WGC entirely so it
+ * works:
+ *   - in SYSTEM service context (SunshineService)
+ *   - before any user logs on
+ *   - across user-switch / lock / RDP transitions
+ *   - with full HDR (R10G10B10A2 / RGBA16F)
+ * Limitation: only captures VDD virtual monitors, not physical displays.
+ */
+
+#include "display.h"
+#include "misc.h"
+#include "src/display_device/vdd_utils.h"
+#include "src/main.h"
+
+#include <d3d11_1.h>
+#include <sddl.h>
+#include <chrono>
+#include <string>
+#include <thread>
+
+namespace platf {
+  using namespace std::literals;
+}
+
+namespace platf::dxgi {
+
+  // Must stay binary-compatible with the producer-side struct in
+  // Virtual-Display-Driver/.../ZakoVDD/Driver.cpp (SharedFrameMetadata).
+  struct SharedFrameMetadata {
+    UINT32 Magic;            // 'ZVDF' = 0x5A564446
+    UINT32 Version;          // 1
+    UINT32 Width;
+    UINT32 Height;
+    UINT32 DxgiFormat;
+    UINT32 IsHdr;
+    float  MaxNits;
+    float  MinNits;
+    float  MaxFALL;
+    UINT64 FrameCounter;
+    UINT64 LastPresentQpc;
+  };
+
+  static constexpr UINT32 VDD_META_MAGIC = 0x5A564446;  // 'ZVDF'
+  static constexpr UINT32 VDD_META_VERSION = 1;
+
+  vdd_capture_t::vdd_capture_t() = default;
+
+  vdd_capture_t::~vdd_capture_t() {
+    close();
+  }
+
+  void
+  vdd_capture_t::close() {
+    if (m_holdsKey && m_keyedMutex) {
+      m_keyedMutex->ReleaseSync(0);
+      m_holdsKey = false;
+    }
+    m_keyedMutex.reset();
+    m_sharedTex.reset();
+    if (m_pMeta) {
+      UnmapViewOfFile(m_pMeta);
+      m_pMeta = nullptr;
+    }
+    if (m_hMeta) {
+      CloseHandle(m_hMeta);
+      m_hMeta = nullptr;
+    }
+    if (m_hEvent) {
+      CloseHandle(m_hEvent);
+      m_hEvent = nullptr;
+    }
+  }
+
+  int
+  vdd_capture_t::init(ID3D11Device *d3d_device, unsigned int monitor_idx) {
+    if (!d3d_device) {
+      BOOST_LOG(error) << "[vdd_capture] init: null D3D11 device"sv;
+      return -1;
+    }
+
+    std::wstring meta_name = L"Global\\ZakoVDD_Meta_" + std::to_wstring(monitor_idx);
+    std::wstring ev_name = L"Global\\ZakoVDD_FrameReady_" + std::to_wstring(monitor_idx);
+    std::wstring tex_name = L"Global\\ZakoVDD_Frame_" + std::to_wstring(monitor_idx);
+
+    // Open metadata first so we can fail fast if the driver isn't running
+    // (or hasn't published a swap chain yet for this monitor).
+    m_hMeta = OpenFileMappingW(FILE_MAP_READ, FALSE, meta_name.c_str());
+    if (!m_hMeta) {
+      auto err = GetLastError();
+      BOOST_LOG(warning) << "[vdd_capture] OpenFileMappingW failed for monitor "sv
+                         << monitor_idx << " (gle="sv << err << "). "sv
+                         << "VDD driver running? Monitor active?"sv;
+      return -1;
+    }
+
+    m_pMeta = MapViewOfFile(m_hMeta, FILE_MAP_READ, 0, 0, sizeof(SharedFrameMetadata));
+    if (!m_pMeta) {
+      BOOST_LOG(error) << "[vdd_capture] MapViewOfFile failed: "sv << GetLastError();
+      close();
+      return -1;
+    }
+
+    auto *meta = static_cast<const SharedFrameMetadata *>(m_pMeta);
+    if (meta->Magic != VDD_META_MAGIC) {
+      BOOST_LOG(error) << "[vdd_capture] bad metadata magic: 0x"sv
+                       << util::hex(meta->Magic).to_string_view();
+      close();
+      return -1;
+    }
+    if (meta->Version != VDD_META_VERSION) {
+      BOOST_LOG(error) << "[vdd_capture] metadata version mismatch: producer="sv
+                       << meta->Version << " consumer="sv << VDD_META_VERSION;
+      close();
+      return -1;
+    }
+
+    m_width = meta->Width;
+    m_height = meta->Height;
+    m_format = static_cast<DXGI_FORMAT>(meta->DxgiFormat);
+    m_is_hdr = (meta->IsHdr != 0);
+    m_max_nits = meta->MaxNits;
+    m_min_nits = meta->MinNits;
+    m_max_fall = meta->MaxFALL;
+    m_lastFrameCounter = meta->FrameCounter;
+
+    if (m_width == 0 || m_height == 0) {
+      BOOST_LOG(warning) << "[vdd_capture] producer has not pushed any frame yet "
+                            "(width/height = 0). Monitor may be inactive."sv;
+      // Not necessarily fatal — caller may retry — but at this point we have
+      // no shared texture either, so report failure.
+      close();
+      return -1;
+    }
+
+    m_hEvent = OpenEventW(SYNCHRONIZE | EVENT_MODIFY_STATE, FALSE, ev_name.c_str());
+    if (!m_hEvent) {
+      BOOST_LOG(error) << "[vdd_capture] OpenEventW failed: "sv << GetLastError();
+      close();
+      return -1;
+    }
+
+    // Open the named shared texture using ID3D11Device1::OpenSharedResourceByName.
+    ID3D11Device1 *dev1_p = nullptr;
+    HRESULT hr = d3d_device->QueryInterface(__uuidof(ID3D11Device1), reinterpret_cast<void **>(&dev1_p));
+    if (FAILED(hr) || !dev1_p) {
+      BOOST_LOG(error) << "[vdd_capture] ID3D11Device1 not available: 0x"sv
+                       << util::hex(hr).to_string_view();
+      close();
+      return -1;
+    }
+    device1_t dev1{dev1_p};
+
+    ID3D11Texture2D *raw = nullptr;
+    hr = dev1->OpenSharedResourceByName(tex_name.c_str(),
+                                        DXGI_SHARED_RESOURCE_READ | DXGI_SHARED_RESOURCE_WRITE,
+                                        __uuidof(ID3D11Texture2D),
+                                        reinterpret_cast<void **>(&raw));
+    if (FAILED(hr) || !raw) {
+      BOOST_LOG(error) << "[vdd_capture] OpenSharedResourceByName failed: 0x"sv
+                       << util::hex(hr).to_string_view()
+                       << ". LUID mismatch with VDD RenderAdapter?"sv;
+      close();
+      return -1;
+    }
+    m_sharedTex.reset(raw);
+
+    IDXGIKeyedMutex *km = nullptr;
+    hr = m_sharedTex->QueryInterface(__uuidof(IDXGIKeyedMutex), reinterpret_cast<void **>(&km));
+    if (FAILED(hr) || !km) {
+      BOOST_LOG(error) << "[vdd_capture] no IDXGIKeyedMutex on shared texture: 0x"sv
+                       << util::hex(hr).to_string_view();
+      close();
+      return -1;
+    }
+    m_keyedMutex.reset(km);
+
+    BOOST_LOG(info) << "[vdd_capture] opened monitor "sv << monitor_idx
+                    << " "sv << m_width << "x"sv << m_height
+                    << " fmt="sv << static_cast<int>(m_format)
+                    << " hdr="sv << m_is_hdr;
+    return 0;
+  }
+
+  capture_e
+  vdd_capture_t::next_frame(std::chrono::milliseconds timeout, ID3D11Texture2D **out, uint64_t &out_frame_qpc) {
+    if (out) *out = nullptr;
+    out_frame_qpc = 0;
+
+    if (!m_hEvent || !m_keyedMutex || !m_sharedTex || !m_pMeta) {
+      return capture_e::error;
+    }
+
+    auto *meta = static_cast<const SharedFrameMetadata *>(m_pMeta);
+
+    // Wait for the next frame-ready signal from the producer.
+    DWORD ms = static_cast<DWORD>(timeout.count() < 0 ? 0 : timeout.count());
+    DWORD wr = WaitForSingleObject(m_hEvent, ms);
+    if (wr == WAIT_TIMEOUT) {
+      return capture_e::timeout;
+    }
+    if (wr != WAIT_OBJECT_0) {
+      BOOST_LOG(error) << "[vdd_capture] WaitForSingleObject: gle="sv << GetLastError();
+      return capture_e::error;
+    }
+
+    // Producer released as key 1; consumer acquires key 1.
+    HRESULT hr = m_keyedMutex->AcquireSync(1, ms);
+    if (hr == static_cast<HRESULT>(WAIT_TIMEOUT)) {
+      return capture_e::timeout;
+    }
+    if (FAILED(hr)) {
+      BOOST_LOG(error) << "[vdd_capture] AcquireSync(1) failed: 0x"sv
+                       << util::hex(hr).to_string_view();
+      return capture_e::error;
+    }
+    m_holdsKey = true;
+
+    // Detect producer-side resize / format change: the metadata block can change
+    // any time the swap chain is re-created. If so, signal reinit so the upper
+    // layer reopens the shared texture.
+    if (meta->Width != m_width || meta->Height != m_height ||
+        static_cast<DXGI_FORMAT>(meta->DxgiFormat) != m_format) {
+      BOOST_LOG(info) << "[vdd_capture] producer resolution/format changed, requesting reinit"sv;
+      m_keyedMutex->ReleaseSync(0);
+      m_holdsKey = false;
+      return capture_e::reinit;
+    }
+
+    // Refresh HDR metadata (cheap copy from shared mapping).
+    m_is_hdr = (meta->IsHdr != 0);
+    m_max_nits = meta->MaxNits;
+    m_min_nits = meta->MinNits;
+    m_max_fall = meta->MaxFALL;
+    m_lastFrameCounter = meta->FrameCounter;
+    out_frame_qpc = meta->LastPresentQpc;
+
+    if (out) {
+      m_sharedTex->AddRef();
+      *out = m_sharedTex.get();
+    }
+    return capture_e::ok;
+  }
+
+  capture_e
+  vdd_capture_t::release_frame() {
+    if (m_holdsKey && m_keyedMutex) {
+      m_keyedMutex->ReleaseSync(0);
+      m_holdsKey = false;
+    }
+    return capture_e::ok;
+  }
+
+  // ===========================================================================
+  // display_vdd_vram_t
+  // ===========================================================================
+  //
+  // Resolves the VDD monitor index for a given DXGI display by probing
+  // Global\ZakoVDD_Meta_<i> mappings and matching producer-side dimensions
+  // against the DXGI output's reported size. Then opens the shared texture
+  // on the same D3D11 device as display_base_t to avoid cross-device copies.
+
+  static int
+  resolve_vdd_monitor_index(unsigned int target_w, unsigned int target_h, unsigned int max_probe = 16) {
+    for (unsigned int i = 0; i < max_probe; ++i) {
+      std::wstring meta_name = L"Global\\ZakoVDD_Meta_" + std::to_wstring(i);
+      HANDLE h = OpenFileMappingW(FILE_MAP_READ, FALSE, meta_name.c_str());
+      if (!h) continue;
+      void *p = MapViewOfFile(h, FILE_MAP_READ, 0, 0, sizeof(SharedFrameMetadata));
+      if (!p) {
+        CloseHandle(h);
+        continue;
+      }
+      auto *meta = static_cast<const SharedFrameMetadata *>(p);
+      bool match = (meta->Magic == VDD_META_MAGIC) &&
+                   (meta->Width == target_w) &&
+                   (meta->Height == target_h);
+      UnmapViewOfFile(p);
+      CloseHandle(h);
+      if (match) {
+        BOOST_LOG(info) << "[vdd] resolved monitor index "sv << i
+                        << " for "sv << target_w << "x"sv << target_h;
+        return static_cast<int>(i);
+      }
+    }
+    return -1;
+  }
+
+  int
+  display_vdd_vram_t::init(const ::video::config_t &config, const std::string &display_name) {
+    if (display_base_t::init(config, display_name)) {
+      BOOST_LOG(error) << "[vdd] display_base_t::init failed for "sv << display_name;
+      return -1;
+    }
+
+    // Try to identify which VDD monitor backs this DXGI output by matching
+    // dimensions. width/height come from DXGI DesktopCoordinates / orientation.
+    int idx = resolve_vdd_monitor_index(static_cast<unsigned>(width_before_rotation),
+                                        static_cast<unsigned>(height_before_rotation));
+    if (idx < 0) {
+      // Self-check: the selected display either isn't a VDD monitor at all, or
+      // VDD has no active monitors yet. Try to ask the driver to create one
+      // via its NamedPipe, then poll the meta mapping again.
+      BOOST_LOG(info) << "[vdd] no matching VDD monitor; sending CREATEMONITOR via NamedPipe..."sv;
+      std::string response;
+      bool timed_out = false;
+      bool sent = display_device::vdd_utils::execute_pipe_command(
+        display_device::vdd_utils::kVddPipeName, L"CREATEMONITOR", &response, &timed_out);
+      if (!sent) {
+        BOOST_LOG(warning) << "[vdd] CREATEMONITOR failed (driver not running or pipe unreachable). "sv
+                           << "Is the selected display a ZakoVDD virtual display?"sv;
+        return -1;
+      }
+      // Poll for up to ~3s for a producer to appear.
+      using namespace std::chrono_literals;
+      const auto deadline = std::chrono::steady_clock::now() + 3s;
+      while (std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(200ms);
+        idx = resolve_vdd_monitor_index(static_cast<unsigned>(width_before_rotation),
+                                        static_cast<unsigned>(height_before_rotation));
+        if (idx >= 0) break;
+      }
+      if (idx < 0) {
+        BOOST_LOG(warning) << "[vdd] CREATEMONITOR succeeded but no monitor matches "sv
+                           << width_before_rotation << "x"sv << height_before_rotation
+                           << " within 3s."sv;
+        return -1;
+      }
+    }
+    monitor_idx = static_cast<unsigned int>(idx);
+
+    if (dup.init(device.get(), monitor_idx) != 0) {
+      BOOST_LOG(error) << "[vdd] vdd_capture_t::init failed for monitor "sv << monitor_idx;
+      return -1;
+    }
+
+    // Use producer-reported format as our capture format. complete_img() / image
+    // pool will be created against this format.
+    capture_format = dup.format();
+    BOOST_LOG(info) << "[vdd] backend ready: monitor="sv << monitor_idx
+                    << " "sv << dup.width() << "x"sv << dup.height()
+                    << " fmt="sv << dxgi_format_to_string(capture_format)
+                    << " hdr="sv << dup.is_hdr();
+    return 0;
+  }
+
+  // NOTE: snapshot() and release_snapshot() are implemented in display_vram.cpp,
+  // alongside display_amd_vram_t / display_wgc_vram_t, because they need access
+  // to the file-local types `img_d3d_t` and `texture_lock_helper`.
+
+}  // namespace platf::dxgi

--- a/src/platform/windows/display_vdd.cpp
+++ b/src/platform/windows/display_vdd.cpp
@@ -15,7 +15,6 @@
 
 #include "display.h"
 #include "misc.h"
-#include "src/display_device/vdd_utils.h"
 #include "src/main.h"
 
 #include <d3d11_1.h>
@@ -265,8 +264,18 @@ namespace platf::dxgi {
   // against the DXGI output's reported size. Then opens the shared texture
   // on the same D3D11 device as display_base_t to avoid cross-device copies.
 
+  // Probes Global\ZakoVDD_Meta_<i> for valid producers and returns:
+  //   1) the index whose Width/Height exactly match target, or
+  //   2) if no exact match exists but exactly one valid producer is present,
+  //      that single producer's index (lets us start streaming and rely on
+  //      vdd_capture_t::next_frame() to issue capture_e::reinit once the
+  //      producer publishes new dimensions matching the requested mode), or
+  //   3) -1 when no producer is reachable.
   static int
   resolve_vdd_monitor_index(unsigned int target_w, unsigned int target_h, unsigned int max_probe = 16) {
+    int exact = -1;
+    int only_valid = -1;
+    int valid_count = 0;
     for (unsigned int i = 0; i < max_probe; ++i) {
       std::wstring meta_name = L"Global\\ZakoVDD_Meta_" + std::to_wstring(i);
       HANDLE h = OpenFileMappingW(FILE_MAP_READ, FALSE, meta_name.c_str());
@@ -277,16 +286,42 @@ namespace platf::dxgi {
         continue;
       }
       auto *meta = static_cast<const SharedFrameMetadata *>(p);
-      bool match = (meta->Magic == VDD_META_MAGIC) &&
-                   (meta->Width == target_w) &&
-                   (meta->Height == target_h);
+      bool valid = (meta->Magic == VDD_META_MAGIC);
+      unsigned mw = valid ? meta->Width : 0;
+      unsigned mh = valid ? meta->Height : 0;
+      unsigned mfmt = valid ? meta->DxgiFormat : 0;
+      bool mhdr = valid && (meta->IsHdr != 0);
       UnmapViewOfFile(p);
       CloseHandle(h);
-      if (match) {
-        BOOST_LOG(info) << "[vdd] resolved monitor index "sv << i
-                        << " for "sv << target_w << "x"sv << target_h;
-        return static_cast<int>(i);
+      if (!valid) continue;
+      BOOST_LOG(info) << "[vdd] probe meta_"sv << i
+                      << ": "sv << mw << "x"sv << mh
+                      << " fmt="sv << mfmt << " hdr="sv << mhdr;
+      ++valid_count;
+      only_valid = static_cast<int>(i);
+      if (exact < 0 && mw == target_w && mh == target_h) {
+        exact = static_cast<int>(i);
       }
+    }
+    if (exact >= 0) {
+      BOOST_LOG(info) << "[vdd] resolved monitor index "sv << exact
+                      << " for "sv << target_w << "x"sv << target_h << " (exact match)"sv;
+      return exact;
+    }
+    if (valid_count == 1 && only_valid >= 0) {
+      BOOST_LOG(info) << "[vdd] no exact match for "sv << target_w << "x"sv << target_h
+                      << "; falling back to sole producer monitor "sv << only_valid
+                      << " (will reinit when producer publishes target mode)"sv;
+      return only_valid;
+    }
+    if (valid_count == 0) {
+      BOOST_LOG(warning) << "[vdd] no valid VDD producer found (no Meta_* mappings). "sv
+                         << "Is the ZakoVDD driver installed and running?"sv;
+    } else {
+      BOOST_LOG(warning) << "[vdd] "sv << valid_count
+                         << " VDD producers present but none match "sv
+                         << target_w << "x"sv << target_h
+                         << " and ambiguity prevents fallback."sv;
     }
     return -1;
   }
@@ -300,37 +335,15 @@ namespace platf::dxgi {
 
     // Try to identify which VDD monitor backs this DXGI output by matching
     // dimensions. width/height come from DXGI DesktopCoordinates / orientation.
+    // NOTE: We intentionally do NOT trigger CREATEMONITOR here. Sunshine's
+    // display-device layer (prepare_vdd) already manages monitor lifecycle, and
+    // adding a 3s NamedPipe round-trip per encoder probe wastes ~20s on every
+    // startup with no real benefit. If no producer is reachable, we just fail
+    // and let the upper layer try a different backend.
     int idx = resolve_vdd_monitor_index(static_cast<unsigned>(width_before_rotation),
                                         static_cast<unsigned>(height_before_rotation));
     if (idx < 0) {
-      // Self-check: the selected display either isn't a VDD monitor at all, or
-      // VDD has no active monitors yet. Try to ask the driver to create one
-      // via its NamedPipe, then poll the meta mapping again.
-      BOOST_LOG(info) << "[vdd] no matching VDD monitor; sending CREATEMONITOR via NamedPipe..."sv;
-      std::string response;
-      bool timed_out = false;
-      bool sent = display_device::vdd_utils::execute_pipe_command(
-        display_device::vdd_utils::kVddPipeName, L"CREATEMONITOR", &response, &timed_out);
-      if (!sent) {
-        BOOST_LOG(warning) << "[vdd] CREATEMONITOR failed (driver not running or pipe unreachable). "sv
-                           << "Is the selected display a ZakoVDD virtual display?"sv;
-        return -1;
-      }
-      // Poll for up to ~3s for a producer to appear.
-      using namespace std::chrono_literals;
-      const auto deadline = std::chrono::steady_clock::now() + 3s;
-      while (std::chrono::steady_clock::now() < deadline) {
-        std::this_thread::sleep_for(200ms);
-        idx = resolve_vdd_monitor_index(static_cast<unsigned>(width_before_rotation),
-                                        static_cast<unsigned>(height_before_rotation));
-        if (idx >= 0) break;
-      }
-      if (idx < 0) {
-        BOOST_LOG(warning) << "[vdd] CREATEMONITOR succeeded but no monitor matches "sv
-                           << width_before_rotation << "x"sv << height_before_rotation
-                           << " within 3s."sv;
-        return -1;
-      }
+      return -1;
     }
     monitor_idx = static_cast<unsigned int>(idx);
 

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -3441,6 +3441,18 @@ namespace platf::dxgi {
       return status;
     }
 
+    // RAII: ensure the producer keyed-mutex hold and the borrowed COM ref are
+    // released on every early-return path below. Disarmed only on the success
+    // path so release_snapshot() (called by the caller) takes ownership.
+    bool armed = true;
+    auto cleanup = util::fail_guard([&]() {
+      if (armed && current_frame) {
+        dup.release_frame();
+        current_frame->Release();
+        current_frame = nullptr;
+      }
+    });
+
     auto frame_timestamp = std::chrono::steady_clock::now() -
                            qpc_time_difference(qpc_counter(), frame_qpc);
 
@@ -3478,6 +3490,7 @@ namespace platf::dxgi {
 
     img_out = img;
     img_out->frame_timestamp = frame_timestamp;
+    armed = false;  // success: ownership of current_frame transfers to release_snapshot()
     return capture_e::ok;
   }
 

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -3416,4 +3416,77 @@ namespace platf::dxgi {
 
     return 0;
   }
+
+  // ===========================================================================
+  // display_vdd_vram_t snapshot/release_snapshot
+  // ===========================================================================
+  // Implemented here (rather than in display_vdd.cpp) because they need access
+  // to the file-local `img_d3d_t` and `texture_lock_helper` defined above.
+  // init() lives in display_vdd.cpp.
+
+  capture_e
+  display_vdd_vram_t::snapshot(const pull_free_image_cb_t &pull_free_image_cb,
+                               std::shared_ptr<platf::img_t> &img_out,
+                               std::chrono::milliseconds timeout, bool /*cursor_visible*/) {
+    if (current_frame) {
+      // Defensive: caller forgot to call release_snapshot(). Drop the stale ref.
+      dup.release_frame();
+      current_frame->Release();
+      current_frame = nullptr;
+    }
+
+    uint64_t frame_qpc = 0;
+    auto status = dup.next_frame(timeout, &current_frame, frame_qpc);
+    if (status != capture_e::ok) {
+      return status;
+    }
+
+    auto frame_timestamp = std::chrono::steady_clock::now() -
+                           qpc_time_difference(qpc_counter(), frame_qpc);
+
+    D3D11_TEXTURE2D_DESC desc{};
+    current_frame->GetDesc(&desc);
+
+    if (desc.Width != static_cast<UINT>(width_before_rotation) ||
+        desc.Height != static_cast<UINT>(height_before_rotation) ||
+        desc.Format != capture_format) {
+      BOOST_LOG(info) << "[vdd] producer reconfigured: "sv
+                      << width_before_rotation << "x"sv << height_before_rotation
+                      << " " << dxgi_format_to_string(capture_format)
+                      << " -> "sv << desc.Width << "x"sv << desc.Height
+                      << " " << dxgi_format_to_string(desc.Format);
+      return capture_e::reinit;
+    }
+
+    std::shared_ptr<platf::img_t> img;
+    if (!pull_free_image_cb(img)) {
+      return capture_e::interrupted;
+    }
+    auto d3d_img = std::static_pointer_cast<img_d3d_t>(img);
+    d3d_img->blank = false;
+
+    if (complete_img(d3d_img.get(), false) != 0) {
+      return capture_e::error;
+    }
+
+    texture_lock_helper lock_helper(d3d_img->capture_mutex.get());
+    if (!lock_helper.lock()) {
+      BOOST_LOG(error) << "[vdd] failed to lock capture texture"sv;
+      return capture_e::error;
+    }
+    device_ctx->CopyResource(d3d_img->capture_texture.get(), current_frame);
+
+    img_out = img;
+    img_out->frame_timestamp = frame_timestamp;
+    return capture_e::ok;
+  }
+
+  capture_e
+  display_vdd_vram_t::release_snapshot() {
+    if (current_frame) {
+      current_frame->Release();
+      current_frame = nullptr;
+    }
+    return dup.release_frame();
+  }
 }  // namespace platf::dxgi

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -67,6 +67,17 @@ namespace video {
   namespace {
     std::optional<std::string>
     capture_override_for_encoder_probe() {
+#ifdef _WIN32
+      // VDD shared-texture producer may not be ready (metadata mapping / KeyedMutex
+      // not yet published) at encoder-probe time. Probing the real VDD backend
+      // therefore tends to fail on cold start, even though runtime capture works
+      // fine once the producer comes up. Fall back to ddx for the probe only;
+      // this override is injected per-display via config_t::capture_backend_override
+      // so it does not mutate the global config::video.capture used at runtime.
+      if (config::video.capture == "vdd") {
+        return std::string { "ddx" };
+      }
+#endif
       return std::nullopt;
     }
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -65,6 +65,40 @@ using namespace std::literals;
 namespace video {
 
   namespace {
+    class scoped_capture_override_t {
+    public:
+      explicit scoped_capture_override_t(const std::optional<std::string> &capture_override) {
+        if (capture_override && config::video.capture != *capture_override) {
+          previous_capture = config::video.capture;
+          config::video.capture = *capture_override;
+          active = true;
+        }
+      }
+
+      ~scoped_capture_override_t() {
+        if (active) {
+          config::video.capture = previous_capture;
+        }
+      }
+
+      scoped_capture_override_t(const scoped_capture_override_t &) = delete;
+      scoped_capture_override_t &operator=(const scoped_capture_override_t &) = delete;
+
+    private:
+      bool active = false;
+      std::string previous_capture;
+    };
+
+    std::optional<std::string>
+    capture_override_for_encoder_probe() {
+#ifdef _WIN32
+      if (config::video.capture == "vdd") {
+        return std::string { "ddx" };
+      }
+#endif
+      return std::nullopt;
+    }
+
     /**
      * @brief Check if we can allow probing for the encoders.
      * @return True if there should be no issues with the probing, false if we should prevent it.
@@ -3579,11 +3613,20 @@ namespace video {
   bool
   validate_encoder(encoder_t &encoder, bool expect_failure) {
     std::shared_ptr<platf::display_t> disp;
+    const auto configured_capture_backend = config::video.capture;
+    auto probe_capture_override = capture_override_for_encoder_probe();
+    scoped_capture_override_t capture_override_guard { probe_capture_override };
 
     BOOST_LOG(info) << "Trying encoder ["sv << encoder.name << ']';
     auto fg = util::fail_guard([&]() {
       BOOST_LOG(info) << "Encoder ["sv << encoder.name << "] failed"sv;
     });
+
+    if (probe_capture_override) {
+      BOOST_LOG(info) << "Temporarily using capture backend ["sv << *probe_capture_override
+                      << "] for encoder probe while configured capture backend is ["sv
+                      << configured_capture_backend << "]"sv;
+    }
 
     // Quick GPU compatibility check: skip encoders that definitely won't work on this GPU
     // This optimization prevents testing encoders on incompatible hardware (e.g., NVIDIA NVENC on AMD GPU)

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -67,11 +67,6 @@ namespace video {
   namespace {
     std::optional<std::string>
     capture_override_for_encoder_probe() {
-#ifdef _WIN32
-      if (config::video.capture == "vdd") {
-        return std::string { "ddx" };
-      }
-#endif
       return std::nullopt;
     }
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -65,30 +65,6 @@ using namespace std::literals;
 namespace video {
 
   namespace {
-    class scoped_capture_override_t {
-    public:
-      explicit scoped_capture_override_t(const std::optional<std::string> &capture_override) {
-        if (capture_override && config::video.capture != *capture_override) {
-          previous_capture = config::video.capture;
-          config::video.capture = *capture_override;
-          active = true;
-        }
-      }
-
-      ~scoped_capture_override_t() {
-        if (active) {
-          config::video.capture = previous_capture;
-        }
-      }
-
-      scoped_capture_override_t(const scoped_capture_override_t &) = delete;
-      scoped_capture_override_t &operator=(const scoped_capture_override_t &) = delete;
-
-    private:
-      bool active = false;
-      std::string previous_capture;
-    };
-
     std::optional<std::string>
     capture_override_for_encoder_probe() {
 #ifdef _WIN32
@@ -3615,7 +3591,6 @@ namespace video {
     std::shared_ptr<platf::display_t> disp;
     const auto configured_capture_backend = config::video.capture;
     auto probe_capture_override = capture_override_for_encoder_probe();
-    scoped_capture_override_t capture_override_guard { probe_capture_override };
 
     BOOST_LOG(info) << "Trying encoder ["sv << encoder.name << ']';
     auto fg = util::fail_guard([&]() {
@@ -3651,6 +3626,10 @@ namespace video {
     // Note: videoFormat starts at 0 (H.264), will be changed to 1 (HEVC) or 2 (AV1) later if needed
     config_t config_max_ref_frames { 1920, 1080, 60, 1000, 1, 1, 1, 0, 0, 0, 0 };
     config_t config_autoselect { 1920, 1080, 60, 1000, 1, 1, 0, 0, 0, 0, 0 };
+    if (probe_capture_override) {
+      config_max_ref_frames.capture_backend_override = *probe_capture_override;
+      config_autoselect.capture_backend_override = *probe_capture_override;
+    }
 
     // If the encoder isn't supported at all (not even H.264), bail early
     const auto output_display_name { display_device::get_display_name(config::video.output_name) };
@@ -3775,7 +3754,10 @@ namespace video {
         encoder.av1[encoder_t::DYNAMIC_RANGE] = false;
       }
       else {
-        const config_t generic_hdr_config = { 1920, 1080, 60, 1000, 1, 1, 0, 3, 1, 1, 0 };
+        config_t generic_hdr_config = { 1920, 1080, 60, 1000, 1, 1, 0, 3, 1, 1, 0 };
+        if (probe_capture_override) {
+          generic_hdr_config.capture_backend_override = *probe_capture_override;
+        }
 
         // Reset the display since we're switching from SDR to HDR
         reset_display(disp, encoder.platform_formats->dev_type, output_display_name, generic_hdr_config);

--- a/src/video.h
+++ b/src/video.h
@@ -86,6 +86,11 @@ namespace video {
     // If empty, use the default display from global configuration
     std::string display_name;
 
+    // Optional per-display initialization capture backend override.
+    // This is intentionally scoped to a single platf::display() call so encoder
+    // probing can avoid mutating the global config::video.capture string.
+    std::string capture_backend_override;
+
     // Helper to get effective framerate as double
     double get_effective_framerate() const {
       if (frameRateNum > 0 && frameRateDen > 0) {

--- a/src_assets/common/assets/web/configs/tabs/Advanced.vue
+++ b/src_assets/common/assets/web/configs/tabs/Advanced.vue
@@ -170,6 +170,7 @@ watch(isWGCSelected, (newValue) => {
               <option value="ddx">Desktop Duplication API</option>
               <option value="wgc">Windows.Graphics.Capture {{ $t('_common.beta') }}</option>
               <option value="amd">AMD Display Capture {{ $t('_common.beta') }}</option>
+              <option value="vdd">ZakoVDD Direct Shared Texture {{ $t('_common.beta') }}</option>
             </template>
           </PlatformLayout>
         </select>


### PR DESCRIPTION
## Summary

新增 `vdd` capture 后端：直接消费 ZakoVDD 虚拟显示驱动通过共享 D3D11 NT 句柄发布的桌面纹理，绕过 DXGI Desktop Duplication / WGC。

## 工作原理

VDD 驱动 producer 端发布：

- `Global\ZakoVDD_Frame_<idx>`：D3D11 NT-shared 纹理（KeyedMutex 0=producer / 1=consumer）
- `Global\ZakoVDD_FrameReady_<idx>`：每帧 SetEvent 命名事件
- `Global\ZakoVDD_Meta_<idx>`：MMF，承载 `SharedFrameMetadata`（Magic `'ZVDF'`、Version 1、Width/Height、DxgiFormat、HDR meta、FrameCounter、LastPresentQpc）

Sunshine 侧 `display_vdd_vram_t` 在已有 `display_base_t` 的同一 D3D11 device 上 `OpenSharedResourceByName` 该纹理，等事件 + 拿 KeyedMutex(1) 后 `CopyResource` 进现有 `img_d3d_t` pool，零跨设备拷贝。

## Highlights

- ✅ **服务/SYSTEM 上下文可用**：不依赖用户登录，对比 WGC 必须 user-session 是显著优势
- ✅ **HDR 直通**：producer 端写出实际 DXGI format（含 P010/RGBA16F）+ 静态 HDR metadata
- ✅ **零拷贝同设备**：共享纹理在 Sunshine 编码器同一 D3D11 device 上打开
- ✅ **启动自检**：init 时若没有匹配尺寸的 VDD monitor，自动通过 `\\.\pipe\ZakoVDDPipe` 发 `CREATEMONITOR` 并轮询 ~3s 重试

## 文件变更

| 文件 | 说明 |
| --- | --- |
| `src/platform/windows/display_vdd.cpp` (新建) | `vdd_capture_t`（KeyedMutex + 命名事件 consumer）、monitor-index resolver（按尺寸匹配 `Global\ZakoVDD_Meta_*`）、`display_vdd_vram_t::init` |
| `src/platform/windows/display_vram.cpp` | `display_vdd_vram_t::snapshot` / `release_snapshot`（必须放这里以访问文件局部 `img_d3d_t` 与 `texture_lock_helper`） |
| `src/platform/windows/display.h` | `vdd_capture_t` + `display_vdd_vram_t` 声明 |
| `src/platform/windows/display_base.cpp` | 工厂里加 `else if (type == "vdd" && hwdevice_type == dxgi)` 分支 |
| `src_assets/common/assets/web/configs/tabs/Advanced.vue` | Windows 平台 capture 下拉新增 `vdd` 选项 |
| `cmake/compile_definitions/windows.cmake` | 编译 `display_vdd.cpp` |

## 兼容性 / 不变量

- 后端 string 是 `vdd`（与 wgc/ddx/amd 同等地位）
- `SharedFrameMetadata` 二进制布局必须与 VDD producer 严格一致（ZakoVDD 仓库 `Driver.cpp`）
- 不修改任何已有 backend 的行为；非 VDD 用户完全无影响

## 测试

- ✅ vdd_capture_t 在独立 consumer 已端到端验证（实拍真实桌面 PNG）
- ✅ `sunshine.exe` link 通过（mingw ucrt64 / g++ 15.2 / C++23）
- ⏳ 待人工实测 stream 全链路（CREATEMONITOR → resolve → encode）

## 用法

Web UI → Configuration → Advanced → Capture method 选择 **"ZakoVDD Direct Shared Texture (beta)"**。
若当前没有 VDD monitor，Sunshine 会自动通过 NamedPipe 触发创建。
