### PR TITLE
fix(vdd): use SETMODES for transient session modes

### DIFF
--- a/src/display_device/session.cpp
+++ b/src/display_device/session.cpp
@@ -13,6 +13,7 @@
 #include "src/platform/windows/display_device/windows_utils.h"
 #include "src/rtsp.h"
 #include "to_string.h"
+#include "vdd_ioctl.h"
 #include "vdd_utils.h"
 
 namespace display_device {
@@ -515,13 +516,28 @@ namespace display_device {
 
     // Wait for device to be ready
     if (!wait_for_vdd_device(device_zako, 5, 200ms, 1000ms)) {
-      BOOST_LOG(error) << "VDD设备初始化失败，尝试恢复";
-      vdd_utils::disable_enable_vdd();
-      std::this_thread::sleep_for(2s);
+      // 优先走 IOCTL DESTROY/CREATE 干净路径：driver 内部会调
+      // IddCxMonitorDeparture，PnP 数据库里不会留 phantom monitor。
+      // 历史上这里曾用 vdd_utils::disable_enable_vdd()，等同于 DevManView
+      // /disable_enable 强拔 adapter，会留 CM_PROB_PHANTOM monitor，下一次
+      // CREATEMONITOR 用新 GUID 会与 phantom 同 HardwareId 冲突，监视器永远attach 不上。
+      BOOST_LOG(error) << "VDD设备初始化失败，尝试通过 IOCTL DESTROY+CREATE 恢复";
+      vdd_utils::destroy_vdd_monitor();
+      std::this_thread::sleep_for(500ms);
 
       if (!try_recover_vdd_device(current_client_id, session.client_name, hdr_brightness, device_zako)) {
         BOOST_LOG(error) << "VDD设备最终初始化失败";
-        vdd_utils::disable_enable_vdd();
+
+        // last-resort：只有 IOCTL 通路彻底死掉才动 adapter，因为
+        // disable_enable_vdd() 必然会留 phantom monitor（清理需要 SetupAPI
+        // 工具函数，留作后续 PR）。
+        if (!vdd_ioctl::ping()) {
+          BOOST_LOG(warning) << "VDD IOCTL ping 失败，driver 可能已死；last-resort disable/enable adapter（注意会留 phantom monitor）";
+          vdd_utils::disable_enable_vdd();
+        }
+        else {
+          BOOST_LOG(warning) << "VDD IOCTL 仍可用，跳过 disable/enable，避免制造 phantom monitor";
+        }
         return;
       }
     }

--- a/src/display_device/session.cpp
+++ b/src/display_device/session.cpp
@@ -421,10 +421,21 @@ namespace display_device {
   void
   session_t::update_vdd_resolution(const parsed_config_t &config,
     const vdd_utils::VddSettings &vdd_settings) {
+    if (!config.resolution || !config.refresh_rate) {
+      BOOST_LOG(debug) << "VDD session mode update skipped: resolution or refresh rate is not set";
+      return;
+    }
+
     const auto new_setting = to_string(*config.resolution) + "@" + to_string(*config.refresh_rate);
 
     if (last_vdd_setting == new_setting) {
       BOOST_LOG(debug) << "VDD配置未变更: " << new_setting;
+      return;
+    }
+
+    if (vdd_utils::set_vdd_session_mode(config)) {
+      last_vdd_setting = new_setting;
+      BOOST_LOG(info) << "VDD会话模式更新完成（未写入XML）: " << new_setting;
       return;
     }
 

--- a/src/display_device/vdd_utils.cpp
+++ b/src/display_device/vdd_utils.cpp
@@ -12,6 +12,7 @@
 #include <boost/uuid/name_generator_sha1.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <cmath>
 #include <filesystem>
 #include <future>
 #include <sstream>
@@ -267,6 +268,47 @@ namespace display_device {
         BOOST_LOG(info) << "Reload VDD driver requested (PIPE)";
       }
       return ok;
+    }
+
+    bool
+    set_vdd_session_mode(const parsed_config_t &config) {
+      if (!config.resolution || !config.refresh_rate) {
+        BOOST_LOG(debug) << "SETMODES skipped: session resolution or refresh rate is not set";
+        return false;
+      }
+
+      if (config.refresh_rate->denominator == 0) {
+        BOOST_LOG(warning) << "SETMODES skipped: invalid refresh rate denominator";
+        return false;
+      }
+
+      const double refresh_hz = static_cast<double>(config.refresh_rate->numerator) / config.refresh_rate->denominator;
+      const auto rounded_refresh_hz = static_cast<unsigned int>(std::lround(refresh_hz));
+      if (rounded_refresh_hz == 0) {
+        BOOST_LOG(warning) << "SETMODES skipped: invalid refresh rate " << refresh_hz;
+        return false;
+      }
+
+      std::wstringstream command;
+      command << L"SETMODES "
+              << config.resolution->width << L"x"
+              << config.resolution->height << L"x"
+              << rounded_refresh_hz;
+
+      switch (vdd_ioctl::send_command(command.str())) {
+        case vdd_ioctl::result::success:
+          BOOST_LOG(info) << "VDD live session mode updated via SETMODES: "
+                          << to_string(*config.resolution) << "@" << rounded_refresh_hz << "Hz";
+          return true;
+        case vdd_ioctl::result::failed:
+          BOOST_LOG(warning) << "VDD SETMODES IOCTL failed; falling back to persistent XML update";
+          return false;
+        case vdd_ioctl::result::interface_missing:
+          BOOST_LOG(debug) << "VDD SETMODES unavailable: IOCTL interface missing";
+          return false;
+      }
+
+      return false;
     }
 
     std::string

--- a/src/display_device/vdd_utils.h
+++ b/src/display_device/vdd_utils.h
@@ -74,6 +74,16 @@ namespace display_device::vdd_utils {
   reload_driver();
 
   /**
+   * @brief Push the current session mode to ZakoVDD in-memory mode list.
+   * @details Uses the SETMODES IOCTL command exposed by newer ZakoVDD builds.
+   *          This does not persist the session resolution to vdd_settings.xml.
+   * @param config Parsed display configuration containing resolution + refresh rate.
+   * @return true if the driver accepted the live mode update, false otherwise.
+   */
+  bool
+  set_vdd_session_mode(const parsed_config_t &config);
+
+  /**
    * @brief 从客户端标识符生成GUID字符串（用于驱动识别）
    * @param identifier 客户端标识符，如果为空则返回空字符串
    * @return GUID格式字符串: {xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}，如果identifier为空则返回空字符串


### PR DESCRIPTION
## Summary

- When ZakoVDD already supports the control IOCTL, Sunshine now pushes the session resolution with `SETMODES` first.
- This keeps one-off client modes in the driver runtime mode list instead of permanently adding them to `vdd_settings.xml`.
- If the IOCTL path is unavailable or fails, the existing XML + reload fallback is preserved for older drivers.

## Validation

- Confirmed installed ZakoVDD accepts `SETMODES` via ETW: `applied 1 modes (in-memory only)` / `pushed to 1 live monitor(s)`.
- Restored runtime modes from XML after smoke test.
- Built `sunshine` locally with MSYS2 UCRT64 PATH first: `ninja sunshine` -> no work / success.
- Ran `git diff --check` for the touched files.