### PR TITLE
fix(abr): 让 LLM 会话静态状态拥有进程生命周期以避免关机崩溃

### DIFF
--- a/src/abr.cpp
+++ b/src/abr.cpp
@@ -35,6 +35,17 @@ using json = nlohmann::json;
 
 namespace abr {
 
+  // NOTE: sessions are keyed by client_name (the device display name), which is the
+  // identifier that bridges the stateless HTTPS REST endpoints (abrFeedback/
+  // configureAbr resolve the client by source IP) and the streaming layer
+  // (stream::session::change_dynamic_param_for_client also routes by client_name).
+  // Limitation: two concurrently-running sessions that share the same device name
+  // would collide on a single entry and cross-contaminate state. This is acceptable
+  // because single-session deployments are immune and normally-paired devices have
+  // distinct names; supporting multi-session-same-name would require a coordinated
+  // rekey to a session-level id across resolve_client, this map, and
+  // change_dynamic_param_for_client.
+  //
   // The LLM worker runs on a detached thread and may still be in flight (its HTTP
   // call has a 300s timeout) when the process begins shutting down. To avoid a
   // static-destruction-order crash — where the worker reacquires the lock and
@@ -625,6 +636,14 @@ namespace abr {
 
     std::lock_guard lock(sessions_mutex);
     auto it = sessions.find(client_name);
+    // The BOOST_LOG calls below touch the global severity loggers, which (unlike
+    // sessions/sessions_mutex) are destroyed at static teardown. A late worker
+    // logging after logging::deinit() would be a use-after-free. This is safe in
+    // practice: on shutdown the stream session is torn down first, which calls
+    // abr::cleanup() and erases this entry, so the lookup below fails and the
+    // worker returns *before* reaching any BOOST_LOG. The only residual exposure
+    // is an extremely narrow race (entry not yet erased while logging is mid-
+    // deinit), deemed acceptable rather than coupling abr to the shutdown sequence.
     if (it == sessions.end() || it->second.generation != generation) {
       return;  // Session was cleaned up or re-created while LLM was in flight
     }

--- a/src/abr.cpp
+++ b/src/abr.cpp
@@ -35,8 +35,13 @@ using json = nlohmann::json;
 
 namespace abr {
 
-  static std::mutex sessions_mutex;
-  static std::unordered_map<std::string, session_state_t> sessions;
+  // The LLM worker runs on a detached thread and may still be in flight (its HTTP
+  // call has a 300s timeout) when the process begins shutting down. To avoid a
+  // static-destruction-order crash — where the worker reacquires the lock and
+  // touches these globals after they have been destroyed — both are allocated with
+  // process lifetime and intentionally never freed, so a late worker is always safe.
+  static std::mutex &sessions_mutex = *new std::mutex();
+  static std::unordered_map<std::string, session_state_t> &sessions = *new std::unordered_map<std::string, session_state_t>();
 
   /**
    * @brief Sanitize client-provided network feedback values.


### PR DESCRIPTION
## 问题

ABR 的 LLM 决策跑在 **detached 线程**上（[abr.cpp](src/abr.cpp) `process_feedback` 里 `std::thread(llm_worker, ...).detach()`），而其 HTTP 调用的 `CURLOPT_TIMEOUT` 是 300 秒。因此进程开始关闭时，该 worker 可能仍在飞行（最长 5 分钟）。

`llm_worker` 在 curl 返回后会重新获取 `sessions_mutex` 并访问 `sessions` map。如果此时这两个文件作用域静态对象已被销毁（静态析构顺序），就是一次 **use-after-free**，可能导致进程退出时崩溃。

> 注：正常运行期的 use-after-free 已被 `generation` 校验防住（worker 重新加锁后校验 `it->second.generation != generation`）；本问题仅在**关机期撞上在途 LLM 调用**时触发。

## 修复

把 `sessions_mutex` 和 `sessions` 改为**进程生命周期**分配（故意不释放），这样即使有 worker 在关机后才返回，访问的也始终是有效内存。

- 改动仅 2 行（外加注释），通过引用绑定，**所有调用点不变**。
- 一次性泄漏属可接受——这是进程级单例状态，标准做法。
- 不阻塞关机（不需要 join 长达 5 分钟的在途线程）。

## 验证

`ninja sunshine` 编译通过，`abr.cpp.obj` 干净编译，`sunshine.exe` 正常链接。
