### PR TITLE
fix(vdd): fallback display modes after CCD failures

### DIFF
--- a/src/display_device/session.cpp
+++ b/src/display_device/session.cpp
@@ -498,13 +498,8 @@ namespace display_device {
         BOOST_LOG(warning) << "VDD 会话模式参数无效，跳过更新: " << new_setting;
         return;
       case vdd_utils::set_vdd_result::interface_missing:
-        // Old driver without IOCTL: fall through to persistent XML + reload path below.
+        // Old driver without IOCTL: XML + reload is the only way to refresh the runtime mode list.
         break;
-    }
-
-    if (!vdd_settings.needs_update) {
-      BOOST_LOG(debug) << "VDD SETMODES unavailable and persistent config already contains session mode: " << new_setting;
-      return;
     }
 
     if (!confighttp::saveVddSettings(vdd_settings.resolutions, vdd_settings.fps, config::video.adapter_name)) {
@@ -584,7 +579,8 @@ namespace display_device {
       }
     }
 
-    // Update VDD resolution configuration
+    // Always push the session mode first. vdd_settings.needs_update only describes
+    // whether the legacy persistent mode list needs new entries.
     if (auto vdd_settings = vdd_utils::prepare_vdd_settings(config);
       config.resolution) {
       update_vdd_resolution(config, vdd_settings);

--- a/src/display_device/session.cpp
+++ b/src/display_device/session.cpp
@@ -455,6 +455,7 @@ namespace display_device {
 
   bool
   session_t::destroy_vdd_monitor() {
+    last_vdd_setting.clear();
     current_vdd_client_id.clear();
     return vdd_utils::destroy_vdd_monitor();
   }

--- a/src/display_device/session.cpp
+++ b/src/display_device/session.cpp
@@ -501,6 +501,11 @@ namespace display_device {
         break;
     }
 
+    if (!vdd_settings.needs_update) {
+      BOOST_LOG(debug) << "VDD SETMODES unavailable and persistent config already contains session mode: " << new_setting;
+      return;
+    }
+
     if (!confighttp::saveVddSettings(vdd_settings.resolutions, vdd_settings.fps, config::video.adapter_name)) {
       BOOST_LOG(error) << "VDD配置保存失败 [resolutions: " << vdd_settings.resolutions
                        << " fps: " << vdd_settings.fps << "]";
@@ -580,7 +585,7 @@ namespace display_device {
 
     // Update VDD resolution configuration
     if (auto vdd_settings = vdd_utils::prepare_vdd_settings(config);
-      vdd_settings.needs_update && config.resolution) {
+      config.resolution) {
       update_vdd_resolution(config, vdd_settings);
     }
 

--- a/src/platform/windows/display_device/settings.cpp
+++ b/src/platform/windows/display_device/settings.cpp
@@ -216,41 +216,72 @@ namespace display_device {
       });
     }
 
-    device_display_mode_map_t
-    with_display_mode(const device_display_mode_map_t &base_modes, const display_mode_t &mode) {
-      device_display_mode_map_t fallback_modes { base_modes };
-      for (auto &[_, fallback_mode] : fallback_modes) {
-        fallback_mode = mode;
+    bool
+    same_display_mode_map(const device_display_mode_map_t &a, const device_display_mode_map_t &b) {
+      if (a.size() != b.size()) {
+        return false;
       }
-      return fallback_modes;
+
+      for (const auto &[device_id, mode] : a) {
+        const auto b_mode = b.find(device_id);
+        if (b_mode == std::end(b) || !same_mode(mode, b_mode->second)) {
+          return false;
+        }
+      }
+
+      return true;
     }
 
-    std::vector<display_mode_t>
+    std::vector<device_display_mode_map_t>
     make_vdd_fallback_modes(const device_display_mode_map_t &requested_modes) {
-      std::vector<display_mode_t> fallback_modes;
+      std::vector<device_display_mode_map_t> fallback_modes;
       if (requested_modes.empty()) {
         return fallback_modes;
       }
 
-      const auto requested_mode = std::begin(requested_modes)->second;
-      const auto add_candidate = [&fallback_modes](const display_mode_t &mode) {
-        const auto existing = std::find_if(std::begin(fallback_modes), std::end(fallback_modes), [&mode](const auto &candidate) {
-          return same_mode(candidate, mode);
+      const auto add_candidate = [&fallback_modes, &requested_modes](const device_display_mode_map_t &modes) {
+        if (same_display_mode_map(modes, requested_modes)) {
+          return;
+        }
+
+        const auto existing = std::find_if(std::begin(fallback_modes), std::end(fallback_modes), [&modes](const auto &candidate) {
+          return same_display_mode_map(candidate, modes);
         });
         if (existing == std::end(fallback_modes)) {
-          fallback_modes.push_back(mode);
+          fallback_modes.push_back(modes);
         }
       };
 
-      const double requested_hz = refresh_rate_hz(requested_mode.refresh_rate);
-      if (requested_hz > 121.0) {
-        add_candidate(display_mode_t { requested_mode.resolution, refresh_rate_t { 120, 1 } });
+      auto candidate_modes = requested_modes;
+      bool changed = false;
+      for (auto &[_, mode] : candidate_modes) {
+        if (refresh_rate_hz(mode.refresh_rate) > 121.0) {
+          mode.refresh_rate = refresh_rate_t { 120, 1 };
+          changed = true;
+        }
       }
-      if (requested_hz > 61.0) {
-        add_candidate(display_mode_t { requested_mode.resolution, refresh_rate_t { 60, 1 } });
+      if (changed) {
+        add_candidate(candidate_modes);
       }
 
-      add_candidate(display_mode_t { resolution_t { 1920, 1080 }, refresh_rate_t { 60, 1 } });
+      candidate_modes = requested_modes;
+      changed = false;
+      for (auto &[_, mode] : candidate_modes) {
+        if (refresh_rate_hz(mode.refresh_rate) > 61.0) {
+          mode.refresh_rate = refresh_rate_t { 60, 1 };
+          changed = true;
+        }
+      }
+      if (changed) {
+        add_candidate(candidate_modes);
+      }
+
+      candidate_modes = requested_modes;
+      for (auto &[_, mode] : candidate_modes) {
+        mode = display_mode_t { resolution_t { 1920, 1080 }, refresh_rate_t { 60, 1 } };
+      }
+      add_candidate(candidate_modes);
+
       return fallback_modes;
     }
 
@@ -279,8 +310,7 @@ namespace display_device {
         }
       }
 
-      for (const auto &fallback_mode : make_vdd_fallback_modes(requested_modes)) {
-        const auto fallback_modes = with_display_mode(requested_modes, fallback_mode);
+      for (const auto &fallback_modes : make_vdd_fallback_modes(requested_modes)) {
         BOOST_LOG(warning) << "Trying VDD display mode fallback: " << to_string(fallback_modes);
         if (set_display_modes(fallback_modes)) {
           BOOST_LOG(warning) << "VDD display mode fallback succeeded. Requested: "

--- a/src/platform/windows/display_device/settings.cpp
+++ b/src/platform/windows/display_device/settings.cpp
@@ -1,8 +1,10 @@
 // standard includes
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <fstream>
 #include <thread>
+#include <vector>
 
 // local includes
 #include "settings_topology.h"
@@ -186,6 +188,110 @@ namespace display_device {
       return new_modes;
     }
 
+    double
+    refresh_rate_hz(const refresh_rate_t &refresh_rate) {
+      if (refresh_rate.denominator == 0) {
+        return 0.0;
+      }
+
+      return static_cast<double>(refresh_rate.numerator) / refresh_rate.denominator;
+    }
+
+    bool
+    same_mode(const display_mode_t &a, const display_mode_t &b) {
+      return a.resolution.width == b.resolution.width &&
+             a.resolution.height == b.resolution.height &&
+             a.refresh_rate.numerator == b.refresh_rate.numerator &&
+             a.refresh_rate.denominator == b.refresh_rate.denominator;
+    }
+
+    bool
+    all_modes_target_vdd(const device_display_mode_map_t &modes) {
+      if (modes.empty()) {
+        return false;
+      }
+
+      return std::all_of(std::begin(modes), std::end(modes), [](const auto &entry) {
+        return get_display_friendly_name(entry.first) == ZAKO_NAME;
+      });
+    }
+
+    device_display_mode_map_t
+    with_display_mode(const device_display_mode_map_t &base_modes, const display_mode_t &mode) {
+      device_display_mode_map_t fallback_modes { base_modes };
+      for (auto &[_, fallback_mode] : fallback_modes) {
+        fallback_mode = mode;
+      }
+      return fallback_modes;
+    }
+
+    std::vector<display_mode_t>
+    make_vdd_fallback_modes(const device_display_mode_map_t &requested_modes) {
+      std::vector<display_mode_t> fallback_modes;
+      if (requested_modes.empty()) {
+        return fallback_modes;
+      }
+
+      const auto requested_mode = std::begin(requested_modes)->second;
+      const auto add_candidate = [&fallback_modes](const display_mode_t &mode) {
+        const auto existing = std::find_if(std::begin(fallback_modes), std::end(fallback_modes), [&mode](const auto &candidate) {
+          return same_mode(candidate, mode);
+        });
+        if (existing == std::end(fallback_modes)) {
+          fallback_modes.push_back(mode);
+        }
+      };
+
+      const double requested_hz = refresh_rate_hz(requested_mode.refresh_rate);
+      if (requested_hz > 121.0) {
+        add_candidate(display_mode_t { requested_mode.resolution, refresh_rate_t { 120, 1 } });
+      }
+      if (requested_hz > 61.0) {
+        add_candidate(display_mode_t { requested_mode.resolution, refresh_rate_t { 60, 1 } });
+      }
+
+      add_candidate(display_mode_t { resolution_t { 1920, 1080 }, refresh_rate_t { 60, 1 } });
+      return fallback_modes;
+    }
+
+    bool
+    set_vdd_display_modes_with_fallback(const device_display_mode_map_t &requested_modes) {
+      if (set_display_modes(requested_modes)) {
+        return true;
+      }
+
+      if (!all_modes_target_vdd(requested_modes)) {
+        return false;
+      }
+
+      BOOST_LOG(warning) << "VDD display mode apply failed; waiting briefly for Windows display mode state to settle before retrying.";
+      constexpr std::array retry_delays {
+        std::chrono::milliseconds { 250 },
+        std::chrono::milliseconds { 500 },
+        std::chrono::milliseconds { 1000 }
+      };
+
+      for (const auto delay : retry_delays) {
+        std::this_thread::sleep_for(delay);
+        if (set_display_modes(requested_modes)) {
+          BOOST_LOG(info) << "VDD display mode apply succeeded after waiting for Windows display mode state.";
+          return true;
+        }
+      }
+
+      for (const auto &fallback_mode : make_vdd_fallback_modes(requested_modes)) {
+        const auto fallback_modes = with_display_mode(requested_modes, fallback_mode);
+        BOOST_LOG(warning) << "Trying VDD display mode fallback: " << to_string(fallback_modes);
+        if (set_display_modes(fallback_modes)) {
+          BOOST_LOG(warning) << "VDD display mode fallback succeeded. Requested: "
+                             << to_string(requested_modes) << " Actual: " << to_string(fallback_modes);
+          return true;
+        }
+      }
+
+      return false;
+    }
+
     /**
      * @brief Remove entries from a device_id-keyed map whose keys are not in the valid set.
      */
@@ -250,7 +356,7 @@ namespace display_device {
         filter_stale_devices(new_display_modes, valid_ids_set, "display modes");
 
         BOOST_LOG(info) << "Changing display modes to: " << to_string(new_display_modes);
-        if (!set_display_modes(new_display_modes)) {
+        if (!set_vdd_display_modes_with_fallback(new_display_modes)) {
           // Error already logged
           return boost::none;
         }

--- a/src/platform/windows/display_device/settings.cpp
+++ b/src/platform/windows/display_device/settings.cpp
@@ -206,6 +206,11 @@ namespace display_device {
     }
 
     bool
+    is_exact_refresh_rate(const refresh_rate_t &refresh_rate, unsigned int numerator, unsigned int denominator) {
+      return refresh_rate.numerator == numerator && refresh_rate.denominator == denominator;
+    }
+
+    bool
     all_modes_target_vdd(const device_display_mode_map_t &modes) {
       if (modes.empty()) {
         return false;
@@ -255,7 +260,8 @@ namespace display_device {
       auto candidate_modes = requested_modes;
       bool changed = false;
       for (auto &[_, mode] : candidate_modes) {
-        if (refresh_rate_hz(mode.refresh_rate) > 121.0) {
+        if (!is_exact_refresh_rate(mode.refresh_rate, 120, 1) &&
+            refresh_rate_hz(mode.refresh_rate) >= 119.5) {
           mode.refresh_rate = refresh_rate_t { 120, 1 };
           changed = true;
         }
@@ -267,7 +273,8 @@ namespace display_device {
       candidate_modes = requested_modes;
       changed = false;
       for (auto &[_, mode] : candidate_modes) {
-        if (refresh_rate_hz(mode.refresh_rate) > 61.0) {
+        if (!is_exact_refresh_rate(mode.refresh_rate, 60, 1) &&
+            refresh_rate_hz(mode.refresh_rate) >= 59.5) {
           mode.refresh_rate = refresh_rate_t { 60, 1 };
           changed = true;
         }


### PR DESCRIPTION
## 改了啥呀

- 在 Windows 显示模式应用失败后，给 VDD 目标增加一层专用 fallback。
- 原目标模式仍然先走现有 `set_display_modes()` 三段式逻辑；只有目标全是 `Zako HDR` 且失败时，才进入补强路径。
- VDD fallback 会先短暂等待 Windows CCD / active path / mode state 稳定后重试目标模式。
- 目标模式仍失败时，按顺序尝试更稳的模式：同分辨率 `120Hz`、同分辨率 `60Hz`，最后 `1920x1080@60`。
- VDD 会话启动时现在会优先用 `SETMODES` 同步本次请求的运行态 mode；标准分辨率也走这条路径，不再只有“配置列表里没有的模式”才同步。
- 物理显示器失败路径保持原行为，不让这个小补丁乱碰正常物理屏，杂鱼 CCD 状态只在 VDD 小房间里挨打。

## 为啥要改

BlackCat 的日志显示 VDD 已经创建出来，但 `2560x1600@144` 在 `SetDisplayConfig` 的 recommended / strict / explicit target 三种方式里都被 Windows 返回 `ERROR_GEN_FAILURE` / `1610` 拒绝。

后续用户日志里又看到更明确的一类场景：`1920x1080@60` 已经在配置列表里，但 VDD 创建后直接让 CCD 应用该模式仍失败；随后客户端请求 `2296x1080@60` 时先触发 `SETMODES`，同一个 VDD 设备就能成功应用并进入串流。

这说明问题不只是“非标准分辨率不稳”，也可能是 VDD 运行态 mode list 和 Sunshine 后续 CCD 请求没有先同步。继续直接 503 会让用户感觉“标准分辨率都坏了”，但实际更像 VDD mode 状态没准备好。

这次改成：会话开始先把本次 mode 推给 VDD，再让 Windows 应用显示模式；失败后再按 VDD-only fallback 链路降级。能自己兜就自己兜，别把杂鱼 503 直接甩给用户。

## 验证

- `git diff --check -- src/display_device/session.cpp src/platform/windows/display_device/settings.cpp`
- 分析用户日志 `sunshine-logs-2026-06-07T13-41-39.txt`：`1920x1080@60` 两次未触发 `SETMODES` 且 CCD 失败；`2296x1080@60` 触发 `SETMODES` 后成功应用并开始串流。
- `cmake --preset dev-win -DPKG_CONFIG_EXECUTABLE=C:/Strawberry/perl/bin/pkg-config.bat` 未完成：当前本地工具链缺 `libcurl.pc`，配置停在依赖发现阶段，还没进入本次 C++ 改动编译。CI 需要继续验证 Windows build。