### PR TITLE
ci(driver-deps): fork-friendly vmouse fetch via public mirror + non-fatal mode

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -194,6 +194,11 @@ jobs:
           BUILD_VERSION: ${{ needs.setup_release.outputs.release_tag }}.杂鱼
           COMMIT: ${{ needs.setup_release.outputs.release_commit }}
           GITHUB_TOKEN: ${{ secrets.DRIVER_DOWNLOAD_TOKEN }}
+          # Fork PRs cannot access org-scoped secrets, so private-repo driver
+          # downloads (vmouse) may fail. Downgrade missing drivers from
+          # FATAL_ERROR to WARNING so the build/configure still succeeds; the
+          # affected drivers are simply excluded from the installer.
+          DRIVER_DEPS_REQUIRED: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) && 'OFF' || 'ON' }}
         run: |
           mkdir -p build
           cmake \
@@ -203,6 +208,7 @@ jobs:
             -DBUILD_DOCS=OFF \
             -DBUILD_WEB_UI=OFF \
             -DSUNSHINE_ASSETS_DIR=assets \
+            -DDRIVER_DEPS_REQUIRED=${DRIVER_DEPS_REQUIRED} \
             -DSUNSHINE_PUBLISHER_NAME='${{ github.repository_owner }}' \
             -DSUNSHINE_PUBLISHER_WEBSITE='https://github.com/AlkaidLab/foundation-sunshine' \
             -DSUNSHINE_PUBLISHER_ISSUE_URL='https://github.com/AlkaidLab/foundation-sunshine/issues'

--- a/cmake/packaging/FetchDriverDeps.cmake
+++ b/cmake/packaging/FetchDriverDeps.cmake
@@ -5,7 +5,15 @@
 #
 # Configuration (CMake cache variables):
 #   FETCH_DRIVER_DEPS       — Enable/disable downloads (default: ON)
+#   DRIVER_DEPS_REQUIRED    — If ON (default), missing driver files are a
+#                             FATAL_ERROR. If OFF (typical for fork-PR CI),
+#                             missing files become a WARNING and the affected
+#                             driver is excluded from packaging.
 #   VMOUSE_DRIVER_VERSION   — ZakoVirtualMouse release tag (e.g. v1.1.0)
+#   VMOUSE_PUBLIC_REPO      — Public mirror repo for vmouse release assets
+#                             (default: AlkaidLab/zako-vmouse-release). Tried
+#                             first; falls back to private repo via API if
+#                             GITHUB_TOKEN is available.
 #   VDD_DRIVER_VERSION      — ZakoVDD release tag (e.g. v0.1.4)
 #   VDD_WIN10_DRIVER_VERSION — Win10-pinned ZakoVDD release tag
 #   NEFCON_VERSION          — nefcon release tag (e.g. v1.10.0)
@@ -24,6 +32,7 @@ if(NOT WIN32)
 endif()
 
 option(FETCH_DRIVER_DEPS "Download driver dependencies from GitHub Releases" ON)
+option(DRIVER_DEPS_REQUIRED "Treat missing driver dependencies as a fatal error" ON)
 
 # Version pins
 set(VMOUSE_DRIVER_VERSION "v1.2.0" CACHE STRING "ZakoVirtualMouse driver version tag")
@@ -35,6 +44,8 @@ set(NEFCON_VERSION "v1.10.0" CACHE STRING "nefcon version tag")
 
 # Repositories
 set(_VMOUSE_REPO "AlkaidLab/ZakoVirtualMouse")
+set(VMOUSE_PUBLIC_REPO "AlkaidLab/zako-vmouse-release" CACHE STRING
+    "Public mirror repo (owner/name) hosting ZakoVirtualMouse release assets")
 set(_VDD_REPO "qiin2333/zako-vdd")
 set(_NEFCON_REPO "nefarius/nefcon")
 
@@ -133,13 +144,43 @@ function(_fetch_vmouse)
     return()
   endif()
 
+  file(MAKE_DIRECTORY "${VMOUSE_DRIVER_DIR}")
+
+  # ---- Attempt 1: public mirror repo (no auth needed) ----
+  if(VMOUSE_PUBLIC_REPO)
+    message(STATUS "  Trying public mirror ${VMOUSE_PUBLIC_REPO} ...")
+    foreach(_f ${_files})
+      if(EXISTS "${VMOUSE_DRIVER_DIR}/${_f}")
+        continue()
+      endif()
+      set(_url "https://github.com/${VMOUSE_PUBLIC_REPO}/releases/download/${VMOUSE_DRIVER_VERSION}/${_f}")
+      _driver_download("${_url}" "${VMOUSE_DRIVER_DIR}/${_f}")
+    endforeach()
+
+    # If all files now present, we're done.
+    set(_all_ok TRUE)
+    foreach(_f ${_files})
+      if(NOT EXISTS "${VMOUSE_DRIVER_DIR}/${_f}")
+        set(_all_ok FALSE)
+        break()
+      endif()
+    endforeach()
+    if(_all_ok)
+      message(STATUS "  vmouse fetched from public mirror")
+      return()
+    endif()
+  endif()
+
+  # ---- Attempt 2: private repo via GitHub API (requires token) ----
   if(NOT GITHUB_TOKEN)
