### PR TITLE
fix(security): reject untrusted client certificates

### DIFF
--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -31,8 +31,6 @@ namespace crypto {
       // Expired or not-yet-valid certificates are fine. Sometimes Moonlight is running on embedded devices
       // that don't have accurate clocks (or haven't yet synchronized by the time Moonlight first runs).
       // This behavior also matches what GeForce Experience does.
-      // TODO: Checking for X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY is a temporary workaround to get moonlight-embedded to work on the raspberry pi
-      case X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY:
       case X509_V_ERR_CERT_NOT_YET_VALID:
       case X509_V_ERR_CERT_HAS_EXPIRED:
         return 1;


### PR DESCRIPTION
## Summary
- Backport the upstream security fix for GHSA-ph75-mgxh-mv57 / CVE-2026-32253.
- Stop treating `X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY` as a successful client-certificate verification result in `src/crypto.cpp`.
- Keep the existing Moonlight clock-skew compatibility behavior for not-yet-valid and expired paired certificates, matching upstream `v2026.516.143833`.

## Root Cause
Sunshine's HTTPS client-certificate authentication path uses `cert_chain_t::verify` from `src/crypto.cpp`. The custom OpenSSL verification callback previously converted an unknown local issuer error into success, which could allow an untrusted certificate chain to pass authentication.

## Security Impact
This closes the authentication-bypass condition described in the upstream critical advisory for protected Sunshine HTTPS endpoints. The change mirrors the upstream fix commit `888a6bb0` and the patched release `v2026.516.143833`.

## Validation
- `rg` confirmed `X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY` is no longer allowed in `src/crypto.cpp`.
- `git diff --check` passed.
- CMake/unit tests were not run because `cmake` is not available in the current Windows PATH, and the repository preset expects an MSYS2 UCRT64 shell.

## Notes
- Supersedes #709 after renaming the source branch to remove the `codex/` prefix.

## References
- https://github.com/LizardByte/Sunshine/security/advisories/GHSA-ph75-mgxh-mv57
- https://github.com/LizardByte/Sunshine/releases/tag/v2026.516.143833