### PR TITLE
perf(windows): deadline-schedule virtual mouse flush

### DIFF
--- a/src/platform/windows/virtual_mouse.cpp
+++ b/src/platform/windows/virtual_mouse.cpp
@@ -151,6 +151,13 @@ namespace platf {
       // button/scroll paths don't race each other.
       std::mutex send_mutex;
 
+      // Throttle reopen attempts after the device disconnects (e.g. driver
+      // re-enumeration via `pnputil /remove-device` + `devcon install`).
+      // Without this, streaming would be permanently degraded to SendInput
+      // until the Sunshine service is restarted manually.
+      std::chrono::steady_clock::time_point last_reopen_attempt {};
+      static constexpr auto REOPEN_RETRY_INTERVAL = std::chrono::seconds(2);
+
       // Flush thread and timer.
       std::thread flush_thread;
       std::unique_ptr<high_precision_timer> flush_timer = create_high_precision_timer();
@@ -171,6 +178,13 @@ namespace platf {
 
       void
       start_flush_thread() {
+        // Guard: if a flush thread is already running (typical for the
+        // reopen-from-flush-thread path), do nothing. Replacing the
+        // std::thread object while the old one is joinable would call
+        // std::terminate() and crash the process.
+        if (flush_thread.joinable()) {
+          return;
+        }
         stop_requested.store(false, std::memory_order_release);
         flush_thread = std::thread([this]() {
           adjust_thread_priority(thread_priority_e::high);
@@ -181,12 +195,55 @@ namespace platf {
           while (!stop_requested.load(std::memory_order_acquire)) {
             if (!active) {
               std::unique_lock<std::mutex> lk(state_mutex);
-              wake_cv.wait(lk, [this]() {
+              // Wait with timeout so we can periodically poll for device
+              // re-arrival even when there is no pending input. Without this,
+              // an unplug/reinstall while the client has no input activity
+              // would leave the handle closed forever.
+              wake_cv.wait_for(lk, REOPEN_RETRY_INTERVAL, [this]() {
                 return stop_requested.load(std::memory_order_acquire) || accum_dirty;
               });
 
               if (stop_requested.load(std::memory_order_acquire)) {
                 break;
+              }
+
+              // Periodic re-acquire / liveness path: if device handle is closed,
+              // try to reopen even without input. If handle is open, query
+              // preparsed data as a read-only liveness ping so we can detect
+              // a silent driver removal and close the stale handle.
+              // Throttled by REOPEN_RETRY_INTERVAL.
+              //
+              // Drop state_mutex before taking send_mutex: every public API
+              // (move/button/scroll) takes state_mutex first and only then
+              // touches send_mutex via sendReportDirect, so reversing the
+              // order here would risk a future deadlock if any caller starts
+              // holding both at the same time.
+              if (!accum_dirty) {
+                lk.unlock();
+                std::lock_guard<std::mutex> send_lk(send_mutex);
+                const auto now = std::chrono::steady_clock::now();
+                if (now - last_reopen_attempt >= REOPEN_RETRY_INTERVAL) {
+                  last_reopen_attempt = now;
+                  if (hDevice == INVALID_HANDLE_VALUE) {
+                    if (open()) {
+                      VMOUSE_LOG(info) << "vmouse: Re-acquired virtual mouse device after disconnect (proactive)"sv;
+                    }
+                  }
+                  else {
+                    PHIDP_PREPARSED_DATA pp = nullptr;
+                    if (!HidD_GetPreparsedData(hDevice, &pp)) {
+                      // Treat any failure as device gone (the only documented
+                      // way this fails on a still-attached device is OOM).
+                      VMOUSE_LOG(warning) << "vmouse: Liveness ping failed, closing stale handle"sv;
+                      close();
+                      last_reopen_attempt = {};
+                    }
+                    else {
+                      HidD_FreePreparsedData(pp);
+                    }
+                  }
+                }
+                continue;
               }
 
               active = true;
@@ -351,7 +408,21 @@ namespace platf {
       bool
       sendReportDirect(uint8_t buttons, int16_t dx, int16_t dy, int8_t sv, int8_t sh) {
         std::lock_guard<std::mutex> send_lk(send_mutex);
-        if (hDevice == INVALID_HANDLE_VALUE) return false;
+
+        // If the handle was closed (device disconnected, driver reinstalled),
+        // try to re-open at most once every REOPEN_RETRY_INTERVAL so a
+        // back-to-back stream of input events doesn't enumerate HID devices on
+        // every call.
+        if (hDevice == INVALID_HANDLE_VALUE) {
+          const auto now = std::chrono::steady_clock::now();
+          if (now - last_reopen_attempt >= REOPEN_RETRY_INTERVAL) {
+            last_reopen_attempt = now;
+            if (open()) {
+              VMOUSE_LOG(info) << "vmouse: Re-acquired virtual mouse device after disconnect"sv;
+            }
+          }
+          if (hDevice == INVALID_HANDLE_VALUE) return false;
+        }
 
         auto report = detail::build_output_report(buttons, dx, dy, sv, sh);
 
@@ -360,10 +431,26 @@ namespace platf {
         if (!result) {
           DWORD err = GetLastError();
           if (detail::should_close_on_write_error(err)) {
-            VMOUSE_LOG(warning) << "vmouse: Device disconnected, closing handle"sv;
-            stop_requested.store(true, std::memory_order_release);
+            VMOUSE_LOG(warning) << "vmouse: Device disconnected, closing handle (will retry)"sv;
             close();
-            wake_cv.notify_one();
+            // Do NOT stop the flush thread here: keeping it alive lets queued
+            // mouse movement be flushed automatically once the device is back.
+            //
+            // Zero-latency recovery: try to reopen and resend immediately so
+            // the current input event isn't dropped. The new PDO is usually
+            // already enumerable by the time HidD_SetFeature returns the
+            // error. Bookkeep last_reopen_attempt so the flush-thread
+            // heartbeat doesn't re-attempt within REOPEN_RETRY_INTERVAL.
+            last_reopen_attempt = std::chrono::steady_clock::now();
+            if (open()) {
+              VMOUSE_LOG(info) << "vmouse: Re-acquired virtual mouse device after disconnect (immediate)"sv;
+              if (HidD_SetFeature(hDevice, (PVOID) report.data(), static_cast<ULONG>(report.size()))) {
+                return true;
+              }
+              // Reopen succeeded but write still failed — fall through and let
+              // future calls retry. Don't close again; the handle may still be
+              // valid, just temporarily refusing.
+            }
           }
           return false;
         }
@@ -388,10 +475,14 @@ namespace platf {
 
     bool
     device_t::move(int16_t delta_x, int16_t delta_y) {
-      if (!impl || impl->hDevice == INVALID_HANDLE_VALUE) {
+      if (!impl) {
         return false;
       }
 
+      // Even if hDevice is currently INVALID (driver disconnect / re-install),
+      // we keep accumulating so that when the flush thread or the next
+      // button/scroll call re-opens the device, the latest deltas are flushed
+      // out instead of getting silently dropped.
       bool should_notify = false;
       {
         std::lock_guard<std::mutex> lk(impl->state_mutex);

--- a/src/platform/windows/virtual_mouse.cpp
+++ b/src/platform/windows/virtual_mouse.cpp
@@ -504,7 +504,6 @@ namespace platf {
       uint8_t buttons;
       int16_t dx = 0;
       int16_t dy = 0;
-      bool had_pending_movement = false;
 
       {
         std::lock_guard<std::mutex> lk(impl->state_mutex);
@@ -517,15 +516,19 @@ namespace platf {
           impl->accum_dx = 0;
           impl->accum_dy = 0;
           impl->accum_dirty = false;
-          had_pending_movement = true;
         }
       }
 
-      if (had_pending_movement) {
-        impl->sendReportDirect(buttons, dx, dy, 0, 0);
-      }
-
-      return impl->sendReportDirect(buttons, 0, 0, 0, 0);
+      // Single combined report: a HID mouse input report carries buttons +
+      // movement together, so we don't need a separate button-only follow-up.
+      // If movement was pending, fold it into this same report.
+      //
+      // Note: on send failure we do NOT re-queue dx/dy. The handle teardown
+      // path inside sendReportDirect already attempts an immediate reopen +
+      // resend, so a single dropped delta is rare. Re-queuing under the
+      // state_mutex here would also race with movement that arrived between
+      // the take above and the failure, producing out-of-order accumulation.
+      return impl->sendReportDirect(buttons, dx, dy, 0, 0);
     }
 
     bool

--- a/src/platform/windows/virtual_mouse.cpp
+++ b/src/platform/windows/virtual_mouse.cpp
@@ -268,6 +268,18 @@ namespace platf {
             flush_accumulated();
             next_deadline += FLUSH_INTERVAL;
 
+            // Catch-up clamp: if HidD_SetFeature stalled (it can take >2ms,
+            // and the send_mutex may also block on a synchronous button() /
+            // scroll() call), next_deadline can fall arbitrarily far behind
+            // wall clock, which would otherwise cause an unbounded burst of
+            // back-to-back reports once the stall clears. Clamp the deadline
+            // to one interval ahead of now so we resync with the wall clock
+            // and pace at FLUSH_INTERVAL again.
+            const auto after_send = std::chrono::steady_clock::now();
+            if (next_deadline + FLUSH_INTERVAL < after_send) {
+              next_deadline = after_send + FLUSH_INTERVAL;
+            }
+
             std::lock_guard<std::mutex> lk(state_mutex);
             active = accum_dirty;
           }

--- a/src/platform/windows/virtual_mouse.cpp
+++ b/src/platform/windows/virtual_mouse.cpp
@@ -14,13 +14,16 @@
 #include <hidpi.h>
 #include <setupapi.h>
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <mutex>
 #include <thread>
 
 #include "virtual_mouse.h"
 #include "src/logging.h"
+#include "src/platform/common.h"
 
 // From vmouse_shared.h - duplicated here to avoid driver header dependency
 static constexpr uint16_t VMOUSE_VID = 0x1ACE;
@@ -119,23 +122,38 @@ namespace platf {
     // Implementation Detail
     // ========================================================================
 
-    // Flush interval for accumulated mouse movement (4ms ≈ 250Hz).
-    // HidD_SetFeature takes ~3ms, so this is the practical minimum.
-    static constexpr auto FLUSH_INTERVAL = std::chrono::milliseconds(4);
+    // Flush interval for accumulated mouse movement.
+    // Combined with deadline-based scheduling, 2ms is enough to push toward
+    // the current UMDF/HID path limit without adding an extra sleep after each
+    // HidD_SetFeature() call.
+    static constexpr auto FLUSH_INTERVAL = std::chrono::milliseconds(2);
+
+    namespace {
+      int16_t
+      clamp_relative_delta(int32_t delta) {
+        return static_cast<int16_t>(std::clamp(delta, -32767, 32767));
+      }
+    }  // namespace
 
     struct device_t::impl_t {
       HANDLE hDevice = INVALID_HANDLE_VALUE;
-      uint8_t buttonState = 0;  // Current button state (accumulated)
 
-      // Accumulated mouse deltas (written by callers, read by flush thread)
-      std::mutex accum_mutex;
+      // Shared state for accumulated mouse deltas and current button state.
+      std::mutex state_mutex;
+      std::condition_variable wake_cv;
+      uint8_t buttonState = 0;
       int32_t accum_dx = 0;
       int32_t accum_dy = 0;
       bool accum_dirty = false;
+      std::atomic<bool> stop_requested { false };
 
-      // Flush thread
+      // Serialize writes to the HID handle so the flush thread and synchronous
+      // button/scroll paths don't race each other.
+      std::mutex send_mutex;
+
+      // Flush thread and timer.
       std::thread flush_thread;
-      std::atomic<bool> flush_running { false };
+      std::unique_ptr<high_precision_timer> flush_timer = create_high_precision_timer();
 
       ~impl_t() {
         stop_flush_thread();
@@ -144,7 +162,8 @@ namespace platf {
 
       void
       stop_flush_thread() {
-        flush_running.store(false, std::memory_order_release);
+        stop_requested.store(true, std::memory_order_release);
+        wake_cv.notify_one();
         if (flush_thread.joinable()) {
           flush_thread.join();
         }
@@ -152,30 +171,81 @@ namespace platf {
 
       void
       start_flush_thread() {
-        flush_running.store(true, std::memory_order_release);
+        stop_requested.store(false, std::memory_order_release);
         flush_thread = std::thread([this]() {
-          while (flush_running.load(std::memory_order_acquire)) {
+          adjust_thread_priority(thread_priority_e::high);
+
+          bool active = false;
+          auto next_deadline = std::chrono::steady_clock::time_point {};
+
+          while (!stop_requested.load(std::memory_order_acquire)) {
+            if (!active) {
+              std::unique_lock<std::mutex> lk(state_mutex);
+              wake_cv.wait(lk, [this]() {
+                return stop_requested.load(std::memory_order_acquire) || accum_dirty;
+              });
+
+              if (stop_requested.load(std::memory_order_acquire)) {
+                break;
+              }
+
+              active = true;
+              next_deadline = std::chrono::steady_clock::now() + FLUSH_INTERVAL;
+            }
+
+            const auto now = std::chrono::steady_clock::now();
+            if (next_deadline > now) {
+              const auto sleep_period = next_deadline - now;
+              if (flush_timer && static_cast<bool>(*flush_timer)) {
+                flush_timer->sleep_for(sleep_period);
+              }
+              else {
+                std::this_thread::sleep_for(sleep_period);
+              }
+            }
+
+            if (stop_requested.load(std::memory_order_acquire)) {
+              break;
+            }
+
             flush_accumulated();
-            std::this_thread::sleep_for(FLUSH_INTERVAL);
+            next_deadline += FLUSH_INTERVAL;
+
+            std::lock_guard<std::mutex> lk(state_mutex);
+            active = accum_dirty;
           }
         });
       }
 
-      void
-      flush_accumulated() {
-        int16_t dx, dy;
-        uint8_t buttons;
-        {
-          std::lock_guard<std::mutex> lk(accum_mutex);
-          if (!accum_dirty) return;
-          dx = static_cast<int16_t>(std::clamp(accum_dx, -32767, 32767));
-          dy = static_cast<int16_t>(std::clamp(accum_dy, -32767, 32767));
-          buttons = buttonState;
-          accum_dx = 0;
-          accum_dy = 0;
-          accum_dirty = false;
+      bool
+      take_accumulated_report(
+          uint8_t &buttons,
+          int16_t &dx,
+          int16_t &dy) {
+        std::lock_guard<std::mutex> lk(state_mutex);
+        if (!accum_dirty) {
+          return false;
         }
-        sendReportDirect(buttons, dx, dy, 0, 0);
+
+        buttons = buttonState;
+        dx = clamp_relative_delta(accum_dx);
+        dy = clamp_relative_delta(accum_dy);
+        accum_dx = 0;
+        accum_dy = 0;
+        accum_dirty = false;
+        return true;
+      }
+
+      bool
+      flush_accumulated() {
+        uint8_t buttons;
+        int16_t dx;
+        int16_t dy;
+        if (!take_accumulated_report(buttons, dx, dy)) {
+          return false;
+        }
+
+        return sendReportDirect(buttons, dx, dy, 0, 0);
       }
 
       void
@@ -280,6 +350,7 @@ namespace platf {
        */
       bool
       sendReportDirect(uint8_t buttons, int16_t dx, int16_t dy, int8_t sv, int8_t sh) {
+        std::lock_guard<std::mutex> send_lk(send_mutex);
         if (hDevice == INVALID_HANDLE_VALUE) return false;
 
         auto report = detail::build_output_report(buttons, dx, dy, sv, sh);
@@ -290,8 +361,9 @@ namespace platf {
           DWORD err = GetLastError();
           if (detail::should_close_on_write_error(err)) {
             VMOUSE_LOG(warning) << "vmouse: Device disconnected, closing handle"sv;
-            flush_running.store(false, std::memory_order_release);
+            stop_requested.store(true, std::memory_order_release);
             close();
+            wake_cv.notify_one();
           }
           return false;
         }
@@ -316,36 +388,82 @@ namespace platf {
 
     bool
     device_t::move(int16_t delta_x, int16_t delta_y) {
-      // Accumulate deltas; the flush thread will send them periodically
-      std::lock_guard<std::mutex> lk(impl->accum_mutex);
-      impl->accum_dx += delta_x;
-      impl->accum_dy += delta_y;
-      impl->accum_dirty = true;
+      if (!impl || impl->hDevice == INVALID_HANDLE_VALUE) {
+        return false;
+      }
+
+      bool should_notify = false;
+      {
+        std::lock_guard<std::mutex> lk(impl->state_mutex);
+        should_notify = !impl->accum_dirty;
+        impl->accum_dx += delta_x;
+        impl->accum_dy += delta_y;
+        impl->accum_dirty = true;
+      }
+
+      if (should_notify) {
+        impl->wake_cv.notify_one();
+      }
+
       return true;
     }
 
     bool
     device_t::button(uint8_t button_mask, bool release) {
-      impl->buttonState = detail::apply_button_transition(impl->buttonState, button_mask, release);
-      // Flush any pending movement with the new button state
-      impl->flush_accumulated();
-      return impl->sendReportDirect(impl->buttonState, 0, 0, 0, 0);
+      uint8_t buttons;
+      int16_t dx = 0;
+      int16_t dy = 0;
+      bool had_pending_movement = false;
+
+      {
+        std::lock_guard<std::mutex> lk(impl->state_mutex);
+        impl->buttonState = detail::apply_button_transition(impl->buttonState, button_mask, release);
+        buttons = impl->buttonState;
+
+        if (impl->accum_dirty) {
+          dx = clamp_relative_delta(impl->accum_dx);
+          dy = clamp_relative_delta(impl->accum_dy);
+          impl->accum_dx = 0;
+          impl->accum_dy = 0;
+          impl->accum_dirty = false;
+          had_pending_movement = true;
+        }
+      }
+
+      if (had_pending_movement) {
+        impl->sendReportDirect(buttons, dx, dy, 0, 0);
+      }
+
+      return impl->sendReportDirect(buttons, 0, 0, 0, 0);
     }
 
     bool
     device_t::scroll(int8_t distance) {
-      return impl->sendReportDirect(impl->buttonState, 0, 0, distance, 0);
+      uint8_t buttons;
+      {
+        std::lock_guard<std::mutex> lk(impl->state_mutex);
+        buttons = impl->buttonState;
+      }
+      return impl->sendReportDirect(buttons, 0, 0, distance, 0);
     }
 
     bool
     device_t::hscroll(int8_t distance) {
-      return impl->sendReportDirect(impl->buttonState, 0, 0, 0, distance);
+      uint8_t buttons;
+      {
+        std::lock_guard<std::mutex> lk(impl->state_mutex);
+        buttons = impl->buttonState;
+      }
+      return impl->sendReportDirect(buttons, 0, 0, 0, distance);
     }
 
     bool
     device_t::send_report(uint8_t buttons, int16_t delta_x, int16_t delta_y,
                           int8_t scroll_v, int8_t scroll_h) {
-      impl->buttonState = buttons;
+      {
+        std::lock_guard<std::mutex> lk(impl->state_mutex);
+        impl->buttonState = buttons;
+      }
       return impl->sendReportDirect(buttons, delta_x, delta_y, scroll_v, scroll_h);
     }
 


### PR DESCRIPTION
## Summary
- switch the Windows virtual mouse movement flusher to deadline-based scheduling
- reduce the movement flush interval from 4ms to 2ms
- serialize HID writes and coordinate pending movement/button state through shared state

## Why
The previous loop slept for a full flush interval after every `HidD_SetFeature()` call, so the effective update cadence was lower than the configured interval under load. This change removes that extra idle gap and pushes the current UMDF/HID path closer to its practical limit.

## Testing
- verified editor diagnostics for `src/platform/windows/virtual_mouse.cpp`
- attempted local build validation, but the current workspace build has unrelated toolchain/build failures outside this file