-    message(WARNING "  GITHUB_TOKEN required for private repo ${_VMOUSE_REPO}")
+    message(WARNING
+      "  vmouse not available from public mirror '${VMOUSE_PUBLIC_REPO}' "
+      "at tag ${VMOUSE_DRIVER_VERSION}, and GITHUB_TOKEN is not set to fall "
+      "back on private repo ${_VMOUSE_REPO}.")
     return()
   endif()
 
   find_program(_CURL curl REQUIRED)
-  file(MAKE_DIRECTORY "${VMOUSE_DRIVER_DIR}")
 
   # Query release assets via GitHub API
   set(_api_url "https://api.github.com/repos/${_VMOUSE_REPO}/releases/tags/${VMOUSE_DRIVER_VERSION}")
@@ -254,23 +295,42 @@ _fetch_vdd()
 _fetch_nefcon()
 
 # ---------------------------------------------------------------------------
-# Verify critical files
+# Verify critical files (per-driver, so optional drivers can be skipped
+# individually when DRIVER_DEPS_REQUIRED=OFF, e.g. fork-PR CI).
 # ---------------------------------------------------------------------------
-set(_missing)
-foreach(_f
-    "${VMOUSE_DRIVER_DIR}/ZakoVirtualMouse.dll"
-    "${VDD_DRIVER_DIR}/ZakoVDD.dll"
-    "${VDD_WIN10_DRIVER_DIR}/ZakoVDD.dll"
-    "${NEFCON_DRIVER_DIR}/nefconw.exe")
-  if(NOT EXISTS "${_f}")
-    list(APPEND _missing "${_f}")
+function(_check_driver name available_var)
+  set(_missing)
+  foreach(_f ${ARGN})
+    if(NOT EXISTS "${_f}")
+      list(APPEND _missing "${_f}")
+    endif()
+  endforeach()
+  if(_missing)
+    string(REPLACE ";" "\n  " _list "${_missing}")
+    if(DRIVER_DEPS_REQUIRED)
+      message(FATAL_ERROR
+        "Missing ${name} driver dependencies:\n  ${_list}\n"
+        "For private repos, set -DGITHUB_TOKEN=<token> or env GITHUB_TOKEN.\n"
+        "To skip downloads: -DFETCH_DRIVER_DEPS=OFF (provide files manually in ${DRIVER_DEPS_CACHE}).\n"
+        "To make missing drivers non-fatal (e.g. for fork-PR CI): -DDRIVER_DEPS_REQUIRED=OFF.")
+    else()
+      message(WARNING
+        "Missing ${name} driver dependencies (packaging will skip this driver):\n  ${_list}")
+    endif()
+    set(${available_var} FALSE CACHE INTERNAL "" FORCE)
+  else()
+    set(${available_var} TRUE CACHE INTERNAL "" FORCE)
   endif()
-endforeach()
+endfunction()
 
-if(_missing)
-  string(REPLACE ";" "\n  " _list "${_missing}")
-  message(FATAL_ERROR
-    "Missing driver dependencies:\n  ${_list}\n"
-    "For private repos, set -DGITHUB_TOKEN=<token> or env GITHUB_TOKEN.\n"
-    "To skip downloads: -DFETCH_DRIVER_DEPS=OFF (provide files manually in ${DRIVER_DEPS_CACHE}).")
-endif()
+_check_driver("vmouse" VMOUSE_DRIVER_AVAILABLE
+    "${VMOUSE_DRIVER_DIR}/ZakoVirtualMouse.dll"
+    "${VMOUSE_DRIVER_DIR}/ZakoVirtualMouse.inf"
+    "${VMOUSE_DRIVER_DIR}/ZakoVirtualMouse.cat"
+    "${VMOUSE_DRIVER_DIR}/ZakoVirtualMouse.cer")
+_check_driver("vdd (latest)" VDD_DRIVER_AVAILABLE
+    "${VDD_DRIVER_DIR}/ZakoVDD.dll")
+_check_driver("vdd (win10)" VDD_WIN10_DRIVER_AVAILABLE
+    "${VDD_WIN10_DRIVER_DIR}/ZakoVDD.dll")
+_check_driver("nefcon" NEFCON_DRIVER_AVAILABLE
+    "${NEFCON_DRIVER_DIR}/nefconw.exe")

