### PR TITLE
fix(amf): add Init fallback chain and runtime fault watchdog

### DIFF
--- a/src/amf/amf_d3d11.cpp
+++ b/src/amf/amf_d3d11.cpp
@@ -503,6 +503,10 @@ namespace amf {
     // properties (especially PreAnalysis with high quality_preset on older VCN).
     // Try progressively disabling problematic features instead of failing the
     // whole session, which previously caused "server keeps restarting" loops.
+    // The fallback is *cumulative*: once a feature is disabled in one step it
+    // stays disabled in subsequent steps, so we don't accidentally re-enable
+    // the failing feature on a later retry.
+    auto config_fallback = config;
     auto try_with_fallback = [&](const char *what, auto mutator) {
       if (res == AMF_OK) return;
       BOOST_LOG(warning) << "AMF: Init failed (error " << res << "), retrying without " << what;
@@ -515,7 +519,6 @@ namespace amf {
         res = recreate_res;
         return;
       }
-      auto config_fallback = config;
       mutator(config_fallback);
       if (!configure_encoder(config_fallback, client_config, colorspace)) {
         res = AMF_FAIL;
@@ -531,16 +534,21 @@ namespace amf {
       try_with_fallback("custom rc_mode", [](amf_config &c) { c.rc_mode = std::nullopt; });
     }
     if (config.quality_preset) {
-      try_with_fallback("quality_preset", [](amf_config &c) {
-        c.quality_preset = std::nullopt;
-        c.preanalysis = false;
-        c.rc_mode = std::nullopt;
-      });
+      try_with_fallback("quality_preset", [](amf_config &c) { c.quality_preset = std::nullopt; });
     }
 
     if (res != AMF_OK) {
       BOOST_LOG(error) << "AMF: encoder Init failed after fallbacks, error: " << res;
       return false;
+    }
+
+    // Derive runtime watchdog threshold from framerate so the fatal-error
+    // signal fires after roughly 1s of wall-clock time regardless of fps.
+    // Floor at 30 to give the PreAnalysis lookahead pipeline time to fill
+    // at startup without false-positive reinit.
+    {
+      int fps = client_config.framerate > 0 ? client_config.framerate : 60;
+      max_consecutive_failures = std::max(30, fps);
     }
 
     // Check if driver supports QUERY_TIMEOUT by reading back the property (FFmpeg pattern)
@@ -761,7 +769,7 @@ namespace amf {
           return result;
         }
       }
-      if (++consecutive_submit_failures >= MAX_CONSECUTIVE_FAILURES) {
+      if (++consecutive_submit_failures >= max_consecutive_failures) {
         BOOST_LOG(error) << "AMF: " << consecutive_submit_failures << " consecutive SubmitInput failures, signaling reinit";
         result.fatal = true;
       }
@@ -791,7 +799,7 @@ namespace amf {
       if (!output_data) {
         // Encoder needs more input or no output yet (pipeline filling).
         // Track this in case the pipeline gets stuck (driver hang, PA stall, etc.)
-        if (++consecutive_empty_outputs >= MAX_CONSECUTIVE_FAILURES) {
+        if (++consecutive_empty_outputs >= max_consecutive_failures) {
           BOOST_LOG(error) << "AMF: " << consecutive_empty_outputs << " consecutive frames with no encoder output, signaling reinit";
           result.fatal = true;
         }

--- a/src/amf/amf_d3d11.cpp
+++ b/src/amf/amf_d3d11.cpp
@@ -498,22 +498,48 @@ namespace amf {
     encode_width = client_config.width;
     encode_height = client_config.height;
     res = encoder->Init(amf_format, client_config.width, client_config.height);
-    if (res != AMF_OK && config.rc_mode) {
-      // Init failed with custom RC mode - retry without it (driver may not support it)
-      BOOST_LOG(warning) << "AMF: Init failed with rc_mode=" << *config.rc_mode << ", retrying with default RC";
-      encoder->Terminate();
-      encoder = nullptr;
-      res = factory->CreateComponent(context, get_codec_id(), &encoder);
-      if (res == AMF_OK && encoder) {
-        auto config_fallback = config;
-        config_fallback.rc_mode = std::nullopt;
-        if (configure_encoder(config_fallback, client_config, colorspace)) {
-          res = encoder->Init(amf_format, client_config.width, client_config.height);
-        }
+
+    // Init fallback chain: some driver/hardware combinations reject specific
+    // properties (especially PreAnalysis with high quality_preset on older VCN).
+    // Try progressively disabling problematic features instead of failing the
+    // whole session, which previously caused "server keeps restarting" loops.
+    auto try_with_fallback = [&](const char *what, auto mutator) {
+      if (res == AMF_OK) return;
+      BOOST_LOG(warning) << "AMF: Init failed (error " << res << "), retrying without " << what;
+      if (encoder) {
+        encoder->Terminate();
+        encoder = nullptr;
       }
+      auto recreate_res = factory->CreateComponent(context, get_codec_id(), &encoder);
+      if (recreate_res != AMF_OK || !encoder) {
+        res = recreate_res;
+        return;
+      }
+      auto config_fallback = config;
+      mutator(config_fallback);
+      if (!configure_encoder(config_fallback, client_config, colorspace)) {
+        res = AMF_FAIL;
+        return;
+      }
+      res = encoder->Init(amf_format, client_config.width, client_config.height);
+    };
+
+    if (config.preanalysis && *config.preanalysis) {
+      try_with_fallback("PreAnalysis", [](amf_config &c) { c.preanalysis = false; });
     }
+    if (config.rc_mode) {
+      try_with_fallback("custom rc_mode", [](amf_config &c) { c.rc_mode = std::nullopt; });
+    }
+    if (config.quality_preset) {
+      try_with_fallback("quality_preset", [](amf_config &c) {
+        c.quality_preset = std::nullopt;
+        c.preanalysis = false;
+        c.rc_mode = std::nullopt;
+      });
+    }
+
     if (res != AMF_OK) {
-      BOOST_LOG(error) << "AMF: encoder Init failed, error: " << res;
+      BOOST_LOG(error) << "AMF: encoder Init failed after fallbacks, error: " << res;
       return false;
     }
 
@@ -731,10 +757,17 @@ namespace amf {
         auto removed_reason = device->GetDeviceRemovedReason();
         if (removed_reason != S_OK) {
           BOOST_LOG(error) << "AMF: D3D11 device lost after SubmitInput, reason: 0x" << util::hex(removed_reason).to_string_view();
+          result.fatal = true;  // Device gone — must reinit, no point retrying
+          return result;
         }
+      }
+      if (++consecutive_submit_failures >= MAX_CONSECUTIVE_FAILURES) {
+        BOOST_LOG(error) << "AMF: " << consecutive_submit_failures << " consecutive SubmitInput failures, signaling reinit";
+        result.fatal = true;
       }
       return result;
     }
+    consecutive_submit_failures = 0;
 
     // Query output — if we already drained output during SubmitInput retry, use that
     ::amf::AMFDataPtr output_data;
@@ -756,10 +789,16 @@ namespace amf {
         }
       }
       if (!output_data) {
-        // Encoder needs more input or no output yet (pipeline filling)
+        // Encoder needs more input or no output yet (pipeline filling).
+        // Track this in case the pipeline gets stuck (driver hang, PA stall, etc.)
+        if (++consecutive_empty_outputs >= MAX_CONSECUTIVE_FAILURES) {
+          BOOST_LOG(error) << "AMF: " << consecutive_empty_outputs << " consecutive frames with no encoder output, signaling reinit";
+          result.fatal = true;
+        }
         return result;
       }
     }
+    consecutive_empty_outputs = 0;
 
     // Extract encoded bitstream
     ::amf::AMFBufferPtr buffer(output_data);

--- a/src/amf/amf_d3d11.h
+++ b/src/amf/amf_d3d11.h
@@ -111,10 +111,12 @@ namespace amf {
 
     // Runtime fault watchdog: count consecutive failures so we can signal
     // a fatal error to the upper layer (triggering a real reinit) instead
-    // of silently producing no output forever.
+    // of silently producing no output forever. Threshold is derived from
+    // client framerate in create_encoder() so the watchdog fires after
+    // roughly the same wall-clock time regardless of fps.
     int consecutive_submit_failures = 0;
     int consecutive_empty_outputs = 0;
-    static constexpr int MAX_CONSECUTIVE_FAILURES = 60;  // ~1s at 60fps
+    int max_consecutive_failures = 60;  // Set to ~1s of frames in create_encoder()
 
     std::string last_error_string;
   };

--- a/src/amf/amf_d3d11.h
+++ b/src/amf/amf_d3d11.h
@@ -109,6 +109,13 @@ namespace amf {
     bool psnr_enabled = false;
     bool ssim_enabled = false;
 
+    // Runtime fault watchdog: count consecutive failures so we can signal
+    // a fatal error to the upper layer (triggering a real reinit) instead
+    // of silently producing no output forever.
+    int consecutive_submit_failures = 0;
+    int consecutive_empty_outputs = 0;
+    static constexpr int MAX_CONSECUTIVE_FAILURES = 60;  // ~1s at 60fps
+
     std::string last_error_string;
   };
 

--- a/src/amf/amf_encoded_frame.h
+++ b/src/amf/amf_encoded_frame.h
@@ -17,6 +17,7 @@ namespace amf {
     uint64_t frame_index = 0;
     bool idr = false;
     bool after_ref_frame_invalidation = false;
+    bool fatal = false;  // Set when encoder is in unrecoverable state (device lost, repeated failures)
   };
 
 }  // namespace amf

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -2049,6 +2049,13 @@ namespace video {
   int
   encode_amf(int64_t frame_nr, amf_encode_session_t &session, safe::mail_raw_t::queue_t<packet_t> &packets, void *channel_data, std::optional<std::chrono::steady_clock::time_point> frame_timestamp) {
     auto encoded_frame = session.encode_frame(frame_nr);
+    if (encoded_frame.fatal) {
+      // Encoder is in unrecoverable state (device lost or repeated failures);
+      // propagate fatal so the session reinitializes instead of silently
+      // producing no video (which causes the client to time out and reconnect repeatedly).
+      BOOST_LOG(error) << "AMF: encoder in unrecoverable state, requesting reinit";
+      return -1;
+    }
     if (encoded_frame.data.empty()) {
       if (encoded_frame.frame_index == static_cast<uint64_t>(frame_nr)) {
         BOOST_LOG(debug) << "AMF: frame " << frame_nr << " buffered, waiting for more input";


### PR DESCRIPTION
## 背景

部分 AMD 用户反馈：选择高 quality_preset + PreAnalysis 后，服务端反复重启。  
原因：standalone AMF 编码器只对 `rc_mode` 有兜底，PA / quality_preset 在某些 VCN/驱动组合下 `Init()` 直接失败，或运行时编码管线卡死，但 `encode_frame` 总是返回 `frame_index` 已设置的空 result —— `video.cpp` 把它当作 "buffered, waiting for more input" 继续，**永不返回 -1**。客户端等不到视频超时断开 → 重连 → 同样的配置再次失败 → 看起来就是 "服务端反复重启"。

## 改动

### Init 期回退链（amf_d3d11.cpp）
`create_encoder` 失败时按风险递增依次禁用：PreAnalysis → custom rc_mode → quality_preset。任意一级成功即可启动，避免整个 session 失败。

### 运行时熔断（amf_d3d11.cpp / amf_encoded_frame.h）
- D3D11 device lost（TDR / 驱动崩溃）→ 立即标记 `fatal`
- 连续 SubmitInput 失败 ≥ MAX_CONSECUTIVE_FAILURES (~1s @ 60fps) → 标记 `fatal`
- 连续无输出帧 ≥ MAX_CONSECUTIVE_FAILURES → 标记 `fatal`

### 上层处理（video.cpp）
`encode_amf` 检测 `encoded_frame.fatal` 时返回 -1，触发 session 真正的 reinit，而不是无限静默无视频。

## 影响

- 用户首次 Init 失败仍可启动流，只是某些功能被自动禁用并写入 warning 日志。
- 运行时驱动卡死/丢卡时不再无声 hang，会触发一次正常 reinit 流程。
- 不改变正常工作场景的行为（计数器在每次成功 encode 时清零）。