### PR TITLE
fix(vdd): 优先 IOCTL DESTROY/CREATE 恢复，避免制造 phantom monitor

### DIFF
--- a/src/display_device/session.cpp
+++ b/src/display_device/session.cpp
@@ -13,6 +13,7 @@
 #include "src/platform/windows/display_device/windows_utils.h"
 #include "src/rtsp.h"
 #include "to_string.h"
+#include "vdd_ioctl.h"
 #include "vdd_utils.h"
 
 namespace display_device {
@@ -515,13 +516,28 @@ namespace display_device {
 
     // Wait for device to be ready
     if (!wait_for_vdd_device(device_zako, 5, 200ms, 1000ms)) {
-      BOOST_LOG(error) << "VDD设备初始化失败，尝试恢复";
-      vdd_utils::disable_enable_vdd();
-      std::this_thread::sleep_for(2s);
+      // 优先走 IOCTL DESTROY/CREATE 干净路径：driver 内部会调
+      // IddCxMonitorDeparture，PnP 数据库里不会留 phantom monitor。
+      // 历史上这里曾用 vdd_utils::disable_enable_vdd()，等同于 DevManView
+      // /disable_enable 强拔 adapter，会留 CM_PROB_PHANTOM monitor，下一次
+      // CREATEMONITOR 用新 GUID 会与 phantom 同 HardwareId 冲突，监视器永远attach 不上。
+      BOOST_LOG(error) << "VDD设备初始化失败，尝试通过 IOCTL DESTROY+CREATE 恢复";
+      vdd_utils::destroy_vdd_monitor();
+      std::this_thread::sleep_for(500ms);
 
       if (!try_recover_vdd_device(current_client_id, session.client_name, hdr_brightness, device_zako)) {
         BOOST_LOG(error) << "VDD设备最终初始化失败";
-        vdd_utils::disable_enable_vdd();
+
+        // last-resort：只有 IOCTL 通路彻底死掉才动 adapter，因为
+        // disable_enable_vdd() 必然会留 phantom monitor（清理需要 SetupAPI
+        // 工具函数，留作后续 PR）。
+        if (!vdd_ioctl::ping()) {
+          BOOST_LOG(warning) << "VDD IOCTL ping 失败，driver 可能已死；last-resort disable/enable adapter（注意会留 phantom monitor）";
+          vdd_utils::disable_enable_vdd();
+        }
+        else {
+          BOOST_LOG(warning) << "VDD IOCTL 仍可用，跳过 disable/enable，避免制造 phantom monitor";
+        }
         return;
       }
     }


### PR DESCRIPTION
## 这次修什么

Sunshine 以前在 VDD 起不来时，会直接 disable/enable 整个虚拟显示适配器。这个动作太粗暴，可能绕过驱动的正常 monitor 移除流程，在 Windows PnP 里留下 phantom monitor。结果就是后面再创建 Zako HDR monitor 时撞到旧记录，Sunshine 一直找不到显示器，客户端连不上。

## 怎么改

把常规恢复路径改成更干净的方式：

1. 先通过 IOCTL 让驱动 DESTROYMONITOR
2. 再重新 CREATEMONITOR
3. 只有 IOCTL ping 都失败、基本确认驱动通路死掉时，才退回旧的 disable/enable adapter 保底

## 好处

- 正常恢复不再制造新的 phantom monitor
- 已存在的 VDD monitor 会走驱动里的 IddCxMonitorDeparture 正常离场
- driver 真挂的极端情况仍保留旧 fallback

## 验证

- MSYS2 ucrt64 下 ninja 构建通过，sunshine.exe 成功重新链接
- 现场 phantom 已用 pnputil /remove-device 清理，串流恢复

## 后续另开

这个 PR 只避免继续制造 phantom。已经存在的 phantom 自动清理、driver 端 D0Entry 自愈，可以后续单独做。
