### PR TITLE
feat: not force enable vdd cursor while capture_cursor is disabled

### DIFF
--- a/src/display_device/session.cpp
+++ b/src/display_device/session.cpp
@@ -521,7 +521,7 @@ namespace display_device {
     const vdd_utils::hdr_brightness_t hdr_brightness { session.max_nits, session.min_nits, session.max_full_nits };
     const vdd_utils::physical_size_t physical_size = vdd_utils::get_client_physical_size(session.client_name);
 
-    if (config::video.capture == "vdd") {
+    if (config::video.capture == "vdd" && config::video.capture_cursor) {
       bool hardware_cursor_changed = false;
       if (vdd_utils::ensure_hardware_cursor_disabled_for_capture(&hardware_cursor_changed)) {
         if (hardware_cursor_changed) {


### PR DESCRIPTION
如题 当设置中 “捕捉指针” 不开启时不再强行开启vdd的指针

~~Not tested 因为本地的vdd爆炸了，在抓gpt修~~

Tested： works well