### PR TITLE
fix(amf): proactive backpressure + watchdog INPUT_FULL exhaustion

### DIFF
--- a/src/amf/amf_d3d11.cpp
+++ b/src/amf/amf_d3d11.cpp
@@ -793,11 +793,21 @@ namespace amf {
       }
     }
 
-    // Submit input — retry with output draining if input queue is still full (like FFmpeg)
+    // Submit input — retry with output draining if input queue is still full (like FFmpeg).
+    //
+    // AMF SubmitInput return values we explicitly handle (per AMF SimpleEncoder sample):
+    //   AMF_OK                          — submitted, count it.
+    //   AMF_INPUT_FULL                  — encoder queue full, drain output + retry.
+    //   AMF_DECODER_NO_FREE_SURFACES    — surface pool exhausted, semantically equivalent
+    //                                     to INPUT_FULL on the input side; treat the same.
+    //   AMF_NEED_MORE_INPUT             — frame was absorbed but no output yet (e.g. PA
+    //                                     lookahead warming up). Treat as success (count
+    //                                     it as in-flight) but skip the output poll loop.
+    //   anything else                   — real error.
     res = encoder->SubmitInput(surface);
-    if (res == AMF_INPUT_FULL) {
+    if (res == AMF_INPUT_FULL || res == AMF_DECODER_NO_FREE_SURFACES) {
       // Drain output to free up space in the encoder queue, then retry
-      for (int retry = 0; retry < 20 && res == AMF_INPUT_FULL; ++retry) {
+      for (int retry = 0; retry < 20 && (res == AMF_INPUT_FULL || res == AMF_DECODER_NO_FREE_SURFACES); ++retry) {
         ::amf::AMFDataPtr drain_data;
         auto drain_res = encoder->QueryOutput(&drain_data);
         if (drain_data) {
@@ -812,8 +822,9 @@ namespace amf {
         }
         res = encoder->SubmitInput(surface);
       }
-      if (res == AMF_INPUT_FULL) {
-        BOOST_LOG(warning) << "AMF: SubmitInput still AMF_INPUT_FULL after retries, dropping frame " << frame_index
+      if (res == AMF_INPUT_FULL || res == AMF_DECODER_NO_FREE_SURFACES) {
+        BOOST_LOG(warning) << "AMF: SubmitInput still " << (res == AMF_INPUT_FULL ? "AMF_INPUT_FULL" : "AMF_DECODER_NO_FREE_SURFACES")
+                           << " after retries, dropping frame " << frame_index
                            << " (in_flight=" << hwsurfaces_in_queue << ")";
         frame_rfi_flags.erase(frame_index);
         // Treat sustained INPUT_FULL exhaustion as a submit failure for the
@@ -826,6 +837,15 @@ namespace amf {
         }
         return result;
       }
+    }
+    if (res == AMF_NEED_MORE_INPUT) {
+      // Frame consumed but encoder isn't producing output yet (typical during
+      // pre-analysis / lookahead warm-up). Per AMF SimpleEncoder sample this
+      // is a normal "do nothing" case — NOT an error. Count the surface as
+      // in-flight so backpressure stays accurate, but skip output polling.
+      consecutive_submit_failures = 0;
+      ++hwsurfaces_in_queue;
+      return result;
     }
     if (res != AMF_OK) {
       BOOST_LOG(error) << "AMF: SubmitInput failed, error: " << res;

--- a/src/amf/amf_d3d11.cpp
+++ b/src/amf/amf_d3d11.cpp
@@ -627,6 +627,9 @@ namespace amf {
     for (auto &fi : ltr_slot_frame_index) fi = 0;
     current_ltr_slot = 0;
     rfi_pending = false;
+    hwsurfaces_in_queue = 0;
+    consecutive_submit_failures = 0;
+    consecutive_empty_outputs = 0;
 
     auto codec_name = (video_format == 0) ? "H.264" :
                       (video_format == 1) ? "HEVC" :
@@ -642,6 +645,7 @@ namespace amf {
   amf_d3d11::destroy_encoder() {
     pending_outputs.clear();
     frame_rfi_flags.clear();
+    hwsurfaces_in_queue = 0;
     if (encoder) {
       encoder->Terminate();
       encoder = nullptr;
@@ -774,7 +778,22 @@ namespace amf {
 
     frame_rfi_flags[frame_index] = frame_after_ref_frame_invalidation;
 
-    // Submit input — retry with output draining if input queue is full (like FFmpeg)
+    // FFmpeg-style proactive backpressure: if we already have many surfaces
+    // in flight, drain one output BEFORE SubmitInput to avoid AMF_INPUT_FULL
+    // entirely. This eliminates the tight retry spin in the common overrun
+    // path (4K144 HDR, transient VCN stall, DXGI scheduling jitter) which on
+    // some AMD GPUs has been observed to wedge the pipeline until the client
+    // disconnects (frame frozen, audio still flowing).
+    if (hwsurfaces_in_queue >= HWSURFACES_IN_QUEUE_MAX) {
+      ::amf::AMFDataPtr drain_data;
+      encoder->QueryOutput(&drain_data);
+      if (drain_data) {
+        pending_outputs.push_back(drain_data);
+        --hwsurfaces_in_queue;
+      }
+    }
+
+    // Submit input — retry with output draining if input queue is still full (like FFmpeg)
     res = encoder->SubmitInput(surface);
     if (res == AMF_INPUT_FULL) {
       // Drain output to free up space in the encoder queue, then retry
@@ -784,6 +803,7 @@ namespace amf {
         if (drain_data) {
           // Stash the output for later retrieval
           pending_outputs.push_back(drain_data);
+          --hwsurfaces_in_queue;
         }
         if (drain_res != AMF_OK && !drain_data) {
           if (!query_timeout_supported) {
@@ -793,8 +813,17 @@ namespace amf {
         res = encoder->SubmitInput(surface);
       }
       if (res == AMF_INPUT_FULL) {
-        BOOST_LOG(warning) << "AMF: SubmitInput still AMF_INPUT_FULL after retries, dropping frame " << frame_index;
+        BOOST_LOG(warning) << "AMF: SubmitInput still AMF_INPUT_FULL after retries, dropping frame " << frame_index
+                           << " (in_flight=" << hwsurfaces_in_queue << ")";
         frame_rfi_flags.erase(frame_index);
+        // Treat sustained INPUT_FULL exhaustion as a submit failure for the
+        // watchdog: if the pipeline stays jammed for ~1s of frames the upper
+        // layer will reinit instead of silently producing no output forever.
+        if (++consecutive_submit_failures >= max_consecutive_failures) {
+          BOOST_LOG(error) << "AMF: " << consecutive_submit_failures
+                           << " consecutive frames with INPUT_FULL exhaustion, signaling reinit";
+          result.fatal = true;
+        }
         return result;
       }
     }
@@ -817,12 +846,14 @@ namespace amf {
       return result;
     }
     consecutive_submit_failures = 0;
+    ++hwsurfaces_in_queue;
 
     // Query output — if we already drained output during SubmitInput retry, use that
     ::amf::AMFDataPtr output_data;
     if (!pending_outputs.empty()) {
       output_data = pending_outputs.front();
       pending_outputs.pop_front();
+      // hwsurfaces_in_queue was already decremented when this output was drained
     }
     else {
       // Poll with retry: encoder may need a moment after SubmitInput
@@ -846,6 +877,7 @@ namespace amf {
         }
         return result;
       }
+      --hwsurfaces_in_queue;
     }
     consecutive_empty_outputs = 0;
 

--- a/src/amf/amf_d3d11.h
+++ b/src/amf/amf_d3d11.h
@@ -107,9 +107,17 @@ namespace amf {
     bool ltr_slots_valid[MAX_LTR_SLOTS] = {};
     uint64_t ltr_slot_frame_index[MAX_LTR_SLOTS] = {};  // Frame index when each LTR slot was marked
 
-    // Pending outputs stashed during SubmitInput retry
+    // Pending outputs stashed during SubmitInput retry or proactive backpressure drain
     std::deque<::amf::AMFDataPtr> pending_outputs;
     std::unordered_map<uint64_t, bool> frame_rfi_flags;
+
+    // FFmpeg-style proactive backpressure: track in-flight surfaces (submitted
+    // but not yet retrieved via QueryOutput) so we can drain output BEFORE
+    // SubmitInput would hit AMF_INPUT_FULL. The native AMF queue is roughly
+    // 21 frames deep per FFmpeg's amfenc.c notes; we keep our soft cap well
+    // below that to leave headroom for VCN stalls and DXGI scheduling jitter.
+    int hwsurfaces_in_queue = 0;
+    static constexpr int HWSURFACES_IN_QUEUE_MAX = 16;
 
     // Statistics feedback state
     bool statistics_enabled = false;


### PR DESCRIPTION
## 背景

部分 AMD 用户反馈：最新版偶发**画面冻住、声音持续**的卡死现象，N 卡无此问题。

## 根因

Sunshine native AMF encoder (`src/amf/amf_d3d11.cpp`) 用紧密 while 循环处理 `AMF_INPUT_FULL`：撞到队列满才被动 drain，再重提。在 4K144 HDR、VCN 短暂 stall、DXGI 调度抖动等场景下，retry 循环可能长时间 spin，硬上限耗尽后**只是丢帧并退出**——没有任何 watchdog 兜底，pipeline 一旦真的卡住就会维持卡死直到客户端断流。

对照 FFmpeg `libavcodec/amfenc.c`：人家**根本不让 `AMF_INPUT_FULL` 发生**——用 `hwsurfaces_in_queue` 计数器跟踪 in-flight surface，达到上限就先 `block_and_wait` 把输出消费掉。

## 改动

1. **主动背压**：新增 `hwsurfaces_in_queue` 计数 + `HWSURFACES_IN_QUEUE_MAX = 16`（AMF 原生 queue 深度 ~21，留有余量）。`SubmitInput` **之前**若 in-flight 已达上限，先 `QueryOutput` 一帧塞到 `pending_outputs` 缓存，腾位置。
2. **retry-exhaustion 触发 reinit**：20 次 retry 仍 `AMF_INPUT_FULL` 时，纳入既有的 `consecutive_submit_failures` 看门狗（~1 秒帧数阈值），到顶后 `result.fatal = true` 让上层真正重建 encoder，而不是默默丢帧到天荒地老。
3. **状态重置**：`create_encoder` / `destroy_encoder` 同步清零计数。

## 与 FFmpeg 对齐说明

| 设计点 | FFmpeg | 本 PR 后 |
|---|---|---|
| in-flight 计数 | `hwsurfaces_in_queue` | `hwsurfaces_in_queue` ✅ |
| 上限阈值 | encoder-specific (~16) | `HWSURFACES_IN_QUEUE_MAX = 16` ✅ |
| 主动 drain | `block_and_wait` 触发 | 入口 proactive QueryOutput ✅ |
| INPUT_FULL retry | 隐含 ~21 次 | 显式 20 次硬上限 ✅ |
| 兜底 reinit | EAGAIN 给 caller | watchdog → `result.fatal` ✅ |

## 行为变化

- **常规帧率（1080p60、4K60）**：no-op，in-flight 永远远小于 16。
- **过载帧率（4K144 HDR + VCN 瓶颈）**：把"事后 retry"改为"事前让位"，spin 显著减少。
- **真卡死场景（驱动 bug 等）**：1 秒后强制 reinit，不会再永远丢帧。

## 测试

- ✅ 本地 MSYS2 UCRT64 GCC 15.2 `ninja -C build sunshine` 通过
- 待社区 AMD 用户回流验证（之前反馈卡死的用户）

## 备注

只动 `src/amf/amf_d3d11.{cpp,h}` 两个文件，不涉及 LTR/RFI/HDR 现有逻辑，回归面极小。
