### PR TITLE
feat(amf): add multi-HW instance encoder option

### DIFF
--- a/src/amf/amf_config.h
+++ b/src/amf/amf_config.h
@@ -83,6 +83,12 @@ namespace amf {
     // For QVBR rate control mode: quality level 1-51 (lower=better)
     std::optional<int> qvbr_quality_level;
 
+    // --- Multi-HW instance encode / Smart Access Video ---
+    // Default nullopt = do not set the property, let the driver decide.
+    // H.264 exposes only Smart Access Video; HEVC/AV1 expose both SAV and
+    // explicit multi-HW instance encode properties.
+    std::optional<bool> multi_hw_instance_encode;
+
     // --- AV1 Encoding Latency Mode ---
     // AMF_VIDEO_ENCODER_AV1_ENCODING_LATENCY_MODE_ENUM: 0=none, 1=power saving RT, 2=RT, 3=lowest latency
     std::optional<int> av1_encoding_latency_mode;

--- a/src/amf/amf_d3d11.cpp
+++ b/src/amf/amf_d3d11.cpp
@@ -135,6 +135,41 @@ namespace amf {
     // legacy Sunshine peak/VBV constraints paired with the selected RC mode.
     user_configured_rate_control = config.rc_mode.has_value();
 
+    auto configure_multi_hw_instance = [&](const wchar_t *multi_hw_property,
+                                           const wchar_t *sav_property,
+                                           const wchar_t *hw_instances_cap,
+                                           const wchar_t *sav_support_cap) {
+      if (!config.multi_hw_instance_encode) return;
+
+      const bool enabled = *config.multi_hw_instance_encode;
+      amf_int64 hw_instances = 0;
+      const bool hw_cap_known = hw_instances_cap && encoder->GetProperty(hw_instances_cap, &hw_instances) == AMF_OK;
+      amf_bool sav_supported = false;
+      const bool sav_cap_known = sav_support_cap && encoder->GetProperty(sav_support_cap, &sav_supported) == AMF_OK;
+
+      auto set_optional_property = [&](const wchar_t *property, bool value, const char *label) {
+        if (!property) return;
+        auto property_res = encoder->SetProperty(property, value);
+        if (property_res != AMF_OK) {
+          BOOST_LOG(warning) << "AMF: failed to " << (value ? "enable " : "disable ")
+                             << label << ", error: " << property_res;
+        }
+      };
+
+      if (enabled && hw_cap_known && hw_instances <= 1 && (!sav_property || (sav_cap_known && !sav_supported))) {
+        BOOST_LOG(info) << "AMF: multi-HW instance encode requested, but this codec reports "
+                        << hw_instances << " hardware encoder instance(s)";
+        return;
+      }
+
+      if (!enabled || !hw_cap_known || hw_instances > 1) {
+        set_optional_property(multi_hw_property, enabled, "multi-HW instance encode");
+      }
+      if (!enabled || !sav_cap_known || sav_supported) {
+        set_optional_property(sav_property, enabled, "Smart Access Video");
+      }
+    };
+
     if (video_format == 0) {
       // H.264
       if (config.usage) encoder->SetProperty(AMF_VIDEO_ENCODER_USAGE, (amf_int64) *config.usage);
@@ -159,6 +194,11 @@ namespace amf {
       // bugs (see AlkaidLab/foundation-sunshine#666 freeze on RDNA4 26.5.x).
       if (config.lowlatency_mode) encoder->SetProperty(AMF_VIDEO_ENCODER_LOWLATENCY_MODE, !!(*config.lowlatency_mode));
       if (config.input_queue_size) encoder->SetProperty(AMF_VIDEO_ENCODER_INPUT_QUEUE_SIZE, (amf_int64) *config.input_queue_size);
+      configure_multi_hw_instance(
+        nullptr,
+        AMF_VIDEO_ENCODER_ENABLE_SMART_ACCESS_VIDEO,
+        AMF_VIDEO_ENCODER_CAP_NUM_OF_HW_INSTANCES,
+        AMF_VIDEO_ENCODER_CAP_SUPPORT_SMART_ACCESS_VIDEO);
       encoder->SetProperty(AMF_VIDEO_ENCODER_QUERY_TIMEOUT, (amf_int64) 1);
 
       // LTR for RFI (Reference Frame Invalidation, weak-network recovery).
@@ -239,6 +279,11 @@ namespace amf {
       // See H.264 block above for rationale (FFmpeg-aligned default behavior).
       if (config.lowlatency_mode) encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_LOWLATENCY_MODE, !!(*config.lowlatency_mode));
       if (config.input_queue_size) encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_INPUT_QUEUE_SIZE, (amf_int64) *config.input_queue_size);
+      configure_multi_hw_instance(
+        AMF_VIDEO_ENCODER_HEVC_MULTI_HW_INSTANCE_ENCODE,
+        AMF_VIDEO_ENCODER_HEVC_ENABLE_SMART_ACCESS_VIDEO,
+        AMF_VIDEO_ENCODER_HEVC_CAP_NUM_OF_HW_INSTANCES,
+        AMF_VIDEO_ENCODER_HEVC_CAP_SUPPORT_SMART_ACCESS_VIDEO);
       encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_QUERY_TIMEOUT, (amf_int64) 1);
 
       if (colorspace.bit_depth == 10) {
@@ -307,6 +352,11 @@ namespace amf {
       // See AlkaidLab/foundation-sunshine#666 for the RDNA4 freeze that
       // motivated stopping aggressive defaults.
       if (config.input_queue_size) encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_INPUT_QUEUE_SIZE, (amf_int64) *config.input_queue_size);
+      configure_multi_hw_instance(
+        AMF_VIDEO_ENCODER_AV1_MULTI_HW_INSTANCE_ENCODE,
+        AMF_VIDEO_ENCODER_AV1_ENABLE_SMART_ACCESS_VIDEO,
+        AMF_VIDEO_ENCODER_AV1_CAP_NUM_OF_HW_INSTANCES,
+        AMF_VIDEO_ENCODER_AV1_CAP_SUPPORT_SMART_ACCESS_VIDEO);
       encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_QUERY_TIMEOUT, (amf_int64) 1);
       if (config.av1_encoding_latency_mode) {
         encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_ENCODING_LATENCY_MODE, (amf_int64) *config.av1_encoding_latency_mode);
@@ -575,6 +625,9 @@ namespace amf {
       res = encoder->Init(amf_format, client_config.width, client_config.height);
     };
 
+    if (config.multi_hw_instance_encode && *config.multi_hw_instance_encode) {
+      try_with_fallback("multi-HW instance encode", [](amf_config &c) { c.multi_hw_instance_encode = std::nullopt; });
+    }
     if (config.preanalysis && *config.preanalysis) {
       try_with_fallback("PreAnalysis", [](amf_config &c) { c.preanalysis = false; });
     }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1225,6 +1225,7 @@ namespace config {
     int_between_f(vars, "amd_qvbr_quality", video.amd.amd_qvbr_quality, { 1, 51 });
     int_between_f(vars, "amd_ltr_frames", video.amd.amd_ltr_frames, { 0, 4 });
     int_between_f(vars, "amd_slices_per_frame", video.amd.amd_slices_per_frame, { 0, 4 });
+    bool_f(vars, "amd_multi_hw_instance", video.amd.amd_multi_hw_instance);
     // FFmpeg-aligned opt-in toggles (default nullopt = let AMD driver decide,
     // matches FFmpeg amfenc.c behavior of never setting the property unless
     // the user explicitly opts in). See AlkaidLab/foundation-sunshine#666 for

--- a/src/config.h
+++ b/src/config.h
@@ -75,6 +75,7 @@ namespace config {
       int amd_qvbr_quality = 23;  // QVBR quality level 1-51 (lower=better, default=23)
       int amd_ltr_frames = 0;  // LTR frames for RFI (0=disabled by default; matches FFmpeg amfenc behavior to avoid static-region color blocks)
       int amd_slices_per_frame = 0;  // Slices/tiles per frame (0=client decides, 1-4=minimum)
+      std::optional<bool> amd_multi_hw_instance;
       // The properties below historically had aggressive hardcoded defaults that
       // forced AMF code paths FFmpeg never touches (HIGH_MOTION_QUALITY_BOOST=on,
       // INPUT_QUEUE_SIZE=1, LOWLATENCY_MODE=on, AV1 LOWEST_LATENCY). Those paths

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -2136,6 +2136,7 @@ namespace platf::dxgi {
       // do not SetProperty, driver picks the default code path.
       amf_cfg.lowlatency_mode = config::video.amd.amd_lowlatency_mode;
       amf_cfg.input_queue_size = config::video.amd.amd_input_queue_size;
+      amf_cfg.multi_hw_instance_encode = config::video.amd.amd_multi_hw_instance;
       amf_cfg.av1_encoding_latency_mode = config::video.amd.amd_av1_latency_mode;
 
       // Apply server-side slices per frame override if configured

--- a/src_assets/common/assets/web/composables/useConfig.js
+++ b/src_assets/common/assets/web/composables/useConfig.js
@@ -174,6 +174,7 @@ const DEFAULT_TABS = [
           // freezes or tuning latency. See issue #666 (RDNA4 26.5.x).
           amd_high_motion_qb: '',
           amd_lowlatency_mode: '',
+          amd_multi_hw_instance: '',
           amd_input_queue_size: '',
           amd_av1_latency_mode: '',
         },

--- a/src_assets/common/assets/web/configs/tabs/encoders/AmdAmfEncoder.vue
+++ b/src_assets/common/assets/web/configs/tabs/encoders/AmdAmfEncoder.vue
@@ -196,6 +196,7 @@ const config = ref(props.config)
               @click="
                 config.amd_high_motion_qb = '';
                 config.amd_lowlatency_mode = '';
+                config.amd_multi_hw_instance = '';
                 config.amd_input_queue_size = '';
                 config.amd_av1_latency_mode = '';
               "
@@ -223,6 +224,17 @@ const config = ref(props.config)
                 <option value="disabled">{{ $t('_common.disabled') }}</option>
               </select>
               <div class="form-text">{{ $t('config.amd_lowlatency_mode_desc') }}</div>
+            </div>
+
+            <!-- Multi-HW Instance Encode -->
+            <div class="mb-3">
+              <label for="amd_multi_hw_instance" class="form-label">{{ $t('config.amd_multi_hw_instance') }}</label>
+              <select id="amd_multi_hw_instance" class="form-select" v-model="config.amd_multi_hw_instance">
+                <option value="">{{ $t('config.amd_driver_default') }}</option>
+                <option value="enabled">{{ $t('_common.enabled') }}</option>
+                <option value="disabled">{{ $t('_common.disabled') }}</option>
+              </select>
+              <div class="form-text">{{ $t('config.amd_multi_hw_instance_desc') }}</div>
             </div>
 
             <!-- Input Queue Size -->

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -198,6 +198,8 @@
     "amd_input_queue_size_desc": "Frames the encoder may buffer internally (1-16). Leave blank for driver default (FFmpeg uses 16). Sunshine's legacy value was 1 for minimum latency. Lower = lower latency, higher = more stable.",
     "amd_lowlatency_mode": "AMF Low Latency Mode",
     "amd_lowlatency_mode_desc": "AMD VCN low-latency code path. Leave blank to use the driver default. 'Enabled' was the legacy Sunshine behavior and minimizes latency; 'Disabled' if you hit driver freezes (RX 9070 / RDNA4 H.264/HEVC).",
+    "amd_multi_hw_instance": "AMF Multi-HW Instance Encode",
+    "amd_multi_hw_instance_desc": "Opt-in AMD multi hardware encoder path. Leave blank for driver default. On HEVC/AV1 this enables multi-HW instance encode and Smart Access Video when supported; on H.264 only Smart Access Video is available.",
     "amd_preanalysis": "AMF Preanalysis",
     "amd_preanalysis_desc": "This enables rate-control preanalysis, which may increase quality at the expense of increased encoding latency.",
     "amd_quality": "AMF Quality",

--- a/src_assets/common/assets/web/public/assets/locale/zh.json
+++ b/src_assets/common/assets/web/public/assets/locale/zh.json
@@ -198,6 +198,8 @@
     "amd_input_queue_size_desc": "编码器内部可缓冲的帧数（1-16）。留空使用驱动默认（FFmpeg 为 16）。Sunshine 旧值为 1 以最小化延迟。值越小延迟越低，值越大越稳定。",
     "amd_lowlatency_mode": "AMF 低延迟模式",
     "amd_lowlatency_mode_desc": "AMD VCN 低延迟代码路径。留空使用驱动默认。'启用' 为 Sunshine 旧行为，能将延迟降至最低；遇到驱动卡死（RX 9070 / RDNA4 H.264/HEVC）可选 '禁用'。",
+    "amd_multi_hw_instance": "AMF 多硬件实例编码",
+    "amd_multi_hw_instance_desc": "可选启用 AMD 多硬件编码器路径。留空使用驱动默认。HEVC/AV1 会在支持时启用 multi-HW instance encode 和 Smart Access Video；H.264 仅支持 Smart Access Video。",
     "amd_preanalysis": "AMF 预分析",
     "amd_preanalysis_desc": "启用码率控制预分析，可能会以增加编码延迟为代价提高质量。",
     "amd_quality": "AMF 质量",


### PR DESCRIPTION
## 改了啥喵

- 新增 `amd_multi_hw_instance` 三态配置：留空走 AMD 驱动默认，`enabled/disabled` 才显式写 AMF 属性。
- AMF 后端按 codec 设置官方 multi-HW / Smart Access Video 属性：
  - H.264: `AMF_VIDEO_ENCODER_ENABLE_SMART_ACCESS_VIDEO`
  - HEVC: `AMF_VIDEO_ENCODER_HEVC_MULTI_HW_INSTANCE_ENCODE` + `AMF_VIDEO_ENCODER_HEVC_ENABLE_SMART_ACCESS_VIDEO`
  - AV1: `AMF_VIDEO_ENCODER_AV1_MULTI_HW_INSTANCE_ENCODE` + `AMF_VIDEO_ENCODER_AV1_ENABLE_SMART_ACCESS_VIDEO`
- 启用前读取 `NUM_OF_HW_INSTANCES` / `SUPPORT_SMART_ACCESS_VIDEO` caps，cap 明确不支持时不硬塞；如果 Init 因该实验选项失败，会先回退到驱动默认。
- WebUI 的 AMF Advanced Tuning 增加该选项，默认空值不改变刚合入的 FFmpeg-aligned 默认路径。

## 为啥要改喵

用户侧想测试 AMD 多硬件编码实例路径，但这个路径比默认 AMF 配置更实验，杂鱼驱动状态不能假装很乖。所以这里做成显式 opt-in：默认稳，想测性能/延迟时再开。

## 验证

- `npm run build` passed
- `ninja -C build CMakeFiles/sunshine.dir/src/amf/amf_d3d11.cpp.obj` passed
- `ninja -C build CMakeFiles/sunshine.dir/src/config.cpp.obj` passed / no work to do
- `ninja -C build CMakeFiles/sunshine.dir/src/platform/windows/display_vram.cpp.obj` passed
- `cmake --build build --target sunshine -- -j 4` did not complete because the current local build stops in unrelated `src/nvhttp/display_scale.cpp` with `-Werror=unused-function` before reaching this change path.