### PR TITLE
fix: 修复退出程序后异常重启

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -56,16 +56,29 @@ namespace logging {
   void
   deinit() {
     log_flush();
+
+    // Order matters for async sinks:
+    //   1) remove_sink: detach the sink from the boost::log core so no new records are delivered
+    //   2) stop:        signal the worker thread to exit and wait for it to finish
+    //   3) flush:       drain any remaining records
+    //   4) reset:       drop our shared_ptr; sink destructor runs once the last ref is gone
+    auto core = bl::core::get();
+
     if (console_sink) {
-      bl::core::get()->remove_sink(console_sink);
+      core->remove_sink(console_sink);
+      console_sink->stop();
+      console_sink->flush();
       console_sink.reset();
     }
     if (file_sink_ptr) {
-      bl::core::get()->remove_sink(file_sink_ptr);
+      core->remove_sink(file_sink_ptr);
+      file_sink_ptr->flush();
       file_sink_ptr.reset();
     }
     if (file_ostream_sink) {
-      bl::core::get()->remove_sink(file_ostream_sink);
+      core->remove_sink(file_ostream_sink);
+      file_ostream_sink->stop();
+      file_ostream_sink->flush();
       file_ostream_sink.reset();
     }
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -137,19 +137,6 @@ main(int argc, char *argv[]) {
   task_pool_util::TaskPool::task_id_t force_shutdown = nullptr;
 
 #ifdef _WIN32
-  // atexit handlers run AFTER stack RAII and INTERLEAVED with static destructors
-  // (LIFO with static dtors). Registering this from inside main() guarantees it
-  // fires very late in the exit sequence — after our own logging::deinit_t,
-  // after every guard in main(), and after most file-scope statics constructed
-  // during static init. By that point all our explicit cleanup (device restore,
-  // CoUninitialize, socket close, log flush, Mouse Keys restore, NVIDIA prefs
-  // undo) has already happened. The remaining DLL_PROCESS_DETACH work for
-  // third-party modules (NVAPI, ViGEm, IDDCx, boost::log core internals,
-  // various GPU runtime DLLs) has a known race window during process unload
-  // that surfaces as 0xC0000005 in ntdll for some launch contexts (e.g. when
-  // started from the --shortcut launcher). Avoid it entirely by terminating
-  // ourselves with the desired exit code before DLL detach can race.
-  //
   // Note: this only fires on a normal `return` from main. If the program
   // crashes mid-run (uncaught exception, AV, abort/terminate), atexit is
   // not invoked, so the service supervisor still observes a non-zero exit

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
  * @brief Definitions for the main entry point for Sunshine.
  */
 // standard includes
+#include <atomic>
 #include <codecvt>
 #include <csignal>
 #include <fstream>
@@ -31,6 +32,19 @@
 extern "C" {
 #include "rswrapper.h"
 }
+
+#ifdef _WIN32
+  #ifndef WIN32_LEAN_AND_MEAN
+    #define WIN32_LEAN_AND_MEAN
+  #endif
+  #include <windows.h>
+
+namespace {
+  // Captures the value main() ends up returning so the atexit terminator can use it.
+  // Defaults to 0 (success) for the common case where main returns lifetime::desired_exit_code.
+  std::atomic<int> g_final_exit_code { 0 };
+}
+#endif
 
 using namespace std::literals;
 
@@ -123,6 +137,28 @@ main(int argc, char *argv[]) {
   task_pool_util::TaskPool::task_id_t force_shutdown = nullptr;
 
 #ifdef _WIN32
+  // atexit handlers run AFTER stack RAII and INTERLEAVED with static destructors
+  // (LIFO with static dtors). Registering this from inside main() guarantees it
+  // fires very late in the exit sequence — after our own logging::deinit_t,
+  // after every guard in main(), and after most file-scope statics constructed
+  // during static init. By that point all our explicit cleanup (device restore,
+  // CoUninitialize, socket close, log flush, Mouse Keys restore, NVIDIA prefs
+  // undo) has already happened. The remaining DLL_PROCESS_DETACH work for
+  // third-party modules (NVAPI, ViGEm, IDDCx, boost::log core internals,
+  // various GPU runtime DLLs) has a known race window during process unload
+  // that surfaces as 0xC0000005 in ntdll for some launch contexts (e.g. when
+  // started from the --shortcut launcher). Avoid it entirely by terminating
+  // ourselves with the desired exit code before DLL detach can race.
+  //
+  // Note: this only fires on a normal `return` from main. If the program
+  // crashes mid-run (uncaught exception, AV, abort/terminate), atexit is
+  // not invoked, so the service supervisor still observes a non-zero exit
+  // code and can restart Sunshine as usual.
+  std::atexit([]() {
+    TerminateProcess(GetCurrentProcess(),
+                     static_cast<UINT>(g_final_exit_code.load(std::memory_order_acquire)));
+  });
+
   // Avoid searching the PATH in case a user has configured their system insecurely
   // by placing a user-writable directory in the system-wide PATH variable.
   SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_APPLICATION_DIR | LOAD_LIBRARY_SEARCH_SYSTEM32);
@@ -451,5 +487,12 @@ main(int argc, char *argv[]) {
   }
 #endif
 
+#ifdef _WIN32
+  // Hand the chosen exit code over to the atexit terminator so it can pass it
+  // straight to TerminateProcess. Without this the terminator would always
+  // exit with 0 even when lifetime::desired_exit_code was set non-zero by a
+  // failure path that still chose to return cleanly from main.
+  g_final_exit_code.store(lifetime::desired_exit_code, std::memory_order_release);
+#endif
   return lifetime::desired_exit_code;
 }

--- a/src/system_tray.cpp
+++ b/src/system_tray.cpp
@@ -1234,6 +1234,15 @@ namespace system_tray {
 
     tray_initialized = false;
     tray_exit();
+
+    if (tray_thread.joinable()) {
+      try {
+        tray_thread.join();
+      }
+      catch (const std::system_error &e) {
+        BOOST_LOG(warning) << "Failed to join tray thread: " << e.what();
+      }
+    }
     return 0;
   }
 
@@ -1395,12 +1404,12 @@ namespace system_tray {
     // Reset the end_tray flag for new tray instance
     end_tray_called = false;
 
-    try {
-      auto tray_thread = std::thread(tray_thread_worker);
+    if (tray_thread.joinable()) {
+      tray_thread.join();
+    }
 
-      // The tray thread doesn't require strong lifetime management.
-      // It will exit asynchronously when tray_exit() is called.
-      tray_thread.detach();
+    try {
+      tray_thread = std::thread(tray_thread_worker);
 
       BOOST_LOG(info) << "System tray thread initialized successfully"sv;
       return 0;


### PR DESCRIPTION
预期行为

场景	流程	exit_code
正常退出（托盘退出 / SIGTERM / WM_ENDSESSION）	RAII → 静态析构 → atexit → TerminateProcess(0)	0 ✅ 不重启
退出码非零的清退（出错但走 main return）	RAII → 静态析构 → atexit → TerminateProcess(non-zero)	非零 ✅ 重启
运行中真崩溃（AV/abort/terminate/未捕获异常）	atexit 不触发 → 走原 ntdll 异常路径	0xC0000005 ✅ 重启