### PR TITLE
fix(amf): disable LTR by default to match FFmpeg amfenc behavior

### DIFF
--- a/src/amf/amf_config.h
+++ b/src/amf/amf_config.h
@@ -55,8 +55,11 @@ namespace amf {
     // Enforce HRD
     std::optional<int> enforce_hrd;
 
-    // Number of LTR frames for RFI
-    int max_ltr_frames = 4;
+    // Number of LTR frames for RFI (0 = disabled, matches FFmpeg amfenc behavior).
+    // When enabled, static screen regions may retain encoder artifacts from the
+    // baseline LTR frame until motion forces a refresh; only opt in when the
+    // network actually needs reference-frame invalidation recovery.
+    int max_ltr_frames = 0;
 
     // --- Pre-Analysis sub-system ---
     // PAQ mode (AMF_PA_PAQ_MODE_ENUM): 0=none, 1=CAQ

--- a/src/amf/amf_d3d11.cpp
+++ b/src/amf/amf_d3d11.cpp
@@ -152,7 +152,23 @@ namespace amf {
       encoder->SetProperty(AMF_VIDEO_ENCODER_INPUT_QUEUE_SIZE, (amf_int64) 1);
       encoder->SetProperty(AMF_VIDEO_ENCODER_QUERY_TIMEOUT, (amf_int64) 1);
 
-      // LTR for RFI
+      // LTR for RFI (Reference Frame Invalidation, weak-network recovery).
+      //
+      // Disabled by default (max_ltr_frames == 0) to match FFmpeg amfenc behavior:
+      // FFmpeg's libavcodec/amfenc.c never sets MAX_LTR_FRAMES / LTR_MODE, so static
+      // screen regions are not pinned to a baseline LTR frame and never accumulate
+      // color-block artifacts.
+      //
+      // Trade-off when the user opts in (amd_ltr_frames >= 1):
+      //   + On lossy links, client-side reference invalidation can recover by
+      //     sending a P-frame referencing a known-good LTR slot instead of a full
+      //     IDR. IDRs are 10-20x larger than P-frames and themselves more likely
+      //     to be lost on weak networks, which can cascade into an "IDR storm".
+      //   - Static regions may inherit the IDR-time quantization noise of the
+      //     baseline LTR slot until motion forces a fresh intra block.
+      //
+      // The slot rotation / IDR-baseline preservation logic below (PR #630) only
+      // takes effect when LTR is opted in.
       max_ltr_frames = config.max_ltr_frames;
       if (max_ltr_frames > 0) {
         encoder->SetProperty(AMF_VIDEO_ENCODER_MAX_LTR_FRAMES, (amf_int64) max_ltr_frames);
@@ -217,6 +233,8 @@ namespace amf {
         encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_PROFILE, (amf_int64) AMF_VIDEO_ENCODER_HEVC_PROFILE_MAIN);
       }
 
+      // LTR for RFI - see H.264 block above for detailed trade-off rationale.
+      // Disabled by default; opt-in via amd_ltr_frames config.
       max_ltr_frames = config.max_ltr_frames;
       if (max_ltr_frames > 0) {
         encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_MAX_LTR_FRAMES, (amf_int64) max_ltr_frames);
@@ -298,6 +316,8 @@ namespace amf {
         encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_AQ_MODE, (amf_int64) *config.pa_paq_mode);
       }
 
+      // LTR for RFI - see H.264 block above for detailed trade-off rationale.
+      // Disabled by default; opt-in via amd_ltr_frames config.
       max_ltr_frames = config.max_ltr_frames;
       if (max_ltr_frames > 0) {
         encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_MAX_LTR_FRAMES, (amf_int64) max_ltr_frames);
@@ -595,7 +615,11 @@ namespace amf {
 
 
 
-    // Clamp effective LTR slots to what the encoder actually reserves
+    // Clamp effective LTR slots to what the encoder actually reserves.
+    // When max_ltr_frames == 0 (default), the entire LTR/RFI subsystem becomes
+    // a no-op: the IDR baseline marking, slot rotation, and invalidate handling
+    // below all gate on `effective_ltr_slots > 0`. The fallback for client-side
+    // invalidate_ref_frames in this case is force_idr=true (see video.cpp).
     effective_ltr_slots = (max_ltr_frames > 0) ? std::min(max_ltr_frames, MAX_LTR_SLOTS) : 0;
 
     // Reset LTR state

--- a/src/config.h
+++ b/src/config.h
@@ -73,7 +73,7 @@ namespace config {
       std::optional<int> amd_vbaq;
       int amd_coder;
       int amd_qvbr_quality = 23;  // QVBR quality level 1-51 (lower=better, default=23)
-      int amd_ltr_frames = 4;  // LTR frames for RFI (0=disabled, default=4)
+      int amd_ltr_frames = 0;  // LTR frames for RFI (0=disabled by default; matches FFmpeg amfenc behavior to avoid static-region color blocks)
       int amd_slices_per_frame = 0;  // Slices/tiles per frame (0=client decides, 1-4=minimum)
     } amd;
 


### PR DESCRIPTION
## 背景

PR #630 默认开启了原生 AMF LTR（4 slots）以提升弱网 RFI 恢复体验，但实测引入回归：**静态画面区域出现持续色块，必须等鼠标/光标划过才会刷新**。本机和外部用户都已复现（LAN 环境，排除丢包）。

## 根因

```cpp
encoder->SetProperty(AMF_VIDEO_ENCODER_LTR_MODE, AMF_VIDEO_ENCODER_LTR_MODE_RESET_UNUSED);
```

在 `USAGE = ULTRA_LOW_LATENCY` 下：
1. IDR 帧把 slot 0 标记为 LTR baseline，**该帧的量化噪声被冻结**
2. 后续 P 帧静态宏块产生 zero residual → 永久引用 slot 0 的烂像素
3. RC 永远不会重写 slot 0 的静态区域 → 色块只能等运动强制 intra 块才被覆盖

## 对照：FFmpeg 为什么没这个问题

查阅 FFmpeg 上游 [`libavcodec/amfenc.c`](https://github.com/FFmpeg/FFmpeg/blob/master/libavcodec/amfenc.c) 与 `amfenc_h264.c`：

- **完全不调用** `AMF_VIDEO_ENCODER_MAX_LTR_FRAMES` 或 `AMF_VIDEO_ENCODER_LTR_MODE`
- 仅在 `preanalysis=1` 时可选启用 `AMF_PA_LTR_ENABLE`（PreAnalysis 子模块的不同机制）
- 默认走纯短时参考路径，每个 P 帧引用前一个 P 帧；RC 每帧都重新优化静态区域，不会卡死

这就是旧的 FFmpeg-AMF 路径从未出现该问题的原因。

## 修复

把 `amd_ltr_frames` 默认值由 `4` 改回 `0`（LTR opt-in），开箱行为对齐 FFmpeg amfenc：

- 默认无静态区域色块
- 真正需要 RFI 弱网恢复的高级用户仍可在配置里把 `amd_ltr_frames` 调到 `1..4`，#630 的 slot 轮转/baseline 保留逻辑会照常工作

## 改动

- `src/config.h`: `amd_ltr_frames = 4` → `0`，注释更新
- `src/amf/amf_config.h`: `max_ltr_frames = 4` → `0`，加 doc 说明 trade-off
- `amf_d3d11.cpp` / `amf_d3d11.h` 中的 `MAX_LTR_SLOTS=4`、`LTR_MARK_INTERVAL=4`、轮转逻辑不变（用户开启时这些常数有意义）

## 验证

- 编译通过（ninja sunshine）
- 已本机打包 Inno Setup 安装并替换 PR #630 二进制（待回归静态画面色块）

Refs #630