### PR TITLE
feat(video): add dynamic_resolution_follow_display toggle for legacy clients (fixes #668)

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -463,6 +463,7 @@ namespace config {
     false,  // hdr_luminance_analysis (disabled by default to avoid GPU overhead)
     "auto"s,  // capture_compute_shader (default: auto -> off until validated)
     false,  // wgc_disable_secure_desktop (disabled by default for security)
+    true,  // dynamic_resolution_follow_display (default: on; matches existing behavior. Set false for legacy clients like PSVita Moonlight.)
   };
 
   audio_t audio {
@@ -1245,6 +1246,7 @@ namespace config {
     int_between_f(vars, "minimum_fps_target", video.minimum_fps_target, { 0, 1000 });
     bool_f(vars, "hdr_luminance_analysis", video.hdr_luminance_analysis);
     bool_f(vars, "wgc_disable_secure_desktop", video.wgc_disable_secure_desktop);
+    bool_f(vars, "dynamic_resolution_follow_display", video.dynamic_resolution_follow_display);
     bool_f(vars, "vdd_keep_enabled", video.vdd_keep_enabled);
     bool_f(vars, "vdd_headless_create", video.vdd_headless_create_enabled);
     bool_f(vars, "vdd_reuse", video.vdd_reuse);

--- a/src/config.h
+++ b/src/config.h
@@ -116,6 +116,7 @@ namespace config {
     bool hdr_luminance_analysis;  // Enable per-frame HDR luminance analysis for dynamic metadata
     std::string capture_compute_shader;  // Use compute shader for HDR RGB->P010 conversion: "auto" (off for now), "on", "off"
     bool wgc_disable_secure_desktop;  // Auto-disable UAC secure desktop when using WGC capture
+    bool dynamic_resolution_follow_display;  // If true, follow mid-stream host display resolution changes and notify client via extension; if false, keep initial stream resolution and let scaler handle changes (compatible with legacy clients like PSVita Moonlight that don't implement the extension)
   };
 
   struct audio_t {

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -3260,22 +3260,31 @@ namespace video {
         last_display_width = current_width;
         last_display_height = current_height;
 
-        if (is_rotation) {
-          std::swap(initial_scale_x, initial_scale_y);
+        if (!config::video.dynamic_resolution_follow_display) {
+          // Toggle off: keep the originally negotiated stream resolution and let the
+          // encoder's scaler adapt. Avoids sending SS_RESOLUTION_CHANGE, which legacy
+          // Moonlight clients (e.g. PSVita port) don't implement and would freeze on.
+          BOOST_LOG(info) << "dynamic_resolution_follow_display=false: keeping stream at "
+                          << config.width << "x" << config.height << " (scaler will adapt)";
         }
+        else {
+          if (is_rotation) {
+            std::swap(initial_scale_x, initial_scale_y);
+          }
 
-        config.width = compute_aligned_resolution(current_width, initial_scale_x);
-        config.height = compute_aligned_resolution(current_height, initial_scale_y);
+          config.width = compute_aligned_resolution(current_width, initial_scale_x);
+          config.height = compute_aligned_resolution(current_height, initial_scale_y);
 
-        BOOST_LOG(info) << "New encoding resolution: " << config.width << "x" << config.height
-                        << " (scale: " << initial_scale_x << "x" << initial_scale_y << ")";
+          BOOST_LOG(info) << "New encoding resolution: " << config.width << "x" << config.height
+                          << " (scale: " << initial_scale_x << "x" << initial_scale_y << ")";
 
-        resolution_change_event->raise(std::make_pair(
-          static_cast<std::uint32_t>(current_width),
-          static_cast<std::uint32_t>(current_height)));
+          resolution_change_event->raise(std::make_pair(
+            static_cast<std::uint32_t>(current_width),
+            static_cast<std::uint32_t>(current_height)));
 
-        idr_events->raise(true);
-        std::this_thread::sleep_for(100ms);
+          idr_events->raise(true);
+          std::this_thread::sleep_for(100ms);
+        }
       }
 
       auto &encoder = *chosen_encoder;

--- a/src_assets/common/assets/web/configs/tabs/audiovideo/ExperimentalFeatures.vue
+++ b/src_assets/common/assets/web/configs/tabs/audiovideo/ExperimentalFeatures.vue
@@ -88,6 +88,15 @@ function addRemapping(type) {
                 default="false"
               ></Checkbox>
 
+              <!-- Dynamic Resolution Follow Display -->
+              <Checkbox
+                class="mb-3"
+                id="dynamic_resolution_follow_display"
+                locale-prefix="config"
+                v-model="config.dynamic_resolution_follow_display"
+                default="true"
+              ></Checkbox>
+
               <!-- Capture Compute Shader (HDR RGB->P010 fast path) -->
               <div class="mb-3">
                 <label for="capture_compute_shader" class="form-label">

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -596,6 +596,8 @@
     "wgc_control_panel_only": "This feature is only available in Sunshine Control Panel",
     "wgc_disable_secure_desktop": "Auto-Elevate UAC (WGC Mode)",
     "wgc_disable_secure_desktop_desc": "When using WGC capture, temporarily disable UAC prompts by auto-elevating admin requests without user confirmation. This allows seamless remote operation without UAC dialog interruptions. The original UAC settings are restored when streaming ends. WARNING: This reduces system security — any program requesting admin privileges will be silently elevated during streaming.",
+    "dynamic_resolution_follow_display": "Follow Host Display Resolution Mid-Stream",
+    "dynamic_resolution_follow_display_desc": "When enabled (default), if the host display resolution changes during a stream, the encoder re-initializes at the new resolution and a protocol extension message tells the client to re-create its decoder. Modern Moonlight clients (Desktop / Android / iOS) handle this seamlessly. Disable this option for legacy clients that don't implement the extension (e.g. PSVita Moonlight) — the stream resolution will then stay fixed and the encoder's scaler will adapt to host display changes, matching upstream Sunshine behavior.",
     "wgc_mode_switch_failed": "Failed to switch mode",
     "wgc_mode_switch_started": "Mode switch initiated. If a UAC prompt appears, please click 'Yes' to confirm.",
     "wgc_service_mode_warning": "WGC capture requires running in user mode. If currently running in service mode, please click the button above to switch to user mode.",

--- a/src_assets/common/assets/web/public/assets/locale/zh.json
+++ b/src_assets/common/assets/web/public/assets/locale/zh.json
@@ -598,6 +598,8 @@
     "wgc_control_panel_only": "此功能仅在 Sunshine Control Panel 中可用",
     "wgc_disable_secure_desktop": "自动提升 UAC（WGC 模式）",
     "wgc_disable_secure_desktop_desc": "使用 WGC 捕获时，临时禁用 UAC 提示，管理员权限请求将自动通过而不弹出确认对话框。这可以避免远程串流时 UAC 弹窗导致的中断。串流结束后自动恢复原始 UAC 设置。警告：这会降低系统安全性——串流期间任何程序请求管理员权限将被静默提升。",
+    "dynamic_resolution_follow_display": "串流中跟随主机分辨率变化",
+    "dynamic_resolution_follow_display_desc": "启用时（默认），主机桌面分辨率在串流期间发生变化，编码器会按新分辨率重建，并通过协议扩展消息通知客户端重建解码器。Moonlight 桌面 / Android / iOS 客户端能正常处理。如果客户端是不支持该扩展的旧端（例如 PSVita Moonlight），请关闭此项——串流分辨率会保持初始值，由编码器的缩放器适配桌面变化，行为与上游 Sunshine 一致。",
     "wgc_mode_switch_failed": "切换模式失败",
     "wgc_mode_switch_started": "模式切换已启动，如果弹出 UAC 提示，请点击\"是\"以确认。",
     "wgc_service_mode_warning": "WGC 捕获需要在用户模式下运行。如果当前以服务模式运行，请点击上方按钮切换到用户模式。",


### PR DESCRIPTION
## Summary

Adds a Web UI / config toggle `dynamic_resolution_follow_display` (default: **on**, matches current behavior) that controls whether the host follows mid-stream display resolution changes and notifies the client via our protocol extension.

When **disabled**, the stream resolution stays fixed at whatever was negotiated at connect time and the encoder's scaler adapts to host display changes — i.e. **upstream Sunshine behavior**.

## Motivation

Fixes #668.

This fork has a feature upstream Sunshine / Apollo don't: when the host display resolution changes mid-stream, we re-init the encoder at the new resolution **and** send a custom `SS_RESOLUTION_CHANGE` control message telling the client to re-create its decoder.

Modern Moonlight clients (Desktop / Android / iOS) implement this extension and handle it seamlessly. But **PSVita Moonlight** (early community port) doesn't implement it — so on a mid-stream resolution change it keeps decoding at the original dimensions while the new bitstream's SPS/PPS describe new dimensions → static picture until the host resolution is reverted or the client reconnects.

Symptoms in #668 match exactly:
```
23:42:43.217  Display resolution changed: 1280x720 -> 1920x1080
23:42:43.275  Sent resolution change: 1920x1080         ← extension message
23:43:52+     AMF pipeline lag: submitted N, got N-1   ← encoder still healthy
(client picture frozen, audio/input still working)
```

The encoder is healthy throughout — only the client decoder is wedged.

## Changes

- **`src/config.h`** — add `bool dynamic_resolution_follow_display` to `video_t`
- **`src/config.cpp`** — default `true`; parse `dynamic_resolution_follow_display` key
- **`src/video.cpp`** — gate the mid-stream resolution change reconfigure block; when flag is off, log the change and update tracking variables but don't recompute `config.width/height` and don't raise `resolution_change_event` (so no `SS_RESOLUTION_CHANGE` is sent and no encoder re-init for resolution reasons)
- **`ExperimentalFeatures.vue`** — expose checkbox in the Audio/Video Experimental section, right after the WGC UAC toggle
- **`locale/en.json` + `locale/zh.json`** — labels + descriptions

## Behavior

| `dynamic_resolution_follow_display` | Host display res change → |
|---|---|
| **true** (default) | Encoder re-inits at new res, client notified, picture follows |
| **false** | Stream stays at original res, encoder scaler adapts, no protocol message |

## Testing

- [x] Builds cleanly (no compile errors in modified files)
- [x] Default-on path preserved; existing setups unchanged
- [ ] Manual: rotate display mid-stream with toggle off → stream should continue at original res via scaler, no client disruption
- [ ] Manual: PSVita Moonlight session with toggle off → resolution changes on host should no longer freeze the picture

I haven't been able to test on PSVita directly, but the analysis from the #668 log is clean and the change is purely additive (default behavior unchanged). @dissidius if you can test this branch, that would confirm.

## Notes

- This is a **workaround**, not a final fix. The proper solution is to negotiate the `SS_RESOLUTION_CHANGE` capability with the client during connect (only send the extension to clients that advertise support) — but that requires Moonlight-side cooperation and a protocol extension flag. The toggle ships immediately and is non-intrusive.
- Initial-setup orientation_mismatch branch in `video.cpp` is intentionally left unaffected (only the runtime mid-stream `else if` branch is gated). The initial event fires before the client video pipeline is up, so it's harmless even on legacy clients.
