### PR TITLE
feat(webui): auto-detect default locale from browser/system language

### DIFF
--- a/src_assets/common/assets/web/components/SetupWizard.vue
+++ b/src_assets/common/assets/web/components/SetupWizard.vue
@@ -420,6 +420,14 @@
 <script>
 import { trackEvents } from '../config/firebase.js'
 import { openExternalUrl } from '../utils/helpers.js'
+import { detectSystemLocale } from '../config/i18n.js'
+
+// 向导第一步只暴露 简体中文(zh) / English(en) 两个选项，
+// 因此把系统语言探测结果折叠到这两者之一即可
+function detectInitialWizardLocale() {
+  const sys = detectSystemLocale() // 已经过支持白名单过滤，未知语言落到 'en'
+  return (sys === 'zh' || sys === 'zh_TW') ? 'zh' : 'en'
+}
 
 export default {
   name: 'SetupWizard',
@@ -440,7 +448,7 @@ export default {
   data() {
     return {
       currentStep: 1,
-      selectedLocale: 'zh', // 默认中文
+      selectedLocale: detectInitialWizardLocale(), // 根据系统/浏览器语言自动选择（zh / en）
       selectedDisplay: 'ZakoHDR', // 默认选择基地显示器
       selectedAdapter: '',
       displayDevicePrep: 'ensure_only_display', // 默认选择：确保唯一显示器（VDD 和普通模式通用）

--- a/src_assets/common/assets/web/components/SetupWizard.vue
+++ b/src_assets/common/assets/web/components/SetupWizard.vue
@@ -448,7 +448,9 @@ export default {
   data() {
     return {
       currentStep: 1,
-      selectedLocale: detectInitialWizardLocale(), // 根据系统/浏览器语言自动选择（zh / en）
+      // 已有 locale 时向导会跳过第一步，不预置，避免 saveConfiguration() 覆盖已有设置（如 de / ja）
+      // 首次进入向导时依然按系统 / 浏览器语言预选 zh / en
+      selectedLocale: this.hasLocale ? null : detectInitialWizardLocale(),
       selectedDisplay: 'ZakoHDR', // 默认选择基地显示器
       selectedAdapter: '',
       displayDevicePrep: 'ensure_only_display', // 默认选择：确保唯一显示器（VDD 和普通模式通用）

--- a/src_assets/common/assets/web/config/i18n.js
+++ b/src_assets/common/assets/web/config/i18n.js
@@ -3,20 +3,56 @@ import {createI18n} from "vue-i18n";
 // Import only the fallback language files
 import en from '../public/assets/locale/en.json'
 
+// 与后端 string_restricted_f("locale", ...) 白名单保持一致
+const SUPPORTED_LOCALES = [
+    'bg', 'cs', 'de', 'en', 'en_GB', 'en_US', 'es', 'fr',
+    'it', 'ja', 'pt', 'ru', 'sv', 'tr', 'zh', 'zh_TW',
+];
+
+// 把浏览器 / 系统语言（navigator.language，例如 "zh-CN" / "en-US"）映射到支持的 locale
+export function detectSystemLocale() {
+    try {
+        const candidates = [];
+        if (typeof navigator !== 'undefined') {
+            if (Array.isArray(navigator.languages)) candidates.push(...navigator.languages);
+            if (navigator.language) candidates.push(navigator.language);
+        }
+        for (const raw of candidates) {
+            if (!raw) continue;
+            const norm = raw.replace('-', '_'); // zh-CN -> zh_CN
+            // 1) 完整匹配（en_GB / en_US / zh_TW）
+            if (SUPPORTED_LOCALES.includes(norm)) return norm;
+            // 2) 繁体中文 / 港澳粤 → zh_TW
+            const lower = norm.toLowerCase();
+            if (lower.startsWith('zh') && /(_tw|_hk|_mo|hant)/.test(lower)) return 'zh_TW';
+            // 3) 主语言匹配（zh_CN -> zh，en_AU -> en，...）
+            const primary = norm.split('_')[0];
+            if (SUPPORTED_LOCALES.includes(primary)) return primary;
+        }
+    } catch (e) {
+        console.warn('detectSystemLocale failed', e);
+    }
+    return 'en';
+}
+
 export default async function() {
     // 先尝试从 /api/config 获取实时配置（会读取配置文件）
-    let locale = "en";
+    // 若用户/配置文件未指定 locale，则按系统语言自动选择，最终回退到 en
+    let locale = null;
     try {
         let config = await (await fetch("/api/config")).json();
-        locale = config.locale ?? "en";
+        locale = config.locale || null;
     } catch (e) {
         // 如果失败，回退到 /api/configLocale（从内存读取）
         try {
             let r = await (await fetch("/api/configLocale")).json();
-            locale = r.locale ?? "en";
+            locale = r.locale || null;
         } catch (e2) {
             console.error("Failed to get locale config", e, e2);
         }
+    }
+    if (!locale) {
+        locale = detectSystemLocale();
     }
     
     document.querySelector('html').setAttribute('lang', locale);

--- a/src_assets/common/assets/web/config/i18n.js
+++ b/src_assets/common/assets/web/config/i18n.js
@@ -36,26 +36,29 @@ export function detectSystemLocale() {
 }
 
 export default async function() {
-    // 先尝试从 /api/config 获取实时配置（会读取配置文件）
-    // 若用户/配置文件未指定 locale，则按系统语言自动选择，最终回退到 en
+    // 优先从 /api/config 拿；读不到再试 /api/configLocale（包括 /api/config 返回但 locale 为空的情况）
+    // 全都拿不到才走系统语言探测，最后回退 en
     let locale = null;
     try {
         let config = await (await fetch("/api/config")).json();
         locale = config.locale || null;
     } catch (e) {
-        // 如果失败，回退到 /api/configLocale（从内存读取）
+        console.warn("Failed to get /api/config", e);
+    }
+    if (!locale) {
         try {
             let r = await (await fetch("/api/configLocale")).json();
             locale = r.locale || null;
         } catch (e2) {
-            console.error("Failed to get locale config", e, e2);
+            console.error("Failed to get /api/configLocale", e2);
         }
     }
     if (!locale) {
         locale = detectSystemLocale();
     }
     
-    document.querySelector('html').setAttribute('lang', locale);
+    // html[lang] 用 BCP-47 连字符形式，让 辅助技术 / 翻译插件 能正确识别 en_US -> en-US, zh_TW -> zh-TW
+    document.querySelector('html').setAttribute('lang', locale.replace(/_/g, '-'));
     let messages = {
         en
     };


### PR DESCRIPTION
## 背景

Issue #647 反馈：全新机器首次打开 Sunshine Web UI / Setup Wizard 时，默认语言直接落到中文，对非中文用户不友好。原因是两处硬编码：

1. `src_assets/common/assets/web/components/SetupWizard.vue` 里 `data().selectedLocale = 'zh'`
2. `src_assets/common/assets/web/config/i18n.js` 在 `config.locale` 缺失时直接落到 `"en"`，未参考浏览器 / 系统语言

## 修改

### 1. `src_assets/common/assets/web/config/i18n.js`

- 新增并 `export` 一个 `detectSystemLocale()`，按 `navigator.languages` → `navigator.language` 的顺序尝试，把 BCP-47 (`zh-CN` / `en-US` / `zh-Hant` 等) 折算成 Sunshine 支持的 locale。
- 白名单与 `src/config.cpp` 的 `string_restricted_f("locale", …)` 保持一致 (`bg, cs, de, en, en_GB, en_US, es, fr, it, ja, pt, ru, sv, tr, zh, zh_TW`)，注释里有明确提示。
- 匹配规则：
  - 完整匹配 → `en_GB` / `en_US` / `zh_TW`
  - `zh-TW` / `zh-HK` / `zh-Hant` → `zh_TW`
  - 主语言匹配 → `zh-CN → zh`，`de-AT → de`
  - 都不匹配 → `en`
- 仅当 `/api/config` 与 `/api/configLocale` 都没有显式 `locale` 时才使用，对已设置过语言的存量用户行为完全不变。

### 2. `src_assets/common/assets/web/components/SetupWizard.vue`

- 引入并复用 `detectSystemLocale()`，把结果折叠到向导只暴露的 `zh` / `en` 两个选项（其它语言落到 `en`）。
- `data().selectedLocale` 不再写死，改为 `detectInitialWizardLocale()` 返回值。

### 不动 / 不需要改

- 后端 `src/config.cpp` 默认 `locale = "en"` 保持不变 —— 服务进程读不到浏览器 locale，强行用 `std::locale("")` 会让 CLI / 日志在不同系统上飘移。把"按系统语言走"的策略放在前端是正确的边界。
- `src/confighttp.cpp` `getLocale()` 不动 —— 它只负责回吐已配置值。
- `dist/` 已 gitignored，不需要随 PR 提交构建产物。

## 验证

- `npm run build` 通过（Vite 3.09s 完成，无警告）；
- 生成的 minified bundle 检查：原本 `selectedLocale:"zh"` 已变为 `selectedLocale:re()` (= `detectInitialWizardLocale()` 调用)，`detectSystemLocale` 符号已正确出现在分块里。

## 建议手测

1. 删除 / 重命名 `sunshine.conf` 里的 `locale` 字段 → 在英文 / 日文 / 中文 Windows 上分别打开 Web UI，应分别落到 en / ja / zh；
2. 全新机器进入 SetupWizard：英文系统第一步预选 English，中文系统预选简体中文；
3. 法语 / 韩语等系统：i18n 这一层会即时切到 `fr` / `en`（韩语未在白名单，落 en），向导仍预选 English；
4. 已有 `locale` 配置的存量用户：完全无变化。

Closes #647