### PR TITLE
fix(installer): Windows installer path/service/legacy-NSIS upgrade hardening

### DIFF
--- a/cmake/packaging/sunshine.iss.in
+++ b/cmake/packaging/sunshine.iss.in
@@ -468,15 +468,44 @@ begin
   end;
 end;
 
-// Best-effort: extract the install directory from the NSIS UninstallString
-// (which is typically the absolute path of Uninstall.exe, optionally quoted).
+// Strip the executable path out of an UninstallString that may include
+// surrounding quotes and/or trailing arguments (e.g. '"...\Uninstall.exe" /S').
+function GetOldNSISUninstallExe(UninstallString: String): String;
+var
+  Path: String;
+  ClosePos, SpacePos: Integer;
+begin
+  Path := Trim(UninstallString);
+  if Path = '' then
+  begin
+    Result := '';
+    Exit;
+  end;
+  if Path[1] = '"' then
+  begin
+    ClosePos := Pos('"', Copy(Path, 2, Length(Path) - 1));
+    if ClosePos > 0 then
+      Path := Copy(Path, 2, ClosePos - 1)
+    else
+      Path := Copy(Path, 2, Length(Path) - 1);
+  end
+  else
+  begin
+    SpacePos := Pos(' ', Path);
+    if SpacePos > 0 then
+      Path := Copy(Path, 1, SpacePos - 1);
+  end;
+  Result := Path;
+end;
+
+// Best-effort: extract the install directory from the NSIS UninstallString.
 function GetOldNSISInstallDir(UninstallString: String): String;
 var
   Path: String;
   SlashPos: Integer;
 begin
   Result := '';
-  Path := RemoveQuotes(UninstallString);
+  Path := GetOldNSISUninstallExe(UninstallString);
   if Path = '' then
     Exit;
   SlashPos := Length(Path);
@@ -581,7 +610,7 @@ begin
   if UninstallString = '' then
     Exit;
 
-  UninstallExe := RemoveQuotes(UninstallString);
+  UninstallExe := GetOldNSISUninstallExe(UninstallString);
   InstallDir := GetOldNSISInstallDir(UninstallString);
 
   // If the uninstaller binary itself is gone, the registry entry is just stale

--- a/cmake/packaging/sunshine.iss.in
+++ b/cmake/packaging/sunshine.iss.in
@@ -537,8 +537,22 @@ begin
   // Fall back to HKLM32 for legacy 32-bit installs that wrote into Wow6432Node.
   if not Found then
     Found := RegQueryStringValue(HKLM32, 'SOFTWARE\AlkaidLab\Sunshine', 'InstallDir', InstallDir);
-  if Found and (InstallDir <> '') and DirExists(InstallDir) and
+  if not Found or (InstallDir = '') then
+    Exit;
+  if DirExists(InstallDir) and
      FileExists(AddBackslash(InstallDir) + '{#MyAppExeName}') then
+  begin
+    Result := InstallDir;
+    Exit;
+  end;
+  // Silent-mode safety net (auto-update path):
+  // The GUI updater launches us with /VERYSILENT (no dir page, no user
+  // interaction). If the previous sunshine.exe is missing (user deleted/moved
+  // it, AV quarantine, etc.) but the registry still points at a real
+  // directory, prefer that directory over falling back to {autopf}\Sunshine
+  // so the silent auto-update reliably overwrites the original location
+  // instead of creating a duplicate install in Program Files.
+  if WizardSilent and DirExists(InstallDir) then
     Result := InstallDir;
 end;
 

--- a/cmake/packaging/sunshine.iss.in
+++ b/cmake/packaging/sunshine.iss.in
@@ -99,6 +99,8 @@ english.FinishOpenDocs=Open documentation
 english.FinishLaunchGUI=Launch Sunshine GUI
 english.MsgOldNSISDetected=Detected a previous NSIS installation of Sunshine.%nIt must be uninstalled before continuing.%n%nUninstall the previous version now?
 english.MsgOldNSISFailed=The previous installation could not be fully removed.%nPlease uninstall it manually and try again.
