### PR TITLE
fix(vdd): use SETMODES for transient session modes

### DIFF
--- a/src/display_device/session.cpp
+++ b/src/display_device/session.cpp
@@ -421,10 +421,21 @@ namespace display_device {
   void
   session_t::update_vdd_resolution(const parsed_config_t &config,
     const vdd_utils::VddSettings &vdd_settings) {
+    if (!config.resolution || !config.refresh_rate) {
+      BOOST_LOG(debug) << "VDD session mode update skipped: resolution or refresh rate is not set";
+      return;
+    }
+
     const auto new_setting = to_string(*config.resolution) + "@" + to_string(*config.refresh_rate);
 
     if (last_vdd_setting == new_setting) {
       BOOST_LOG(debug) << "VDD配置未变更: " << new_setting;
+      return;
+    }
+
+    if (vdd_utils::set_vdd_session_mode(config)) {
+      last_vdd_setting = new_setting;
+      BOOST_LOG(info) << "VDD会话模式更新完成（未写入XML）: " << new_setting;
       return;
     }
 

--- a/src/display_device/session.cpp
+++ b/src/display_device/session.cpp
@@ -433,10 +433,21 @@ namespace display_device {
       return;
     }
 
-    if (vdd_utils::set_vdd_session_mode(config)) {
-      last_vdd_setting = new_setting;
-      BOOST_LOG(info) << "VDD会话模式更新完成（未写入XML）: " << new_setting;
-      return;
+    const auto setmodes_result = vdd_utils::set_vdd_session_mode(config);
+    switch (setmodes_result) {
+      case vdd_utils::set_vdd_result::ok:
+        last_vdd_setting = new_setting;
+        BOOST_LOG(info) << "VDD会话模式更新完成（未写入XML）: " << new_setting;
+        return;
+      case vdd_utils::set_vdd_result::failed:
+        BOOST_LOG(error) << "VDD SETMODES 被驱动拒绝，跳过 XML 回退以避免运行态/持久态不一致: " << new_setting;
+        return;
+      case vdd_utils::set_vdd_result::invalid_config:
+        BOOST_LOG(warning) << "VDD 会话模式参数无效，跳过更新: " << new_setting;
+        return;
+      case vdd_utils::set_vdd_result::interface_missing:
+        // Old driver without IOCTL: fall through to persistent XML + reload path below.
+        break;
     }
 
     if (!confighttp::saveVddSettings(vdd_settings.resolutions, vdd_settings.fps, config::video.adapter_name)) {

--- a/src/display_device/vdd_utils.cpp
+++ b/src/display_device/vdd_utils.cpp
@@ -270,23 +270,23 @@ namespace display_device {
       return ok;
     }
 
-    bool
+    set_vdd_result
     set_vdd_session_mode(const parsed_config_t &config) {
       if (!config.resolution || !config.refresh_rate) {
         BOOST_LOG(debug) << "SETMODES skipped: session resolution or refresh rate is not set";
-        return false;
+        return set_vdd_result::invalid_config;
       }
 
       if (config.refresh_rate->denominator == 0) {
         BOOST_LOG(warning) << "SETMODES skipped: invalid refresh rate denominator";
-        return false;
+        return set_vdd_result::invalid_config;
       }
 
       const double refresh_hz = static_cast<double>(config.refresh_rate->numerator) / config.refresh_rate->denominator;
       const auto rounded_refresh_hz = static_cast<unsigned int>(std::lround(refresh_hz));
       if (rounded_refresh_hz == 0) {
         BOOST_LOG(warning) << "SETMODES skipped: invalid refresh rate " << refresh_hz;
-        return false;
+        return set_vdd_result::invalid_config;
       }
 
       std::wstringstream command;
@@ -299,16 +299,16 @@ namespace display_device {
         case vdd_ioctl::result::success:
           BOOST_LOG(info) << "VDD live session mode updated via SETMODES: "
                           << to_string(*config.resolution) << "@" << rounded_refresh_hz << "Hz";
-          return true;
+          return set_vdd_result::ok;
         case vdd_ioctl::result::failed:
-          BOOST_LOG(warning) << "VDD SETMODES IOCTL failed; falling back to persistent XML update";
-          return false;
+          BOOST_LOG(warning) << "VDD SETMODES IOCTL rejected by driver; not falling back to XML to avoid partial state";
+          return set_vdd_result::failed;
         case vdd_ioctl::result::interface_missing:
-          BOOST_LOG(debug) << "VDD SETMODES unavailable: IOCTL interface missing";
-          return false;
+          BOOST_LOG(debug) << "VDD SETMODES unavailable: IOCTL interface missing; XML fallback will be used";
+          return set_vdd_result::interface_missing;
       }
 
-      return false;
+      return set_vdd_result::failed;
     }
 
     std::string

--- a/src/display_device/vdd_utils.cpp
+++ b/src/display_device/vdd_utils.cpp
@@ -12,6 +12,7 @@
 #include <boost/uuid/name_generator_sha1.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <cmath>
 #include <filesystem>
 #include <future>
 #include <sstream>
@@ -267,6 +268,47 @@ namespace display_device {
         BOOST_LOG(info) << "Reload VDD driver requested (PIPE)";
       }
       return ok;
+    }
+
+    bool
+    set_vdd_session_mode(const parsed_config_t &config) {
+      if (!config.resolution || !config.refresh_rate) {
+        BOOST_LOG(debug) << "SETMODES skipped: session resolution or refresh rate is not set";
+        return false;
+      }
+
+      if (config.refresh_rate->denominator == 0) {
+        BOOST_LOG(warning) << "SETMODES skipped: invalid refresh rate denominator";
+        return false;
+      }
+
+      const double refresh_hz = static_cast<double>(config.refresh_rate->numerator) / config.refresh_rate->denominator;
+      const auto rounded_refresh_hz = static_cast<unsigned int>(std::lround(refresh_hz));
+      if (rounded_refresh_hz == 0) {
+        BOOST_LOG(warning) << "SETMODES skipped: invalid refresh rate " << refresh_hz;
+        return false;
+      }
+
+      std::wstringstream command;
+      command << L"SETMODES "
+              << config.resolution->width << L"x"
+              << config.resolution->height << L"x"
+              << rounded_refresh_hz;
+
+      switch (vdd_ioctl::send_command(command.str())) {
+        case vdd_ioctl::result::success:
+          BOOST_LOG(info) << "VDD live session mode updated via SETMODES: "
+                          << to_string(*config.resolution) << "@" << rounded_refresh_hz << "Hz";
+          return true;
+        case vdd_ioctl::result::failed:
+          BOOST_LOG(warning) << "VDD SETMODES IOCTL failed; falling back to persistent XML update";
+          return false;
+        case vdd_ioctl::result::interface_missing:
+          BOOST_LOG(debug) << "VDD SETMODES unavailable: IOCTL interface missing";
+          return false;
+      }
+
+      return false;
     }
 
     std::string

--- a/src/display_device/vdd_utils.h
+++ b/src/display_device/vdd_utils.h
@@ -74,13 +74,27 @@ namespace display_device::vdd_utils {
   reload_driver();
 
   /**
+   * @brief Outcome of attempting a live SETMODES update.
+   * @details Lets callers distinguish "driver accepted" / "driver rejected" /
+   *          "feature not present" / "config is unusable" so the persistent
+   *          XML fallback only triggers when the driver genuinely lacks the
+   *          IOCTL interface.
+   */
+  enum class set_vdd_result {
+    ok,                 ///< Driver accepted the live mode update.
+    failed,             ///< Driver reachable but rejected the IOCTL.
+    interface_missing,  ///< IOCTL interface not present (old driver) -> safe to XML-fallback.
+    invalid_config,     ///< Resolution/refresh rate missing or unusable; nothing was sent.
+  };
+
+  /**
    * @brief Push the current session mode to ZakoVDD in-memory mode list.
    * @details Uses the SETMODES IOCTL command exposed by newer ZakoVDD builds.
    *          This does not persist the session resolution to vdd_settings.xml.
    * @param config Parsed display configuration containing resolution + refresh rate.
-   * @return true if the driver accepted the live mode update, false otherwise.
+   * @return Typed outcome; only ::interface_missing should trigger XML fallback.
    */
-  bool
+  set_vdd_result
   set_vdd_session_mode(const parsed_config_t &config);
 
   /**

--- a/src/display_device/vdd_utils.h
+++ b/src/display_device/vdd_utils.h
@@ -74,6 +74,16 @@ namespace display_device::vdd_utils {
   reload_driver();
 
   /**
+   * @brief Push the current session mode to ZakoVDD in-memory mode list.
+   * @details Uses the SETMODES IOCTL command exposed by newer ZakoVDD builds.
+   *          This does not persist the session resolution to vdd_settings.xml.
+   * @param config Parsed display configuration containing resolution + refresh rate.
+   * @return true if the driver accepted the live mode update, false otherwise.
+   */
+  bool
+  set_vdd_session_mode(const parsed_config_t &config);
+
+  /**
    * @brief 从客户端标识符生成GUID字符串（用于驱动识别）
    * @param identifier 客户端标识符，如果为空则返回空字符串
    * @return GUID格式字符串: {xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}，如果identifier为空则返回空字符串


### PR DESCRIPTION
## Summary

- Push the current VDD session resolution through `SETMODES` first, when the installed driver supports the control channel.
- Keeps one-off client modes in the driver runtime mode list instead of permanently adding them to `vdd_settings.xml`.
- Falls back to the existing XML + reload path for older or unavailable drivers.

## Validation

- Confirmed installed ZakoVDD accepts `SETMODES` via ETW: `applied 1 modes (in-memory only)` / `pushed to 1 live monitor(s)`.
- Restored runtime modes from XML after the smoke test.
- Built `sunshine` locally with MSYS2 UCRT64 PATH first: `ninja sunshine` -> no work / success.
- Ran `git diff --check` for the touched files.