### PR TITLE
Enforce host bitrate cap for ABR

### DIFF
--- a/src/abr.cpp
+++ b/src/abr.cpp
@@ -549,22 +549,31 @@ namespace abr {
       state.last_fg_detect = std::chrono::steady_clock::now();
     }
 
-    // Apply mode presets if min/max not explicitly configured
-    if (cfg.min_bitrate_kbps <= 0 || cfg.max_bitrate_kbps <= 0) {
+    // Apply mode presets only for bounds that were not explicitly configured.
+    // This preserves a client/host maxBitrate cap when minBitrate is omitted.
+    if (state.config.min_bitrate_kbps <= 0 || state.config.max_bitrate_kbps <= 0) {
+      int preset_min_bitrate_kbps = 0;
+      int preset_max_bitrate_kbps = 0;
       switch (cfg.mode) {
         case mode_e::QUALITY:
-          state.config.min_bitrate_kbps = std::max(5000, initial_bitrate_kbps / 2);
-          state.config.max_bitrate_kbps = std::min(150000, initial_bitrate_kbps * 3 / 2);
+          preset_min_bitrate_kbps = std::max(5000, initial_bitrate_kbps / 2);
+          preset_max_bitrate_kbps = std::min(150000, initial_bitrate_kbps * 3 / 2);
           break;
         case mode_e::LOW_LATENCY:
-          state.config.min_bitrate_kbps = 2000;
-          state.config.max_bitrate_kbps = initial_bitrate_kbps * 6 / 5;
+          preset_min_bitrate_kbps = 2000;
+          preset_max_bitrate_kbps = initial_bitrate_kbps * 6 / 5;
           break;
         case mode_e::BALANCED:
         default:
-          state.config.min_bitrate_kbps = std::max(3000, initial_bitrate_kbps * 3 / 10);
-          state.config.max_bitrate_kbps = std::min(150000, initial_bitrate_kbps * 2);
+          preset_min_bitrate_kbps = std::max(3000, initial_bitrate_kbps * 3 / 10);
+          preset_max_bitrate_kbps = std::min(150000, initial_bitrate_kbps * 2);
           break;
+      }
+      if (state.config.min_bitrate_kbps <= 0) {
+        state.config.min_bitrate_kbps = preset_min_bitrate_kbps;
+      }
+      if (state.config.max_bitrate_kbps <= 0) {
+        state.config.max_bitrate_kbps = preset_max_bitrate_kbps;
       }
       // Guard against inverted range when initial_bitrate is very low
       if (state.config.min_bitrate_kbps > state.config.max_bitrate_kbps) {
@@ -854,6 +863,30 @@ TEST(AbrLlmParseTests, DetectsTruncatedReasoningWhenFinishReasonLength) {
   EXPECT_EQ(action.new_bitrate_kbps, 0);
   EXPECT_EQ(action.target_bitrate_kbps, 0);
   EXPECT_EQ(action.reason, "llm_truncated: reasoning exceeded max_tokens");
+}
+
+TEST(AbrConfigTests, PreservesExplicitMaxBitrateWhenMinIsOmitted) {
+  abr::config_t cfg;
+  cfg.enabled = true;
+  cfg.min_bitrate_kbps = 0;
+  cfg.max_bitrate_kbps = 15000;
+  cfg.mode = abr::mode_e::BALANCED;
+
+  const std::string client_name = "abr-max-cap-test";
+  abr::enable(client_name, cfg, 50000, "Test Game");
+
+  auto action = abr::process_feedback(client_name, {
+    .packet_loss = 6.0,
+    .rtt_ms = 10.0,
+    .decode_fps = 60.0,
+    .dropped_frames = 0,
+    .current_bitrate_kbps = 50000,
+  });
+
+  EXPECT_GT(action.new_bitrate_kbps, 0);
+  EXPECT_LE(action.new_bitrate_kbps, cfg.max_bitrate_kbps);
+
+  abr::cleanup(client_name);
 }
 
 #endif

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -6,6 +6,7 @@
 #define BOOST_BIND_GLOBAL_PLACEHOLDERS
 
 // standard includes
+#include <algorithm>
 #include <chrono>
 #include <filesystem>
 #include <map>
@@ -1554,6 +1555,41 @@ namespace nvhttp {
     return {};
   }
 
+  static int
+  host_max_bitrate_kbps() {
+    return std::max(config::video.max_bitrate, 0);
+  }
+
+  static bool
+  apply_host_bitrate_cap(abr::config_t &cfg) {
+    const auto host_cap = host_max_bitrate_kbps();
+    if (host_cap <= 0) {
+      return false;
+    }
+
+    const auto requested_max = cfg.max_bitrate_kbps;
+    cfg.max_bitrate_kbps = requested_max > 0 ? std::min(requested_max, host_cap) : host_cap;
+    if (cfg.min_bitrate_kbps > cfg.max_bitrate_kbps) {
+      cfg.min_bitrate_kbps = cfg.max_bitrate_kbps;
+    }
+
+    return requested_max <= 0 || cfg.max_bitrate_kbps != requested_max;
+  }
+
+  static int
+  clamp_bitrate_to_range(int bitrate, const abr::config_t &cfg) {
+    if (cfg.min_bitrate_kbps > 0 && cfg.max_bitrate_kbps > 0) {
+      return std::clamp(bitrate, cfg.min_bitrate_kbps, cfg.max_bitrate_kbps);
+    }
+    if (cfg.max_bitrate_kbps > 0) {
+      return std::min(bitrate, cfg.max_bitrate_kbps);
+    }
+    if (cfg.min_bitrate_kbps > 0) {
+      return std::max(bitrate, cfg.min_bitrate_kbps);
+    }
+    return bitrate;
+  }
+
   /**
    * @brief GET /api/abr/capabilities — Query server ABR support.
    */
@@ -1566,8 +1602,9 @@ namespace nvhttp {
     json resp_json;
     resp_json["supported"] = caps.supported;
     resp_json["version"] = caps.version;
-    resp_json["features"] = json::array({ "llm_ai", "game_aware", "fallback_threshold" });
+    resp_json["features"] = json::array({ "llm_ai", "game_aware", "fallback_threshold", "bitrate_cap" });
     resp_json["llmEnabled"] = confighttp::isAiEnabled();
+    resp_json["hostMaxBitrate"] = host_max_bitrate_kbps();
 
     SimpleWeb::CaseInsensitiveMultimap headers;
     headers.emplace("Content-Type", "application/json");
@@ -1644,6 +1681,8 @@ namespace nvhttp {
       cfg.min_bitrate_kbps = body.value("minBitrate", 0);
       cfg.max_bitrate_kbps = body.value("maxBitrate", 0);
       cfg.mode = mode;
+      const auto requested_max_bitrate = cfg.max_bitrate_kbps;
+      const auto host_max_bitrate = host_max_bitrate_kbps();
 
       // Validate bitrate range
       if (cfg.min_bitrate_kbps < 0 || cfg.max_bitrate_kbps < 0) {
@@ -1661,11 +1700,24 @@ namespace nvhttp {
         return;
       }
 
+      apply_host_bitrate_cap(cfg);
+      const auto capped_by_host = host_max_bitrate > 0 && requested_max_bitrate > 0 && cfg.max_bitrate_kbps < requested_max_bitrate;
+      const auto inherited_host_cap = host_max_bitrate > 0 && requested_max_bitrate <= 0;
+
       int initial_bitrate = client.bitrate > 0 ? client.bitrate
                             : cfg.max_bitrate_kbps > 0 ? cfg.max_bitrate_kbps
                             : 20000;
+      initial_bitrate = clamp_bitrate_to_range(initial_bitrate, cfg);
 
       abr::enable(client.name, cfg, initial_bitrate, client.app_name);
+
+      if (client.bitrate > 0 && cfg.max_bitrate_kbps > 0 && client.bitrate > cfg.max_bitrate_kbps) {
+        video::dynamic_param_t param;
+        param.type = video::dynamic_param_type_e::BITRATE;
+        param.value.int_value = cfg.max_bitrate_kbps;
+        param.valid = true;
+        stream::session::change_dynamic_param_for_client(client.name, param);
+      }
 
       json resp_json;
       resp_json["success"] = true;
@@ -1674,6 +1726,10 @@ namespace nvhttp {
       resp_json["minBitrate"] = cfg.min_bitrate_kbps;
       resp_json["maxBitrate"] = cfg.max_bitrate_kbps;
       resp_json["initialBitrate"] = initial_bitrate;
+      resp_json["requestedMaxBitrate"] = requested_max_bitrate;
+      resp_json["hostMaxBitrate"] = host_max_bitrate;
+      resp_json["maxBitrateCapped"] = capped_by_host;
+      resp_json["maxBitrateInheritedFromHost"] = inherited_host_cap;
       response->write(SimpleWeb::StatusCode::success_ok, resp_json.dump(), headers);
     }
     catch (const json::exception &e) {

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -729,6 +729,17 @@ namespace stream {
   void
   end_broadcast(broadcast_ctx_t &ctx);
 
+  static int
+  clamp_total_bitrate_to_host_cap(int bitrate_kbps, std::string_view client_name) {
+    if (config::video.max_bitrate > 0 && bitrate_kbps > config::video.max_bitrate) {
+      BOOST_LOG(info) << "Clamping dynamic bitrate for client '" << client_name
+                      << "' from " << bitrate_kbps << " Kbps to host maximum "
+                      << config::video.max_bitrate << " Kbps";
+      return config::video.max_bitrate;
+    }
+    return bitrate_kbps;
+  }
+
   static auto broadcast_shared = safe::make_shared<broadcast_ctx_t>(start_broadcast, end_broadcast);
 
   session_t *
@@ -1537,11 +1548,14 @@ namespace stream {
       };
 
       switch (param_type_enum) {
-        case video::dynamic_param_type_e::BITRATE:
-          if (validate_and_raise(param_value > 0 && param_value <= 800000, param_value, "bitrate", " Kbps")) {
-            session->current_total_bitrate = param_value;
+        case video::dynamic_param_type_e::BITRATE: {
+          const auto valid_bitrate = param_value > 0 && param_value <= 800000;
+          const auto capped_bitrate = valid_bitrate ? clamp_total_bitrate_to_host_cap(param_value, session->client_name) : param_value;
+          if (validate_and_raise(valid_bitrate, capped_bitrate, "bitrate", " Kbps")) {
+            session->current_total_bitrate = capped_bitrate;
           }
           break;
+        }
         case video::dynamic_param_type_e::QP:
           validate_and_raise(param_value >= 0 && param_value <= 51, param_value, "QP");
           break;
@@ -3245,6 +3259,8 @@ namespace stream {
 
     bool
     change_dynamic_param_for_client(const std::string &client_name, const video::dynamic_param_t &param) {
+      auto effective_param = param;
+
       // 先检查是否有活动的广播引用，避免在无活跃session时
       // 触发start_broadcast/end_broadcast循环（"僵尸广播"），
       // 这可能阻塞HTTPS服务器线程导致客户端显示主机离线
@@ -3263,16 +3279,17 @@ namespace stream {
         if (session_p->client_name == client_name &&
             session_p->state.load(std::memory_order_relaxed) == state_e::RUNNING) {
           // Update session's current total bitrate if this is a bitrate change
-          if (param.type == video::dynamic_param_type_e::BITRATE && param.valid) {
+          if (effective_param.type == video::dynamic_param_type_e::BITRATE && effective_param.valid) {
+            effective_param.value.int_value = clamp_total_bitrate_to_host_cap(effective_param.value.int_value, client_name);
             // The param.value.int_value is the total bitrate (user-configured, including FEC)
-            session_p->current_total_bitrate = param.value.int_value;
+            session_p->current_total_bitrate = effective_param.value.int_value;
             BOOST_LOG(info) << "Updated session total bitrate for client '" << client_name
-                            << "': " << param.value.int_value << " Kbps (including FEC)";
+                            << "': " << effective_param.value.int_value << " Kbps (including FEC)";
           }
 
-          session_p->video.dynamic_param_change_events->raise(param);
+          session_p->video.dynamic_param_change_events->raise(effective_param);
           BOOST_LOG(info) << "Sent dynamic parameter change event to client '" << client_name
-                          << "': type=" << (int) param.type;
+                          << "': type=" << (int) effective_param.type;
           return true;
         }
       }


### PR DESCRIPTION
## Summary
- Treat the host `max_bitrate` setting as a hard ceiling for ABR session configuration.
- Advertise the host bitrate cap in `/api/abr/capabilities` and return effective/requested cap details from `/api/abr`.
- Clamp runtime dynamic bitrate changes through the shared stream path so ABR, runtime APIs, and protocol dynamic bitrate updates cannot exceed the host cap.
- Preserve explicit ABR min/max bounds when only one side is omitted, plus add a regression test for max-only configuration.

Refs #688

## Validation
- `cmake --build build --target sunshine -j 8`
- `ctest --test-dir build --output-on-failure -R Abr` (no tests registered in this build directory)