+english.MsgOldNSISStaleRegistry=The previous installation files appear to be gone, but registry entries remain.%nClean up the leftover registry and continue installing?
+english.MsgOldNSISCleanupFailed=Failed to clean up the previous installation registry entries.%nPlease remove HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Sunshine manually and try again.
 english.MsgServiceInstallFailed=Sunshine service could not be installed or verified.%nPlease check the installer log and run the installer as administrator.
 english.MsgUninstallGamepad=Do you want to remove Virtual Gamepad?
 english.MsgUninstallData=Do you want to remove all data in %1?%n(This includes configuration, cover images, and settings)
@@ -137,6 +139,8 @@ chinesesimplified.FinishOpenDocs=打开使用文档
 chinesesimplified.FinishLaunchGUI=启动 Sunshine 管理界面
 chinesesimplified.MsgOldNSISDetected=检测到旧版 NSIS 安装的 Sunshine。%n需要先卸载才能继续。%n%n是否现在卸载旧版本？
 chinesesimplified.MsgOldNSISFailed=无法完全移除旧版安装。%n请手动卸载后重试。
+chinesesimplified.MsgOldNSISStaleRegistry=旧版本的文件已经不存在，但注册表中仍残留旧版的卸载信息。%n是否清理残留的注册表项并继续安装？
+chinesesimplified.MsgOldNSISCleanupFailed=清理旧版注册表项失败。%n请手动删除 HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Sunshine 后重试。
 chinesesimplified.MsgServiceInstallFailed=无法安装或验证 Sunshine 服务。%n请检查安装日志，并确认以管理员身份运行安装程序。
 chinesesimplified.MsgUninstallGamepad=是否移除虚拟手柄（ViGEmBus）？
 chinesesimplified.MsgUninstallData=是否删除 %1 中的所有数据？%n（包括配置文件、封面图片和设置）
@@ -464,6 +468,35 @@ begin
   end;
 end;
 
