### PR TITLE
fix: expose clipboard blob routes on nvhttp

### DIFF
--- a/src/clipboard_blob_store.cpp
+++ b/src/clipboard_blob_store.cpp
@@ -5,12 +5,14 @@
 #include "clipboard_blob_store.h"
 
 #include <chrono>
+#include <cstdint>
 #include <deque>
 #include <mutex>
-#include <random>
-#include <sstream>
+#include <stdexcept>
 #include <unordered_map>
 #include <utility>
+
+#include <openssl/rand.h>
 
 namespace clipboard_blob_store {
   namespace {
@@ -28,38 +30,34 @@ namespace clipboard_blob_store {
     std::deque<blob_id> g_fifo;
     std::size_t g_total_bytes = 0;
 
-    /// Generate a UUID-v4-shaped 36-char hex id without pulling in boost::uuid
-    /// here. Cryptographic strength is not required — these ids are scoped to
-    /// a live HTTPS-authenticated session and expire in 60 s.
+    /// Generate a UUID-v4-shaped 36-char hex id using OpenSSL's CSPRNG.
+    ///
+    /// The id functions as a bearer capability: any HTTPS-authenticated client
+    /// that learns it (via a KIND_REF wire frame) can fetch the blob bytes
+    /// without further per-blob authorisation. To keep that property safe we
+    /// must use a cryptographically-strong random source, not std::mt19937 —
+    /// 122 bits of CSPRNG entropy + the 60 s TTL make guessing infeasible.
     std::string
     make_id() {
-      thread_local std::mt19937_64 rng { std::random_device {}() };
-      std::uniform_int_distribution<std::uint64_t> dist;
+      std::uint8_t raw[16];
+      if (RAND_bytes(raw, sizeof(raw)) != 1) {
+        // RAND_bytes only fails when the OpenSSL RNG is uninitialised, which
+        // would make the whole TLS stack unusable too — surface as a hard
+        // error rather than silently degrading entropy.
+        throw std::runtime_error("clipboard_blob_store: RAND_bytes failed");
+      }
 
-      std::uint64_t hi = dist(rng);
-      std::uint64_t lo = dist(rng);
-
-      // Force version=4 nibble and variant bits per RFC 4122.
-      hi = (hi & 0xFFFFFFFFFFFF0FFFULL) | 0x0000000000004000ULL;
-      lo = (lo & 0x3FFFFFFFFFFFFFFFULL) | 0x8000000000000000ULL;
+      // Force version=4 nibble and RFC 4122 variant bits.
+      raw[6] = static_cast<std::uint8_t>((raw[6] & 0x0F) | 0x40);
+      raw[8] = static_cast<std::uint8_t>((raw[8] & 0x3F) | 0x80);
 
       static constexpr char kHex[] = "0123456789abcdef";
       std::string s(36, '-');
-      auto write_byte = [&](std::size_t pos, std::uint8_t b) {
-        s[pos] = kHex[b >> 4];
-        s[pos + 1] = kHex[b & 0xF];
-      };
-
-      // 8-4-4-4-12 layout. Bytes 0..7 = hi, bytes 8..15 = lo.
-      auto byte_at = [&](int i) -> std::uint8_t {
-        std::uint64_t v = (i < 8) ? hi : lo;
-        int shift = (7 - (i & 7)) * 8;
-        return static_cast<std::uint8_t>((v >> shift) & 0xFF);
-      };
-
       static constexpr int kSlots[] = { 0, 2, 4, 6, 9, 11, 14, 16, 19, 21, 24, 26, 28, 30, 32, 34 };
       for (int i = 0; i < 16; ++i) {
-        write_byte(static_cast<std::size_t>(kSlots[i]), byte_at(i));
+        const std::size_t pos = static_cast<std::size_t>(kSlots[i]);
+        s[pos] = kHex[raw[i] >> 4];
+        s[pos + 1] = kHex[raw[i] & 0xF];
       }
       return s;
     }

--- a/src/clipboard_http.cpp
+++ b/src/clipboard_http.cpp
@@ -6,8 +6,10 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cctype>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -300,61 +302,94 @@ namespace clipboard_http {
       return true;
     }
 
+    blob_response_t
+    json_blob_response(SimpleWeb::StatusCode status, std::string body) {
+      SimpleWeb::CaseInsensitiveMultimap headers;
+      headers.emplace("Content-Type", "application/json");
+      return { status, std::move(body), std::move(headers) };
+    }
+
+    bool
+    parse_content_length(const std::string &value, std::uint64_t &out) {
+      if (value.empty()) {
+        return false;
+      }
+      if (!std::all_of(value.begin(), value.end(), [](unsigned char c) { return std::isdigit(c); })) {
+        return false;
+      }
+
+      try {
+        std::size_t consumed = 0;
+        out = std::stoull(value, &consumed);
+        return consumed == value.size();
+      } catch (...) {
+        return false;
+      }
+    }
+
     void
     handle_blob_upload(const auth_fn &auth, resp_https_t resp, req_https_t req) {
       if (!auth(resp, req)) {
         return;
       }
-      if (!config::input.clipboard_sync) {
-        resp->write(SimpleWeb::StatusCode::client_error_forbidden,
-          R"({"error":"clipboard_sync_disabled"})");
+
+      if (auto out = make_blob_upload_preflight_response(req->header)) {
+        resp->write(out->status, out->body, out->headers);
         return;
       }
 
-      auto mime_it = req->header.find("X-Clipboard-Mime");
-      if (mime_it == req->header.end() || mime_it->second.empty()) {
-        resp->write(SimpleWeb::StatusCode::client_error_bad_request,
-          R"({"error":"missing_mime"})");
+      std::stringstream ss;
+      ss << req->content.rdbuf();
+      auto out = make_blob_upload_response(req->header, ss.str());
+      resp->write(out.status, out.body, out.headers);
+    }
+
+    void
+    handle_blob_get(const auth_fn &auth, resp_https_t resp, req_https_t req) {
+      if (!auth(resp, req)) {
         return;
+      }
+
+      const std::string id = req->path_match.size() >= 2 ? req->path_match[1].str() : std::string {};
+      auto out = make_blob_get_response(id);
+      resp->write(out.status, out.body, out.headers);
+    }
+  }  // namespace
+
+  blob_response_t
+  make_blob_upload_response(
+    const SimpleWeb::CaseInsensitiveMultimap &request_headers,
+    const std::string &body) {
+      if (auto out = make_blob_upload_preflight_response(request_headers)) {
+        return *out;
+      }
+
+      if (!config::input.clipboard_sync) {
+        return json_blob_response(SimpleWeb::StatusCode::client_error_forbidden,
+          R"({"error":"clipboard_sync_disabled"})");
+      }
+
+      auto mime_it = request_headers.find("X-Clipboard-Mime");
+      if (mime_it == request_headers.end() || mime_it->second.empty()) {
+        return json_blob_response(SimpleWeb::StatusCode::client_error_bad_request,
+          R"({"error":"missing_mime"})");
       }
       // Strict RFC 6838 token shape: type "/" subtype, each non-empty and made
       // of [A-Za-z0-9!#$&^_.+-]. Length capped to keep logs/json bounded and
       // to prevent the value being abused as an XSS vector when it is later
       // echoed verbatim into the Content-Type header on the GET path.
       if (!is_valid_mime(mime_it->second)) {
-        resp->write(SimpleWeb::StatusCode::client_error_bad_request,
+        return json_blob_response(SimpleWeb::StatusCode::client_error_bad_request,
           R"({"error":"bad_mime"})");
-        return;
       }
 
-      // Pre-flight on Content-Length so we don't even read a giant body.
-      auto content_length = req->header.find("Content-Length");
-      if (content_length != req->header.end() && !content_length->second.empty()) {
-        try {
-          if (std::stoull(content_length->second) > clipboard_blob_store::kMaxBlobBytes) {
-            resp->write(SimpleWeb::StatusCode::client_error_payload_too_large,
-              R"({"error":"payload_too_large"})");
-            return;
-          }
-        } catch (...) {
-          resp->write(SimpleWeb::StatusCode::client_error_bad_request,
-            R"({"error":"bad_content_length"})");
-          return;
-        }
-      }
-
-      std::stringstream ss;
-      ss << req->content.rdbuf();
-      const std::string body = ss.str();
       if (body.empty()) {
-        resp->write(SimpleWeb::StatusCode::client_error_bad_request,
+        return json_blob_response(SimpleWeb::StatusCode::client_error_bad_request,
           R"({"error":"empty_body"})");
-        return;
       }
       if (body.size() > clipboard_blob_store::kMaxBlobBytes) {
-        resp->write(SimpleWeb::StatusCode::client_error_payload_too_large,
+        return json_blob_response(SimpleWeb::StatusCode::client_error_payload_too_large,
           R"({"error":"payload_too_large"})");
-        return;
       }
 
       clipboard_blob_store::payload_t bytes(body.begin(), body.end());
@@ -363,8 +398,7 @@ namespace clipboard_http {
       if (!put.ok) {
         nlohmann::json err;
         err["error"] = put.err.empty() ? std::string { "put_failed" } : put.err;
-        resp->write(SimpleWeb::StatusCode::client_error_payload_too_large, err.dump());
-        return;
+        return json_blob_response(SimpleWeb::StatusCode::client_error_payload_too_large, err.dump());
       }
 
       nlohmann::json out;
@@ -374,41 +408,54 @@ namespace clipboard_http {
 
       SimpleWeb::CaseInsensitiveMultimap headers;
       headers.emplace("Content-Type", "application/json");
-      resp->write(SimpleWeb::StatusCode::success_ok, out.dump(), headers);
+      return { SimpleWeb::StatusCode::success_ok, out.dump(), std::move(headers) };
     }
 
-    void
-    handle_blob_get(const auth_fn &auth, resp_https_t resp, req_https_t req) {
-      if (!auth(resp, req)) {
-        return;
-      }
-      if (!config::input.clipboard_sync) {
-        resp->write(SimpleWeb::StatusCode::client_error_forbidden,
-          R"({"error":"clipboard_sync_disabled"})");
-        return;
+  std::optional<blob_response_t>
+  make_blob_upload_preflight_response(const SimpleWeb::CaseInsensitiveMultimap &request_headers) {
+      auto content_length = request_headers.find("Content-Length");
+      if (content_length == request_headers.end()) {
+        return json_blob_response(SimpleWeb::StatusCode::client_error_bad_request,
+          R"({"error":"bad_content_length"})");
       }
 
-      // path_match[1] is the captured <id>.
-      if (req->path_match.size() < 2) {
-        resp->write(SimpleWeb::StatusCode::client_error_bad_request,
-          R"({"error":"bad_id"})");
-        return;
+      std::uint64_t length = 0;
+      if (!parse_content_length(content_length->second, length)) {
+        return json_blob_response(SimpleWeb::StatusCode::client_error_bad_request,
+          R"({"error":"bad_content_length"})");
       }
-      const std::string id = req->path_match[1];
+
+      if (length > clipboard_blob_store::kMaxBlobBytes) {
+        return json_blob_response(SimpleWeb::StatusCode::client_error_payload_too_large,
+          R"({"error":"payload_too_large"})");
+      }
+
+      return std::nullopt;
+  }
+
+  blob_response_t
+  make_blob_get_response(const std::string &id) {
+      if (!config::input.clipboard_sync) {
+        return json_blob_response(SimpleWeb::StatusCode::client_error_forbidden,
+          R"({"error":"clipboard_sync_disabled"})");
+      }
+
+      if (id.empty()) {
+        return json_blob_response(SimpleWeb::StatusCode::client_error_bad_request,
+          R"({"error":"bad_id"})");
+      }
 
       // Constrain to canonical UUID-v4 shape (36 chars, hex + dashes) to
       // avoid the path regex accidentally matching weird inputs.
       if (id.size() != 36) {
-        resp->write(SimpleWeb::StatusCode::client_error_not_found,
+        return json_blob_response(SimpleWeb::StatusCode::client_error_not_found,
           R"({"error":"not_found"})");
-        return;
       }
 
       auto got = clipboard_blob_store::get(id, /*consume=*/false);
       if (!got.found) {
-        resp->write(SimpleWeb::StatusCode::client_error_not_found,
+        return json_blob_response(SimpleWeb::StatusCode::client_error_not_found,
           R"({"error":"not_found"})");
-        return;
       }
 
       SimpleWeb::CaseInsensitiveMultimap headers;
@@ -421,9 +468,8 @@ namespace clipboard_http {
       // Bytes-as-string copy: SimpleWebServer's `write(string)` is binary-safe
       // (string isn't NUL-terminated-sensitive).
       std::string body(reinterpret_cast<const char *>(got.bytes.data()), got.bytes.size());
-      resp->write(SimpleWeb::StatusCode::success_ok, body, headers);
-    }
-  }  // namespace
+      return { SimpleWeb::StatusCode::success_ok, std::move(body), std::move(headers) };
+  }
 
   void
   register_routes(https_server_t &server, auth_fn auth) {

--- a/src/clipboard_http.cpp
+++ b/src/clipboard_http.cpp
@@ -332,15 +332,7 @@ namespace clipboard_http {
       if (!auth(resp, req)) {
         return;
       }
-
-      if (auto out = make_blob_upload_preflight_response(req->header)) {
-        resp->write(out->status, out->body, out->headers);
-        return;
-      }
-
-      std::stringstream ss;
-      ss << req->content.rdbuf();
-      auto out = make_blob_upload_response(req->header, ss.str());
+      auto out = process_blob_upload(req);
       resp->write(out.status, out.body, out.headers);
     }
 
@@ -349,9 +341,7 @@ namespace clipboard_http {
       if (!auth(resp, req)) {
         return;
       }
-
-      const std::string id = req->path_match.size() >= 2 ? req->path_match[1].str() : std::string {};
-      auto out = make_blob_get_response(id);
+      auto out = process_blob_get(req);
       resp->write(out.status, out.body, out.headers);
     }
   }  // namespace

--- a/src/clipboard_http.h
+++ b/src/clipboard_http.h
@@ -46,6 +46,8 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
+#include <string>
 
 #include <Simple-Web-Server/server_https.hpp>
 
@@ -54,6 +56,30 @@ namespace clipboard_http {
   using resp_https_t = std::shared_ptr<typename SimpleWeb::ServerBase<SimpleWeb::HTTPS>::Response>;
   using req_https_t = std::shared_ptr<typename SimpleWeb::ServerBase<SimpleWeb::HTTPS>::Request>;
   using auth_fn = std::function<bool(resp_https_t, req_https_t)>;
+
+  struct blob_response_t {
+    SimpleWeb::StatusCode status;
+    std::string body;
+    SimpleWeb::CaseInsensitiveMultimap headers;
+  };
+
+  /// Build the HTTP response for POST /api/v1/clipboard/blob.
+  ///
+  /// The caller provides request headers and the raw body bytes. This helper is
+  /// transport-agnostic so Sunshine can expose the same blob store on multiple
+  /// HTTPS servers (e.g. confighttp for the local GUI agent and nvhttp for
+  /// paired Moonlight clients) without duplicating validation or storage logic.
+  blob_response_t make_blob_upload_response(
+    const SimpleWeb::CaseInsensitiveMultimap &request_headers,
+    const std::string &body);
+
+  /// Validate upload headers that must be checked before reading the request
+  /// body. Returns a response to send immediately when the request is rejected.
+  std::optional<blob_response_t> make_blob_upload_preflight_response(
+    const SimpleWeb::CaseInsensitiveMultimap &request_headers);
+
+  /// Build the HTTP response for GET /api/v1/clipboard/blob/<id>.
+  blob_response_t make_blob_get_response(const std::string &id);
 
   /// Register the /api/v1/clipboard/* routes on `server`. `auth` is invoked
   /// at the start of every handler; it must return true for authorised

--- a/src/clipboard_http.h
+++ b/src/clipboard_http.h
@@ -47,6 +47,7 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <sstream>
 #include <string>
 
 #include <Simple-Web-Server/server_https.hpp>
@@ -80,6 +81,28 @@ namespace clipboard_http {
 
   /// Build the HTTP response for GET /api/v1/clipboard/blob/<id>.
   blob_response_t make_blob_get_response(const std::string &id);
+
+  /// End-to-end blob upload handler: runs preflight, reads body iff preflight
+  /// passes, then invokes `make_blob_upload_response`. Templated on the
+  /// request type so confighttp's `SimpleWeb::HTTPS` and nvhttp's bespoke
+  /// `SunshineHTTPS` Request types can share one definition.
+  template <typename Request>
+  inline blob_response_t process_blob_upload(const Request &req) {
+    if (auto out = make_blob_upload_preflight_response(req->header)) {
+      return *out;
+    }
+    std::stringstream ss;
+    ss << req->content.rdbuf();
+    return make_blob_upload_response(req->header, ss.str());
+  }
+
+  /// End-to-end blob fetch handler: extracts the id from `req->path_match[1]`
+  /// and invokes `make_blob_get_response`.
+  template <typename Request>
+  inline blob_response_t process_blob_get(const Request &req) {
+    const std::string id = req->path_match.size() >= 2 ? req->path_match[1].str() : std::string {};
+    return make_blob_get_response(id);
+  }
 
   /// Register the /api/v1/clipboard/* routes on `server`. `auth` is invoked
   /// at the start of every handler; it must return true for authorised

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -30,6 +30,7 @@
 
 // local includes
 #include "config.h"
+#include "clipboard_http.h"
 #include "confighttp.h"
 #include "display_device/display_device.h"
 #include "display_device/session.h"
@@ -2425,6 +2426,27 @@ namespace nvhttp {
     https_server.resource["^/bitrate$"]["GET"] = changeBitrate;
     https_server.resource["^/stream/settings$"]["GET"] = changeDynamicParam;
     https_server.resource["^/sessions$"]["GET"] = getSessionsInfo;
+
+    // Clipboard blob routes are mirrored onto nvhttp so paired Moonlight
+    // clients can reuse their existing certificate-authenticated GameStream
+    // channel for large clipboard payloads. The local GUI agent continues to
+    // use the confighttp /api/v1/clipboard/* endpoints on loopback.
+    https_server.resource["^/api/v1/clipboard/blob$"]["POST"] = [](resp_https_t response, req_https_t request) {
+      if (auto out = clipboard_http::make_blob_upload_preflight_response(request->header)) {
+        response->write(out->status, out->body, out->headers);
+        return;
+      }
+
+      std::stringstream ss;
+      ss << request->content.rdbuf();
+      auto out = clipboard_http::make_blob_upload_response(request->header, ss.str());
+      response->write(out.status, out.body, out.headers);
+    };
+    https_server.resource["^/api/v1/clipboard/blob/([A-Za-z0-9_\\-]{1,128})$"]["GET"] = [](resp_https_t response, req_https_t request) {
+      const std::string id = request->path_match.size() >= 2 ? request->path_match[1].str() : std::string {};
+      auto out = clipboard_http::make_blob_get_response(id);
+      response->write(out.status, out.body, out.headers);
+    };
 
     // ABR (Adaptive Bitrate) API routes - client-facing with cert auth
     https_server.resource["^/api/abr/capabilities$"]["GET"] = getAbrCapabilities;

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -2432,19 +2432,11 @@ namespace nvhttp {
     // channel for large clipboard payloads. The local GUI agent continues to
     // use the confighttp /api/v1/clipboard/* endpoints on loopback.
     https_server.resource["^/api/v1/clipboard/blob$"]["POST"] = [](resp_https_t response, req_https_t request) {
-      if (auto out = clipboard_http::make_blob_upload_preflight_response(request->header)) {
-        response->write(out->status, out->body, out->headers);
-        return;
-      }
-
-      std::stringstream ss;
-      ss << request->content.rdbuf();
-      auto out = clipboard_http::make_blob_upload_response(request->header, ss.str());
+      auto out = clipboard_http::process_blob_upload(request);
       response->write(out.status, out.body, out.headers);
     };
     https_server.resource["^/api/v1/clipboard/blob/([A-Za-z0-9_\\-]{1,128})$"]["GET"] = [](resp_https_t response, req_https_t request) {
-      const std::string id = request->path_match.size() >= 2 ? request->path_match[1].str() : std::string {};
-      auto out = clipboard_http::make_blob_get_response(id);
+      auto out = clipboard_http::process_blob_get(request);
       response->write(out.status, out.body, out.headers);
     };
 


### PR DESCRIPTION
## Summary
- keep Sunshine clipboard processing GUI-agent-centric: the user-session GUI agent still owns system clipboard access, frame encoding/decoding, PNG/text handling, and SSE/event flow
- factor clipboard blob upload/get response building out of the confighttp-only handlers so the blob store logic can be reused safely
- expose only the short-lived `POST /api/v1/clipboard/blob` and `GET /api/v1/clipboard/blob/<id>` blob transport on `nvhttp` for paired Moonlight clients
- keep `capability`, `item`, and `events` on `confighttp`; the local GUI agent loopback flow is unchanged

## Problem
The existing clipboard design intentionally routes real clipboard handling through the user-session GUI agent. The C++ service is an opaque byte bridge because it runs outside the interactive user session and should not parse clipboard payloads or touch the OS clipboard directly.

That design works for normal text and small image payloads, but large payloads use the REF + blob path: a small `KIND_REF` frame is sent over the encrypted control stream while the actual bytes are stored in the short-lived clipboard blob store.

Before this patch, the blob HTTP endpoints were only available through `confighttp`, which is the right endpoint for the local GUI agent (`https://127.0.0.1:<web-ui-port>`), but it is not a natural endpoint for paired remote Moonlight clients. Those clients already authenticate to `nvhttp` with their pairing certificate and should not need Web UI credentials just to resolve a clipboard blob reference.

## Solution
This patch does **not** move clipboard processing into `nvhttp` and does **not** remove or replace the `confighttp` GUI-agent endpoints.

Instead, it keeps the original architecture intact and mirrors only the blob object transport onto `nvhttp`:
- GUI agent remains the owner of local OS clipboard access and continues using `confighttp` for `capability`, `item`, `events`, and blob access on loopback
- paired Moonlight clients can upload/download short-lived blob objects through certificate-authenticated `nvhttp` when they send or receive `KIND_REF` frames
- the C++ service still treats clipboard frames as opaque bytes; it only stores/fetches blob bytes by id

The shared helper also validates `Content-Length` before reading upload bodies, so missing/invalid lengths are rejected with `bad_content_length` and oversized uploads are rejected with `payload_too_large` before allocating the full body.

## Testing
- verified no diagnostics in `src/clipboard_http.h`, `src/clipboard_http.cpp`, and `src/nvhttp.cpp`
- built `sunshine` successfully with `cmake --build build --target sunshine -j4`
- confirmed the build required the MSYS2 UCRT toolchain path to take precedence over `/mingw64/bin` locally

## Notes
I intentionally did not remove any `confighttp` clipboard routes. They are the canonical local GUI-agent transport and are still required for the user-session clipboard bridge. This PR only adds a paired-client blob transport path for REF payloads.
