### PR TITLE
fix: prep-cmd permission_denied 例外未覆盖 wait/exit_code 检查

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -198,7 +198,7 @@ jobs:
           # downloads (vmouse) may fail. Downgrade missing drivers from
           # FATAL_ERROR to WARNING so the build/configure still succeeds; the
           # affected drivers are simply excluded from the installer.
-          DRIVER_DEPS_REQUIRED: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) && 'OFF' || 'ON' }}
+          DRIVER_DEPS_REQUIRED: ${{ ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) || github.event_name == 'workflow_dispatch') && 'OFF' || 'ON' }}
         run: |
           mkdir -p build
           cmake \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,7 +161,7 @@ jobs:
           which cmake || (echo "cmake not found" && exit 1)
           which ninja || (echo "ninja not found" && exit 1)
           which gcc || (echo "gcc not found" && exit 1)
-          
+
           echo "All build tools verified successfully"
           echo "  CMake: $(cmake --version | head -1)"
           echo "  Ninja: $(ninja --version)"
@@ -198,7 +198,7 @@ jobs:
           # downloads (vmouse) may fail. Downgrade missing drivers from
           # FATAL_ERROR to WARNING so the build/configure still succeeds; the
           # affected drivers are simply excluded from the installer.
-          DRIVER_DEPS_REQUIRED: ${{ ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) || github.event_name == 'workflow_dispatch') && 'OFF' || 'ON' }}
+          DRIVER_DEPS_REQUIRED: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) && 'OFF' || 'ON' }}
         run: |
           mkdir -p build
           cmake \
@@ -245,10 +245,10 @@ jobs:
           # package - 生成 Inno Setup 安装包和 ZIP 便携版
           # 先安装到 staging 目录
           cmake --install . --prefix ./inno_staging
-          
+
           # 运行 Inno Setup 编译器
           "/c/Program Files (x86)/Inno Setup 6/ISCC.exe" sunshine_installer.iss
-          
+
           # 生成 ZIP 便携版
           cpack -G ZIP --config ./CPackConfig.cmake --verbose
 

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -243,25 +243,32 @@ namespace proc {
       BOOST_LOG(info) << "Executing Do Cmd: ["sv << cmd.do_cmd << ']';
       auto child = platf::run_command(cmd.elevated, true, cmd.do_cmd, working_dir, _env, _pipe.get(), ec, nullptr);
 
+      // Track if we hit the desktop-mode permission_denied exception,
+      // so we can also skip the wait/exit_code checks that would otherwise fail.
+      bool skip_prep_failure = false;
       if (ec) {
         BOOST_LOG(error) << "Couldn't run ["sv << cmd.do_cmd << "]: System: "sv << ec.message();
         // We don't want any prep commands failing launch of the desktop.
         // This is to prevent the issue where users reboot their PC and need to log in with Sunshine.
         // permission_denied is typically returned when the user impersonation fails, which can happen when user is not signed in yet.
-        if (!(_app.cmd.empty() && ec == std::errc::permission_denied)) {
+        if (_app.cmd.empty() && ec == std::errc::permission_denied) {
+          skip_prep_failure = true;
+        } else {
           return -1;
         }
       }
 
-      child.wait(ec);
-      if (ec) {
-        BOOST_LOG(error) << '[' << cmd.do_cmd << "] wait failed with error code ["sv << ec << ']';
-        return -1;
-      }
-      auto ret = child.exit_code();
-      if (ret != 0) {
-        BOOST_LOG(error) << '[' << cmd.do_cmd << "] exited with code ["sv << ret << ']';
-        return -1;
+      if (!skip_prep_failure) {
+        child.wait(ec);
+        if (ec) {
+          BOOST_LOG(error) << '[' << cmd.do_cmd << "] wait failed with error code ["sv << ec << ']';
+          return -1;
+        }
+        auto ret = child.exit_code();
+        if (ret != 0) {
+          BOOST_LOG(error) << '[' << cmd.do_cmd << "] exited with code ["sv << ret << ']';
+          return -1;
+        }
       }
     }
 


### PR DESCRIPTION
## 问题

在桌面模式（`_app.cmd` 为空）下，当 Windows 会话锁定时，Session 0 中的进程创建会返回 `permission_denied`。

`execute()` 函数已有例外处理：当 `run_command` 返回 `permission_denied` 且为桌面模式时，跳过错误继续执行。但后续的 `child.wait()` 同样返回 `permission_denied`，**没有被例外覆盖**，直接 `return -1`，触发 `fail_guard` 调用 `terminate()` 销毁 VDD，串流中断。

## 日志证据

```
[16:53:59.910]: Error: Couldn't run [.\tools\SetDpi.exe 175]: System: Permission denied
[16:53:59.910]: Error: [.\tools\SetDpi.exe 175] wait failed with error code [generic:13]
[16:53:59.910]: Error: [.\tools\SetDpi.exe 175] exited with code [-1]
[16:53:59.913]: Info: apply_config 未执行（无persistent_data），销毁VDD并跳过拓扑恢复
```

第一层 `run_command` 失败被例外跳过，但第二层 `child.wait()` 失败未被跳过。

## 修复

添加 `skip_prep_failure` 标志，当命中桌面模式 + `permission_denied` 例外时，同时跳过 `wait()` 和 `exit_code()` 检查，prep-cmd 被记录为失败但不阻止串流继续。

## 效果

- **锁屏时**：prep-cmd 失败被跳过，串流正常启动
- **解锁时**：prep-cmd 正常执行（如 DPI 切换）
- 不需要清空 apps.json 中的 prep-cmd 配置