--- a/cmake/packaging/FetchDriverDeps.cmake
+++ b/cmake/packaging/FetchDriverDeps.cmake
@@ -329,8 +329,14 @@ _check_driver("vmouse" VMOUSE_DRIVER_AVAILABLE
     "${VMOUSE_DRIVER_DIR}/ZakoVirtualMouse.cat"
     "${VMOUSE_DRIVER_DIR}/ZakoVirtualMouse.cer")
 _check_driver("vdd (latest)" VDD_DRIVER_AVAILABLE
-    "${VDD_DRIVER_DIR}/ZakoVDD.dll")
+    "${VDD_DRIVER_DIR}/ZakoVDD.dll"
+    "${VDD_DRIVER_DIR}/ZakoVDD.inf"
+    "${VDD_DRIVER_DIR}/ZakoVDD.cat"
+    "${VDD_DRIVER_DIR}/ZakoVDD.cer")
 _check_driver("vdd (win10)" VDD_WIN10_DRIVER_AVAILABLE
-    "${VDD_WIN10_DRIVER_DIR}/ZakoVDD.dll")
+    "${VDD_WIN10_DRIVER_DIR}/ZakoVDD.dll"
+    "${VDD_WIN10_DRIVER_DIR}/ZakoVDD.inf"
+    "${VDD_WIN10_DRIVER_DIR}/ZakoVDD.cat"
+    "${VDD_WIN10_DRIVER_DIR}/ZakoVDD.cer")
 _check_driver("nefcon" NEFCON_DRIVER_AVAILABLE
     "${NEFCON_DRIVER_DIR}/nefconw.exe")

--- a/cmake/packaging/sunshine.iss.in
+++ b/cmake/packaging/sunshine.iss.in
@@ -228,7 +228,7 @@ Source: "{#MySourceDir}\scripts\uninstall-gamepad.bat"; DestDir: "{app}\scripts"
 ; Virtual Mouse Driver scripts & files
 Source: "{#MySourceDir}\scripts\vmouse\install-vmouse.bat"; DestDir: "{app}\scripts\vmouse"; Flags: ignoreversion
 Source: "{#MySourceDir}\scripts\vmouse\uninstall-vmouse.bat"; DestDir: "{app}\scripts\vmouse"; Flags: ignoreversion
-Source: "{#MySourceDir}\scripts\vmouse\driver\*"; DestDir: "{app}\scripts\vmouse\driver"; Flags: ignoreversion recursesubdirs
+Source: "{#MySourceDir}\scripts\vmouse\driver\*"; DestDir: "{app}\scripts\vmouse\driver"; Flags: ignoreversion recursesubdirs skipifsourcedoesntexist
 
 ; Virtual audio sink (microphone / VB-Cable) scripts
 ; Always shipped — there is no install-time component for this; the user can

