### PR TITLE
fix(display): treat adapter_name "default"/"auto" sentinel as empty (#671)

### DIFF
--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -562,7 +562,15 @@ namespace platf::dxgi {
       return -1;
     }
 
-    const auto adapter_name = from_utf8(config::video.adapter_name);
+    auto adapter_name = from_utf8(config::video.adapter_name);
+    // Treat the legacy sentinel values "default"/"auto" as an empty selector so the
+    // adapter is auto-picked. The external control panel and some users put the
+    // literal string "default" in sunshine.conf expecting auto behavior, but the
+    // code below does an exact wstring match against DXGI_ADAPTER_DESC1::Description
+    // and would otherwise skip every adapter (see issue #671).
+    if (adapter_name == L"default" || adapter_name == L"auto") {
+      adapter_name.clear();
+    }
     const bool is_rdp_session = !is_running_as_system_user && display_device::w_utils::is_any_rdp_session_active();
     auto output_name = is_rdp_session ? std::wstring {} : from_utf8(display_name);
 


### PR DESCRIPTION
## Closes
Fixes #671

## 背景

控制面板（以及一些跟着旧文档手写 `adapter_name = default` 的用户）会把字面字符串 `default` 写进 `sunshine.conf`，期望它代表「自动选卡」。

但 `display_base.cpp` 里的 DXGI 枚举循环对 `DXGI_ADAPTER_DESC1::Description` 做精确 `wstring` 比较：

```cpp
if (!adapter_name.empty() && adapter_desc.Description != adapter_name) {
  continue;
}
```

`default` 永远匹配不到任何真实显卡 → 所有 adapter 被跳过 → 报：

```
Error: Failed to locate an output device
Error: Video failed to find working encoder
```

客户端看到 HTTP 503。

## 为什么 Win11 25H2 上更容易暴露

#671 报告者在 25H2 上 `EnumAdapters1` 看到 **3 个同名 NVIDIA 实例**，只有第一个挂着真正的 output。其实 sunshine 在 `adapter_name` 为空时本来就能正确处理这种情形（靠 `desc.AttachedToDesktop && test_dxgi_duplication(...)` 过滤），所以**只要让 `default` 走 empty 分支即可**。

## 改动

在 `from_utf8` 之后判断哨兵字符串，转成空：

```cpp
auto adapter_name = from_utf8(config::video.adapter_name);
if (adapter_name == L"default" || adapter_name == L"auto") {
  adapter_name.clear();
}
```

`auto` 也一并兼容，避免后续再踩坑。

## 影响范围

- 仅 `src/platform/windows/display_base.cpp`，+9/-1
- 不改任何配置 schema / 写盘逻辑
- 主仓没有任何代码主动写入 `"default"`（`config.cpp` 默认值是 `{}`，前端 `useConfig.js`/`SetupWizard.vue` 默认值都是 `''`）；写入源头来自外置控制面板和用户手写
- 长期方向可以让控制面板改为写空串，但 sunshine 端兜底也很便宜，先把用户解封

## 测试

- 本地 Win11 + AMD 780M：`adapter_name = default` 修改前空跑日志见 `Failed to locate an output device`；改后正常进入编码器探测
- `adapter_name = NVIDIA GeForce RTX 3080 Ti` 等真实名字行为不变（empty 检查在前，不影响精确匹配路径）
