### PR TITLE
fix(windows-service): Triple-quote SERVICE_BIN path to prevent injection (CVE-2025-54081)

### DIFF
--- a/src_assets/windows/misc/service/install-service.bat
+++ b/src_assets/windows/misc/service/install-service.bat
@@ -67,7 +67,7 @@ rem Run the sc command to create/reconfigure the service
 set "SC_START_TYPE=!SERVICE_START_TYPE!"
 if /I "!SERVICE_START_TYPE!"=="delayed-auto" set "SC_START_TYPE=auto"
 
-sc !SC_CMD! %SERVICE_NAME% binPath= "%SERVICE_BIN%" start= !SC_START_TYPE! DisplayName= "Sunshine Service"
+sc !SC_CMD! %SERVICE_NAME% binPath= """%SERVICE_BIN%""" start= !SC_START_TYPE! DisplayName= "Sunshine Service"
 if errorlevel 1 (
     echo ERROR: Failed to !SC_CMD! %SERVICE_NAME%.
     exit /b 1


### PR DESCRIPTION
backports upstream LizardByte/Sunshine f22b00d6981f for CVE-2025-54081. one-character fix: wraps `%SERVICE_BIN%` in triple quotes in `install-service.bat` line 70 so `sc create` handles binary paths with spaces correctly.

AlkaidLab's variant uses `!SC_CMD!` / `!SC_START_TYPE!` (delayed expansion) instead of upstream's `%SC_CMD%`, so i kept that style and just added the triple-quote wrapper.

upstream: https://github.com/LizardByte/Sunshine/commit/f22b00d6981f756d3531fba0028723d4a5065824
CVE: https://nvd.nist.gov/vuln/detail/CVE-2025-54081

haven't reinstalled the windows service to verify after this — the fix is mechanical and identical in effect to upstream's.