### PR TITLE
fix(windows-service): Triple-quote SERVICE_BIN path to prevent injection (CVE-2025-54081)

### DIFF
--- a/src_assets/windows/misc/service/install-service.bat
+++ b/src_assets/windows/misc/service/install-service.bat
@@ -67,7 +67,7 @@ rem Run the sc command to create/reconfigure the service
 set "SC_START_TYPE=!SERVICE_START_TYPE!"
 if /I "!SERVICE_START_TYPE!"=="delayed-auto" set "SC_START_TYPE=auto"
 
-sc !SC_CMD! %SERVICE_NAME% binPath= "%SERVICE_BIN%" start= !SC_START_TYPE! DisplayName= "Sunshine Service"
+sc !SC_CMD! %SERVICE_NAME% binPath= """%SERVICE_BIN%""" start= !SC_START_TYPE! DisplayName= "Sunshine Service"
 if errorlevel 1 (
     echo ERROR: Failed to !SC_CMD! %SERVICE_NAME%.
     exit /b 1


### PR DESCRIPTION
Backport of CVE-2025-54081 — Windows service binPath injection hardening.

### Issue
AlkaidLab's `src_assets/windows/misc/service/install-service.bat` line 70 has `binPath= "%SERVICE_BIN%"` (single-quoted), which allows path-injection if `%SERVICE_BIN%` contains spaces. Upstream's CVE-2025-54081 fix wraps it as `binPath= """%SERVICE_BIN%"""`.

AlkaidLab's variant uses `!SC_CMD!` and `!SC_START_TYPE!` (delayed-expansion); this port preserves AlkaidLab's logic and applies the triple-quote fix in place.

### Change
`src_assets/windows/misc/service/install-service.bat | 1 -1 +1` — minimal one-character fix (add `""` wrapper).

### References
- Upstream commit: https://github.com/LizardByte/Sunshine/commit/f22b00d6981f756d3531fba0028723d4a5065824
- CVE: https://nvd.nist.gov/vuln/detail/CVE-2025-54081

### Caveat
I have not test-installed the Windows service after this change; the fix is the same as upstream's (triple-quote the path), just adapted to AlkaidLab's delayed-expansion syntax.
