### PR TITLE
fix(adapter): 修复adapter默认值导致选择显卡编码器失败

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1256,7 +1256,10 @@ namespace config {
         [](unsigned char c) { return std::tolower(c); }
       );
       if (trimmed.empty() || lower == "default" || lower == "auto") {
-          video.adapter_name.clear();
+        video.adapter_name.clear();
+      }
+      else {
+        video.adapter_name = std::move(trimmed);
       }
     }
     string_f(vars, "output_name", video.output_name);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1247,6 +1247,18 @@ namespace config {
     
     string_f(vars, "encoder", video.encoder);
     string_f(vars, "adapter_name", video.adapter_name);
+    {
+      auto first = video.adapter_name.find_first_not_of(" \t\r\n");
+      auto last = video.adapter_name.find_last_not_of(" \t\r\n");
+      std::string trimmed = (first == std::string::npos) ? std::string {} : video.adapter_name.substr(first, last - first + 1);
+      std::string lower = trimmed;
+      std::transform(lower.begin(), lower.end(), lower.begin(),
+        [](unsigned char c) { return std::tolower(c); }
+      );
+      if (trimmed.empty() || lower == "default" || lower == "auto") {
+          video.adapter_name.clear();
+      }
+    }
     string_f(vars, "output_name", video.output_name);
     
 #ifdef _WIN32

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -562,7 +562,7 @@ namespace platf::dxgi {
       return -1;
     }
 
-    const auto adapter_name = from_utf8(config::video.adapter_name);
+    auto adapter_name = from_utf8(config::video.adapter_name);
     const bool is_rdp_session = !is_running_as_system_user && display_device::w_utils::is_any_rdp_session_active();
     auto output_name = is_rdp_session ? std::wstring {} : from_utf8(display_name);
 
@@ -574,10 +574,23 @@ namespace platf::dxgi {
     }
 
     adapter_t::pointer adapter_p;
-    for (int tries = 0; tries < 2 && !output; ++tries) {
+    // Tries:
+    //   0 - normal pass with the configured adapter filter (if any).
+    //   1 - same filter, but after nudging the display power state.
+    //   2 - last resort: if the configured adapter never matched, drop the
+    //       filter and accept any adapter so a misconfigured / stale
+    //       adapter_name doesn't make capture init fail outright.
+    for (int tries = 0; tries < 3 && !output; ++tries) {
       if (tries == 1) {
         SetThreadExecutionState(ES_DISPLAY_REQUIRED);
         Sleep(500);
+      }
+      if (tries == 2) {
+        if (adapter_name.empty()) {
+          break;
+        }
+        BOOST_LOG(warning) << "[Display Init] Configured adapter ["sv << to_utf8(adapter_name) << "] did not match any enumerated adapter; falling back to auto-select"sv;
+        adapter_name.clear();
       }
 
       for (int x = 0; factory->EnumAdapters1(x, &adapter_p) != DXGI_ERROR_NOT_FOUND; ++x) {


### PR DESCRIPTION
在加载配置的入口做一次归一化处理，adapter_name默认值default是给vdd使用的，原本默认值是空值，自动选择显卡的编码器，但是为了适配vdd，设置了default传入给vdd使用，应该是修复vdd创建失败时引入的bug。

本次更新还加入了一层兜底机制，如果用户选择或者手动填入了错误的显卡名称，导致sunshine找不到，比如说换了显卡，没有修改设置。那么sunshine应该自动兜底使用自动处理显卡问题。

TODO：未来要添加自动轮询，找到合适的显卡，而不是Auto，本次更新只做简单处理，不要复杂化。