### PR TITLE
fix(installer): require admin, drop user-mode override

### DIFF
--- a/cmake/packaging/sunshine.iss.in
+++ b/cmake/packaging/sunshine.iss.in
@@ -28,9 +28,10 @@ DefaultDirName={code:GetPreviousInstallDir|{autopf}\{#MyAppName}}
 ; Always show the directory page so users can recover from a bad remembered path.
 DisableDirPage=no
 DefaultGroupName={#MyAppName}
-; 管理员权限
+; 管理员权限。Sunshine 必须以管理员安装：写 HKLM 注册表、安装服务/驱动/防火墙、
+; 写入 {autopf}\Sunshine 都需要提权。不允许用户在 UAC 对话框中降级到 "为当前用户安装"，
+; 否则 HKLM\SOFTWARE\AlkaidLab\Sunshine 会以错误 5 (拒绝访问) 失败。
 PrivilegesRequired=admin
-PrivilegesRequiredOverridesAllowed=dialog
 ; 输出设置
 OutputDir=@CPACK_PACKAGE_DIRECTORY@
 OutputBaseFilename=Sunshine


### PR DESCRIPTION
## 问题

用户安装新版报错：

```
创建注册表项时出错:
HKEY_LOCAL_MACHINE\SOFTWARE\AlkaidLab\Sunshine
RegCreateKeyEx 失败; 错误代码 5.
拒绝访问。
```

## 根因

[`sunshine.iss.in`](https://github.com/AlkaidLab/foundation-sunshine/blob/master/cmake/packaging/sunshine.iss.in) 之前同时设置了：

```ini
PrivilegesRequired=admin
PrivilegesRequiredOverridesAllowed=dialog
```

`PrivilegesRequiredOverridesAllowed=dialog` 会在 UAC 提权前弹一个 "为所有人安装 / 只为我安装" 对话框。用户选了 **只为我安装** → 安装器以普通用户权限运行 → 后续步骤几乎全部失败：

- `[Registry] HKLM64\SOFTWARE\AlkaidLab\Sunshine` 写入 → 拒绝访问 (错误 5)
- 写入 `{autopf}\Sunshine` (Program Files) → 拒绝访问
- `sc create SunshineService` → 拒绝访问
- ViGEm / VDD / ZakoVirtualMouse 驱动安装 → 拒绝访问
- 防火墙规则 → 拒绝访问

Sunshine 没有有意义的 per-user 安装布局，留这个开关有害无益。

## 修复

去掉 `PrivilegesRequiredOverridesAllowed=dialog`，强制必须管理员。Inno Setup 仍会自动触发 UAC，不影响用户体验。

## 自救方案 (已被坑的用户)

右键安装包 → **以管理员身份运行**，或在 UAC 对话框选 "为所有人安装"。