### PR TITLE
fix(amf): restore periodic HEVC IDRs

### DIFF
--- a/src/amf/amf_d3d11.cpp
+++ b/src/amf/amf_d3d11.cpp
@@ -222,7 +222,10 @@ namespace amf {
       encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_FILLER_DATA_ENABLE, false);
       if (config.enforce_hrd) encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_ENFORCE_HRD, !!(*config.enforce_hrd));
       encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_NUM_GOPS_PER_IDR, (amf_int64) 1);
-      encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_GOP_SIZE, (amf_int64) 0);
+      // Match FFmpeg hevc_amf default behavior (-g -1 -> AMF default GOP size 60).
+      // A GOP size of 0 disables automatic IDRs, which leaves long-running HEVC
+      // streams without periodic encoder state refresh on RDNA4.
+      encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_GOP_SIZE, (amf_int64) 60);
       encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_HEADER_INSERTION_MODE, (amf_int64) AMF_VIDEO_ENCODER_HEVC_HEADER_INSERTION_MODE_IDR_ALIGNED);
       if (config.preanalysis) encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_PRE_ANALYSIS_ENABLE, !!(*config.preanalysis));
       if (config.vbaq) encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_ENABLE_VBAQ, !!(*config.vbaq));


### PR DESCRIPTION
## Summary
- set AMF HEVC GOP size to 60 frames instead of 0
- keep NUM_GOPS_PER_IDR=1 so AMF emits periodic IDRs, matching FFmpeg hevc_amf default behavior (-g -1 -> AMF default GOP size 60)
- document why disabling automatic IDRs can leave long-running HEVC streams without periodic encoder state refresh on RDNA4

## Notes
- FFmpeg also leaves HEVC header insertion mode unset by default; this PR intentionally keeps our IDR-aligned header insertion because it only controls VPS/SPS/PPS repetition around IDRs and is useful for stream recovery.
- The stability-relevant divergence for issue #666 is GOP_SIZE=0, which removes the periodic IDR refresh entirely.

## Test
- Built locally with MSYS2 UCRT64: ninja -C build sunshine

Fixes #666