### PR TITLE
feat(clipboard): add Moonlight clipboard sync bridge

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -105,6 +105,8 @@ set(SUNSHINE_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/rtsp.h"
         "${CMAKE_SOURCE_DIR}/src/stream.cpp"
         "${CMAKE_SOURCE_DIR}/src/stream.h"
+        "${CMAKE_SOURCE_DIR}/src/clipboard_bridge.cpp"
+        "${CMAKE_SOURCE_DIR}/src/clipboard_bridge.h"
         "${CMAKE_SOURCE_DIR}/src/video.cpp"
         "${CMAKE_SOURCE_DIR}/src/video.h"
         "${CMAKE_SOURCE_DIR}/src/video_colorspace.cpp"

--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -107,6 +107,8 @@ set(SUNSHINE_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/stream.h"
         "${CMAKE_SOURCE_DIR}/src/clipboard_bridge.cpp"
         "${CMAKE_SOURCE_DIR}/src/clipboard_bridge.h"
+        "${CMAKE_SOURCE_DIR}/src/clipboard_http.cpp"
+        "${CMAKE_SOURCE_DIR}/src/clipboard_http.h"
         "${CMAKE_SOURCE_DIR}/src/video.cpp"
         "${CMAKE_SOURCE_DIR}/src/video.h"
         "${CMAKE_SOURCE_DIR}/src/video_colorspace.cpp"

--- a/src/clipboard_bridge.cpp
+++ b/src/clipboard_bridge.cpp
@@ -6,7 +6,7 @@
 
 #include <chrono>
 #include <mutex>
-#include <unordered_map>
+#include <unordered_set>
 
 namespace clipboard_bridge {
   namespace {
@@ -16,7 +16,8 @@ namespace clipboard_bridge {
   struct bridge_t::impl_t {
     mutable std::mutex mu;
     inbound_sink_fn inbound_sink;
-    std::unordered_map<session_id, session_sink_fn> sessions;
+    std::deque<outbound_msg_t> outbox;
+    std::unordered_set<session_id> active_sessions;
     std::chrono::steady_clock::time_point last_gui_alive {};
   };
 
@@ -43,57 +44,46 @@ namespace clipboard_bridge {
     }
   }
 
-  std::size_t
-  bridge_t::broadcast(const payload_t &bytes) {
-    std::vector<session_sink_fn> sinks;
-    {
-      std::lock_guard<std::mutex> lk(_impl->mu);
-      sinks.reserve(_impl->sessions.size());
-      for (auto &kv : _impl->sessions) {
-        sinks.push_back(kv.second);
-      }
-    }
-    for (auto &s : sinks) {
-      if (s) {
-        s(bytes);
-      }
-    }
-    return sinks.size();
-  }
-
-  bool
-  bridge_t::send_to(session_id sid, const payload_t &bytes) {
-    session_sink_fn s;
-    {
-      std::lock_guard<std::mutex> lk(_impl->mu);
-      auto it = _impl->sessions.find(sid);
-      if (it == _impl->sessions.end()) {
-        return false;
-      }
-      s = it->second;
-    }
-    if (s) {
-      s(bytes);
-    }
-    return true;
-  }
-
-  void
-  bridge_t::register_session(session_id sid, session_sink_fn sink) {
-    std::lock_guard<std::mutex> lk(_impl->mu);
-    _impl->sessions[sid] = std::move(sink);
-  }
-
-  void
-  bridge_t::unregister_session(session_id sid) {
-    std::lock_guard<std::mutex> lk(_impl->mu);
-    _impl->sessions.erase(sid);
-  }
-
   void
   bridge_t::set_inbound_sink(inbound_sink_fn cb) {
     std::lock_guard<std::mutex> lk(_impl->mu);
     _impl->inbound_sink = std::move(cb);
+  }
+
+  void
+  bridge_t::enqueue_outbound(session_id target, payload_t bytes) {
+    std::lock_guard<std::mutex> lk(_impl->mu);
+    _impl->outbox.push_back({target, std::move(bytes)});
+  }
+
+  void
+  bridge_t::drain_outbound(std::deque<outbound_msg_t> &out) {
+    std::lock_guard<std::mutex> lk(_impl->mu);
+    if (_impl->outbox.empty()) {
+      return;
+    }
+    out.insert(out.end(),
+               std::make_move_iterator(_impl->outbox.begin()),
+               std::make_move_iterator(_impl->outbox.end()));
+    _impl->outbox.clear();
+  }
+
+  void
+  bridge_t::session_started(session_id sid) {
+    std::lock_guard<std::mutex> lk(_impl->mu);
+    _impl->active_sessions.insert(sid);
+  }
+
+  void
+  bridge_t::session_stopped(session_id sid) {
+    std::lock_guard<std::mutex> lk(_impl->mu);
+    _impl->active_sessions.erase(sid);
+  }
+
+  std::size_t
+  bridge_t::session_count() const {
+    std::lock_guard<std::mutex> lk(_impl->mu);
+    return _impl->active_sessions.size();
   }
 
   void

--- a/src/clipboard_bridge.cpp
+++ b/src/clipboard_bridge.cpp
@@ -1,0 +1,114 @@
+/**
+ * @file src/clipboard_bridge.cpp
+ * @brief See clipboard_bridge.h.
+ */
+#include "clipboard_bridge.h"
+
+#include <chrono>
+#include <mutex>
+#include <unordered_map>
+
+namespace clipboard_bridge {
+  namespace {
+    constexpr auto kGuiAliveWindow = std::chrono::seconds(30);
+  }  // namespace
+
+  struct bridge_t::impl_t {
+    mutable std::mutex mu;
+    inbound_sink_fn inbound_sink;
+    std::unordered_map<session_id, session_sink_fn> sessions;
+    std::chrono::steady_clock::time_point last_gui_alive {};
+  };
+
+  bridge_t &
+  bridge_t::instance() {
+    static bridge_t inst;
+    return inst;
+  }
+
+  bridge_t::bridge_t():
+      _impl(std::make_unique<impl_t>()) {}
+
+  bridge_t::~bridge_t() = default;
+
+  void
+  bridge_t::on_inbound(session_id sid, payload_t bytes) {
+    inbound_sink_fn cb;
+    {
+      std::lock_guard<std::mutex> lk(_impl->mu);
+      cb = _impl->inbound_sink;
+    }
+    if (cb) {
+      cb(sid, bytes);
+    }
+  }
+
+  std::size_t
+  bridge_t::broadcast(const payload_t &bytes) {
+    std::vector<session_sink_fn> sinks;
+    {
+      std::lock_guard<std::mutex> lk(_impl->mu);
+      sinks.reserve(_impl->sessions.size());
+      for (auto &kv : _impl->sessions) {
+        sinks.push_back(kv.second);
+      }
+    }
+    for (auto &s : sinks) {
+      if (s) {
+        s(bytes);
+      }
+    }
+    return sinks.size();
+  }
+
+  bool
+  bridge_t::send_to(session_id sid, const payload_t &bytes) {
+    session_sink_fn s;
+    {
+      std::lock_guard<std::mutex> lk(_impl->mu);
+      auto it = _impl->sessions.find(sid);
+      if (it == _impl->sessions.end()) {
+        return false;
+      }
+      s = it->second;
+    }
+    if (s) {
+      s(bytes);
+    }
+    return true;
+  }
+
+  void
+  bridge_t::register_session(session_id sid, session_sink_fn sink) {
+    std::lock_guard<std::mutex> lk(_impl->mu);
+    _impl->sessions[sid] = std::move(sink);
+  }
+
+  void
+  bridge_t::unregister_session(session_id sid) {
+    std::lock_guard<std::mutex> lk(_impl->mu);
+    _impl->sessions.erase(sid);
+  }
+
+  void
+  bridge_t::set_inbound_sink(inbound_sink_fn cb) {
+    std::lock_guard<std::mutex> lk(_impl->mu);
+    _impl->inbound_sink = std::move(cb);
+  }
+
+  void
+  bridge_t::notify_gui_alive() {
+    std::lock_guard<std::mutex> lk(_impl->mu);
+    _impl->last_gui_alive = std::chrono::steady_clock::now();
+  }
+
+  bool
+  bridge_t::gui_alive() const {
+    std::lock_guard<std::mutex> lk(_impl->mu);
+    if (!_impl->inbound_sink) {
+      return false;
+    }
+    const auto now = std::chrono::steady_clock::now();
+    return (now - _impl->last_gui_alive) < kGuiAliveWindow;
+  }
+}  // namespace clipboard_bridge

--- a/src/clipboard_bridge.h
+++ b/src/clipboard_bridge.h
@@ -1,38 +1,48 @@
 /**
  * @file src/clipboard_bridge.h
  * @brief Pure byte-forwarder between the streaming protocol and the user-session
- *        Rust GUI agent. The C++ service intentionally has zero clipboard
- *        protocol knowledge here -- no item-type parsing, no chunk reassembly,
- *        no PNG/UTF handling. All of that lives in the GUI.
+ *        Rust GUI agent.
  *
- * Inbound  (client -> host): stream.cpp receives an `IDX_CLIPBOARD` control
- *          packet, decrypts it to plaintext, and calls `on_inbound()`. The
- *          bytes are forwarded verbatim to the GUI via the registered inbound
- *          sink (HTTP/SSE).
+ * The C++ service intentionally has zero clipboard protocol knowledge -- no
+ * item-type parsing, no chunk reassembly, no PNG/UTF handling. The Rust GUI
+ * does all of that.
  *
- * Outbound (host -> client): the GUI POSTs a clipboard control payload to the
- *          HTTP layer, which calls `broadcast()` (or `send_to()`). Each bound
- *          stream session re-encrypts and emits the bytes as an
- *          `IDX_CLIPBOARD` packet.
+ * Wiring:
+ *
+ *   client -> stream.cpp::IDX_CLIPBOARD handler
+ *           -> bridge.on_inbound(sid, bytes)
+ *           -> inbound_sink (HTTP/SSE) -> GUI
+ *
+ *   GUI -> POST /api/v1/clipboard/item
+ *       -> bridge.enqueue_outbound(target_sid_or_0, bytes)
+ *       -> controlBroadcastThread drains via drain_outbound()
+ *       -> encrypted IDX_CLIPBOARD packet -> client
+ *
+ * No callbacks ever cross thread boundaries holding session_t pointers; outbound
+ * is strictly pull-based from the enet thread, which also owns session_t state.
  */
 #pragma once
 
 #include <cstdint>
+#include <deque>
 #include <functional>
 #include <memory>
+#include <utility>
 #include <vector>
 
 namespace clipboard_bridge {
   using payload_t = std::vector<std::uint8_t>;
   using session_id = std::uint64_t;
 
-  /// Sink installed by stream.cpp on session start; emits an outbound packet
-  /// to the specific remote client backing this session.
-  using session_sink_fn = std::function<void(const payload_t &)>;
+  /// 0 means broadcast to every currently-active session.
+  constexpr session_id kBroadcast = 0;
 
-  /// Sink installed by the HTTP layer when a GUI subscribes; receives every
-  /// inbound packet plus the originating session id.
   using inbound_sink_fn = std::function<void(session_id, const payload_t &)>;
+
+  struct outbound_msg_t {
+    session_id target;  ///< kBroadcast or a specific session id
+    payload_t bytes;
+  };
 
   class bridge_t {
   public:
@@ -40,24 +50,29 @@ namespace clipboard_bridge {
 
     // ---- Inbound: stream.cpp -> GUI ----
     void on_inbound(session_id sid, payload_t bytes);
-
-    // ---- Outbound: GUI -> stream sessions ----
-    /// Returns the number of sessions notified.
-    std::size_t broadcast(const payload_t &bytes);
-    /// Returns true if the session is currently registered.
-    bool send_to(session_id sid, const payload_t &bytes);
-
-    // ---- Session registration (stream.cpp) ----
-    void register_session(session_id sid, session_sink_fn sink);
-    void unregister_session(session_id sid);
-
-    // ---- GUI subscription (HTTP layer) ----
     void set_inbound_sink(inbound_sink_fn cb);
 
-    // ---- Liveness / capability ----
+    // ---- Outbound: GUI -> stream sessions ----
+    /// Enqueue a payload to be sent on the next controlBroadcastThread tick.
+    /// `target` may be `kBroadcast` to fan out to every session.
+    void enqueue_outbound(session_id target, payload_t bytes);
+
+    /// Drain all queued outbound messages into `out`. Called by
+    /// controlBroadcastThread once per tick. Appends to `out`.
+    void drain_outbound(std::deque<outbound_msg_t> &out);
+
+    // ---- Session liveness (stream.cpp) ----
+    void session_started(session_id sid);
+    void session_stopped(session_id sid);
+    /// Snapshot the count of currently active sessions. Used by HTTP layer
+    /// for diagnostics; capability negotiation only uses gui_alive().
+    std::size_t session_count() const;
+
+    // ---- GUI heartbeat / capability gate ----
     void notify_gui_alive();
-    /// True iff a GUI checked in within the heartbeat window AND is currently
-    /// subscribed. Used by stream.cpp to decide capability negotiation.
+    /// True iff a GUI checked in within the heartbeat window AND has an
+    /// inbound sink registered. Used by rtsp.cpp to decide whether to
+    /// advertise `platform_caps::clipboard_*` in the SDP feature flags.
     bool gui_alive() const;
 
     bridge_t(const bridge_t &) = delete;

--- a/src/clipboard_bridge.h
+++ b/src/clipboard_bridge.h
@@ -23,6 +23,7 @@
  */
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <deque>
 #include <functional>
@@ -36,6 +37,11 @@ namespace clipboard_bridge {
 
   /// 0 means broadcast to every currently-active session.
   constexpr session_id kBroadcast = 0;
+
+  /// Maximum raw clipboard payload that still fits into Sunshine's encrypted
+  /// 16-bit control-frame length after adding control_header_v2, AES padding,
+  /// GCM tag, and sequence number overhead.
+  constexpr std::size_t kMaxPayloadBytes = 65500;
 
   using inbound_sink_fn = std::function<void(session_id, const payload_t &)>;
 

--- a/src/clipboard_bridge.h
+++ b/src/clipboard_bridge.h
@@ -1,0 +1,72 @@
+/**
+ * @file src/clipboard_bridge.h
+ * @brief Pure byte-forwarder between the streaming protocol and the user-session
+ *        Rust GUI agent. The C++ service intentionally has zero clipboard
+ *        protocol knowledge here -- no item-type parsing, no chunk reassembly,
+ *        no PNG/UTF handling. All of that lives in the GUI.
+ *
+ * Inbound  (client -> host): stream.cpp receives an `IDX_CLIPBOARD` control
+ *          packet, decrypts it to plaintext, and calls `on_inbound()`. The
+ *          bytes are forwarded verbatim to the GUI via the registered inbound
+ *          sink (HTTP/SSE).
+ *
+ * Outbound (host -> client): the GUI POSTs a clipboard control payload to the
+ *          HTTP layer, which calls `broadcast()` (or `send_to()`). Each bound
+ *          stream session re-encrypts and emits the bytes as an
+ *          `IDX_CLIPBOARD` packet.
+ */
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <vector>
+
+namespace clipboard_bridge {
+  using payload_t = std::vector<std::uint8_t>;
+  using session_id = std::uint64_t;
+
+  /// Sink installed by stream.cpp on session start; emits an outbound packet
+  /// to the specific remote client backing this session.
+  using session_sink_fn = std::function<void(const payload_t &)>;
+
+  /// Sink installed by the HTTP layer when a GUI subscribes; receives every
+  /// inbound packet plus the originating session id.
+  using inbound_sink_fn = std::function<void(session_id, const payload_t &)>;
+
+  class bridge_t {
+  public:
+    static bridge_t &instance();
+
+    // ---- Inbound: stream.cpp -> GUI ----
+    void on_inbound(session_id sid, payload_t bytes);
+
+    // ---- Outbound: GUI -> stream sessions ----
+    /// Returns the number of sessions notified.
+    std::size_t broadcast(const payload_t &bytes);
+    /// Returns true if the session is currently registered.
+    bool send_to(session_id sid, const payload_t &bytes);
+
+    // ---- Session registration (stream.cpp) ----
+    void register_session(session_id sid, session_sink_fn sink);
+    void unregister_session(session_id sid);
+
+    // ---- GUI subscription (HTTP layer) ----
+    void set_inbound_sink(inbound_sink_fn cb);
+
+    // ---- Liveness / capability ----
+    void notify_gui_alive();
+    /// True iff a GUI checked in within the heartbeat window AND is currently
+    /// subscribed. Used by stream.cpp to decide capability negotiation.
+    bool gui_alive() const;
+
+    bridge_t(const bridge_t &) = delete;
+    bridge_t &operator=(const bridge_t &) = delete;
+
+  private:
+    bridge_t();
+    ~bridge_t();
+    struct impl_t;
+    std::unique_ptr<impl_t> _impl;
+  };
+}  // namespace clipboard_bridge

--- a/src/clipboard_http.cpp
+++ b/src/clipboard_http.cpp
@@ -67,9 +67,7 @@ namespace clipboard_http {
     }
 
     void
-    fanout_inbound(clipboard_bridge::session_id sid, const clipboard_bridge::payload_t &bytes) {
-      const std::string frame = build_event(sid, bytes);
-
+    fanout_frame(const std::string &frame) {
       std::vector<std::shared_ptr<subscriber_t>> snapshot;
       {
         std::lock_guard<std::mutex> lk(g_mu);
@@ -103,6 +101,16 @@ namespace clipboard_http {
     }
 
     void
+    fanout_inbound(clipboard_bridge::session_id sid, const clipboard_bridge::payload_t &bytes) {
+      fanout_frame(build_event(sid, bytes));
+    }
+
+    void
+    fanout_keepalive() {
+      fanout_frame(": clipboard-keepalive\n\n");
+    }
+
+    void
     ensure_inbound_sink() {
       // Idempotent: install once on first /events subscription.
       std::lock_guard<std::mutex> lk(g_mu);
@@ -123,6 +131,7 @@ namespace clipboard_http {
 
       auto &bridge = clipboard_bridge::bridge_t::instance();
       bridge.notify_gui_alive();
+      fanout_keepalive();
 
       nlohmann::json out;
       out["ok"] = true;
@@ -188,14 +197,16 @@ namespace clipboard_http {
       ensure_inbound_sink();
       clipboard_bridge::bridge_t::instance().notify_gui_alive();
 
-      // Send SSE preamble. Use raw write so we can keep the stream open and
-      // push events from the bridge callback.
-      *resp << "HTTP/1.1 200 OK\r\n";
-      *resp << "Content-Type: text/event-stream\r\n";
-      *resp << "Cache-Control: no-cache\r\n";
-      *resp << "Connection: keep-alive\r\n";
-      *resp << "X-Accel-Buffering: no\r\n";
-      *resp << "\r\n";
+      resp->close_connection_after_response = true;
+
+      SimpleWeb::CaseInsensitiveMultimap headers;
+      headers.emplace("Content-Type", "text/event-stream");
+      headers.emplace("Cache-Control", "no-cache");
+      headers.emplace("Connection", "keep-alive");
+      headers.emplace("X-Accel-Buffering", "no");
+      resp->write(headers);
+      resp->send();
+
       // Initial comment frame to flush headers through any intermediaries.
       *resp << ": clipboard-stream-ready\n\n";
       resp->send();

--- a/src/clipboard_http.cpp
+++ b/src/clipboard_http.cpp
@@ -1,0 +1,230 @@
+/**
+ * @file src/clipboard_http.cpp
+ * @brief See clipboard_http.h.
+ */
+#include "clipboard_http.h"
+
+#include <algorithm>
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <openssl/evp.h>
+
+#include <nlohmann/json.hpp>
+
+#include "clipboard_bridge.h"
+#include "config.h"
+#include "logging.h"
+
+namespace clipboard_http {
+  using namespace std::literals;
+  namespace {
+    struct subscriber_t {
+      resp_https_t resp;
+      std::atomic_bool alive { true };
+    };
+
+    std::mutex g_mu;
+    std::vector<std::shared_ptr<subscriber_t>> g_subs;
+    bool g_inbound_sink_installed = false;
+
+    std::string
+    base64_encode(const std::uint8_t *data, std::size_t len) {
+      if (!len) {
+        return {};
+      }
+      std::string out;
+      out.resize(4 * ((len + 2) / 3));
+      const int n = EVP_EncodeBlock(
+        reinterpret_cast<unsigned char *>(out.data()),
+        data,
+        static_cast<int>(len));
+      if (n < 0) {
+        return {};
+      }
+      out.resize(static_cast<std::size_t>(n));
+      return out;
+    }
+
+    /// Build the SSE frame for a single inbound payload.
+    std::string
+    build_event(clipboard_bridge::session_id sid, const clipboard_bridge::payload_t &bytes) {
+      const std::string b64 = base64_encode(bytes.data(), bytes.size());
+      std::string frame;
+      frame.reserve(b64.size() + 64);
+      frame += "event: clipboard\n";
+      frame += "id: ";
+      frame += std::to_string(sid);
+      frame += "\n";
+      frame += "data: ";
+      frame += b64;
+      frame += "\n\n";
+      return frame;
+    }
+
+    void
+    fanout_inbound(clipboard_bridge::session_id sid, const clipboard_bridge::payload_t &bytes) {
+      const std::string frame = build_event(sid, bytes);
+
+      std::vector<std::shared_ptr<subscriber_t>> snapshot;
+      {
+        std::lock_guard<std::mutex> lk(g_mu);
+        snapshot = g_subs;
+      }
+
+      for (auto &sub : snapshot) {
+        if (!sub->alive.load(std::memory_order_acquire)) {
+          continue;
+        }
+        try {
+          *sub->resp << frame;
+          sub->resp->send([sub](const SimpleWeb::error_code &ec) {
+            if (ec) {
+              sub->alive.store(false, std::memory_order_release);
+            }
+          });
+        } catch (const std::exception &e) {
+          BOOST_LOG(debug) << "clipboard SSE write failed: "sv << e.what();
+          sub->alive.store(false, std::memory_order_release);
+        }
+      }
+
+      // Prune dead subscribers (cheap; clipboard events are infrequent).
+      std::lock_guard<std::mutex> lk(g_mu);
+      g_subs.erase(std::remove_if(g_subs.begin(), g_subs.end(),
+                     [](const std::shared_ptr<subscriber_t> &s) {
+                       return !s->alive.load(std::memory_order_acquire);
+                     }),
+        g_subs.end());
+    }
+
+    void
+    ensure_inbound_sink() {
+      // Idempotent: install once on first /events subscription.
+      std::lock_guard<std::mutex> lk(g_mu);
+      if (g_inbound_sink_installed) {
+        return;
+      }
+      clipboard_bridge::bridge_t::instance().set_inbound_sink(&fanout_inbound);
+      g_inbound_sink_installed = true;
+    }
+
+    // ---- Endpoint handlers ----
+
+    void
+    handle_capability(const auth_fn &auth, resp_https_t resp, req_https_t req) {
+      if (!auth(resp, req)) {
+        return;
+      }
+
+      auto &bridge = clipboard_bridge::bridge_t::instance();
+      bridge.notify_gui_alive();
+
+      nlohmann::json out;
+      out["ok"] = true;
+      out["clipboard_sync"] = config::input.clipboard_sync;
+      out["session_count"] = bridge.session_count();
+      out["gui_alive"] = bridge.gui_alive();
+
+      SimpleWeb::CaseInsensitiveMultimap headers;
+      headers.emplace("Content-Type", "application/json");
+      resp->write(SimpleWeb::StatusCode::success_ok, out.dump(), headers);
+    }
+
+    void
+    handle_item(const auth_fn &auth, resp_https_t resp, req_https_t req) {
+      if (!auth(resp, req)) {
+        return;
+      }
+      if (!config::input.clipboard_sync) {
+        resp->write(SimpleWeb::StatusCode::client_error_forbidden,
+          R"({"error":"clipboard_sync_disabled"})");
+        return;
+      }
+
+      // Refresh GUI heartbeat — any /item POST is also implicit liveness.
+      auto &bridge = clipboard_bridge::bridge_t::instance();
+      bridge.notify_gui_alive();
+
+      // Parse optional target sid from header.
+      clipboard_bridge::session_id target = clipboard_bridge::kBroadcast;
+      auto it = req->header.find("X-Clipboard-Target-Sid");
+      if (it != req->header.end() && !it->second.empty()) {
+        try {
+          target = static_cast<clipboard_bridge::session_id>(std::stoull(it->second));
+        } catch (...) {
+          resp->write(SimpleWeb::StatusCode::client_error_bad_request,
+            R"({"error":"bad_target_sid"})");
+          return;
+        }
+      }
+
+      // Read raw body bytes.
+      std::stringstream ss;
+      ss << req->content.rdbuf();
+      const std::string body = ss.str();
+      if (body.empty()) {
+        resp->write(SimpleWeb::StatusCode::client_error_bad_request,
+          R"({"error":"empty_body"})");
+        return;
+      }
+
+      clipboard_bridge::payload_t bytes(body.begin(), body.end());
+      bridge.enqueue_outbound(target, std::move(bytes));
+
+      resp->write(SimpleWeb::StatusCode::success_accepted, R"({"ok":true})");
+    }
+
+    void
+    handle_events(const auth_fn &auth, resp_https_t resp, req_https_t req) {
+      if (!auth(resp, req)) {
+        return;
+      }
+
+      ensure_inbound_sink();
+      clipboard_bridge::bridge_t::instance().notify_gui_alive();
+
+      // Send SSE preamble. Use raw write so we can keep the stream open and
+      // push events from the bridge callback.
+      *resp << "HTTP/1.1 200 OK\r\n";
+      *resp << "Content-Type: text/event-stream\r\n";
+      *resp << "Cache-Control: no-cache\r\n";
+      *resp << "Connection: keep-alive\r\n";
+      *resp << "X-Accel-Buffering: no\r\n";
+      *resp << "\r\n";
+      // Initial comment frame to flush headers through any intermediaries.
+      *resp << ": clipboard-stream-ready\n\n";
+      resp->send();
+
+      auto sub = std::make_shared<subscriber_t>();
+      sub->resp = std::move(resp);
+
+      std::lock_guard<std::mutex> lk(g_mu);
+      g_subs.push_back(std::move(sub));
+    }
+  }  // namespace
+
+  void
+  register_routes(https_server_t &server, auth_fn auth) {
+    auto auth_cap = std::make_shared<auth_fn>(std::move(auth));
+
+    server.resource["^/api/v1/clipboard/capability$"]["POST"] =
+      [auth_cap](resp_https_t resp, req_https_t req) {
+        handle_capability(*auth_cap, std::move(resp), std::move(req));
+      };
+
+    server.resource["^/api/v1/clipboard/item$"]["POST"] =
+      [auth_cap](resp_https_t resp, req_https_t req) {
+        handle_item(*auth_cap, std::move(resp), std::move(req));
+      };
+
+    server.resource["^/api/v1/clipboard/events$"]["GET"] =
+      [auth_cap](resp_https_t resp, req_https_t req) {
+        handle_events(*auth_cap, std::move(resp), std::move(req));
+      };
+  }
+}  // namespace clipboard_http

--- a/src/clipboard_http.cpp
+++ b/src/clipboard_http.cpp
@@ -26,6 +26,7 @@ namespace clipboard_http {
     struct subscriber_t {
       resp_https_t resp;
       std::atomic_bool alive { true };
+      std::mutex send_mu;
     };
 
     std::mutex g_mu;
@@ -67,6 +68,42 @@ namespace clipboard_http {
     }
 
     void
+    prune_dead_subscribers_locked() {
+      g_subs.erase(std::remove_if(g_subs.begin(), g_subs.end(),
+                     [](const std::shared_ptr<subscriber_t> &s) {
+                       return !s->alive.load(std::memory_order_acquire);
+                     }),
+        g_subs.end());
+
+      if (g_subs.empty() && g_inbound_sink_installed) {
+        clipboard_bridge::bridge_t::instance().set_inbound_sink({});
+        g_inbound_sink_installed = false;
+      }
+    }
+
+    void
+    send_frame(const std::shared_ptr<subscriber_t> &sub, const std::string &frame) {
+      if (!sub->alive.load(std::memory_order_acquire)) {
+        return;
+      }
+
+      try {
+        std::lock_guard<std::mutex> lk(sub->send_mu);
+        if (sub->alive.load(std::memory_order_acquire)) {
+          *sub->resp << frame;
+          sub->resp->send([sub](const SimpleWeb::error_code &ec) {
+            if (ec) {
+              sub->alive.store(false, std::memory_order_release);
+            }
+          });
+        }
+      } catch (const std::exception &e) {
+        BOOST_LOG(debug) << "clipboard SSE write failed: "sv << e.what();
+        sub->alive.store(false, std::memory_order_release);
+      }
+    }
+
+    void
     fanout_frame(const std::string &frame) {
       std::vector<std::shared_ptr<subscriber_t>> snapshot;
       {
@@ -75,29 +112,12 @@ namespace clipboard_http {
       }
 
       for (auto &sub : snapshot) {
-        if (!sub->alive.load(std::memory_order_acquire)) {
-          continue;
-        }
-        try {
-          *sub->resp << frame;
-          sub->resp->send([sub](const SimpleWeb::error_code &ec) {
-            if (ec) {
-              sub->alive.store(false, std::memory_order_release);
-            }
-          });
-        } catch (const std::exception &e) {
-          BOOST_LOG(debug) << "clipboard SSE write failed: "sv << e.what();
-          sub->alive.store(false, std::memory_order_release);
-        }
+        send_frame(sub, frame);
       }
 
       // Prune dead subscribers (cheap; clipboard events are infrequent).
       std::lock_guard<std::mutex> lk(g_mu);
-      g_subs.erase(std::remove_if(g_subs.begin(), g_subs.end(),
-                     [](const std::shared_ptr<subscriber_t> &s) {
-                       return !s->alive.load(std::memory_order_acquire);
-                     }),
-        g_subs.end());
+      prune_dead_subscribers_locked();
     }
 
     void
@@ -111,14 +131,11 @@ namespace clipboard_http {
     }
 
     void
-    ensure_inbound_sink() {
-      // Idempotent: install once on first /events subscription.
-      std::lock_guard<std::mutex> lk(g_mu);
-      if (g_inbound_sink_installed) {
-        return;
+    ensure_inbound_sink_locked() {
+      if (!g_inbound_sink_installed) {
+        clipboard_bridge::bridge_t::instance().set_inbound_sink(&fanout_inbound);
+        g_inbound_sink_installed = true;
       }
-      clipboard_bridge::bridge_t::instance().set_inbound_sink(&fanout_inbound);
-      g_inbound_sink_installed = true;
     }
 
     // ---- Endpoint handlers ----
@@ -159,6 +176,21 @@ namespace clipboard_http {
       auto &bridge = clipboard_bridge::bridge_t::instance();
       bridge.notify_gui_alive();
 
+      auto content_length = req->header.find("Content-Length");
+      if (content_length != req->header.end() && !content_length->second.empty()) {
+        try {
+          if (std::stoull(content_length->second) > clipboard_bridge::kMaxPayloadBytes) {
+            resp->write(SimpleWeb::StatusCode::client_error_payload_too_large,
+              R"({"error":"payload_too_large"})");
+            return;
+          }
+        } catch (...) {
+          resp->write(SimpleWeb::StatusCode::client_error_bad_request,
+            R"({"error":"bad_content_length"})");
+          return;
+        }
+      }
+
       // Parse optional target sid from header.
       clipboard_bridge::session_id target = clipboard_bridge::kBroadcast;
       auto it = req->header.find("X-Clipboard-Target-Sid");
@@ -181,6 +213,11 @@ namespace clipboard_http {
           R"({"error":"empty_body"})");
         return;
       }
+      if (body.size() > clipboard_bridge::kMaxPayloadBytes) {
+        resp->write(SimpleWeb::StatusCode::client_error_payload_too_large,
+          R"({"error":"payload_too_large"})");
+        return;
+      }
 
       clipboard_bridge::payload_t bytes(body.begin(), body.end());
       bridge.enqueue_outbound(target, std::move(bytes));
@@ -194,28 +231,26 @@ namespace clipboard_http {
         return;
       }
 
-      ensure_inbound_sink();
       clipboard_bridge::bridge_t::instance().notify_gui_alive();
 
-      resp->close_connection_after_response = true;
+      auto sub = std::make_shared<subscriber_t>();
+      sub->resp = std::move(resp);
+      sub->resp->close_connection_after_response = true;
 
       SimpleWeb::CaseInsensitiveMultimap headers;
       headers.emplace("Content-Type", "text/event-stream");
       headers.emplace("Cache-Control", "no-cache");
       headers.emplace("Connection", "keep-alive");
       headers.emplace("X-Accel-Buffering", "no");
-      resp->write(headers);
-      resp->send();
+      sub->resp->write(headers);
+      sub->resp->send();
 
       // Initial comment frame to flush headers through any intermediaries.
-      *resp << ": clipboard-stream-ready\n\n";
-      resp->send();
-
-      auto sub = std::make_shared<subscriber_t>();
-      sub->resp = std::move(resp);
+      send_frame(sub, ": clipboard-stream-ready\n\n");
 
       std::lock_guard<std::mutex> lk(g_mu);
       g_subs.push_back(std::move(sub));
+      ensure_inbound_sink_locked();
     }
   }  // namespace
 

--- a/src/clipboard_http.h
+++ b/src/clipboard_http.h
@@ -1,0 +1,48 @@
+/**
+ * @file src/clipboard_http.h
+ * @brief HTTP/SSE bridge between the user-session GUI agent and the
+ *        clipboard_bridge (in-process control-stream forwarder).
+ *
+ * Endpoints (registered on the existing confighttp HTTPS server, so they
+ * inherit its auth and TLS):
+ *
+ *   POST /api/v1/clipboard/capability
+ *     GUI heartbeat. Marks the bridge as "GUI alive" so rtsp.cpp will
+ *     advertise clipboard caps. Optional JSON body is currently ignored.
+ *     Response: 200 {"ok": true, "sessions": [<sid>...]}.
+ *
+ *   POST /api/v1/clipboard/item
+ *     Body: raw opaque bytes (the clipboard protocol payload constructed by
+ *     the GUI). Optional header `X-Clipboard-Target-Sid` (decimal); 0 or
+ *     missing means broadcast to every active session.
+ *     Response: 202 Accepted.
+ *
+ *   GET /api/v1/clipboard/events
+ *     Server-Sent Events stream. Long-lived. Each inbound clipboard packet
+ *     from any client is delivered as:
+ *         event: clipboard
+ *         id: <sid>
+ *         data: <base64(payload)>
+ *
+ * Auth is delegated to the caller via the function passed to register_routes,
+ * so we don't duplicate confighttp's basic-auth logic here.
+ */
+#pragma once
+
+#include <functional>
+#include <memory>
+
+#include <Simple-Web-Server/server_https.hpp>
+
+namespace clipboard_http {
+  using https_server_t = SimpleWeb::Server<SimpleWeb::HTTPS>;
+  using resp_https_t = std::shared_ptr<typename SimpleWeb::ServerBase<SimpleWeb::HTTPS>::Response>;
+  using req_https_t = std::shared_ptr<typename SimpleWeb::ServerBase<SimpleWeb::HTTPS>::Request>;
+  using auth_fn = std::function<bool(resp_https_t, req_https_t)>;
+
+  /// Register the /api/v1/clipboard/* routes on `server`. `auth` is invoked
+  /// at the start of every handler; it must return true for authorised
+  /// requests (and is responsible for sending the 401 response itself when
+  /// returning false).
+  void register_routes(https_server_t &server, auth_fn auth);
+}  // namespace clipboard_http

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -546,6 +546,8 @@ namespace config {
     true,  // high resolution scrolling
     true,  // native pen/touch support
     true,  // virtual mouse (use driver if available)
+    false, // amf_draw_mouse_cursor
+    false, // clipboard_sync (off by default for privacy; requires Sunshine GUI to perform actual IO)
   };
 
   sunshine_t sunshine {
@@ -1372,6 +1374,7 @@ namespace config {
     bool_f(vars, "native_pen_touch", input.native_pen_touch);
     bool_f(vars, "virtual_mouse", input.virtual_mouse);
     bool_f(vars, "amf_draw_mouse_cursor", input.amf_draw_mouse_cursor);
+    bool_f(vars, "clipboard_sync", input.clipboard_sync);
 
     bool_f(vars, "notify_pre_releases", sunshine.notify_pre_releases);
 

--- a/src/config.h
+++ b/src/config.h
@@ -199,6 +199,7 @@ namespace config {
     bool native_pen_touch;
     bool virtual_mouse;
     bool amf_draw_mouse_cursor;
+    bool clipboard_sync;  ///< Bidirectional clipboard sync (text + single image). Off by default for privacy.
   };
 
   namespace flag {

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -40,6 +40,7 @@
 
 #include "config.h"
 #include "confighttp.h"
+#include "clipboard_http.h"
 #include "crypto.h"
 #include "display_device/session.h"
 #include "file_handler.h"
@@ -2788,6 +2789,14 @@ namespace confighttp {
     server.resource["^/images/sunshine.ico$"]["GET"] = getFaviconImage;
     server.resource["^/images/logo-sunshine-256.png$"]["GET"] = getSunshineLogoImage;
     server.resource["^/boxart/.+$"]["GET"] = getBoxArt;
+
+    // Clipboard sync routes are registered in a sibling module so the
+    // existing 2700+ line confighttp doesn't grow further. They reuse our
+    // basic-auth via the lambda below.
+    clipboard_http::register_routes(server,
+      [](clipboard_http::resp_https_t resp, clipboard_http::req_https_t req) {
+        return authenticate(std::move(resp), std::move(req));
+      });
     server.resource["^/assets\\/.+$"]["GET"] = getNodeModules;
     server.config.reuse_address = true;
     server.config.address = net::get_bind_address(address_family);

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -296,6 +296,8 @@ namespace platf {
 
     constexpr caps_t pen_touch = 0x01;  // Pen and touch events
     constexpr caps_t controller_touch = 0x02;  // Controller touch events
+    constexpr caps_t clipboard_text = 0x04;  // Clipboard text sync (negotiated only when GUI agent is alive)
+    constexpr caps_t clipboard_image = 0x08;  // Clipboard image sync (negotiated only when GUI agent is alive)
   };  // namespace platform_caps
 
   struct gamepad_state_t {

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -23,6 +23,7 @@ extern "C" {
 #include <boost/bind.hpp>
 
 // local includes
+#include "clipboard_bridge.h"
 #include "config.h"
 #include "globals.h"
 #include "input.h"
@@ -911,7 +912,16 @@ namespace rtsp_stream {
     std::stringstream ss;
 
     // Tell the client about our supported features
-    ss << "a=x-ss-general.featureFlags:" << (uint32_t) platf::get_capabilities() << std::endl;
+    {
+      auto caps = (uint32_t) platf::get_capabilities();
+      // Advertise clipboard sync only when the user opted in AND a user-session
+      // GUI agent is currently subscribed; otherwise the client would attempt
+      // sync into a black hole.
+      if (config::input.clipboard_sync && clipboard_bridge::bridge_t::instance().gui_alive()) {
+        caps |= platf::platform_caps::clipboard_text | platf::platform_caps::clipboard_image;
+      }
+      ss << "a=x-ss-general.featureFlags:" << caps << std::endl;
+    }
 
     // Always request new control stream encryption if the client supports it
     uint32_t encryption_flags_supported = SS_ENC_CONTROL_V2 | SS_ENC_AUDIO | SS_ENC_MIC;

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -1191,6 +1191,106 @@ namespace stream {
     return 0;
   }
 
+  /**
+   * Variable-length sibling of encode_control(). Encrypts an arbitrary-sized
+   * plaintext into the caller-provided output buffer. The output buffer must be
+   * at least `sizeof(control_encrypted_t) + round_to_pkcs7_padded(plaintext.size()) + tag_size`.
+   * Returns the encoded view, or empty on failure / insufficient capacity.
+   */
+  static std::string_view
+  encode_control_buf(session_t *session, std::string_view plaintext, std::uint8_t *out, std::size_t out_cap) {
+    const std::size_t needed = sizeof(control_encrypted_t)
+                               + crypto::cipher::round_to_pkcs7_padded(plaintext.size())
+                               + crypto::cipher::tag_size;
+    if (out_cap < needed) {
+      BOOST_LOG(error) << "encode_control_buf: insufficient buffer ("sv << out_cap << " < "sv << needed << ")"sv;
+      return {};
+    }
+
+    if (session->config.controlProtocolType != 13) {
+      // Pre-v2 control protocol — caller must already have written plaintext;
+      // not used by clipboard sync (gated by gui_alive() + capability flags).
+      return plaintext;
+    }
+
+    auto seq = session->control.seq++;
+
+    auto &iv = session->control.outgoing_iv;
+    if (session->config.encryptionFlagsEnabled & SS_ENC_CONTROL_V2) {
+      iv.resize(12);
+      std::copy_n((uint8_t *) &seq, sizeof(seq), std::begin(iv));
+      iv[10] = 'H';
+      iv[11] = 'C';
+    }
+    else {
+      iv.resize(16);
+      iv[0] = (std::uint8_t) seq;
+    }
+
+    auto packet = (control_encrypted_p) out;
+    auto bytes = session->control.cipher.encrypt(plaintext, packet->payload(), &iv);
+    if (bytes <= 0) {
+      BOOST_LOG(error) << "encode_control_buf: encrypt failed"sv;
+      return {};
+    }
+
+    std::uint16_t packet_length = bytes + crypto::cipher::tag_size + sizeof(control_encrypted_t::seq);
+    packet->encryptedHeaderType = util::endian::little(0x0001);
+    packet->length = util::endian::little(packet_length);
+    packet->seq = util::endian::little(seq);
+
+    return std::string_view {
+      (char *) out,
+      packet_length + sizeof(control_encrypted_t) - sizeof(control_encrypted_t::seq)
+    };
+  }
+
+  /**
+   * Send a clipboard payload as an IDX_CLIPBOARD control packet. `payload` is
+   * an opaque byte string; this function adds the framing header and encrypts.
+   * Returns 0 on success, -1 on failure or oversized payload (>65535 bytes,
+   * the protocol cap on payloadLength).
+   */
+  int
+  send_clipboard(session_t *session, const clipboard_bridge::payload_t &payload) {
+    if (!session->control.peer) {
+      return -1;
+    }
+    if (payload.size() > std::numeric_limits<std::uint16_t>::max()) {
+      BOOST_LOG(warning) << "send_clipboard: payload too large ("sv << payload.size()
+                         << " bytes; protocol cap is 65535)"sv;
+      return -1;
+    }
+
+    std::vector<std::uint8_t> plaintext(sizeof(control_header_v2) + payload.size());
+    auto *hdr = reinterpret_cast<control_header_v2 *>(plaintext.data());
+    hdr->type = packetTypes[IDX_CLIPBOARD];
+    hdr->payloadLength = (std::uint16_t) payload.size();
+    if (!payload.empty()) {
+      std::memcpy(plaintext.data() + sizeof(control_header_v2), payload.data(), payload.size());
+    }
+
+    std::vector<std::uint8_t> encrypted(
+      sizeof(control_encrypted_t)
+      + crypto::cipher::round_to_pkcs7_padded(plaintext.size())
+      + crypto::cipher::tag_size);
+
+    auto view = encode_control_buf(
+      session,
+      std::string_view { (char *) plaintext.data(), plaintext.size() },
+      encrypted.data(),
+      encrypted.size());
+    if (view.empty()) {
+      return -1;
+    }
+
+    if (session->broadcast_ref->control_server.send(view, session->control.peer)) {
+      BOOST_LOG(warning) << "Couldn't send clipboard packet"sv;
+      return -1;
+    }
+    return 0;
+  }
+
   void
   controlBroadcastThread(control_server_t *server) {
     server->map(packetTypes[IDX_PERIODIC_PING], [](session_t *session, const std::string_view &payload) {
@@ -1631,6 +1731,27 @@ namespace stream {
 
           ++pos;
         })
+
+        // Drain any clipboard messages enqueued by the GUI HTTP layer and
+        // dispatch them to matching sessions. We're already holding the
+        // _sessions lock here, which serialises with the per-session
+        // erase/insert above.
+        {
+          std::deque<clipboard_bridge::outbound_msg_t> msgs;
+          clipboard_bridge::bridge_t::instance().drain_outbound(msgs);
+          for (auto &msg : msgs) {
+            for (auto *s : *server->_sessions) {
+              if (!s->control.peer) {
+                continue;
+              }
+              if (msg.target != clipboard_bridge::kBroadcast
+                  && s->launch_session_id != msg.target) {
+                continue;
+              }
+              send_clipboard(s, msg.bytes);
+            }
+          }
+        }
       }
 
       // Don't break until any pending sessions either expire or connect

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -1248,21 +1248,30 @@ namespace stream {
   /**
    * Send a clipboard payload as an IDX_CLIPBOARD control packet. `payload` is
    * an opaque byte string; this function adds the framing header and encrypts.
-   * Returns 0 on success, -1 on failure or oversized payload (>65535 bytes,
-   * the protocol cap on payloadLength).
+   * Returns 0 on success, -1 on failure or oversized payload. The raw payload
+   * is capped below 65535 bytes so the encrypted control frame length also
+   * fits in the protocol's 16-bit length field.
    */
   int
   send_clipboard(session_t *session, const clipboard_bridge::payload_t &payload) {
     if (!session->control.peer) {
       return -1;
     }
-    if (payload.size() > std::numeric_limits<std::uint16_t>::max()) {
+
+    const std::size_t plaintext_size = sizeof(control_header_v2) + payload.size();
+    const std::size_t encrypted_packet_length =
+      crypto::cipher::round_to_pkcs7_padded(plaintext_size)
+      + crypto::cipher::tag_size
+      + sizeof(control_encrypted_t::seq);
+    if (payload.size() > clipboard_bridge::kMaxPayloadBytes ||
+        encrypted_packet_length > std::numeric_limits<std::uint16_t>::max()) {
       BOOST_LOG(warning) << "send_clipboard: payload too large ("sv << payload.size()
-                         << " bytes; protocol cap is 65535)"sv;
+                         << " bytes; encrypted control frame would be "sv
+                         << encrypted_packet_length << " bytes)"sv;
       return -1;
     }
 
-    std::vector<std::uint8_t> plaintext(sizeof(control_header_v2) + payload.size());
+    std::vector<std::uint8_t> plaintext(plaintext_size);
     auto *hdr = reinterpret_cast<control_header_v2 *>(plaintext.data());
     hdr->type = packetTypes[IDX_CLIPBOARD];
     hdr->payloadLength = (std::uint16_t) payload.size();

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -1789,6 +1789,12 @@ namespace stream {
     for (auto pos = std::begin(*server->_sessions); pos != std::end(*server->_sessions); ++pos) {
       auto session = *pos;
 
+      // The normal STOPPING path removes sessions from _sessions and updates
+      // the clipboard bridge immediately. If the control thread exits via the
+      // final shutdown path instead, make the same paired lifecycle update here
+      // so capability/session_count cannot retain stale launch IDs.
+      clipboard_bridge::bridge_t::instance().session_stopped(session->launch_session_id);
+
       // We may not have gotten far enough to have an ENet connection yet
       if (session->control.peer) {
         auto payload = encode_control(session, util::view(plaintext), encrypted_payload);

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -46,6 +46,7 @@ extern "C" {
 #include "thread_safe.h"
 #include "utility.h"
 
+#include "clipboard_bridge.h"
 #include "platform/common.h"
 
 #define IDX_START_A 0
@@ -67,6 +68,7 @@ extern "C" {
 #define IDX_MIC_CONFIG 17
 #define IDX_DYNAMIC_PARAM_CHANGE 18  // 统一动态参数调整消息类型（支持码率、分辨率等）
 #define IDX_RESOLUTION_CHANGE 19  // 分辨率变化通知
+#define IDX_CLIPBOARD 20  // Clipboard sync (Sunshine protocol extension; payload forwarded to user-session GUI agent)
 
 static const short packetTypes[] = {
   0x0305,  // Start A
@@ -89,6 +91,7 @@ static const short packetTypes[] = {
   0x5505,  // Microphone config (Sunshine protocol extension)
   0x5506,  // Dynamic parameter change (Sunshine protocol extension) - 统一动态参数调整
   0x5507,  // Resolution change (Sunshine protocol extension) - 分辨率变化通知
+  0x5508,  // Clipboard sync (Sunshine protocol extension) - opaque payload forwarded to user-session GUI agent
 };
 
 namespace asio = boost::asio;
@@ -1440,6 +1443,20 @@ namespace stream {
       session->video.invalidate_ref_frames_events->raise(std::make_pair(firstFrame, lastFrame));
     });
 
+    server->map(packetTypes[IDX_CLIPBOARD], [](session_t *session, const std::string_view &payload) {
+      // Forward opaque payload to the user-session GUI agent. Drop silently if
+      // disabled by config or if the GUI is not currently subscribed.
+      if (!config::input.clipboard_sync) {
+        return;
+      }
+      auto &bridge = clipboard_bridge::bridge_t::instance();
+      if (!bridge.gui_alive()) {
+        return;
+      }
+      clipboard_bridge::payload_t bytes(payload.begin(), payload.end());
+      bridge.on_inbound(session->launch_session_id, std::move(bytes));
+    });
+
     server->map(packetTypes[IDX_INPUT_DATA], [&](session_t *session, const std::string_view &payload) {
       BOOST_LOG(debug) << "type [IDX_INPUT_DATA]"sv;
 
@@ -1565,6 +1582,7 @@ namespace stream {
           }
 
           if (session->state.load(std::memory_order_acquire) == session::state_e::STOPPING) {
+            clipboard_bridge::bridge_t::instance().session_stopped(session->launch_session_id);
             pos = server->_sessions->erase(pos);
 
             if (session->control.peer) {
@@ -2890,6 +2908,7 @@ namespace stream {
         auto lg = session.broadcast_ref->control_server._sessions.lock();
         session.broadcast_ref->control_server._sessions->push_back(&session);
       }
+      clipboard_bridge::bridge_t::instance().session_started(session.launch_session_id);
 
       auto addr = boost::asio::ip::make_address(addr_string);
       session.video.peer.address(addr);


### PR DESCRIPTION
## Summary
Add the Sunshine-side clipboard sync bridge and GUI agent plumbing for Moonlight clipboard sync.

## Changes
- Add clipboard bridge/capability plumbing for stream sessions.
- Register clipboard HTTP/SSE endpoints for GUI bridge integration.
- Dispatch outbound clipboard frames to active streaming sessions.
- Update the Rust/Tauri control panel submodule to include the user-session clipboard agent work.
- Fix clipboard SSE keepalive behavior.

## Compatibility
- Supports the current Moonlight Qt private v1 clipboard frame over control packet `0x5508`.
- Keeps clipboard sync behind capability/config plumbing so hosts without the GUI agent can report availability accurately.

## Verification
- Built and launched an isolated Sunshine instance on alternate ports.
- `POST /api/v1/clipboard/capability` returned `clipboard_sync: true`.
- `POST /api/v1/clipboard/item` accepted a v1 text clipboard frame with HTTP 202.
- `/api/v1/clipboard/events` SSE endpoint connected successfully.
