### PR TITLE
fix(amf): preserve IDR baseline LTR slot for resilient RFI recovery

### DIFF
--- a/src/amf/amf_config.h
+++ b/src/amf/amf_config.h
@@ -56,7 +56,7 @@ namespace amf {
     std::optional<int> enforce_hrd;
 
     // Number of LTR frames for RFI
-    int max_ltr_frames = 1;
+    int max_ltr_frames = 4;
 
     // --- Pre-Analysis sub-system ---
     // PAQ mode (AMF_PA_PAQ_MODE_ENUM): 0=none, 1=CAQ

--- a/src/amf/amf_d3d11.cpp
+++ b/src/amf/amf_d3d11.cpp
@@ -700,7 +700,10 @@ namespace amf {
         }
         ltr_slots_valid[0] = true;
         ltr_slot_frame_index[0] = frame_index;
-        current_ltr_slot = 1 % effective_ltr_slots;
+        // Slot 0 is reserved as the permanent IDR baseline. Periodic rotation
+        // begins at slot 1 (or stays at 0 when only a single slot exists, in
+        // which case the baseline must be sacrificed for fresher anchors).
+        current_ltr_slot = (effective_ltr_slots > 1) ? 1 : 0;
       }
     }
     else if (rfi_pending && effective_ltr_slots > 0) {
@@ -721,9 +724,10 @@ namespace amf {
       frame_after_ref_frame_invalidation = true;
     }
     else if (effective_ltr_slots > 0 && (frame_index % LTR_MARK_INTERVAL) == 0) {
-      // Periodically mark current frame as LTR for future RFI use
-      // Only mark every LTR_MARK_INTERVAL frames to avoid limiting encoder reference freedom
-      // Only use slots < effective_ltr_slots (clamped to max_ltr_frames)
+      // Periodically mark current frame as LTR for future RFI use.
+      // Rotate through slots 1..N-1 so the IDR baseline in slot 0 stays valid
+      // even if every recent periodic anchor lands inside a loss burst. With a
+      // single slot configured, fall back to overwriting slot 0.
       if (video_format == 0) {
         surface->SetProperty(AMF_VIDEO_ENCODER_MARK_CURRENT_WITH_LTR_INDEX, (amf_int64) current_ltr_slot);
       }
@@ -735,7 +739,13 @@ namespace amf {
       }
       ltr_slots_valid[current_ltr_slot] = true;
       ltr_slot_frame_index[current_ltr_slot] = frame_index;
-      current_ltr_slot = (current_ltr_slot + 1) % effective_ltr_slots;
+      if (effective_ltr_slots > 1) {
+        current_ltr_slot++;
+        if (current_ltr_slot >= effective_ltr_slots) {
+          current_ltr_slot = 1;  // wrap, skipping the reserved slot 0
+        }
+      }
+      // else: stays at 0 (single-slot fallback)
     }
 
     frame_rfi_flags[frame_index] = frame_after_ref_frame_invalidation;

--- a/src/amf/amf_d3d11.h
+++ b/src/amf/amf_d3d11.h
@@ -95,9 +95,13 @@ namespace amf {
     // Whether the driver supports QUERY_TIMEOUT (FFmpeg-style safety check)
     bool query_timeout_supported = false;
 
-    // Current LTR state for RFI
-    static constexpr int MAX_LTR_SLOTS = 2;
-    static constexpr uint64_t LTR_MARK_INTERVAL = 30;  // Mark LTR every N frames
+    // Current LTR state for RFI.
+    // Slot 0 is reserved as the IDR baseline (set on every IDR, never overwritten by
+    // periodic marks) so RFI always has a known-good fallback even when every recent
+    // periodic-marked frame was inside a packet-loss window. Slots 1..N-1 form a
+    // sliding window of more recent anchors.
+    static constexpr int MAX_LTR_SLOTS = 4;
+    static constexpr uint64_t LTR_MARK_INTERVAL = 4;  // Mark LTR every N frames
     int effective_ltr_slots = 0;    // Clamped to min(max_ltr_frames, MAX_LTR_SLOTS)
     int current_ltr_slot = 0;      // Which LTR slot to mark next
     bool ltr_slots_valid[MAX_LTR_SLOTS] = {};

--- a/src/config.h
+++ b/src/config.h
@@ -73,7 +73,7 @@ namespace config {
       std::optional<int> amd_vbaq;
       int amd_coder;
       int amd_qvbr_quality = 23;  // QVBR quality level 1-51 (lower=better, default=23)
-      int amd_ltr_frames = 1;  // LTR frames for RFI (0=disabled, default=1)
+      int amd_ltr_frames = 4;  // LTR frames for RFI (0=disabled, default=4)
       int amd_slices_per_frame = 0;  // Slices/tiles per frame (0=client decides, 1-4=minimum)
     } amd;
 


### PR DESCRIPTION
## 现象

弱网下 AMD AMF 编码会**持续局部花屏**，只有遇到大画面变化或自然 IDR 时才会清除；NVENC 不受影响。

## 根因

两个 bug 联手把 RFI（Reference-Frame-Invalidation）恢复链路打瘫：

1. **默认 `amd_ltr_frames = 1`** —— 只有一个 LTR 槽。每 30 帧周期性标记当前帧为 LTR 时会**覆盖 IDR baseline**。客户端因丢包请求 RFI 时，`invalidate_ref_frames()` 找不到丢包之前的有效 LTR → 返回 false → 兜底 force IDR。但弱网下大 IDR 帧又容易丢包，导致花屏长期无法恢复。

2. **轮换策略 `current_ltr_slot = (current_ltr_slot + 1) % effective_ltr_slots`** 把 slot 0 当成普通槽轮换，**最可靠的 IDR 对齐参考一定会在一轮后被丢弃**。

## 修复

- `MAX_LTR_SLOTS`：2 → 4
- 默认 `amd_ltr_frames`：1 → 4
- `LTR_MARK_INTERVAL`：30 → 4，让 slot 1..N-1 形成覆盖最近约 16 帧的滚动锚点窗口
- **slot 0 永久保留为 IDR baseline**：IDR 后从 slot 1 开始轮换，wrap 时从 N-1 回到 1，永不覆盖 slot 0；单槽配置回退到原有行为

## 延迟影响

**零额外延迟**。仅编码器 DPB 多保留约 3 个参考帧（4K 10bit ≈ +30 MB 显存），无额外编码 pass、无每帧附加工作；IDR 触发频率因 RFI 成功率提升反而下降，网络码率更平稳。

## 兼容性

- 与 7f41eee94（输出帧身份保持）正交，不触碰 PTS / pending_outputs / frame_rfi_flags
- `src/video.cpp` 中既有 `force_idr` 兜底链路保留，覆盖所有 LTR 同时失效的极端情形
- `amd_ltr_frames ∈ {0..4}` 配置范围之前已支持；老用户配 1 行为不变

## 验证

- 本地 MSYS2 UCRT64 GCC 15.2 编译通过；`sunshine.exe --version` 正常
- Inno Setup 打包成功
- 已安装到本机；`SunshineService` 正常运行
- 回归冒烟：建议开 `min_log_level = debug`，模拟 5% 丢包，观察 `AMF: RFI pending, using LTR index ...` 比例显著高于 `AMF: RFI failed ...`