+// Best-effort: extract the install directory from the NSIS UninstallString
+// (which is typically the absolute path of Uninstall.exe, optionally quoted).
+function GetOldNSISInstallDir(UninstallString: String): String;
+var
+  Path: String;
+  SlashPos: Integer;
+begin
+  Result := '';
+  Path := RemoveQuotes(UninstallString);
+  if Path = '' then
+    Exit;
+  SlashPos := Length(Path);
+  while (SlashPos > 0) and (Path[SlashPos] <> '\') and (Path[SlashPos] <> '/') do
+    SlashPos := SlashPos - 1;
+  if SlashPos > 1 then
+    Result := Copy(Path, 1, SlashPos - 1);
+end;
+
+// Force-delete the NSIS uninstall registry entries left behind by an old
+// installation. Used as a fallback when the silent uninstall finishes but
+// the registry still claims the product is installed (or when the install
+// directory is already gone).
+function CleanupOldNSISRegistry(): Boolean;
+begin
+  RegDeleteKeyIncludingSubkeys(HKLM, 'SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Sunshine');
+  RegDeleteKeyIncludingSubkeys(HKLM, 'SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Sunshine');
+  Result := not DetectOldNSISInstall();
+end;
+
 // Read previous install directory from registry
 function GetPreviousInstallDir(Default: String): String;
 var
@@ -503,35 +536,91 @@ end;
 function InitializeSetup(): Boolean;
 var
   UninstallString: String;
+  UninstallExe: String;
+  InstallDir: String;
+  Params: String;
   ResultCode: Integer;
+  Waited: Integer;
 begin
   Result := True;
 
-  if DetectOldNSISInstall() then
+  if not DetectOldNSISInstall() then
+    Exit;
+
+  UninstallString := GetOldNSISUninstallString();
+  if UninstallString = '' then
+    Exit;
+
+  UninstallExe := RemoveQuotes(UninstallString);
+  InstallDir := GetOldNSISInstallDir(UninstallString);
+
+  // If the uninstaller binary itself is gone, the registry entry is just stale
+  // metadata. Offer to clean it up rather than blocking the install entirely.
+  if (UninstallExe = '') or (not FileExists(UninstallExe)) then
   begin
-    UninstallString := GetOldNSISUninstallString();
-    if UninstallString <> '' then
+    if MsgBox(CustomMessage('MsgOldNSISStaleRegistry'), mbConfirmation, MB_YESNO) = IDYES then
     begin
-      if MsgBox(CustomMessage('MsgOldNSISDetected'),
-        mbConfirmation, MB_YESNO) = IDYES then
+      if not CleanupOldNSISRegistry() then
       begin
-        // Run the NSIS uninstaller silently
-        Exec(RemoveQuotes(UninstallString), '/S', '', SW_SHOW, ewWaitUntilTerminated, ResultCode);
-        // Give it a moment to finish
-        Sleep(2000);
-        // Check if uninstall was successful
-        if DetectOldNSISInstall() then
-        begin
-          MsgBox(CustomMessage('MsgOldNSISFailed'), mbError, MB_OK);
-          Result := False;
-        end;
-      end
-      else
-      begin
+        MsgBox(CustomMessage('MsgOldNSISCleanupFailed'), mbError, MB_OK);
         Result := False;
       end;
+    end
+    else
+    begin
+      Result := False;
+    end;
+    Exit;
+  end;
+
+  if MsgBox(CustomMessage('MsgOldNSISDetected'), mbConfirmation, MB_YESNO) <> IDYES then
+  begin
+    Result := False;
+    Exit;
+  end;
+
+  // NSIS silent uninstall quirk: with bare '/S' the uninstaller copies itself
+  // to %TEMP% and re-launches a detached process, so ewWaitUntilTerminated
+  // returns almost immediately while the real cleanup is still running. Pass
+  // '_?=<InstallDir>' so the uninstaller runs in-place and we actually wait.
+  Params := '/S';
+  if (InstallDir <> '') and DirExists(InstallDir) then
+    Params := Params + ' _?=' + InstallDir;
+
+  Exec(UninstallExe, Params, '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+
+  // Poll for up to ~60 seconds in case the uninstaller still detached or its
+  // post-uninstall steps (firewall/service/driver scripts) take a while.
+  Waited := 0;
+  while DetectOldNSISInstall() and (Waited < 60) do
+  begin
+    Sleep(1000);
+    Waited := Waited + 1;
+  end;
+
+  if not DetectOldNSISInstall() then
+    Exit;
+
+  // Still detected. If the install directory is empty/gone, the uninstaller
+  // succeeded at removing files but failed to delete its own registry key
+  // (a known NSIS issue when launched with _?=). Offer to clean it up so
+  // the user is not stuck in an unrecoverable state.
+  if (InstallDir = '') or (not DirExists(InstallDir)) or
+     (not FileExists(UninstallExe)) then
+  begin
+    if MsgBox(CustomMessage('MsgOldNSISStaleRegistry'), mbConfirmation, MB_YESNO) = IDYES then
+    begin
+      if not CleanupOldNSISRegistry() then
+      begin
+        MsgBox(CustomMessage('MsgOldNSISCleanupFailed'), mbError, MB_OK);
+        Result := False;
+      end;
+      Exit;
     end;
   end;
+
+  MsgBox(CustomMessage('MsgOldNSISFailed'), mbError, MB_OK);
+  Result := False;
 end;
 
 // Stop services and processes before installation to avoid locked files

--- a/cmake/packaging/sunshine.iss.in
+++ b/cmake/packaging/sunshine.iss.in
@@ -25,6 +25,8 @@ AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}/support
 AppUpdatesURL={#MyAppURL}
 DefaultDirName={code:GetPreviousInstallDir|{autopf}\{#MyAppName}}
+; Always show the directory page so users can recover from a bad remembered path.
+DisableDirPage=no
 DefaultGroupName={#MyAppName}
 ; 管理员权限
 PrivilegesRequired=admin
@@ -49,8 +51,8 @@ VersionInfoDescription=Sunshine Foundation Game Streaming Server
 VersionInfoProductName={#MyAppName}
 ; 其他
 LicenseFile={#MyLicenseFile}
-; 允许覆盖安装
-UsePreviousAppDir=yes
+; Use our validated InstallDir registry value instead of Inno Setup's implicit previous app dir.
+UsePreviousAppDir=no
 ; 最小 Windows 版本 (Windows 10)
 MinVersion=10.0
 ; 64 位安装
@@ -97,6 +99,7 @@ english.FinishOpenDocs=Open documentation
 english.FinishLaunchGUI=Launch Sunshine GUI
 english.MsgOldNSISDetected=Detected a previous NSIS installation of Sunshine.%nIt must be uninstalled before continuing.%n%nUninstall the previous version now?
 english.MsgOldNSISFailed=The previous installation could not be fully removed.%nPlease uninstall it manually and try again.
+english.MsgServiceInstallFailed=Sunshine service could not be installed or verified.%nPlease check the installer log and run the installer as administrator.
 english.MsgUninstallGamepad=Do you want to remove Virtual Gamepad?
 english.MsgUninstallData=Do you want to remove all data in %1?%n(This includes configuration, cover images, and settings)
 english.StatusStoppingService=Stopping Sunshine service...
@@ -134,6 +137,7 @@ chinesesimplified.FinishOpenDocs=打开使用文档
 chinesesimplified.FinishLaunchGUI=启动 Sunshine 管理界面
 chinesesimplified.MsgOldNSISDetected=检测到旧版 NSIS 安装的 Sunshine。%n需要先卸载才能继续。%n%n是否现在卸载旧版本？
 chinesesimplified.MsgOldNSISFailed=无法完全移除旧版安装。%n请手动卸载后重试。
+chinesesimplified.MsgServiceInstallFailed=无法安装或验证 Sunshine 服务。%n请检查安装日志，并确认以管理员身份运行安装程序。
 chinesesimplified.MsgUninstallGamepad=是否移除虚拟手柄（ViGEmBus）？
 chinesesimplified.MsgUninstallData=是否删除 %1 中的所有数据？%n（包括配置文件、封面图片和设置）
 chinesesimplified.StatusStoppingService=正在停止 Sunshine 服务...
@@ -250,7 +254,7 @@ Filename: "{app}\scripts\add-firewall-rule.bat"; StatusMsg: "{cm:StatusFirewall}
 Filename: "{app}\scripts\install-vdd.bat"; StatusMsg: "{cm:StatusInstallVDD}"; Flags: runhidden waituntilterminated; Components: vdd
 Filename: "{app}\scripts\install-gamepad.bat"; StatusMsg: "{cm:StatusInstallGamepad}"; Flags: runhidden waituntilterminated; Components: gamepad
 Filename: "{app}\scripts\vmouse\install-vmouse.bat"; StatusMsg: "{cm:StatusInstallVmouse}"; Flags: runhidden waituntilterminated; Components: vmouse
-Filename: "{app}\scripts\install-service.bat"; StatusMsg: "{cm:StatusInstallService}"; Flags: runhidden waituntilterminated
+Filename: "{app}\scripts\install-service.bat"; StatusMsg: "{cm:StatusInstallService}"; Flags: runhidden waituntilterminated; AfterInstall: VerifyServiceInstalled
 Filename: "{app}\scripts\autostart-service.bat"; StatusMsg: "{cm:StatusAutostart}"; Flags: runhidden waituntilterminated; Components: autostart
 
 ; Finish page actions - user selectable
@@ -468,8 +472,30 @@ begin
   Result := Default;
   if RegQueryStringValue(HKLM64, 'SOFTWARE\AlkaidLab\Sunshine', 'InstallDir', InstallDir) then
   begin
-    if DirExists(InstallDir) then
+    if DirExists(InstallDir) and FileExists(AddBackslash(InstallDir) + '{#MyAppExeName}') then
       Result := InstallDir;
+  end;
+end;
+
+procedure DeleteInstallDirRegistry();
+begin
+  RegDeleteValue(HKLM64, 'SOFTWARE\AlkaidLab\Sunshine', 'InstallDir');
+  RegDeleteValue(HKLM32, 'SOFTWARE\AlkaidLab\Sunshine', 'InstallDir');
+  RegDeleteKeyIfEmpty(HKLM64, 'SOFTWARE\AlkaidLab\Sunshine');
+  RegDeleteKeyIfEmpty(HKLM32, 'SOFTWARE\AlkaidLab\Sunshine');
+  RegDeleteKeyIfEmpty(HKLM64, 'SOFTWARE\AlkaidLab');
+  RegDeleteKeyIfEmpty(HKLM32, 'SOFTWARE\AlkaidLab');
+end;
+
+procedure VerifyServiceInstalled();
+var
+  ResultCode: Integer;
+  ExpectedPath: String;
+begin
+  ExpectedPath := ExpandConstant('{app}\tools\sunshinesvc.exe');
+  if (not Exec(ExpandConstant('{cmd}'), '/c sc qc SunshineService | find /I "' + ExpectedPath + '" >nul', '', SW_HIDE, ewWaitUntilTerminated, ResultCode)) or (ResultCode <> 0) then
+  begin
+    RaiseException(CustomMessage('MsgServiceInstallFailed'));
   end;
 end;
 
@@ -551,6 +577,10 @@ begin
 
   if CurUninstallStep = usPostUninstall then
   begin
+    // InstallDir is installer state, not user data. Always remove it so a failed
+    // installation cannot lock future installs to a stale drive/path.
+    DeleteInstallDirRegistry();
+
     // Ask about data removal
     if MsgBox(FmtMessage(CustomMessage('MsgUninstallData'), [ExpandConstant('{app}')]),
       mbConfirmation, MB_YESNO or MB_DEFBUTTON2) = IDNO then
@@ -561,10 +591,6 @@ begin
     begin
       // Remove the installation directory
       DelTree(ExpandConstant('{app}'), True, True, True);
-      // Clean up registry
-      RegDeleteValue(HKLM64, 'SOFTWARE\AlkaidLab\Sunshine', 'InstallDir');
-      RegDeleteKeyIfEmpty(HKLM64, 'SOFTWARE\AlkaidLab\Sunshine');
-      RegDeleteKeyIfEmpty(HKLM64, 'SOFTWARE\AlkaidLab');
     end;
   end;
 end;

--- a/cmake/packaging/sunshine.iss.in
+++ b/cmake/packaging/sunshine.iss.in
@@ -501,17 +501,24 @@ end;
 function GetPreviousInstallDir(Default: String): String;
 var
   InstallDir: String;
+  Found: Boolean;
 begin
   Result := Default;
-  if RegQueryStringValue(HKLM64, 'SOFTWARE\AlkaidLab\Sunshine', 'InstallDir', InstallDir) then
-  begin
-    if DirExists(InstallDir) and FileExists(AddBackslash(InstallDir) + '{#MyAppExeName}') then
-      Result := InstallDir;
-  end;
+  Found := RegQueryStringValue(HKLM64, 'SOFTWARE\AlkaidLab\Sunshine', 'InstallDir', InstallDir);
+  // Fall back to HKLM32 for legacy 32-bit installs that wrote into Wow6432Node.
+  if not Found then
+    Found := RegQueryStringValue(HKLM32, 'SOFTWARE\AlkaidLab\Sunshine', 'InstallDir', InstallDir);
+  if Found and (InstallDir <> '') and DirExists(InstallDir) and
+     FileExists(AddBackslash(InstallDir) + '{#MyAppExeName}') then
+    Result := InstallDir;
 end;
 
 procedure DeleteInstallDirRegistry();
 begin
+  // The HKLM64 InstallDir value is also covered by [Registry] uninsdeletevalue,
+  // but we explicitly clean HKLM32 legacy values (older installs may have
+  // written there) and prune empty parent keys regardless of the user's
+  // "keep data" choice.
   RegDeleteValue(HKLM64, 'SOFTWARE\AlkaidLab\Sunshine', 'InstallDir');
   RegDeleteValue(HKLM32, 'SOFTWARE\AlkaidLab\Sunshine', 'InstallDir');
   RegDeleteKeyIfEmpty(HKLM64, 'SOFTWARE\AlkaidLab\Sunshine');
@@ -523,13 +530,36 @@ end;
 procedure VerifyServiceInstalled();
 var
   ResultCode: Integer;
-  ExpectedPath: String;
+  TmpFile, ExpectedPath, Line, Lower: String;
+  Lines: TArrayOfString;
+  i: Integer;
+  Matched: Boolean;
 begin
   ExpectedPath := ExpandConstant('{app}\tools\sunshinesvc.exe');
-  if (not Exec(ExpandConstant('{cmd}'), '/c sc qc SunshineService | find /I "' + ExpectedPath + '" >nul', '', SW_HIDE, ewWaitUntilTerminated, ResultCode)) or (ResultCode <> 0) then
+  TmpFile := ExpandConstant('{tmp}\sc_qc_sunshineservice.txt');
+  // Redirect to a temp file and parse in Pascal so we don't depend on cmd.exe
+  // performing %VAR% expansion on the captured path or on `find` substring
+  // matching (which would mis-handle e.g. "sunshinesvc.exe.bak").
+  Exec(ExpandConstant('{cmd}'), '/c sc qc SunshineService > "' + TmpFile + '" 2>&1',
+       '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+  Matched := False;
+  if (ResultCode = 0) and LoadStringsFromFile(TmpFile, Lines) then
   begin
-    RaiseException(CustomMessage('MsgServiceInstallFailed'));
+    Lower := Lowercase(ExpectedPath);
+    for i := 0 to GetArrayLength(Lines) - 1 do
+    begin
+      Line := Trim(Lines[i]);
+      if (Pos('BINARY_PATH_NAME', Uppercase(Line)) = 1) and
+         (Pos(Lower, Lowercase(Line)) > 0) then
+      begin
+        Matched := True;
+        Break;
+      end;
+    end;
   end;
+  DeleteFile(TmpFile);
+  if not Matched then
+    RaiseException(CustomMessage('MsgServiceInstallFailed'));
 end;
 
 // Initialization: handle old NSIS upgrade

--- a/src_assets/windows/misc/service/install-service.bat
+++ b/src_assets/windows/misc/service/install-service.bat
@@ -9,6 +9,11 @@ set "SERVICE_BIN=%ROOT_DIR%\tools\sunshinesvc.exe"
 set "SERVICE_CONFIG_DIR=%LOCALAPPDATA%\LizardByte\Sunshine"
 set "SERVICE_CONFIG_FILE=%SERVICE_CONFIG_DIR%\service_start_type.txt"
 
+if not exist "%SERVICE_BIN%" (
+    echo ERROR: Service binary not found: "%SERVICE_BIN%"
+    exit /b 1
+)
+
 rem Set service to demand start. It will be changed to auto later if the user selected that option.
 set SERVICE_START_TYPE=demand
 
@@ -58,13 +63,47 @@ if exist "%SERVICE_CONFIG_FILE%" (
 echo Setting service start type set to: [!SERVICE_START_TYPE!]
 
 rem Run the sc command to create/reconfigure the service
-sc %SC_CMD% %SERVICE_NAME% binPath= "%SERVICE_BIN%" start= %SERVICE_START_TYPE% DisplayName= "Sunshine Service"
+set "SC_START_TYPE=!SERVICE_START_TYPE!"
+if /I "!SERVICE_START_TYPE!"=="delayed-auto" set "SC_START_TYPE=auto"
+
+sc !SC_CMD! %SERVICE_NAME% binPath= "%SERVICE_BIN%" start= !SC_START_TYPE! DisplayName= "Sunshine Service"
+if errorlevel 1 (
+    echo ERROR: Failed to !SC_CMD! %SERVICE_NAME%.
+    exit /b 1
+)
+
+if /I "!SERVICE_START_TYPE!"=="delayed-auto" (
+    sc config %SERVICE_NAME% start= delayed-auto
+    if errorlevel 1 (
+        echo ERROR: Failed to configure delayed auto-start for %SERVICE_NAME%.
+        exit /b 1
+    )
+)
+
+sc qc %SERVICE_NAME% >nul 2>&1
+if errorlevel 1 (
+    echo ERROR: %SERVICE_NAME% was not created.
+    exit /b 1
+)
 
 rem Set the description of the service
 sc description %SERVICE_NAME% "Sunshine is a self-hosted game stream host for Moonlight."
+if errorlevel 1 (
+    echo ERROR: Failed to set %SERVICE_NAME% description.
+    exit /b 1
+)
+
+if /I "!SERVICE_START_TYPE!"=="disabled" (
+    echo %SERVICE_NAME% installed with disabled start type; skipping service start.
+    exit /b 0
+)
 
 rem Start the new service
 net start %SERVICE_NAME%
+if errorlevel 1 (
+    echo ERROR: Failed to start %SERVICE_NAME%.
+    exit /b 1
+)
 
 rem Determine the Web UI port from config (default base port 47989 + 1 = 47990)
 set /a WEB_PORT=47990
@@ -100,3 +139,5 @@ set /a WAIT_COUNT+=1
 timeout /t 1 /nobreak >nul
 goto :wait_loop
 :wait_done
+
+exit /b 0

--- a/src_assets/windows/misc/service/install-service.bat
+++ b/src_assets/windows/misc/service/install-service.bat
@@ -80,17 +80,20 @@ if /I "!SERVICE_START_TYPE!"=="delayed-auto" (
     )
 )
 
-sc qc %SERVICE_NAME% >nul 2>&1
+rem Verify the service was created/reconfigured AND that its binPath actually
+rem points to the binary we just shipped. Substring match is enough here
+rem because %SERVICE_BIN% is fully qualified and unique per install.
+sc qc %SERVICE_NAME% | find /I "%SERVICE_BIN%" >nul
 if errorlevel 1 (
-    echo ERROR: %SERVICE_NAME% was not created.
+    echo ERROR: %SERVICE_NAME% binPath does not match "%SERVICE_BIN%".
     exit /b 1
 )
 
-rem Set the description of the service
+rem Set the description of the service. Description is metadata only and can
+rem fail under SCM contention or AV interference; never abort install for it.
 sc description %SERVICE_NAME% "Sunshine is a self-hosted game stream host for Moonlight."
 if errorlevel 1 (
-    echo ERROR: Failed to set %SERVICE_NAME% description.
-    exit /b 1
+    echo WARNING: Failed to set %SERVICE_NAME% description; continuing.
 )
 
 if /I "!SERVICE_START_TYPE!"=="disabled" (
@@ -98,11 +101,16 @@ if /I "!SERVICE_START_TYPE!"=="disabled" (
     exit /b 0
 )
 
-rem Start the new service
+rem Start the new service. net start returns non-zero when the service is
+rem already running (e.g. SCM auto-started it after sc config), so verify the
+rem actual state via sc query before treating that as a failure.
 net start %SERVICE_NAME%
 if errorlevel 1 (
-    echo ERROR: Failed to start %SERVICE_NAME%.
-    exit /b 1
+    sc query %SERVICE_NAME% | find /I "RUNNING" >nul
+    if errorlevel 1 (
+        echo ERROR: Failed to start %SERVICE_NAME%.
+        exit /b 1
+    )
 )
 
 rem Determine the Web UI port from config (default base port 47989 + 1 = 47990)


### PR DESCRIPTION
## Summary

修复 Windows 安装器在以下场景下的多个回归问题：

### 安装目录与注册表
- 不再依赖 Inno Setup 的隐式 `UsePreviousAppDir`，统一从我们自己的 `HKLM\SOFTWARE\AlkaidLab\Sunshine\InstallDir` 读取上次目录。
- 校验 `DirExists + sunshine.exe FileExists` 后才回填路径，避免被陈旧/已迁移的目录卡死。
- `GetPreviousInstallDir` 在 `HKLM64` 未命中时回退查询 `HKLM32`，覆盖更早 32-bit 安装。
- 始终保留目录页（`DisableDirPage=no`），让用户可以从坏路径手动恢复。
- 卸载时无论用户是否选择保留数据，都清理 `HKLM64/HKLM32` 下的 `InstallDir` 残留键，避免下一次安装继承到旧驱动器。

### 服务安装可靠性
- `install-service.bat` 全程 fail-fast：缺失 binary、`sc create/config` 失败、`net start` 启动失败均 `exit /b 1`，便于安装器抓取错误。
- `sc qc` 检查升级为 **binPath 校验**（`find /I "%SERVICE_BIN%"`），脚本侧就能确认服务确实指向当前 `{app}\tools\sunshinesvc.exe`。
- `sc description` 失败仅 WARNING；元数据写入失败不应阻断安装。
- `net start` 返回非 0 时再用 `sc query` 校验是否已 `RUNNING`，避免"服务已被 SCM 自启动"被误报为失败。
- `delayed-auto` 拆成 `auto` + 二次 `sc config start= delayed-auto`，规避 sc 对 `start=` 的解析差异。
- 安装器在 `[Run]` 调用后用 Pascal 端 `VerifyServiceInstalled` 二次校验：将 `sc qc` 输出重定向到临时文件，逐行解析 `BINARY_PATH_NAME`，规范化大小写后比对，避免 `cmd.exe` 对 `%` 的展开和 `find` 子串匹配的误报（如 `sunshinesvc.exe.bak`）。校验失败抛出本地化的 `MsgServiceInstallFailed`。

### v0324（NSIS）→ 新版（Inno）覆盖安装失败
**症状**：用户用 v2026.0324 之前的 NSIS 包覆盖安装新版时，弹出"卸载旧版本失败"。

**根因**：CPack 生成的 NSIS 卸载器以裸 `/S` 启动时会复制自身到 `%TEMP%` 并 fork 一个脱离的进程，原始进程立即返回，`Exec/ewWaitUntilTerminated + Sleep(2000)` 实际只等到了启动器，注册表清理还没跑完，被我们 re-detect → 弹 `MsgOldNSISFailed`。

**修复**（`InitializeSetup` / `cmake/packaging/sunshine.iss.in`）：
1. 从 `UninstallString` 解析旧 InstallDir，给 NSIS 卸载器追加 `_?=<InstallDir>`，让其在原地运行不脱离，`Exec` 才能真正等到完成。
2. 仍残留时轮询最多 60s，覆盖防火墙/服务/驱动卸载脚本耗时。
3. 兜底：若文件已不存在但注册表项还在（NSIS `_?=` 已知不会自删卸载键的副作用，或被半残安装），弹窗询问是否清理 `HKLM[\WOW6432Node]\...\Uninstall\Sunshine` 后继续，避免用户卡死。
4. 新增中英文 `MsgOldNSISStaleRegistry` / `MsgOldNSISCleanupFailed` 文案。

## Verification

- `cmake --build build --target innosetup` 多次成功（最近 23.4s），产物 `build/cpack_artifacts/Sunshine.exe` (~23 MB)。
- 验证 Pascal 脚本无语法错误（Inno 编译器通过）。

## Notes

- 本地未提交：`.env`、`src_assets/common/sunshine-control-panel` 子模块状态。
- 已应用 CodeRabbit 第一轮 review 的 2 个 actionable + 4 个 nitpick 建议。
