### PR TITLE
Fix VDD recovery fallback

### DIFF
--- a/src/nvhttp_stream_start.cpp
+++ b/src/nvhttp_stream_start.cpp
@@ -383,14 +383,15 @@ namespace nvhttp::stream_start {
     // encoders only after the display stack has settled.
     auto display_result = display_device::session_t::get().configure_display(config::video, launch_session, is_reconfigure);
     auto_recovery_result_t recovery_result;
+    const auto should_try_vdd = should_try_vdd_for_display_config(display_result.result);
 
-    if (should_try_vdd_for_display_config(display_result.result) &&
+    if (should_try_vdd &&
         recover_display_with_vdd(launch_session, is_reconfigure, display_result, recovery_result)) {
       set_auto_recovery_status(tree, recovery_result);
       return true;
     }
 
-    if (should_try_vdd_for_display_config(display_result.result)) {
+    if (should_try_vdd) {
       set_auto_recovery_status(tree, recovery_result);
       set_display_config_error(tree, display_result);
       return false;

--- a/src/nvhttp_stream_start.cpp
+++ b/src/nvhttp_stream_start.cpp
@@ -282,6 +282,11 @@ namespace nvhttp::stream_start {
       fill_vdd_recovery_session(recovery_session, launch_session);
 
       display_result = display_device::session_t::get().configure_display(config::video, recovery_session, is_reconfigure);
+      if (display_result.result != display_device::session_t::configure_result_t::result_e::success) {
+        recovery_result.detail = "VDD-backed display recovery was attempted, but the VDD display configuration failed.";
+        return false;
+      }
+
       if (!video::probe_encoders()) {
         commit_vdd_recovery_to_launch_session(launch_session);
         recovery_result.succeeded = true;
@@ -383,6 +388,12 @@ namespace nvhttp::stream_start {
         recover_display_with_vdd(launch_session, is_reconfigure, display_result, recovery_result)) {
       set_auto_recovery_status(tree, recovery_result);
       return true;
+    }
+
+    if (should_try_vdd_for_display_config(display_result.result)) {
+      set_auto_recovery_status(tree, recovery_result);
+      set_display_config_error(tree, display_result);
+      return false;
     }
 
     if (!video::probe_encoders()) {


### PR DESCRIPTION
## 改了啥呀

- 修正 PR #698 引入的 VDD recovery 控制流。
- VDD-backed display recovery 现在必须等 `configure_display()` 真正成功后，才会继续 probe encoder 并把 launch session 标记为 VDD。
- 如果 VDD 配置失败，会直接返回结构化 503 的 display config 错误，不再静默回退到物理显示器继续串流。

## 为啥要改

Fixes #700。

issue 日志显示 VDD 实际已经创建成功，但在设置 `1280x720x60` 时 Windows CCD 返回 `ERROR_GEN_FAILURE` 和 `1610`。旧逻辑随后仍然对物理显示器 probe 成功，并错误记录 `Recovered stream startup by preparing a VDD-backed display`，导致会话继续启动但最终捕获 `\\.\DISPLAY1`，表现为用户要求的 VDD 没有生效。

## 验证

- `git diff --check`
- 这次改动在独立 worktree `C:\tmp\sunshine-hotfix-700` 完成，避免影响当前本地 `codex/display-scale-endpoints` 工作区。