### PR TITLE
fix(http): HTTPS servers 多线程池 + on_error 清理 cert UUID map

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -2792,6 +2792,10 @@ namespace confighttp {
     server.config.reuse_address = true;
     server.config.address = net::get_bind_address(address_family);
     server.config.port = port_https;
+    // Use a small thread pool so that a slow request handler (proxy upstream,
+    // file upload, etc.) doesn't block other web UI requests on the same
+    // single-threaded io_service.
+    server.config.thread_pool_size = 2;
 
     auto accept_and_run = [&](https_server_t *server) {
       try {

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -232,8 +232,22 @@ namespace nvhttp {
                     std::shared_lock<std::shared_mutex> cl(client_root_mutex);
                     for (const auto &named_cert : client_root.named_devices) {
                       if (named_cert.cert == client_cert_pem) {
-                        // Store UUID in map using request pointer as key
+                        // Store UUID in map using request pointer as key.
+                        // Opportunistically sweep expired entries on every
+                        // insert so that requests which never reach
+                        // get_client_cert_uuid_from_request() (e.g. serverinfo
+                        // polling, applist) and never trigger on_error don't
+                        // accumulate forever. This bounds the map size at
+                        // ~(live requests + recently completed requests).
                         std::lock_guard<std::mutex> lock(request_cert_uuid_map_mutex);
+                        for (auto it = request_cert_uuid_map.begin(); it != request_cert_uuid_map.end();) {
+                          if (it->second.first.expired()) {
+                            it = request_cert_uuid_map.erase(it);
+                          }
+                          else {
+                            ++it;
+                          }
+                        }
                         request_cert_uuid_map[session->request.get()] =
                           std::make_pair(std::weak_ptr<void>(std::static_pointer_cast<void>(session->request)), named_cert.uuid);
                         break;

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -90,6 +90,18 @@ namespace nvhttp {
 
   static std::string last_pair_name;
 
+  // Protects map_id_sess and last_pair_name. Pairing is rare and short-lived,
+  // a plain mutex is fine. The pair() request handler holds this for its full
+  // critical section (incl. nested calls to remove_session / fail_pair).
+  std::mutex map_id_sess_mutex;
+
+  // Protects client_root. Reads (SSL verify on every TLS handshake) are hot,
+  // writes (pair completion / unpair / rename / load_state) are rare, so use
+  // a shared_mutex. NEVER call save_state() while holding this mutex with
+  // unique ownership: save_state() takes a shared lock and std::shared_mutex
+  // does not support recursive locking.
+  std::shared_mutex client_root_mutex;
+
   // Preset PIN for QR code pairing
   static struct {
     std::string pin;
@@ -217,6 +229,7 @@ namespace nvhttp {
                   if (x509) {
                     std::string client_cert_pem = crypto::pem(x509);
                     // Find matching certificate UUID
+                    std::shared_lock<std::shared_mutex> cl(client_root_mutex);
                     for (const auto &named_cert : client_root.named_devices) {
                       if (named_cert.cert == client_cert_pem) {
                         // Store UUID in map using request pointer as key
@@ -325,16 +338,18 @@ namespace nvhttp {
     root.erase("root"s);
 
     root.put("root.uniqueid", http::unique_id);
-    client_t &client = client_root;
     pt::ptree node;
 
     pt::ptree named_cert_nodes;
-    for (auto &named_cert : client.named_devices) {
-      pt::ptree named_cert_node;
-      named_cert_node.put("name"s, named_cert.name);
-      named_cert_node.put("cert"s, named_cert.cert);
-      named_cert_node.put("uuid"s, named_cert.uuid);
-      named_cert_nodes.push_back(std::make_pair(""s, named_cert_node));
+    {
+      std::shared_lock<std::shared_mutex> cl(client_root_mutex);
+      for (auto &named_cert : client_root.named_devices) {
+        pt::ptree named_cert_node;
+        named_cert_node.put("name"s, named_cert.name);
+        named_cert_node.put("cert"s, named_cert.cert);
+        named_cert_node.put("uuid"s, named_cert.uuid);
+        named_cert_nodes.push_back(std::make_pair(""s, named_cert_node));
+      }
     }
     root.add_child("root.named_devices"s, named_cert_nodes);
 
@@ -413,17 +428,22 @@ namespace nvhttp {
       }
     }
 
-    client_root = client;
+    {
+      std::unique_lock<std::shared_mutex> ul(client_root_mutex);
+      client_root = std::move(client);
+    }
   }
 
   void
   add_authorized_client(const std::string &name, std::string &&cert) {
-    client_t &client = client_root;
     named_cert_t named_cert;
     named_cert.name = name;
     named_cert.cert = std::move(cert);
     named_cert.uuid = uuid_util::uuid_t::generate().string();
-    client.named_devices.emplace_back(named_cert);
+    {
+      std::unique_lock<std::shared_mutex> ul(client_root_mutex);
+      client_root.named_devices.emplace_back(std::move(named_cert));
+    }
 
     if (!config::sunshine.flags[config::flag::FRESH_STATE]) {
       save_state();
@@ -529,6 +549,9 @@ namespace nvhttp {
 
   void
   remove_session(const pair_session_t &sess) {
+    // Caller MUST hold map_id_sess_mutex (called from fail_pair /
+    // clientpairingsecret, both invoked inside the pair() handler critical
+    // section).
     map_id_sess.erase(sess.client.uniqueID);
   }
 
@@ -835,6 +858,13 @@ namespace nvhttp {
 
     auto uniqID { get_arg(args, "uniqueid") };
 
+    // Serialize all access to map_id_sess and last_pair_name. The pair flow is
+    // multi-step (emplace -> later access via iterator -> later erase) and the
+    // map / iterators must not be touched by another worker thread mid-flight.
+    // Holding this for the whole handler is fine: pairing is rare and crypto
+    // is CPU-bound (no async waits).
+    std::lock_guard<std::mutex> map_lock(map_id_sess_mutex);
+
     args_t::const_iterator it;
     if (it = args.find("phrase"); it != std::end(args)) {
       if (it->second == "getservercert"sv) {
@@ -915,6 +945,7 @@ namespace nvhttp {
   bool
   pin(std::string pin, std::string name) {
     pt::ptree tree;
+    std::lock_guard<std::mutex> map_lock(map_id_sess_mutex);
     if (map_id_sess.empty()) {
       return false;
     }
@@ -1064,8 +1095,8 @@ namespace nvhttp {
   nlohmann::json
   get_all_clients() {
     nlohmann::json named_cert_nodes = nlohmann::json::array();
-    client_t &client = client_root;
-    for (auto &named_cert : client.named_devices) {
+    std::shared_lock<std::shared_mutex> cl(client_root_mutex);
+    for (auto &named_cert : client_root.named_devices) {
       nlohmann::json named_cert_node;
       named_cert_node["name"] = named_cert.name;
       named_cert_node["uuid"] = named_cert.uuid;
@@ -1077,6 +1108,7 @@ namespace nvhttp {
 
   std::string
   get_pair_name() {
+    std::lock_guard<std::mutex> map_lock(map_id_sess_mutex);
     return last_pair_name;
   }
 
@@ -2514,8 +2546,10 @@ namespace nvhttp {
 
   void
   erase_all_clients() {
-    client_t client;
-    client_root = client;
+    {
+      std::unique_lock<std::shared_mutex> ul(client_root_mutex);
+      client_root = client_t {};
+    }
     {
       std::unique_lock<std::shared_mutex> ul(cert_chain_mutex);
       cert_chain.clear();
@@ -2526,14 +2560,17 @@ namespace nvhttp {
   int
   unpair_client(std::string uuid) {
     bool removed = false;
-    client_t &client = client_root;
-    for (auto it = client.named_devices.begin(); it != client.named_devices.end();) {
-      if ((*it).uuid == uuid) {
-        it = client.named_devices.erase(it);
-        removed = true;
-      }
-      else {
-        ++it;
+    {
+      std::unique_lock<std::shared_mutex> ul(client_root_mutex);
+      auto &devices = client_root.named_devices;
+      for (auto it = devices.begin(); it != devices.end();) {
+        if (it->uuid == uuid) {
+          it = devices.erase(it);
+          removed = true;
+        }
+        else {
+          ++it;
+        }
       }
     }
 
@@ -2544,14 +2581,20 @@ namespace nvhttp {
 
   bool
   rename_client(const std::string &uuid, const std::string &new_name) {
-    client_t &client = client_root;
-    for (auto &named_cert : client.named_devices) {
-      if (named_cert.uuid == uuid) {
-        named_cert.name = new_name;
-        save_state();
-        return true;
+    bool renamed = false;
+    {
+      std::unique_lock<std::shared_mutex> ul(client_root_mutex);
+      for (auto &named_cert : client_root.named_devices) {
+        if (named_cert.uuid == uuid) {
+          named_cert.name = new_name;
+          renamed = true;
+          break;
+        }
       }
     }
-    return false;
+    if (renamed) {
+      save_state();
+    }
+    return renamed;
   }
 }  // namespace nvhttp

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -2435,6 +2435,29 @@ namespace nvhttp {
     https_server.config.reuse_address = true;
     https_server.config.address = net::get_bind_address(address_family);
     https_server.config.port = port_https;
+    // Run nvhttps server with a small thread pool. The HTTPS endpoint serves
+    // SSL handshakes + request handlers on the same io_service. With the default
+    // single thread, any slow handshake / aborted SSL cleanup (e.g. a client
+    // sending TCP RST while in-flight HTTP/2 streams are open) blocks accept
+    // for all other clients until Sunshine is restarted. Multiple worker
+    // threads keep the listener responsive under such conditions.
+    https_server.config.thread_pool_size = 4;
+
+    // Clean up request_cert_uuid_map entries when a request fails before
+    // get_client_cert_uuid_from_request() is reached, otherwise stale entries
+    // (with expired weak_ptr) accumulate over the lifetime of the process.
+    https_server.on_error = [](req_https_t request, const SimpleWeb::error_code & /*ec*/) {
+      std::lock_guard<std::mutex> lock(request_cert_uuid_map_mutex);
+      request_cert_uuid_map.erase(request.get());
+      // Opportunistic sweep of any other entries whose request has gone away.
+      for (auto it = request_cert_uuid_map.begin(); it != request_cert_uuid_map.end();) {
+        if (it->second.first.expired()) {
+          it = request_cert_uuid_map.erase(it);
+        } else {
+          ++it;
+        }
+      }
+    };
 
     http_server.default_resource["GET"] = not_found<SimpleWeb::HTTP>;
     http_server.resource["^/serverinfo$"]["GET"] = serverinfo<SimpleWeb::HTTP>;


### PR DESCRIPTION
## 问题

nvhttp（串流 HTTPS 端点）与 confighttp（Web UI）都跑在 Simple-Web-Server 默认的 `thread_pool_size = 1`。SSL handshake、请求 handler、SSL cleanup 共用同一个 io_service 线程。

当客户端在请求飞行中中断连接（例如 HarmonyOS rcp `session.close()` 在 HTTP/2 streams 还在飞时触发 TCP RST），OpenSSL 的 shutdown / cleanup 路径可能卡住唯一的 io 线程。

**期间所有其他客户端**——包括完全健康的 Android / Windows Moonlight 客户端——**都无法完成 TLS handshake**，所有 PC 在 Moonlight 客户端列表里全部显示离线，直到 Sunshine 重启。

## 复现

1. 用 HarmonyOS Moonlight 连接 Sunshine
2. 在 ServerInfo 请求超时窗口（Sunshine 重启 / 网络抖动）触发客户端 invalidate session
3. 此时 Android Moonlight 也无法连接同一台 PC
4. 必须重启 Sunshine 才能恢复

## 修复

| 改动 | 文件 | 说明 |
|---|---|---|
| `https_server.config.thread_pool_size = 4` | nvhttp.cpp | 让 SSL handshake / 请求处理并发，单连接异常不再阻塞 listener |
| `server.config.thread_pool_size = 2` | confighttp.cpp | Web UI 同问题（流量低，2 线程已够） |
| `https_server.on_error` 清理 `request_cert_uuid_map` | nvhttp.cpp | 失败连接累积内存泄漏修复，顺手清扫已 expired 的 weak_ptr |

## 安全性

- Simple-Web-Server 自身是 thread-safe 的（boost::asio 调度自带 strand）
- `request_cert_uuid_map` 的 mutex 已经做好保护，加线程池安全
- handler 内全局状态（client_root / cert_chain）已用 `std::shared_mutex` 保护

## 客户端侧配套修复

鸿蒙端已修复 timeout 不再 invalidate session 避免触发本问题：AlkaidLab/moonlight-harmony@0b89847。两边都修复后该问题彻底消除。