### PR TITLE
fix(audio): preserve virtual sink restore across display changes

### DIFF
--- a/src/display_device/session.cpp
+++ b/src/display_device/session.cpp
@@ -201,6 +201,23 @@ namespace display_device {
       return {};
     }
 
+    parsed_config_t::device_prep_e
+    get_effective_device_prep(const config::video_t &config, const rtsp_stream::launch_session_t &session) {
+      const auto configured_device_prep = static_cast<parsed_config_t::device_prep_e>(config.display_device_prep);
+      const auto custom_screen_mode = static_cast<parsed_config_t::device_prep_e>(session.custom_screen_mode);
+
+      switch (custom_screen_mode) {
+        case parsed_config_t::device_prep_e::no_operation:
+        case parsed_config_t::device_prep_e::ensure_active:
+        case parsed_config_t::device_prep_e::ensure_primary:
+        case parsed_config_t::device_prep_e::ensure_only_display:
+        case parsed_config_t::device_prep_e::ensure_secondary:
+          return custom_screen_mode;
+        default:
+          return configured_device_prep;
+      }
+    }
+
     /**
      * @brief Wait for VDD device to be available (active or inactive).
      * @param device_zako Output parameter for the device ID.
@@ -361,6 +378,14 @@ namespace display_device {
     // - 其他情况（包括 SYSTEM 权限）：准备 VDD 设备
     const bool is_rdp_blocking_vdd = !is_running_as_system_user && display_device::w_utils::is_any_rdp_session_active();
     const bool will_use_vdd = needs_vdd && !is_rdp_blocking_vdd;
+    const auto effective_device_prep = get_effective_device_prep(config, session);
+    const bool vdd_will_turn_off_physical_displays =
+      will_use_vdd &&
+      parsed_config_t::to_vdd_prep(effective_device_prep) == parsed_config_t::vdd_prep_e::display_off;
+
+    if (vdd_will_turn_off_physical_displays) {
+      settings.capture_audio_sink();
+    }
 
     if (will_use_vdd && !vdd_already_exists) {
 
@@ -393,6 +418,10 @@ namespace display_device {
 
     const auto parsed_config = make_parsed_config(config, session, is_reconfigure);
     if (!parsed_config) {
+      if (vdd_will_turn_off_physical_displays) {
+        settings.release_audio_sink();
+      }
+
       BOOST_LOG(error) << "Failed to parse configuration for the display device settings!";
       restore_state_impl(revert_reason_e::config_cleanup);
       return {
@@ -808,6 +837,7 @@ namespace display_device {
     // 如果 apply_config 从未执行成功，拓扑从未被修改过，不需要恢复
     if (!has_persistent) {
       BOOST_LOG(info) << "apply_config 从未执行成功，跳过拓扑恢复";
+      settings.release_audio_sink();
       stop_timer_and_clear_vdd_state();
       return;
     }

--- a/src/display_device/settings.h
+++ b/src/display_device/settings.h
@@ -126,6 +126,20 @@ namespace display_device {
     is_changing_settings_going_to_fail() const;
 
     /**
+     * @brief Capture and hold the current audio sink until display settings are reverted.
+     * @note This is useful before display topology changes that may make the current
+     *       Windows playback endpoint disappear.
+     */
+    void
+    capture_audio_sink();
+
+    /**
+     * @brief Release the captured audio sink, restoring it if Sunshine changed it.
+     */
+    void
+    release_audio_sink();
+
+    /**
      * @brief Set the file path for persistent data.
      *
      * EXAMPLES:

--- a/src/platform/windows/audio.cpp
+++ b/src/platform/windows/audio.cpp
@@ -7,6 +7,7 @@
 // platform includes
 #include <audioclient.h>
 #include <avrt.h>
+#include <chrono>
 #include <mmdeviceapi.h>
 #include <mutex>
 #include <newdev.h>
@@ -19,6 +20,7 @@
 #include "src/config.h"
 #include "src/logging.h"
 #include "src/platform/common.h"
+#include "src/system_tray.h"
 
 // Must be the last included file
 // clang-format off
@@ -830,6 +832,7 @@ namespace platf::audio {
       if (virtual_sink_info) {
         mic->default_endpt_changed_cb = [this] {
           BOOST_LOG(info) << "Resetting sink to ["sv << assigned_sink << "] after default changed";
+          notify_virtual_sink_managed();
           set_sink(assigned_sink);
         };
       }
@@ -937,6 +940,23 @@ namespace platf::audio {
       }
 
       return failure;
+    }
+
+    void
+    notify_virtual_sink_managed() {
+      const auto now = std::chrono::steady_clock::now();
+      std::lock_guard<std::mutex> lock(last_virtual_sink_notification_mutex);
+      if (now - last_virtual_sink_notification < std::chrono::seconds(30)) {
+        return;
+      }
+
+      last_virtual_sink_notification = now;
+      BOOST_LOG(info) << "Virtual audio sink is being kept selected for host audio streaming";
+#if defined SUNSHINE_TRAY && SUNSHINE_TRAY >= 1
+      system_tray::show_notification(
+        "Audio device kept for streaming",
+        "Sunshine is keeping the virtual audio device selected for host audio streaming. Stop the stream before switching playback devices.");
+#endif
     }
 
     enum class match_field_e {
@@ -1213,6 +1233,8 @@ namespace platf::audio {
     policy_t policy;
     audio::device_enum_t device_enum;
     std::string assigned_sink;
+    std::chrono::steady_clock::time_point last_virtual_sink_notification {};
+    std::mutex last_virtual_sink_notification_mutex;
 
     int
     init_mic_redirect_device() {

--- a/src/platform/windows/display_device/settings.cpp
+++ b/src/platform/windows/display_device/settings.cpp
@@ -786,6 +786,26 @@ namespace display_device {
 
   settings_t::~settings_t() = default;
 
+  void
+  settings_t::capture_audio_sink() {
+    if (audio_data) {
+      return;
+    }
+
+    BOOST_LOG(debug) << "Capturing audio sink before changing display";
+    audio_data = std::make_unique<audio_data_t>();
+  }
+
+  void
+  settings_t::release_audio_sink() {
+    if (!audio_data) {
+      return;
+    }
+
+    BOOST_LOG(debug) << "Releasing captured audio sink";
+    audio_data = nullptr;
+  }
+
   bool
   settings_t::is_changing_settings_going_to_fail() const {
     const bool session_locked = w_utils::is_user_session_locked();
@@ -854,7 +874,7 @@ namespace display_device {
           }
 
           if (audio_sink_was_captured && !audio_data) {
-            audio_data = std::make_unique<audio_data_t>();
+            capture_audio_sink();
           }
           return true;
         }, pre_saved_initial_topology);
@@ -967,8 +987,7 @@ namespace display_device {
     if (display_may_change && !audio_data) {
       // It is very likely that in this situation our "current" audio device will be gone, so we
       // want to capture the audio sink immediately and extend the audio session until we revert our changes.
-      BOOST_LOG(debug) << "Capturing audio sink before changing display";
-      audio_data = std::make_unique<audio_data_t>();
+      capture_audio_sink();
     }
 
     const auto result { do_apply_config(config) };
@@ -978,8 +997,7 @@ namespace display_device {
         // without Sunshine restarting, we should clean up, because in this situation
         // we have had to revert the changes that turned off other displays. Thus, extending
         // the session for a display that again exist is pointless.
-        BOOST_LOG(debug) << "Releasing captured audio sink";
-        audio_data = nullptr;
+        release_audio_sink();
       }
 
       if (config.change_hdr_state) {
@@ -1034,10 +1052,7 @@ namespace display_device {
 
       // 释放音频数据
       if (reason != revert_reason_e::topology_switch) {
-        if (audio_data) {
-          BOOST_LOG(debug) << "释放捕获的音频接收器";
-          audio_data = nullptr;
-        }
+        release_audio_sink();
       }
 
       if (success) {
@@ -1057,10 +1072,7 @@ namespace display_device {
     remove_file(filepath);
     persistent_data = nullptr;
 
-    if (audio_data) {
-      BOOST_LOG(debug) << "Releasing captured audio sink";
-      audio_data = nullptr;
-    }
+    release_audio_sink();
   }
 
   bool

--- a/src/system_tray.cpp
+++ b/src/system_tray.cpp
@@ -1372,6 +1372,26 @@ namespace system_tray {
 
     clear_tray_notification();
   }
+
+  void
+  show_notification(const std::string &title, const std::string &message) {
+    if (!tray_initialized) {
+      return;
+    }
+
+    static std::string notification_title;
+    static std::string notification_message;
+    notification_title = title;
+    notification_message = message;
+
+    clear_tray_notification();
+    tray.notification_title = notification_title.c_str();
+    tray.notification_text = notification_message.c_str();
+    tray.notification_icon = TRAY_ICON;
+    tray_update(&tray);
+
+    clear_tray_notification();
+  }
  
   void
   update_vdd_menu() {

--- a/src/system_tray.h
+++ b/src/system_tray.h
@@ -4,6 +4,8 @@
  */
 #pragma once
 
