### PR TITLE
Improve stream 503 recovery

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -98,6 +98,8 @@ set(SUNSHINE_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/webhook.h"
         "${CMAKE_SOURCE_DIR}/src/nvhttp.cpp"
         "${CMAKE_SOURCE_DIR}/src/nvhttp.h"
+        "${CMAKE_SOURCE_DIR}/src/nvhttp_stream_start.cpp"
+        "${CMAKE_SOURCE_DIR}/src/nvhttp_stream_start.h"
         "${CMAKE_SOURCE_DIR}/src/abr.cpp"
         "${CMAKE_SOURCE_DIR}/src/abr.h"
         "${CMAKE_SOURCE_DIR}/src/httpcommon.cpp"

--- a/src/display_device/session.cpp
+++ b/src/display_device/session.cpp
@@ -273,9 +273,51 @@ namespace display_device {
 
       return false;
     }
+
+    session_t::configure_result_t
+    make_apply_configure_result(settings_t::apply_result_t apply_result) {
+      using configure_result_e = session_t::configure_result_t::result_e;
+      using apply_result_e = settings_t::apply_result_t::result_e;
+
+      configure_result_e result { configure_result_e::success };
+      std::string hint { "Try setting the display, resolution, refresh rate, HDR, and VDD options to Auto, then start the session again." };
+
+      switch (apply_result.result) {
+        case apply_result_e::success:
+          result = configure_result_e::success;
+          hint = {};
+          break;
+        case apply_result_e::topology_fail:
+          result = configure_result_e::topology_fail;
+          hint = "Check that the target display or virtual display is available, then set display/VDD options to Auto and try again.";
+          break;
+        case apply_result_e::primary_display_fail:
+          result = configure_result_e::primary_display_fail;
+          hint = "Set the target display to Auto or choose a connected display that Windows can make primary.";
+          break;
+        case apply_result_e::modes_fail:
+          result = configure_result_e::modes_fail;
+          hint = "Choose a resolution and refresh rate supported by the display, or set resolution and FPS to Auto.";
+          break;
+        case apply_result_e::hdr_states_fail:
+          result = configure_result_e::hdr_states_fail;
+          hint = "Disable HDR for this session or make sure the selected display supports the requested HDR mode.";
+          break;
+        case apply_result_e::file_save_fail:
+          result = configure_result_e::file_save_fail;
+          hint = "Check Sunshine's app data folder permissions and free disk space, then try again.";
+          break;
+        case apply_result_e::revert_fail:
+          result = configure_result_e::revert_fail;
+          hint = "Restore Windows display settings manually or reset Sunshine display persistence before retrying.";
+          break;
+      }
+
+      return { result, apply_result.get_error_message(), hint };
+    }
   }  // namespace
 
-  void
+  session_t::configure_result_t
   session_t::configure_display(const config::video_t &config,
     const rtsp_stream::launch_session_t &session,
     bool is_reconfigure) {
@@ -356,7 +398,11 @@ namespace display_device {
     const auto parsed_config = make_parsed_config(config, session, is_reconfigure);
     if (!parsed_config) {
       BOOST_LOG(error) << "Failed to parse configuration for the display device settings!";
-      return;
+      return {
+        configure_result_t::result_e::parse_fail,
+        "Failed to parse display configuration.",
+        "Set display, VDD, resolution, refresh rate, and HDR options to Auto or valid values, then try again."
+      };
     }
 
     // 保存当前会话的配置模式（可能包含客户端的override）
@@ -381,15 +427,21 @@ namespace display_device {
       });
 
       BOOST_LOG(warning) << "It is already known that display settings cannot be changed. Allowing stream to start without changing the settings, but will retry changing settings later...";
-      return;
+      return {
+        configure_result_t::result_e::deferred_retry,
+        "Display settings cannot be changed yet; Sunshine will retry while the stream starts.",
+        "Unlock the desktop, make sure Windows display settings are available, and Sunshine will retry automatically."
+      };
     }
 
-    if (settings.apply_config(*parsed_config, session, pre_saved_initial_topology)) {
+    const auto apply_result = settings.apply_config(*parsed_config, session, pre_saved_initial_topology);
+    if (apply_result) {
       timer->setup_timer(nullptr);
+      return make_apply_configure_result(apply_result);
     }
-    else {
-      restore_state_impl(revert_reason_e::config_cleanup);
-    }
+
+    restore_state_impl(revert_reason_e::config_cleanup);
+    return make_apply_configure_result(apply_result);
   }
 
   bool

