### PR TITLE
fix(cs-fastpath): use CopySubresourceRegion for QSV-padded output surfaces (#650)

### DIFF
--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -1220,6 +1220,8 @@ namespace platf::dxgi {
     buf_t cs_layout_cbuf;                  // Layout cbuffer (b1) for CS
     int  cs_dispatch_groups_x = 0;         // Dispatch dims over the active rect (saves work in letterbox case)
     int  cs_dispatch_groups_y = 0;
+    int  cs_copy_w = 0;                    // Logical copy width (Intel QSV may back output_texture with a larger padded surface)
+    int  cs_copy_h = 0;                    // Logical copy height (ditto)
     bool cs_path_active = false;           // True when CS conversion path is initialized for this output
     bool cs_use_pq = false;                // Selected transfer function (PQ or HLG) for HDR variant
     bool cs_for_p010 = false;              // True for HDR P010 path, false for SDR NV12 path
@@ -1813,6 +1815,14 @@ namespace platf::dxgi {
       cs_dispatch_groups_x = (active_w + 15) / 16;
       cs_dispatch_groups_y = (active_h + 15) / 16;
 
+      // Logical output extent the encoder consumes. Intel QSV input surfaces are
+      // commonly aligned up internally (e.g. 1080 -> 1088 rows), so the underlying
+      // ID3D11Texture2D backing output_texture can be larger than out_width/out_height.
+      // We use CopySubresourceRegion with this explicit box on the scratch path so
+      // dst/src dimensions never have to match the resource desc exactly.
+      cs_copy_w = out_width;
+      cs_copy_h = out_height;
+
       cs_path_active = true;
       cs_use_pq = use_pq;
       cs_for_p010 = is_p010;
@@ -1880,8 +1890,13 @@ namespace platf::dxgi {
       device_ctx->CSSetShader(nullptr, nullptr, 0);
 
       // Only copy when we couldn't bind the UAV directly to output_texture.
+      // Use CopySubresourceRegion with an explicit box so a padded dst (e.g. Intel
+      // QSV's internally row-aligned NV12/P010 surface) still receives the correct
+      // active region. Plain CopyResource silently fails when src/dst desc differ.
       if (!cs_writes_output_directly) {
-        device_ctx->CopyResource(output_texture.get(), cs_scratch_tex.get());
+        D3D11_BOX src_box = { 0, 0, 0, (UINT) cs_copy_w, (UINT) cs_copy_h, 1 };
+        device_ctx->CopySubresourceRegion(output_texture.get(), 0, 0, 0, 0,
+                                          cs_scratch_tex.get(), 0, &src_box);
       }
       return true;
     }


### PR DESCRIPTION
## 问题

[#650](https://github.com/AlkaidLab/foundation-sunshine/issues/650) — Intel Arc 用户在 **1080p** 下推流黑屏，**1440p/4K 正常**。

## 根因

CS RGB→NV12/P010 快速路径在 Intel QSV 上是这样走的：

1. QSV 的 `init_hwframes` 给输入纹理只设了 `D3D11_BIND_RENDER_TARGET`，没有 `D3D11_BIND_UNORDERED_ACCESS`。
2. CS 不能直接写 `output_texture`，于是回退到「scratch UAV + CopyResource 到 output」。
3. **QSV 内部对输入 surface 行对齐**（典型 1080 → 1088），所以编码器分配的 `output_texture` 实际高度可能是 1088，而我们的 scratch 是按 `out_height = 1080` 创建的。
4. `CopyResource` 要求 src/dst desc 完全匹配，**desc 不匹配时静默失败**，编码器拿到的就是 ClearUAV 之后的黑色像素（Y=0, UV=0.5）→ 黑屏。
5. 1440p (90×16) 和 4K (135×16) 恰好 16 对齐，padding == 实际高度，所以不触发。

NVENC / AMF 的 hwframes 输入纹理本身就有 UAV bind，走 `cs_writes_output_directly == true` 的直写分支，不经过这段拷贝，**不受影响**。

## 修复

把 scratch → output 的 `CopyResource` 换成带显式 `D3D11_BOX(out_width × out_height)` 的 `CopySubresourceRegion`：

- 只拷贝逻辑像素区域，dst 是否带 padding 都没关系；
- 保留 QSV 路径的 CS 加速（无回退到 PS）；
- 对 NVENC/AMF 零影响（它们根本不走这个分支）。

净改动 ~16 行：
- 两个新成员 `cs_copy_w / cs_copy_h` 记录逻辑拷贝尺寸；
- `init_compute_path` 末尾赋值；
- `try_dispatch_cs_convert` 里用 `CopySubresourceRegion` + `D3D11_BOX` 替换 `CopyResource`。

## 验证

- MSYS2 UCRT64 GCC 15.2 本地构建通过。
- 影响面已收敛：仅 QSV 的间接拷贝分支；NVENC/AMF 走直写分支保持不变。

Fixes #650