### PR TITLE
fix(installer): read SunshineService binPath from registry, not localized sc qc

### DIFF
--- a/cmake/packaging/sunshine.iss.in
+++ b/cmake/packaging/sunshine.iss.in
@@ -584,37 +584,29 @@ end;
 
 procedure VerifyServiceInstalled();
 var
-  ResultCode: Integer;
-  TmpFile, ExpectedPath, Line, Lower: String;
-  Lines: TArrayOfString;
-  i: Integer;
-  Matched: Boolean;
+  ExpectedPath, ImagePath, Lower: String;
 begin
   ExpectedPath := ExpandConstant('{app}\tools\sunshinesvc.exe');
-  TmpFile := ExpandConstant('{tmp}\sc_qc_sunshineservice.txt');
-  // Redirect to a temp file and parse in Pascal so we don't depend on cmd.exe
-  // performing %VAR% expansion on the captured path or on `find` substring
-  // matching (which would mis-handle e.g. "sunshinesvc.exe.bak").
-  Exec(ExpandConstant('{cmd}'), '/c sc qc SunshineService > "' + TmpFile + '" 2>&1',
-       '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
-  Matched := False;
-  if (ResultCode = 0) and LoadStringsFromFile(TmpFile, Lines) then
+
+  // Read the service binary path directly from the registry instead of
+  // parsing `sc qc` output. `sc.exe` localizes its column labels
+  // (e.g. on Spanish Windows BINARY_PATH_NAME becomes NOMBRE_RUTA_BINARIO),
+  // so the previous string-prefix match falsely failed on non-English
+  // locales even though install-service.bat had already verified the
+  // binPath via locale-safe `find /I <abs_path>` and exited 0.
+  //
+  // ImagePath is REG_EXPAND_SZ and may be wrapped in quotes when the path
+  // contains spaces (it always does under "Program Files"); substring match
+  // tolerates both forms, plus any future appended arguments.
+  if RegQueryStringValue(HKLM64, 'SYSTEM\CurrentControlSet\Services\SunshineService',
+                         'ImagePath', ImagePath) then
   begin
     Lower := Lowercase(ExpectedPath);
-    for i := 0 to GetArrayLength(Lines) - 1 do
-    begin
-      Line := Trim(Lines[i]);
-      if (Pos('BINARY_PATH_NAME', Uppercase(Line)) = 1) and
-         (Pos(Lower, Lowercase(Line)) > 0) then
-      begin
-        Matched := True;
-        Break;
-      end;
-    end;
+    if Pos(Lower, Lowercase(ImagePath)) > 0 then
+      Exit;  // happy path
   end;
-  DeleteFile(TmpFile);
-  if not Matched then
-    RaiseException(CustomMessage('MsgServiceInstallFailed'));
+
+  RaiseException(CustomMessage('MsgServiceInstallFailed'));
 end;
 
 // Initialization: handle old NSIS upgrade


### PR DESCRIPTION
## 背景

Reddit 用户 [/r/MoonlightStreaming/comments/1tf2ybf](https://www.reddit.com/r/MoonlightStreaming/comments/1tf2ybf/error_installing/) 报告：在西语 Windows 上安装 foundation-sunshine 时安装器在 "Installing system service..." 步骤报错

```
Internal error: Expression error 'Runtime error (at 69:1271):
Sunshine service could not be installed or verified.
Please check the installer log and run the installer as administrator.'
```

并描述：

- 三次干净装系统（Win11 / Win10 多次）都同样报错
- 哥哥电脑（英文 locale）能装
- 管理员身份没用
- `%TEMP%\Sunshine.*.WindowsInstaller.tmp` 是二进制内容（即 Inno 中间文件）

错误源自 `[Code]` 的 `VerifyServiceInstalled`。

## 根因

`VerifyServiceInstalled` 在 `install-service.bat` 跑完之后，再额外用

```pascal
Exec(..., '/c sc qc SunshineService > tmp 2>&1', ...);
...
if (Pos('BINARY_PATH_NAME', Uppercase(Line)) = 1) and
   (Pos(Lower, Lowercase(Line)) > 0) then
  Matched := True;
```

去解析 `sc.exe` 输出，期望找到首列为 `BINARY_PATH_NAME` 的行。但 `sc.exe` 的列标签是 **按 Windows UI 语言本地化** 的：

| Locale | Label |
| --- | --- |
| en-US | `BINARY_PATH_NAME` |
| es-ES | `NOMBRE_RUTA_BINARIO` |
| zh-CN | `二进制路径名` |
| de-DE | `BINÄRPFAD_NAME` |
| … | … |

非英文系统上 `Pos('BINARY_PATH_NAME', …) = 1` 必然为 false，`Matched` 留在 false，`RaiseException(MsgServiceInstallFailed)` 触发 → 安装器中止。但 [`install-service.bat`](src_assets/windows/misc/service/install-service.bat#L88) 自己里早就用 locale-safe 的 `find /I <abs_path>` 校验过 binPath 并退出码 0 —— 服务其实已经正确安装。这是纯解析 bug，不是安装失败。

## 修复

直接从注册表读取服务的 `ImagePath`：

```pascal
RegQueryStringValue(HKLM64,
  'SYSTEM\CurrentControlSet\Services\SunshineService',
  'ImagePath', ImagePath);
if Pos(Lowercase(ExpectedPath), Lowercase(ImagePath)) > 0 then Exit;
```

注册表 `ImagePath` 是 locale-invariant 的 REG_EXPAND_SZ。当二进制路径含空格（`Program Files` 必然含）时会被双引号包裹，附加启动参数也很常见，所以用 **子串匹配** 兼容引号、`%SystemRoot%` 展开形式、以及未来可能加入的命令行参数。

查询失败时仍然抛 `MsgServiceInstallFailed`，保留真正安装失败场景下的原有错误展示。

服务安装在 64-bit registry view 下，所以显式用 `HKLM64` 而不是 `HKLM`，避免 32-bit installer 走到 Wow6432Node 重定向的歧义（理论上 services 不被重定向，但显式优于隐式）。

## 验证

- `cmake --build build --target innosetup` 干净通过：`Successful compile (32.907 sec)`，没有 Pascal 编译错误。
- 行为对比：
  - 英文 Windows：注册表读取成功，binPath 子串命中 → 走 happy path（与旧实现等价）
  - 西语 / 中文 / 任何非英文 Windows：原实现失败，新实现成功（去除 locale 依赖）
  - 服务真没装上（被 AV 杀掉、SCM 拒绝等）：注册表读取返回 false → 仍然抛 `MsgServiceInstallFailed`（与旧实现等价）
- 副作用：移除了 `Exec(sc qc ...)` 这次外部进程调用 + tmp 文件读写，安装步骤略快、副产物更少。

## 用户跟进

已建议 Reddit 报告者来 GitHub 开 issue 附加 `sc qc SunshineService` 的本地化输出，方便未来加 locale 回归用例。