+#include <string>
+
 /**
  * @brief Handles the system tray icon and notification system.
  */
@@ -102,6 +104,14 @@ namespace system_tray {
    */
   void
   update_tray_require_pin(std::string pin_name);
+
+  /**
+   * @brief Spawns a generic system tray notification.
+   * @param title Notification title
+   * @param message Notification body
+   */
+  void
+  show_notification(const std::string &title, const std::string &message);
   
   /**
    * @brief Initializes and runs the system tray in a separate thread.


### PR DESCRIPTION
## 改了啥喵
- Added a reusable tray notification helper for short runtime explanations outside the Web UI.
- When Windows default playback changes during a stream that is using Sunshine's virtual audio sink, Sunshine still restores that sink, but now tells the user why from the tray.
- Capture the host audio sink before VDD `display_off` changes can make monitor audio endpoints disappear, then keep that audio context alive until display settings are reverted.
- Release the captured audio sink through one shared helper, including parse/apply failure cleanup paths.
- Protected the virtual-sink notification throttle timestamp with a mutex so callback threads cannot race while checking/updating it.

## 为啥要改
The confusing hard-control case is host audio streaming with a virtual sink: Windows playback can jump back because Sunshine must keep capturing from the selected virtual sink. A tray notice explains that at the exact moment the user hits it.

The restoration bug was a timing issue, 小杂鱼状态被逮到了: with VDD `ensure_only_display`, the monitor audio device can disappear before Sunshine records the original playback endpoint. Then the virtual sink restores to whatever Windows picked next, like Realtek, instead of the real pre-stream monitor device. Capturing the sink before VDD prep preserves the user's original choice and releases it only after display restore.

The notification throttle can be reached from endpoint-change callback paths, so its timestamp now has a tiny mutex around the check-and-update. 不给 data race 留小尾巴。

## 验证
- `git diff --check -- src/platform/windows/audio.cpp`
- `rg -n last_virtual_sink_notification src/platform/windows/audio.cpp -C 2`
- `git diff --check -- src/display_device/session.cpp src/display_device/settings.h src/platform/windows/display_device/settings.cpp`
- `cmake --build build --target sunshine --config RelWithDebInfo --parallel 2` was attempted earlier, but this local MSYS2 GCC install fails before giving source diagnostics: `/ucrt64/bin/c++.exe -fsyntax-only` also exits 1 with no diagnostics even for `int main(){}` / `cc1plus.exe --version`.