--- a/cmake/packaging/windows.cmake
+++ b/cmake/packaging/windows.cmake
@@ -65,30 +65,36 @@ install(FILES "${SUNSHINE_SOURCE_ASSETS_DIR}/windows/misc/vdd/install-vdd.bat"
 install(FILES "${SUNSHINE_SOURCE_ASSETS_DIR}/windows/misc/vdd/driver/vdd_settings.xml"
         DESTINATION "scripts/driver"
         COMPONENT vdd)
-install(FILES "${VDD_DRIVER_DIR}/ZakoVDD.dll"
-              "${VDD_DRIVER_DIR}/ZakoVDD.inf"
-              "${VDD_DRIVER_DIR}/zakovdd.cat"
-              "${VDD_DRIVER_DIR}/ZakoVDD.cer"
-        DESTINATION "scripts/driver/latest"
-        COMPONENT vdd)
-install(FILES "${VDD_WIN10_DRIVER_DIR}/ZakoVDD.dll"
-              "${VDD_WIN10_DRIVER_DIR}/ZakoVDD.inf"
-              "${VDD_WIN10_DRIVER_DIR}/zakovdd.cat"
-              "${VDD_WIN10_DRIVER_DIR}/ZakoVDD.cer"
-        DESTINATION "scripts/driver/win10"
-        COMPONENT vdd)
+if(VDD_DRIVER_AVAILABLE)
+  install(FILES "${VDD_DRIVER_DIR}/ZakoVDD.dll"
+                "${VDD_DRIVER_DIR}/ZakoVDD.inf"
+                "${VDD_DRIVER_DIR}/zakovdd.cat"
+                "${VDD_DRIVER_DIR}/ZakoVDD.cer"
+          DESTINATION "scripts/driver/latest"
+          COMPONENT vdd)
+endif()
+if(VDD_WIN10_DRIVER_AVAILABLE)
+  install(FILES "${VDD_WIN10_DRIVER_DIR}/ZakoVDD.dll"
+                "${VDD_WIN10_DRIVER_DIR}/ZakoVDD.inf"
+                "${VDD_WIN10_DRIVER_DIR}/zakovdd.cat"
+                "${VDD_WIN10_DRIVER_DIR}/ZakoVDD.cer"
+          DESTINATION "scripts/driver/win10"
+          COMPONENT vdd)
+endif()
 
 # vmouse: scripts from source tree, driver binaries + cert from download cache
 install(FILES "${SUNSHINE_SOURCE_ASSETS_DIR}/windows/misc/vmouse/install-vmouse.bat"
               "${SUNSHINE_SOURCE_ASSETS_DIR}/windows/misc/vmouse/uninstall-vmouse.bat"
         DESTINATION "scripts/vmouse"
         COMPONENT assets)
-install(FILES "${VMOUSE_DRIVER_DIR}/ZakoVirtualMouse.dll"
-              "${VMOUSE_DRIVER_DIR}/ZakoVirtualMouse.inf"
-              "${VMOUSE_DRIVER_DIR}/ZakoVirtualMouse.cat"
-              "${VMOUSE_DRIVER_DIR}/ZakoVirtualMouse.cer"
-        DESTINATION "scripts/vmouse/driver"
-        COMPONENT assets)
+if(VMOUSE_DRIVER_AVAILABLE)
+  install(FILES "${VMOUSE_DRIVER_DIR}/ZakoVirtualMouse.dll"
+                "${VMOUSE_DRIVER_DIR}/ZakoVirtualMouse.inf"
+                "${VMOUSE_DRIVER_DIR}/ZakoVirtualMouse.cat"
+                "${VMOUSE_DRIVER_DIR}/ZakoVirtualMouse.cer"
+          DESTINATION "scripts/vmouse/driver"
+          COMPONENT assets)
+endif()
 
 install(DIRECTORY "${SUNSHINE_SOURCE_ASSETS_DIR}/windows/misc/helper/"
         DESTINATION "tools"


### PR DESCRIPTION
## Problem

Fork PRs (e.g. external CVE backports like #659) cannot access org-scoped secrets in GitHub Actions. CMake configure downloads the vmouse driver from the private repo `AlkaidLab/ZakoVirtualMouse` and aborts with `FATAL_ERROR` when no `GITHUB_TOKEN` is available, blocking the entire Windows build:

```
CMake Error at cmake/packaging/FetchDriverDeps.cmake:272 (message):
  Missing driver dependencies:
    .../build/_driver_deps/vmouse/ZakoVirtualMouse.dll
```

Observed on run [26000570915](https://github.com/AlkaidLab/foundation-sunshine/actions/runs/26000570915) (PR #659, unrelated CVE backport).

## Fix

### 1. Public mirror first
- New cache var `VMOUSE_PUBLIC_REPO` (default `AlkaidLab/zako-vmouse-release`).
- `_fetch_vmouse()` first tries the public mirror via plain `browser_download_url` (no auth); falls back to the private API path only if `GITHUB_TOKEN` is set.

### 2. Graceful degradation (`DRIVER_DEPS_REQUIRED` option)
- New option `DRIVER_DEPS_REQUIRED` (default `ON` — preserves existing behavior).
- When `OFF`, per-driver missing files become `WARNING` and a `<NAME>_DRIVER_AVAILABLE` cache flag is set to `FALSE`.
- `windows.cmake` gates each driver's `install(FILES ...)` block on its availability flag.
- `sunshine.iss.in` adds `skipifsourcedoesntexist` to the vmouse driver wildcard.

### 3. Workflow
- `Build Windows` now passes `-DDRIVER_DEPS_REQUIRED=${DRIVER_DEPS_REQUIRED}`, evaluating to `OFF` **only** for PRs from forks. All other triggers stay `ON`.

## Effect

| Scenario | Before | After |
|---|---|---|
| Push / internal PR / release | OK | OK (unchanged) |
| Fork PR | **FAIL at configure** | OK, vmouse omitted from installer |
| Public mirror populated | n/a | OK without token |
| Public mirror empty + no token | n/a | WARNING + skip |

## Validation

Locally exercised both paths:
- `-DDRIVER_DEPS_REQUIRED=ON` with vmouse cached → normal config
- `-DDRIVER_DEPS_REQUIRED=OFF` with no token, public mirror empty → WARNING, configure completes

## Follow-up

Populate `AlkaidLab/zako-vmouse-release` with the v1.2.0 assets (or whatever `VMOUSE_DRIVER_VERSION` points to) so fork PRs get a full installer.