--- a/src/display_device/session.cpp
+++ b/src/display_device/session.cpp
@@ -398,6 +398,7 @@ namespace display_device {
     const auto parsed_config = make_parsed_config(config, session, is_reconfigure);
     if (!parsed_config) {
       BOOST_LOG(error) << "Failed to parse configuration for the display device settings!";
+      restore_state_impl(revert_reason_e::config_cleanup);
       return {
         configure_result_t::result_e::parse_fail,
         "Failed to parse display configuration.",
@@ -411,13 +412,15 @@ namespace display_device {
     current_use_vdd = parsed_config->use_vdd;
 
     if (settings.is_changing_settings_going_to_fail()) {
-      timer->setup_timer([this, config_copy = *parsed_config, &session, pre_saved_initial_topology]() {
+      timer->setup_timer([this, config_copy = *parsed_config, client_name = session.client_name, pre_saved_initial_topology]() {
         if (settings.is_changing_settings_going_to_fail()) {
           BOOST_LOG(warning) << "Applying display settings will fail - retrying later...";
           return false;
         }
 
-        if (!settings.apply_config(config_copy, session, pre_saved_initial_topology)) {
+        auto retry_session = rtsp_stream::launch_session_t {};
+        retry_session.client_name = client_name;
+        if (!settings.apply_config(config_copy, retry_session, pre_saved_initial_topology)) {
           BOOST_LOG(warning) << "Failed to apply display settings - will stop trying, but will allow stream to continue.";
           // WARNING! After call to the method below, this lambda function is no longer valid!
           // DO NOT access anything from the capture list!

--- a/src/display_device/session.h
+++ b/src/display_device/session.h
@@ -2,6 +2,7 @@
 
 // standard includes
 #include <mutex>
+#include <string>
 // lib includes
 #include <boost/atomic.hpp>
 // local includes
@@ -64,6 +65,32 @@ namespace display_device {
     init();
 
     /**
+     * @brief Result of trying to prepare display settings for a stream.
+     */
+    struct configure_result_t {
+      enum class result_e {
+        success,
+        deferred_retry,
+        parse_fail,
+        topology_fail,
+        primary_display_fail,
+        modes_fail,
+        hdr_states_fail,
+        file_save_fail,
+        revert_fail
+      };
+
+      explicit
+      operator bool() const {
+        return result == result_e::success || result == result_e::deferred_retry;
+      }
+
+      result_e result;
+      std::string message;
+      std::string hint;
+    };
+
+    /**
      * @brief Configure the display device based on the user configuration and the session information.
      *
      * Upon failing to completely apply configuration, the applied settings will be reverted.
@@ -72,19 +99,18 @@ namespace display_device {
      *
      * @param config User's video related configuration.
      * @param session Session information.
-     * @note There is no return value as we still want to continue with the stream, so that
-     *       users can do something about it once they are connected. Otherwise, we might
-     *       prevent users from logging in at all...
+     * @returns A result describing whether the display configuration was applied, deferred,
+     *          or failed. Callers may continue with the stream when appropriate.
      *
      * EXAMPLES:
      * ```cpp
      * const std::shared_ptr<rtsp_stream::launch_session_t> launch_session; // Assuming ptr is properly initialized
      * const config::video_t &video_config { config::video };
      *
-     * session_t::get().configure_display(video_config, *launch_session);
+     * const auto result = session_t::get().configure_display(video_config, *launch_session);
      * ```
      */
-    void
+    configure_result_t
     configure_display(const config::video_t &config, const rtsp_stream::launch_session_t &session, bool is_reconfigure = false);
 
     /**

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -7,6 +7,7 @@
 
 // standard includes
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <filesystem>
 #include <map>
@@ -41,6 +42,7 @@
 #include "logging.h"
 #include "network.h"
 #include "nvhttp.h"
+#include "nvhttp_stream_start.h"
 #include "platform/common.h"
 #include "platform/run_command.h"
 #include "process.h"
@@ -1905,18 +1907,10 @@ namespace nvhttp {
       // We want to prepare display only if there are no active sessions at
       // the moment. This should to be done before probing encoders as it could
       // change display device's state.
-      display_device::session_t::get().configure_display(config::video, *launch_session, true);
-
       // The display should be restored by the fail guard in case something happens.
       need_to_restore_display_state = true;
 
-      // Probe encoders again before streaming to ensure our chosen
-      // encoder matches the active GPU (which could have changed
-      // due to hotplugging, driver crash, primary monitor change,
-      // or any number of other factors).
-      if (video::probe_encoders()) {
-        tree.put("root.<xmlattr>.status_code", 503);
-        tree.put("root.<xmlattr>.status_message", "Failed to initialize video capture/encoding. Is a display connected and turned on?");
+      if (!stream_start::prepare_display_and_probe_encoders(tree, *launch_session, true)) {
         tree.put("root.gamesession", 0);
 
         return;
@@ -2001,8 +1995,16 @@ namespace nvhttp {
     auto current_appid = proc::proc.running();
     if (current_appid == 0) {
       tree.put("root.resume", 0);
-      tree.put("root.<xmlattr>.status_code", 503);
-      tree.put("root.<xmlattr>.status_message", "No running app to resume");
+      stream_start::set_sunshine_error(
+        tree,
+        503,
+        "There is no running app to resume. Start the app again from the client.",
+        "NO_APP_TO_RESUME",
+        "The previous session is no longer active or was already stopped.",
+        "relaunch_app_from_client",
+        "session",
+        "resume",
+        true);
 
       return;
     }
@@ -2037,16 +2039,8 @@ namespace nvhttp {
       // We want to prepare display only if there are no active sessions at
       // the moment. This should be done before probing encoders as it could
       // change the active displays.
-      display_device::session_t::get().configure_display(config::video, *launch_session, false);
-
-      // Probe encoders again before streaming to ensure our chosen
-      // encoder matches the active GPU (which could have changed
-      // due to hotplugging, driver crash, primary monitor change,
-      // or any number of other factors).
-      if (video::probe_encoders()) {
+      if (!stream_start::prepare_display_and_probe_encoders(tree, *launch_session, false)) {
         tree.put("root.resume", 0);
-        tree.put("root.<xmlattr>.status_code", 503);
-        tree.put("root.<xmlattr>.status_message", "Failed to initialize video capture/encoding. Is a display connected and turned on?");
 
         return;
       }

--- a/src/nvhttp_stream_start.cpp
+++ b/src/nvhttp_stream_start.cpp
@@ -33,6 +33,8 @@ namespace nvhttp::stream_start {
 
     class temporary_video_config_t {
     public:
+      // This is only used while preparing a launch when no active RTSP session is
+      // running, so the temporary global config swap cannot race stream encoding.
       explicit temporary_video_config_t(config::video_t replacement):
           original_config { config::video } {
         config::video = std::move(replacement);
@@ -210,6 +212,8 @@ namespace nvhttp::stream_start {
     void
     fill_vdd_recovery_session(rtsp_stream::launch_session_t &recovery_session,
       const rtsp_stream::launch_session_t &launch_session) {
+      // launch_session_t is not copy-assignable because RTSP cipher state is
+      // move-only, so copy only the launch fields needed for display probing.
       recovery_session.id = launch_session.id;
       recovery_session.gcm_key = launch_session.gcm_key;
       recovery_session.iv = launch_session.iv;
@@ -387,6 +391,8 @@ namespace nvhttp::stream_start {
     }
 
     if (recovery_result.attempted) {
+      // A failed display-level recovery already tried the strongest display
+      // fallback. Keep that result instead of masking it with encoder-only fixes.
       set_auto_recovery_status(tree, recovery_result);
     }
     else if (retry_deferred_display_config(launch_session, is_reconfigure, display_result, recovery_result) ||

--- a/src/nvhttp_stream_start.cpp
+++ b/src/nvhttp_stream_start.cpp
@@ -1,0 +1,415 @@
+/**
+ * @file src/nvhttp_stream_start.cpp
+ * @brief Stream startup diagnostics and low-risk recovery for GameStream launch/resume.
+ */
+
+// standard includes
+#include <array>
+#include <chrono>
+#include <string>
+#include <thread>
+#include <utility>
+
+// local includes
+#include "nvhttp_stream_start.h"
+
+#include "config.h"
+#include "display_device/session.h"
+#include "logging.h"
+#include "video.h"
+
+namespace nvhttp::stream_start {
+
+  namespace pt = boost::property_tree;
+
+  namespace {
+
+    struct auto_recovery_result_t {
+      bool attempted { false };
+      bool succeeded { false };
+      std::string action;
+      std::string detail;
+    };
+
+    class temporary_video_config_t {
+    public:
+      explicit temporary_video_config_t(config::video_t replacement):
+          original_config { config::video } {
+        config::video = std::move(replacement);
+      }
+
+      ~temporary_video_config_t() {
+        config::video = std::move(original_config);
+      }
+
+      temporary_video_config_t(const temporary_video_config_t &) = delete;
+      temporary_video_config_t &
+      operator=(const temporary_video_config_t &) = delete;
+
+    private:
+      config::video_t original_config;
+    };
+
+    void
+    set_auto_recovery_status(pt::ptree &tree, const auto_recovery_result_t &recovery_result) {
+      if (!recovery_result.attempted) {
+        return;
+      }
+
+      tree.put("root.sunshine_auto_recovery_attempted", 1);
+      tree.put("root.sunshine_auto_recovery_action", recovery_result.action);
+      tree.put("root.sunshine_auto_recovery_result", recovery_result.succeeded ? "succeeded" : "failed");
+      tree.put("root.sunshine_auto_recovery_detail", recovery_result.detail);
+    }
+
+    std::string
+    video_probe_error_code(video::probe_error_e error) {
+      switch (error) {
+        case video::probe_error_e::no_active_display:
+          return "NO_ACTIVE_DISPLAY";
+        case video::probe_error_e::configured_encoder_unavailable:
+          return "CONFIGURED_ENCODER_UNAVAILABLE";
+        case video::probe_error_e::codec_requirements_unmet:
+          return "CODEC_REQUIREMENTS_UNMET";
+        case video::probe_error_e::no_working_encoder:
+          return "NO_WORKING_ENCODER";
+        case video::probe_error_e::none:
+        default:
+          return "VIDEO_INITIALIZATION_FAILED";
+      }
+    }
+
+    std::string
+    display_config_error_code(display_device::session_t::configure_result_t::result_e result) {
+      using result_e = display_device::session_t::configure_result_t::result_e;
+
+      switch (result) {
+        case result_e::parse_fail:
+          return "DISPLAY_CONFIG_PARSE_FAILED";
+        case result_e::topology_fail:
+          return "DISPLAY_TOPOLOGY_FAILED";
+        case result_e::primary_display_fail:
+          return "DISPLAY_PRIMARY_FAILED";
+        case result_e::modes_fail:
+          return "DISPLAY_MODE_FAILED";
+        case result_e::hdr_states_fail:
+          return "DISPLAY_HDR_FAILED";
+        case result_e::file_save_fail:
+          return "DISPLAY_PERSISTENCE_SAVE_FAILED";
+        case result_e::revert_fail:
+          return "DISPLAY_REVERT_FAILED";
+        case result_e::deferred_retry:
+          return "DISPLAY_CONFIG_DEFERRED";
+        case result_e::success:
+        default:
+          return "DISPLAY_CONFIG_FAILED";
+      }
+    }
+
+    void
+    set_display_config_error(pt::ptree &tree, const display_device::session_t::configure_result_t &display_result) {
+      const std::string status_message = display_result.message.empty() ?
+                                           "Sunshine could not apply the requested display configuration." :
+                                           display_result.message;
+      const std::string hint = display_result.hint.empty() ?
+                                 "Set display, VDD, resolution, refresh rate, and HDR options to Auto, then try again." :
+                                 display_result.hint;
+
+      set_sunshine_error(
+        tree,
+        503,
+        status_message,
+        display_config_error_code(display_result.result),
+        hint,
+        "review_display_settings",
+        "display",
+        "display_configuration",
+        true);
+    }
+
+    void
+    set_video_probe_error(pt::ptree &tree) {
+      const auto &probe_result = video::last_encoder_probe_result;
+      const std::string status_message = probe_result.message.empty() ?
+                                           "Sunshine could not initialize display capture or video encoding." :
+                                           probe_result.message;
+      const std::string hint = probe_result.hint.empty() ?
+                                 "Check that a display or VDD is active, set GPU/display/encoder options to Auto, and try again." :
+                                 probe_result.hint;
+
+      set_sunshine_error(
+        tree,
+        503,
+        status_message,
+        video_probe_error_code(probe_result.error),
+        hint,
+        "review_video_display_settings",
+        "video",
+        "encoder_probe",
+        true);
+    }
+
+    bool
+    retry_deferred_display_config(
+      const rtsp_stream::launch_session_t &launch_session,
+      bool is_reconfigure,
+      display_device::session_t::configure_result_t &display_result,
+      auto_recovery_result_t &recovery_result) {
+      if (display_result.result != display_device::session_t::configure_result_t::result_e::deferred_retry) {
+        return false;
+      }
+
+      recovery_result = {
+        true,
+        false,
+        "deferred_display_retry",
+        "Display configuration was deferred; retrying briefly before returning an error."
+      };
+
+      constexpr std::array retry_delays {
+        std::chrono::milliseconds { 500 },
+        std::chrono::milliseconds { 1000 },
+        std::chrono::milliseconds { 1500 }
+      };
+
+      for (const auto delay : retry_delays) {
+        std::this_thread::sleep_for(delay);
+        display_result = display_device::session_t::get().configure_display(config::video, launch_session, is_reconfigure);
+        if (!video::probe_encoders()) {
+          recovery_result.succeeded = true;
+          recovery_result.detail = "Display configuration became available after a short retry.";
+          BOOST_LOG(info) << "Recovered stream startup after deferred display configuration retry";
+          return true;
+        }
+      }
+
+      recovery_result.detail = "Display configuration was still unavailable after short retries.";
+      return false;
+    }
+
+    bool
+    should_try_vdd_for_display_config(display_device::session_t::configure_result_t::result_e result) {
+      using result_e = display_device::session_t::configure_result_t::result_e;
+
+      switch (result) {
+        case result_e::topology_fail:
+        case result_e::primary_display_fail:
+        case result_e::modes_fail:
+        case result_e::hdr_states_fail:
+          return true;
+        case result_e::success:
+        case result_e::deferred_retry:
+        case result_e::parse_fail:
+        case result_e::file_save_fail:
+        case result_e::revert_fail:
+        default:
+          return false;
+      }
+    }
+
+    void
+    fill_vdd_recovery_session(rtsp_stream::launch_session_t &recovery_session,
+      const rtsp_stream::launch_session_t &launch_session) {
+      recovery_session.id = launch_session.id;
+      recovery_session.gcm_key = launch_session.gcm_key;
+      recovery_session.iv = launch_session.iv;
+      recovery_session.av_ping_payload = launch_session.av_ping_payload;
+      recovery_session.control_connect_data = launch_session.control_connect_data;
+      recovery_session.env = launch_session.env;
+      recovery_session.host_audio = launch_session.host_audio;
+      recovery_session.unique_id = launch_session.unique_id;
+      recovery_session.client_name = launch_session.client_name;
+      recovery_session.width = launch_session.width;
+      recovery_session.height = launch_session.height;
+      recovery_session.fps = launch_session.fps;
+      recovery_session.gcmap = launch_session.gcmap;
+      recovery_session.appid = launch_session.appid;
+      recovery_session.surround_info = launch_session.surround_info;
+      recovery_session.surround_params = launch_session.surround_params;
+      recovery_session.continuous_audio = launch_session.continuous_audio;
+      recovery_session.enable_hdr = launch_session.enable_hdr;
+      recovery_session.enable_sops = launch_session.enable_sops;
+      recovery_session.enable_mic = launch_session.enable_mic;
+      recovery_session.use_vdd = true;
+      recovery_session.custom_screen_mode = launch_session.custom_screen_mode;
+      recovery_session.max_nits = launch_session.max_nits;
+      recovery_session.min_nits = launch_session.min_nits;
+      recovery_session.max_full_nits = launch_session.max_full_nits;
+      recovery_session.rtsp_url_scheme = launch_session.rtsp_url_scheme;
+      recovery_session.rtsp_iv_counter = launch_session.rtsp_iv_counter;
+      recovery_session.setup_video = launch_session.setup_video;
+      recovery_session.setup_audio = launch_session.setup_audio;
+      recovery_session.setup_control = launch_session.setup_control;
+      recovery_session.setup_mic = launch_session.setup_mic;
+      recovery_session.control_only = launch_session.control_only;
+      recovery_session.env["SUNSHINE_CLIENT_USE_VDD"] = "true";
+    }
+
+    void
+    commit_vdd_recovery_to_launch_session(rtsp_stream::launch_session_t &launch_session) {
+      launch_session.use_vdd = true;
+      launch_session.env["SUNSHINE_CLIENT_USE_VDD"] = "true";
+      launch_session.env["SUNSHINE_CLIENT_DISPLAY_NAME"] = config::video.output_name;
+    }
+
+    bool
+    recover_display_with_vdd(
+      rtsp_stream::launch_session_t &launch_session,
+      bool is_reconfigure,
+      display_device::session_t::configure_result_t &display_result,
+      auto_recovery_result_t &recovery_result) {
+      const bool no_active_display = video::last_encoder_probe_result.error == video::probe_error_e::no_active_display;
+      const bool display_config_mismatch = should_try_vdd_for_display_config(display_result.result);
+      if (!no_active_display && !display_config_mismatch) {
+        return false;
+      }
+
+      recovery_result = {
+        true,
+        false,
+        "vdd_display_recovery",
+        display_config_mismatch ?
+          "The physical display could not satisfy the requested stream display settings; trying a VDD-backed display." :
+          "No active display was available; trying a VDD-backed display recovery."
+      };
+
+      const auto original_display_result = display_result;
+      rtsp_stream::launch_session_t recovery_session {};
+      fill_vdd_recovery_session(recovery_session, launch_session);
+
+      display_result = display_device::session_t::get().configure_display(config::video, recovery_session, is_reconfigure);
+      if (!video::probe_encoders()) {
+        commit_vdd_recovery_to_launch_session(launch_session);
+        recovery_result.succeeded = true;
+        recovery_result.detail = "A VDD-backed display became available and encoder probing succeeded.";
+        BOOST_LOG(info) << "Recovered stream startup by preparing a VDD-backed display";
+        return true;
+      }
+
+      display_result = original_display_result;
+      recovery_result.detail = "VDD-backed display recovery was attempted, but encoder probing still failed.";
+      return false;
+    }
+
+    bool
+    recover_with_temporary_encoder_config(auto_recovery_result_t &recovery_result) {
+      const auto probe_error = video::last_encoder_probe_result.error;
+      if (probe_error != video::probe_error_e::configured_encoder_unavailable &&
+          probe_error != video::probe_error_e::codec_requirements_unmet) {
+        return false;
+      }
+
+      const auto original_probe_result = video::last_encoder_probe_result;
+      auto fallback_config = config::video;
+      if (probe_error == video::probe_error_e::configured_encoder_unavailable) {
+        fallback_config.encoder.clear();
+        recovery_result = {
+          true,
+          false,
+          "temporary_auto_encoder_fallback",
+          "The configured encoder was unavailable; trying Auto encoder for this startup."
+        };
+      }
+      else {
+        fallback_config.hevc_mode = 1;
+        fallback_config.av1_mode = 1;
+        recovery_result = {
+          true,
+          false,
+          "temporary_h264_fallback",
+          "The requested HEVC/AV1 requirements were unavailable; trying H.264 for this startup."
+        };
+      }
+
+      {
+        temporary_video_config_t temporary_config { std::move(fallback_config) };
+        if (!video::probe_encoders()) {
+          recovery_result.succeeded = true;
+          recovery_result.detail = "Temporary encoder fallback succeeded without changing the saved configuration.";
+          BOOST_LOG(info) << "Recovered stream startup using " << recovery_result.action;
+          return true;
+        }
+      }
+
+      recovery_result.detail = "Temporary encoder fallback was attempted, but encoder probing still failed.";
+      video::last_encoder_probe_result = original_probe_result;
+      return false;
+    }
+
+  }  // namespace
+
+  void
+  set_sunshine_error(
+    pt::ptree &tree,
+    int status_code,
+    const std::string &status_message,
+    const std::string &error_code,
+    const std::string &hint,
+    const std::string &recovery_action,
+    const std::string &source,
+    const std::string &stage,
+    bool recoverable) {
+    std::string client_status_message = status_message;
+    if (!hint.empty() && client_status_message.find(hint) == std::string::npos) {
+      client_status_message += " ";
+      client_status_message += hint;
+    }
+
+    tree.put("root.<xmlattr>.status_code", status_code);
+    tree.put("root.<xmlattr>.status_message", client_status_message);
+    tree.put("root.sunshine_error_code", error_code);
+    tree.put("root.sunshine_error_hint", hint);
+    tree.put("root.sunshine_recovery_action", recovery_action);
+    tree.put("root.sunshine_error_source", source);
+    tree.put("root.sunshine_error_stage", stage);
+    tree.put("root.sunshine_recoverable", recoverable ? 1 : 0);
+  }
+
+  bool
+  prepare_display_and_probe_encoders(
+    pt::ptree &tree,
+    rtsp_stream::launch_session_t &launch_session,
+    bool is_reconfigure) {
+    // Display configuration can change the active capture target, so probe
+    // encoders only after the display stack has settled.
+    auto display_result = display_device::session_t::get().configure_display(config::video, launch_session, is_reconfigure);
+    auto_recovery_result_t recovery_result;
+
+    if (should_try_vdd_for_display_config(display_result.result) &&
+        recover_display_with_vdd(launch_session, is_reconfigure, display_result, recovery_result)) {
+      set_auto_recovery_status(tree, recovery_result);
+      return true;
+    }
+
+    if (!video::probe_encoders()) {
+      set_auto_recovery_status(tree, recovery_result);
+      return true;
+    }
+
+    if (recovery_result.attempted) {
+      set_auto_recovery_status(tree, recovery_result);
+    }
+    else if (retry_deferred_display_config(launch_session, is_reconfigure, display_result, recovery_result) ||
+        recover_display_with_vdd(launch_session, is_reconfigure, display_result, recovery_result) ||
+        recover_with_temporary_encoder_config(recovery_result)) {
+      set_auto_recovery_status(tree, recovery_result);
+      return true;
+    }
+
+    set_auto_recovery_status(tree, recovery_result);
+
+    const bool deferred_display_likely_caused_probe_failure =
+      display_result.result == display_device::session_t::configure_result_t::result_e::deferred_retry &&
+      video::last_encoder_probe_result.error == video::probe_error_e::no_active_display;
+
+    if (!display_result || deferred_display_likely_caused_probe_failure) {
+      set_display_config_error(tree, display_result);
+    }
+    else {
+      set_video_probe_error(tree);
+    }
+
+    return false;
+  }
+
+}  // namespace nvhttp::stream_start

--- a/src/nvhttp_stream_start.h
+++ b/src/nvhttp_stream_start.h
@@ -1,0 +1,32 @@
+/**
+ * @file src/nvhttp_stream_start.h
+ * @brief Helpers for GameStream launch/resume display preparation, encoder probing, and startup recovery.
+ */
+#pragma once
+
+#include "rtsp.h"
+
+#include <boost/property_tree/ptree.hpp>
+#include <string>
+
+namespace nvhttp::stream_start {
+
+  void
+  set_sunshine_error(
+    boost::property_tree::ptree &tree,
+    int status_code,
+    const std::string &status_message,
+    const std::string &error_code,
+    const std::string &hint,
+    const std::string &recovery_action,
+    const std::string &source,
+    const std::string &stage,
+    bool recoverable);
+
+  bool
+  prepare_display_and_probe_encoders(
+    boost::property_tree::ptree &tree,
+    rtsp_stream::launch_session_t &launch_session,
+    bool is_reconfigure);
+
+}  // namespace nvhttp::stream_start

--- a/src/platform/windows/display_device/settings.cpp
+++ b/src/platform/windows/display_device/settings.cpp
@@ -983,7 +983,7 @@ namespace display_device {
       }
 
       if (config.change_hdr_state) {
-        std::thread { [&client_name = session.client_name]() {
+        std::thread { [client_name = session.client_name]() {
           if (!display_device::apply_hdr_profile(client_name)) {
             BOOST_LOG(warning) << "Failed to apply HDR profile for client: " << client_name << "retrying later...";
             std::this_thread::sleep_for(2s);

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -89,6 +89,11 @@ namespace video {
       }
 
       BOOST_LOG(error) << "No display devices are active at the moment! Cannot probe the encoders.";
+      last_encoder_probe_result = {
+        probe_error_e::no_active_display,
+        "No active display devices are available for capture.",
+        "Turn on a physical display, enable a virtual display, or set Sunshine display/VDD options to Auto and try again."
+      };
       return false;
     }
   }  // namespace
@@ -1266,6 +1271,11 @@ namespace video {
   int active_av1_mode;
   bool last_encoder_probe_supported_ref_frames_invalidation = false;
   std::array<bool, 3> last_encoder_probe_supported_yuv444_for_codec = {};
+  probe_result_t last_encoder_probe_result {
+    probe_error_e::none,
+    "Encoder probe succeeded.",
+    {}
+  };
 
   void
   reset_display(std::shared_ptr<platf::display_t> &disp, const platf::mem_type_e &type, const std::string &display_name, const config_t &config) {
@@ -3687,6 +3697,12 @@ namespace video {
 
   int
   probe_encoders() {
+    last_encoder_probe_result = {
+      probe_error_e::none,
+      "Encoder probe succeeded.",
+      {}
+    };
+
     if (!allow_encoder_probing()) {
       // Error already logged
       return -1;
@@ -3815,6 +3831,27 @@ namespace video {
     if (chosen_encoder == nullptr) {
       const auto output_display_name { display_device::get_display_name(config::video.output_name) };
       BOOST_LOG(error) << "Unable to find display or encoder during startup."sv;
+      if (!config::video.encoder.empty()) {
+        last_encoder_probe_result = {
+          probe_error_e::configured_encoder_unavailable,
+          "The configured video encoder is not available on this system.",
+          "Set the video encoder to Auto, update the GPU driver, or choose an encoder supported by the active GPU."
+        };
+      }
+      else if (config::video.hevc_mode >= 2 || config::video.av1_mode >= 2) {
+        last_encoder_probe_result = {
+          probe_error_e::codec_requirements_unmet,
+          "No working encoder satisfies the requested HEVC or AV1 requirements.",
+          "Set HEVC/AV1 support to Auto or Disabled, or use H.264 and try again."
+        };
+      }
+      else {
+        last_encoder_probe_result = {
+          probe_error_e::no_working_encoder,
+          "Sunshine could not find a working display capture path and video encoder.",
+          "Check that a display is connected or VDD is active, set GPU/display/encoder options to Auto, and update the GPU driver."
+        };
+      }
       if (!config::video.adapter_name.empty() || !output_display_name.empty()) {
         BOOST_LOG(error) << "Please ensure your manually chosen GPU and monitor are connected and powered on."sv;
       }

--- a/src/video.h
+++ b/src/video.h
@@ -9,6 +9,8 @@
 #include "thread_safe.h"
 #include "video_colorspace.h"
 
+#include <string>
+
 extern "C" {
 #include <libavcodec/avcodec.h>
 #include <libswscale/swscale.h>
@@ -425,6 +427,26 @@ namespace video {
   extern int active_av1_mode;
   extern bool last_encoder_probe_supported_ref_frames_invalidation;
   extern std::array<bool, 3> last_encoder_probe_supported_yuv444_for_codec;  // 0 - H.264, 1 - HEVC, 2 - AV1
+
+  enum class probe_error_e {
+    none,
+    no_active_display,
+    configured_encoder_unavailable,
+    codec_requirements_unmet,
+    no_working_encoder
+  };
+
+  struct probe_result_t {
+    probe_error_e error;
+    std::string message;
+    std::string hint;
+
+    explicit operator bool() const {
+      return error == probe_error_e::none;
+    }
+  };
+
+  extern probe_result_t last_encoder_probe_result;
 
   void
   capture(


### PR DESCRIPTION
## 改了啥呀

- 把串流启动阶段的 display configure + encoder probe 逻辑从 `nvhttp.cpp` 拆到 `nvhttp_stream_start`，让 503 处理集中一点。
- 为 `/launch` 和 `/resume` 的 503 响应补充结构化 `sunshine_error_*` 字段，同时保留更可读的 `status_message`。
- 给 display 配置失败、无活动显示器、指定编码器不可用、codec 要求不满足这些场景加了自动恢复尝试。
- 当物理显示器不满足客户端要求或没有可用显示器时，会主动尝试 VDD；VDD 恢复成功后同步回真实 launch session，避免只是 probe 成功但后续串流没用上。
- encoder 和 codec fallback 都是临时 probe 配置，不会持久改用户配置。

## 为啥要改

用户进入串流时看到 503 太像一句冷冰冰的“杂鱼状态”，不知道是显示器、编码器还是 codec 条件导致的。这个 PR 让服务端先尽量自愈；自愈不了时，也把失败来源、建议动作和是否可恢复告诉客户端，后续 UI 可以更明确地提示用户。

## 影响面

- 主要影响 `/launch` 和 `/resume` 串流启动路径。
- 控制面板 proxy 的 503 没有改。
- `probe_encoders()` 签名不变，只新增最后一次 probe 失败原因元数据。
- `configure_display()` 改为返回结果对象；现有忽略返回值的调用点保持可编译、行为不变。
- XML 响应新增字段，旧客户端应按未知字段忽略。

## 验证

- `git diff --cached --check`
- `ninja -C build sunshine`
- `ctest --test-dir build -N`，当前 build 目录没有注册测试。