### PR TITLE
fix(vrr): boost encode cadence after recent input

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -142,6 +142,8 @@ set(SUNSHINE_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/video_colorspace.h"
         "${CMAKE_SOURCE_DIR}/src/input.cpp"
         "${CMAKE_SOURCE_DIR}/src/input.h"
+        "${CMAKE_SOURCE_DIR}/src/input_activity.cpp"
+        "${CMAKE_SOURCE_DIR}/src/input_activity.h"
         "${CMAKE_SOURCE_DIR}/src/audio.cpp"
         "${CMAKE_SOURCE_DIR}/src/audio.h"
         "${CMAKE_SOURCE_DIR}/src/platform/common.h"

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -460,6 +460,9 @@ namespace config {
     {},  // display_mode_remapping
     false,  // variable_refresh_rate
     0,  // minimum_fps_target (0 = auto, about half the stream FPS)
+    true,  // input_activity_boost
+    60,  // input_activity_boost_fps
+    150,  // input_activity_boost_window_ms
     "balanced"s,  // downscaling_quality (default: bicubic for best quality/performance balance)
     false,  // hdr_luminance_analysis (disabled by default to avoid GPU overhead)
     "auto"s,  // capture_compute_shader (default: auto -> off until validated)
@@ -1306,6 +1309,9 @@ namespace config {
     int_f(vars, "max_bitrate", video.max_bitrate);
     bool_f(vars, "variable_refresh_rate", video.variable_refresh_rate);
     int_between_f(vars, "minimum_fps_target", video.minimum_fps_target, { 0, 1000 });
+    bool_f(vars, "input_activity_boost", video.input_activity_boost);
+    int_between_f(vars, "input_activity_boost_fps", video.input_activity_boost_fps, { 0, 1000 });
+    int_between_f(vars, "input_activity_boost_window_ms", video.input_activity_boost_window_ms, { 0, 5000 });
     bool_f(vars, "hdr_luminance_analysis", video.hdr_luminance_analysis);
     bool_f(vars, "wgc_disable_secure_desktop", video.wgc_disable_secure_desktop);
     bool_f(vars, "dynamic_resolution_follow_display", video.dynamic_resolution_follow_display);

--- a/src/config.h
+++ b/src/config.h
@@ -125,6 +125,9 @@ namespace config {
     std::vector<display_mode_remapping_t> display_mode_remapping;
     bool variable_refresh_rate;  // Allow video stream framerate to match render framerate for VRR support
     int minimum_fps_target;  // Minimum FPS target (0 = auto, 1-1000 = minimum FPS to maintain)
+    bool input_activity_boost;  // Temporarily raise encoding cadence after local input while VRR is active
+    int input_activity_boost_fps;  // Minimum FPS floor to maintain during the input activity boost window
+    int input_activity_boost_window_ms;  // Duration of the input activity boost window in milliseconds
     std::string downscaling_quality;  // Downscaling quality: "fast" (bilinear+8pt), "balanced" (bicubic), "high_quality" (future: lanczos)
     bool hdr_luminance_analysis;  // Enable per-frame HDR luminance analysis for dynamic metadata
     std::string capture_compute_shader;  // Use compute shader for HDR RGB->P010 conversion: "auto" (off for now), "on", "off"

--- a/src/globals.h
+++ b/src/globals.h
@@ -69,6 +69,7 @@ namespace mail {
   MAIL(gamepad_feedback);
   MAIL(hdr);
   MAIL(dynamic_param_change);
+  MAIL(input_activity);
   MAIL(resolution_change);
 #undef MAIL
 

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -159,12 +159,14 @@ namespace input {
 
     input_t(
       safe::mail_raw_t::event_t<input::touch_port_t> touch_port_event,
-      platf::feedback_queue_t feedback_queue):
+      platf::feedback_queue_t feedback_queue,
+      safe::mail_raw_t::event_t<std::chrono::steady_clock::time_point> input_activity_event):
         shortcutFlags {},
         gamepads(MAX_GAMEPADS),
         client_context { platf::allocate_client_input_context(platf_input) },
         touch_port_event { std::move(touch_port_event) },
         feedback_queue { std::move(feedback_queue) },
+        input_activity_event { std::move(input_activity_event) },
         mouse_left_button_timeout {},
         touch_port { { 0, 0, 0, 0 }, 0, 0, 1.0f },
         accumulated_vscroll_delta {},
@@ -178,6 +180,7 @@ namespace input {
 
     safe::mail_raw_t::event_t<input::touch_port_t> touch_port_event;
     platf::feedback_queue_t feedback_queue;
+    safe::mail_raw_t::event_t<std::chrono::steady_clock::time_point> input_activity_event;
 
     std::list<std::vector<uint8_t>> input_queue;
     std::mutex input_queue_lock;
@@ -1526,6 +1529,28 @@ namespace input {
     }
   }
 
+  bool
+  should_trigger_input_activity(PNV_INPUT_HEADER payload) {
+    switch (util::endian::little(payload->magic)) {
+      case MOUSE_MOVE_REL_MAGIC_GEN5:
+      case MOUSE_MOVE_ABS_MAGIC:
+      case MOUSE_BUTTON_DOWN_EVENT_MAGIC_GEN5:
+      case MOUSE_BUTTON_UP_EVENT_MAGIC_GEN5:
+      case SCROLL_MAGIC_GEN5:
+      case SS_HSCROLL_MAGIC:
+      case KEY_DOWN_EVENT_MAGIC:
+      case KEY_UP_EVENT_MAGIC:
+      case UTF8_TEXT_EVENT_MAGIC:
+      case MULTI_CONTROLLER_MAGIC_GEN5:
+      case SS_TOUCH_MAGIC:
+      case SS_PEN_MAGIC:
+      case SS_CONTROLLER_TOUCH_MAGIC:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   /**
    * @brief Called on a thread pool thread to process an input message.
    * @param input The input context pointer.
@@ -1633,6 +1658,11 @@ namespace input {
    */
   void
   passthrough(std::shared_ptr<input_t> &input, std::vector<std::uint8_t> &&input_data) {
+    auto payload = input_data.empty() ? nullptr : reinterpret_cast<PNV_INPUT_HEADER>(input_data.data());
+    if (config::video.input_activity_boost && payload != nullptr && should_trigger_input_activity(payload)) {
+      input->input_activity_event->raise(std::chrono::steady_clock::now());
+    }
+
     {
       std::lock_guard<std::mutex> lg(input->input_queue_lock);
       input->input_queue.push_back(std::move(input_data));
@@ -1695,7 +1725,8 @@ namespace input {
   alloc(safe::mail_t mail) {
     auto input = std::make_shared<input_t>(
       mail->event<input::touch_port_t>(mail::touch_port),
-      mail->queue<platf::gamepad_feedback_msg_t>(mail::gamepad_feedback));
+      mail->queue<platf::gamepad_feedback_msg_t>(mail::gamepad_feedback),
+      mail->event<std::chrono::steady_clock::time_point>(mail::input_activity));
 
     // Workaround to ensure new frames will be captured when a client connects
     task_pool.pushDelayed([]() {

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -19,6 +19,7 @@ extern "C" {
 #include "config.h"
 #include "globals.h"
 #include "input.h"
+#include "input_activity.h"
 #include "logging.h"
 #include "platform/common.h"
 #include "display_device/session.h"
@@ -149,17 +150,6 @@ namespace input {
     button_state_e back_button_state;
   };
 
-  struct controller_activity_state_t {
-    bool initialized {};
-    std::uint32_t button_flags {};
-    std::uint8_t left_trigger {};
-    std::uint8_t right_trigger {};
-    std::int16_t left_stick_x {};
-    std::int16_t left_stick_y {};
-    std::int16_t right_stick_x {};
-    std::int16_t right_stick_y {};
-  };
-
   struct input_t {
     enum shortkey_e {
       CTRL = 0x1,  ///< Control key
@@ -174,7 +164,6 @@ namespace input {
       safe::mail_raw_t::event_t<std::chrono::steady_clock::time_point> input_activity_event):
         shortcutFlags {},
         gamepads(MAX_GAMEPADS),
-        controller_activity_states(MAX_GAMEPADS),
         client_context { platf::allocate_client_input_context(platf_input) },
         touch_port_event { std::move(touch_port_event) },
         feedback_queue { std::move(feedback_queue) },
@@ -188,7 +177,7 @@ namespace input {
     int shortcutFlags;
 
     std::vector<gamepad_t> gamepads;
-    std::vector<controller_activity_state_t> controller_activity_states;
+    activity::tracker_t activity_tracker;
     std::unique_ptr<platf::client_input_t> client_context;
 
     safe::mail_raw_t::event_t<input::touch_port_t> touch_port_event;
@@ -1542,128 +1531,6 @@ namespace input {
     }
   }
 
-  // Ignore analog jitter/drift unless the input crosses a small deadzone or changes meaningfully
-  // while active. This matches the common "edge + deadzone + hysteresis" pattern used by input systems.
-  constexpr std::int16_t CONTROLLER_ACTIVITY_STICK_DEADZONE = 2048;
-  constexpr std::int16_t CONTROLLER_ACTIVITY_STICK_DELTA = 1024;
-  constexpr std::uint8_t CONTROLLER_ACTIVITY_TRIGGER_THRESHOLD = 8;
-  constexpr std::uint8_t CONTROLLER_ACTIVITY_TRIGGER_DELTA = 4;
-
-  bool
-  stick_outside_activity_deadzone(std::int16_t value) {
-    return std::abs(static_cast<int>(value)) >= CONTROLLER_ACTIVITY_STICK_DEADZONE;
-  }
-
-  bool
-  trigger_has_meaningful_change(std::uint8_t previous, std::uint8_t current) {
-    const auto previous_active = previous >= CONTROLLER_ACTIVITY_TRIGGER_THRESHOLD;
-    const auto current_active = current >= CONTROLLER_ACTIVITY_TRIGGER_THRESHOLD;
-    if (previous_active != current_active) {
-      return true;
-    }
-
-    return (previous_active || current_active) &&
-           std::abs(static_cast<int>(current) - static_cast<int>(previous)) >= CONTROLLER_ACTIVITY_TRIGGER_DELTA;
-  }
-
-  bool
-  stick_has_meaningful_change(std::int16_t previous, std::int16_t current) {
-    const auto previous_active = stick_outside_activity_deadzone(previous);
-    const auto current_active = stick_outside_activity_deadzone(current);
-    if (previous_active != current_active) {
-      return true;
-    }
-
-    return (previous_active || current_active) &&
-           std::abs(static_cast<int>(current) - static_cast<int>(previous)) >= CONTROLLER_ACTIVITY_STICK_DELTA;
-  }
-
-  bool
-  should_trigger_controller_input_activity(std::shared_ptr<input_t> &input, PNV_MULTI_CONTROLLER_PACKET packet) {
-    const auto controller_number = util::endian::little(packet->controllerNumber);
-    if (controller_number < 0 || controller_number >= static_cast<int>(input->controller_activity_states.size())) {
-      return false;
-    }
-
-    const auto button_flags =
-      static_cast<std::uint32_t>(util::endian::little(static_cast<std::uint16_t>(packet->buttonFlags))) |
-      (static_cast<std::uint32_t>(util::endian::little(static_cast<std::uint16_t>(packet->buttonFlags2))) << 16);
-    const auto left_trigger = packet->leftTrigger;
-    const auto right_trigger = packet->rightTrigger;
-    const auto left_stick_x = util::endian::little(packet->leftStickX);
-    const auto left_stick_y = util::endian::little(packet->leftStickY);
-    const auto right_stick_x = util::endian::little(packet->rightStickX);
-    const auto right_stick_y = util::endian::little(packet->rightStickY);
-
-    auto &state = input->controller_activity_states[controller_number];
-    bool should_trigger = false;
-
-    if (!state.initialized) {
-      should_trigger =
-        button_flags != 0 ||
-        left_trigger >= CONTROLLER_ACTIVITY_TRIGGER_THRESHOLD ||
-        right_trigger >= CONTROLLER_ACTIVITY_TRIGGER_THRESHOLD ||
-        stick_outside_activity_deadzone(left_stick_x) ||
-        stick_outside_activity_deadzone(left_stick_y) ||
-        stick_outside_activity_deadzone(right_stick_x) ||
-        stick_outside_activity_deadzone(right_stick_y);
-    }
-    else {
-      should_trigger =
-        button_flags != state.button_flags ||
-        trigger_has_meaningful_change(state.left_trigger, left_trigger) ||
-        trigger_has_meaningful_change(state.right_trigger, right_trigger) ||
-        stick_has_meaningful_change(state.left_stick_x, left_stick_x) ||
-        stick_has_meaningful_change(state.left_stick_y, left_stick_y) ||
-        stick_has_meaningful_change(state.right_stick_x, right_stick_x) ||
-        stick_has_meaningful_change(state.right_stick_y, right_stick_y);
-    }
-
-    state.initialized = true;
-    state.button_flags = button_flags;
-    state.left_trigger = left_trigger;
-    state.right_trigger = right_trigger;
-    state.left_stick_x = left_stick_x;
-    state.left_stick_y = left_stick_y;
-    state.right_stick_x = right_stick_x;
-    state.right_stick_y = right_stick_y;
-
-    return should_trigger;
-  }
-
-  bool
-  should_trigger_input_activity(std::shared_ptr<input_t> &input, PNV_INPUT_HEADER payload) {
-    switch (util::endian::little(payload->magic)) {
-      case MOUSE_MOVE_REL_MAGIC_GEN5:
-        return config::input.mouse &&
-               (util::endian::big(reinterpret_cast<PNV_REL_MOUSE_MOVE_PACKET>(payload)->deltaX) != 0 ||
-                util::endian::big(reinterpret_cast<PNV_REL_MOUSE_MOVE_PACKET>(payload)->deltaY) != 0);
-      case MOUSE_MOVE_ABS_MAGIC:
-      case MOUSE_BUTTON_DOWN_EVENT_MAGIC_GEN5:
-      case MOUSE_BUTTON_UP_EVENT_MAGIC_GEN5:
-        return config::input.mouse;
-      case KEY_DOWN_EVENT_MAGIC:
-      case KEY_UP_EVENT_MAGIC:
-      case UTF8_TEXT_EVENT_MAGIC:
-        return config::input.keyboard;
-      case SS_TOUCH_MAGIC:
-      case SS_PEN_MAGIC:
-        return config::input.mouse;
-      case SS_CONTROLLER_TOUCH_MAGIC:
-        return config::input.controller;
-      case SCROLL_MAGIC_GEN5:
-        return config::input.mouse &&
-               (util::endian::big(reinterpret_cast<PNV_SCROLL_PACKET>(payload)->scrollAmt1) != 0 ||
-                util::endian::big(reinterpret_cast<PNV_SCROLL_PACKET>(payload)->scrollAmt2) != 0);
-      case SS_HSCROLL_MAGIC:
-        return config::input.mouse && util::endian::big(reinterpret_cast<PSS_HSCROLL_PACKET>(payload)->scrollAmount) != 0;
-      case MULTI_CONTROLLER_MAGIC_GEN5:
-        return config::input.controller && should_trigger_controller_input_activity(input, reinterpret_cast<PNV_MULTI_CONTROLLER_PACKET>(payload));
-      default:
-        return false;
-    }
-  }
-
   /**
    * @brief Called on a thread pool thread to process an input message.
    * @param input The input context pointer.
@@ -1772,7 +1639,7 @@ namespace input {
   void
   passthrough(std::shared_ptr<input_t> &input, std::vector<std::uint8_t> &&input_data) {
     auto payload = input_data.empty() ? nullptr : reinterpret_cast<PNV_INPUT_HEADER>(input_data.data());
-    if (config::video.input_activity_boost && payload != nullptr && should_trigger_input_activity(input, payload)) {
+    if (config::video.input_activity_boost && payload != nullptr && input->activity_tracker.evaluate(payload)) {
       input->input_activity_event->raise(std::chrono::steady_clock::now());
     }
 
@@ -1788,9 +1655,7 @@ namespace input {
     task_pool.cancel(key_press_repeat_id);
     task_pool.cancel(input->mouse_left_button_timeout);
 
-    for (auto &state : input->controller_activity_states) {
-      state = {};
-    }
+    input->activity_tracker.reset();
 
     // Ensure input is synchronous, by using the task_pool
     task_pool.push([]() {

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -149,6 +149,17 @@ namespace input {
     button_state_e back_button_state;
   };
 
+  struct controller_activity_state_t {
+    bool initialized {};
+    std::uint32_t button_flags {};
+    std::uint8_t left_trigger {};
+    std::uint8_t right_trigger {};
+    std::int16_t left_stick_x {};
+    std::int16_t left_stick_y {};
+    std::int16_t right_stick_x {};
+    std::int16_t right_stick_y {};
+  };
+
   struct input_t {
     enum shortkey_e {
       CTRL = 0x1,  ///< Control key
@@ -163,6 +174,7 @@ namespace input {
       safe::mail_raw_t::event_t<std::chrono::steady_clock::time_point> input_activity_event):
         shortcutFlags {},
         gamepads(MAX_GAMEPADS),
+        controller_activity_states(MAX_GAMEPADS),
         client_context { platf::allocate_client_input_context(platf_input) },
         touch_port_event { std::move(touch_port_event) },
         feedback_queue { std::move(feedback_queue) },
@@ -176,6 +188,7 @@ namespace input {
     int shortcutFlags;
 
     std::vector<gamepad_t> gamepads;
+    std::vector<controller_activity_state_t> controller_activity_states;
     std::unique_ptr<platf::client_input_t> client_context;
 
     safe::mail_raw_t::event_t<input::touch_port_t> touch_port_event;
@@ -1529,23 +1542,123 @@ namespace input {
     }
   }
 
+  // Ignore analog jitter/drift unless the input crosses a small deadzone or changes meaningfully
+  // while active. This matches the common "edge + deadzone + hysteresis" pattern used by input systems.
+  constexpr std::int16_t CONTROLLER_ACTIVITY_STICK_DEADZONE = 2048;
+  constexpr std::int16_t CONTROLLER_ACTIVITY_STICK_DELTA = 1024;
+  constexpr std::uint8_t CONTROLLER_ACTIVITY_TRIGGER_THRESHOLD = 8;
+  constexpr std::uint8_t CONTROLLER_ACTIVITY_TRIGGER_DELTA = 4;
+
   bool
-  should_trigger_input_activity(PNV_INPUT_HEADER payload) {
+  stick_outside_activity_deadzone(std::int16_t value) {
+    return std::abs(static_cast<int>(value)) >= CONTROLLER_ACTIVITY_STICK_DEADZONE;
+  }
+
+  bool
+  trigger_has_meaningful_change(std::uint8_t previous, std::uint8_t current) {
+    const auto previous_active = previous >= CONTROLLER_ACTIVITY_TRIGGER_THRESHOLD;
+    const auto current_active = current >= CONTROLLER_ACTIVITY_TRIGGER_THRESHOLD;
+    if (previous_active != current_active) {
+      return true;
+    }
+
+    return (previous_active || current_active) &&
+           std::abs(static_cast<int>(current) - static_cast<int>(previous)) >= CONTROLLER_ACTIVITY_TRIGGER_DELTA;
+  }
+
+  bool
+  stick_has_meaningful_change(std::int16_t previous, std::int16_t current) {
+    const auto previous_active = stick_outside_activity_deadzone(previous);
+    const auto current_active = stick_outside_activity_deadzone(current);
+    if (previous_active != current_active) {
+      return true;
+    }
+
+    return (previous_active || current_active) &&
+           std::abs(static_cast<int>(current) - static_cast<int>(previous)) >= CONTROLLER_ACTIVITY_STICK_DELTA;
+  }
+
+  bool
+  should_trigger_controller_input_activity(std::shared_ptr<input_t> &input, PNV_MULTI_CONTROLLER_PACKET packet) {
+    const auto controller_number = util::endian::little(packet->controllerNumber);
+    if (controller_number < 0 || controller_number >= static_cast<int>(input->controller_activity_states.size())) {
+      return false;
+    }
+
+    const auto button_flags =
+      static_cast<std::uint32_t>(util::endian::little(static_cast<std::uint16_t>(packet->buttonFlags))) |
+      (static_cast<std::uint32_t>(util::endian::little(static_cast<std::uint16_t>(packet->buttonFlags2))) << 16);
+    const auto left_trigger = packet->leftTrigger;
+    const auto right_trigger = packet->rightTrigger;
+    const auto left_stick_x = util::endian::little(packet->leftStickX);
+    const auto left_stick_y = util::endian::little(packet->leftStickY);
+    const auto right_stick_x = util::endian::little(packet->rightStickX);
+    const auto right_stick_y = util::endian::little(packet->rightStickY);
+
+    auto &state = input->controller_activity_states[controller_number];
+    bool should_trigger = false;
+
+    if (!state.initialized) {
+      should_trigger =
+        button_flags != 0 ||
+        left_trigger >= CONTROLLER_ACTIVITY_TRIGGER_THRESHOLD ||
+        right_trigger >= CONTROLLER_ACTIVITY_TRIGGER_THRESHOLD ||
+        stick_outside_activity_deadzone(left_stick_x) ||
+        stick_outside_activity_deadzone(left_stick_y) ||
+        stick_outside_activity_deadzone(right_stick_x) ||
+        stick_outside_activity_deadzone(right_stick_y);
+    }
+    else {
+      should_trigger =
+        button_flags != state.button_flags ||
+        trigger_has_meaningful_change(state.left_trigger, left_trigger) ||
+        trigger_has_meaningful_change(state.right_trigger, right_trigger) ||
+        stick_has_meaningful_change(state.left_stick_x, left_stick_x) ||
+        stick_has_meaningful_change(state.left_stick_y, left_stick_y) ||
+        stick_has_meaningful_change(state.right_stick_x, right_stick_x) ||
+        stick_has_meaningful_change(state.right_stick_y, right_stick_y);
+    }
+
+    state.initialized = true;
+    state.button_flags = button_flags;
+    state.left_trigger = left_trigger;
+    state.right_trigger = right_trigger;
+    state.left_stick_x = left_stick_x;
+    state.left_stick_y = left_stick_y;
+    state.right_stick_x = right_stick_x;
+    state.right_stick_y = right_stick_y;
+
+    return should_trigger;
+  }
+
+  bool
+  should_trigger_input_activity(std::shared_ptr<input_t> &input, PNV_INPUT_HEADER payload) {
     switch (util::endian::little(payload->magic)) {
       case MOUSE_MOVE_REL_MAGIC_GEN5:
+        return config::input.mouse &&
+               (util::endian::big(reinterpret_cast<PNV_REL_MOUSE_MOVE_PACKET>(payload)->deltaX) != 0 ||
+                util::endian::big(reinterpret_cast<PNV_REL_MOUSE_MOVE_PACKET>(payload)->deltaY) != 0);
       case MOUSE_MOVE_ABS_MAGIC:
       case MOUSE_BUTTON_DOWN_EVENT_MAGIC_GEN5:
       case MOUSE_BUTTON_UP_EVENT_MAGIC_GEN5:
-      case SCROLL_MAGIC_GEN5:
-      case SS_HSCROLL_MAGIC:
+        return config::input.mouse;
       case KEY_DOWN_EVENT_MAGIC:
       case KEY_UP_EVENT_MAGIC:
       case UTF8_TEXT_EVENT_MAGIC:
-      case MULTI_CONTROLLER_MAGIC_GEN5:
+        return config::input.keyboard;
       case SS_TOUCH_MAGIC:
       case SS_PEN_MAGIC:
+        return config::input.mouse;
       case SS_CONTROLLER_TOUCH_MAGIC:
-        return true;
+        return config::input.controller;
+      case SCROLL_MAGIC_GEN5:
+        return config::input.mouse &&
+               (util::endian::big(reinterpret_cast<PNV_SCROLL_PACKET>(payload)->scrollAmt1) != 0 ||
+                util::endian::big(reinterpret_cast<PNV_SCROLL_PACKET>(payload)->scrollAmt2) != 0);
+      case SS_HSCROLL_MAGIC:
+        return config::input.mouse && util::endian::big(reinterpret_cast<PSS_HSCROLL_PACKET>(payload)->scrollAmount) != 0;
+      case MULTI_CONTROLLER_MAGIC_GEN5:
+        return config::input.controller && should_trigger_controller_input_activity(input, reinterpret_cast<PNV_MULTI_CONTROLLER_PACKET>(payload));
       default:
         return false;
     }
@@ -1659,7 +1772,7 @@ namespace input {
   void
   passthrough(std::shared_ptr<input_t> &input, std::vector<std::uint8_t> &&input_data) {
     auto payload = input_data.empty() ? nullptr : reinterpret_cast<PNV_INPUT_HEADER>(input_data.data());
-    if (config::video.input_activity_boost && payload != nullptr && should_trigger_input_activity(payload)) {
+    if (config::video.input_activity_boost && payload != nullptr && should_trigger_input_activity(input, payload)) {
       input->input_activity_event->raise(std::chrono::steady_clock::now());
     }
 
@@ -1674,6 +1787,10 @@ namespace input {
   reset(std::shared_ptr<input_t> &input) {
     task_pool.cancel(key_press_repeat_id);
     task_pool.cancel(input->mouse_left_button_timeout);
+
+    for (auto &state : input->controller_activity_states) {
+      state = {};
+    }
 
     // Ensure input is synchronous, by using the task_pool
     task_pool.push([]() {

--- a/src/input_activity.cpp
+++ b/src/input_activity.cpp
@@ -1,0 +1,153 @@
+/**
+ * @file src/input_activity.cpp
+ * @brief Definitions for input activity detection used by the VRR input activity boost.
+ */
+// standard includes
+#include <cmath>
+#include <cstdint>
+
+// lib includes
+#include <moonlight-common-c/src/Input.h>
+#include <moonlight-common-c/src/Limelight.h>
+
+// local includes
+#include "config.h"
+#include "input_activity.h"
+#include "utility.h"
+
+namespace input::activity {
+
+  // Ignore analog jitter/drift unless the input crosses a small deadzone or changes meaningfully
+  // while active. This matches the common "edge + deadzone + hysteresis" pattern used by input systems.
+  constexpr std::int16_t STICK_DEADZONE = 2048;
+  constexpr std::int16_t STICK_DELTA = 1024;
+  constexpr std::uint8_t TRIGGER_THRESHOLD = 8;
+  constexpr std::uint8_t TRIGGER_DELTA = 4;
+
+  namespace {
+
+    bool
+    stick_outside_deadzone(std::int16_t value) {
+      return std::abs(static_cast<int>(value)) >= STICK_DEADZONE;
+    }
+
+    bool
+    trigger_has_meaningful_change(std::uint8_t previous, std::uint8_t current) {
+      const auto previous_active = previous >= TRIGGER_THRESHOLD;
+      const auto current_active = current >= TRIGGER_THRESHOLD;
+      if (previous_active != current_active) {
+        return true;
+      }
+
+      return (previous_active || current_active) &&
+             std::abs(static_cast<int>(current) - static_cast<int>(previous)) >= TRIGGER_DELTA;
+    }
+
+    bool
+    stick_has_meaningful_change(std::int16_t previous, std::int16_t current) {
+      const auto previous_active = stick_outside_deadzone(previous);
+      const auto current_active = stick_outside_deadzone(current);
+      if (previous_active != current_active) {
+        return true;
+      }
+
+      return (previous_active || current_active) &&
+             std::abs(static_cast<int>(current) - static_cast<int>(previous)) >= STICK_DELTA;
+    }
+
+  }  // namespace
+
+  bool
+  tracker_t::evaluate_controller(_NV_MULTI_CONTROLLER_PACKET *packet) {
+    const auto controller_number = util::endian::little(packet->controllerNumber);
+    if (controller_number < 0 || controller_number >= static_cast<int>(controllers_.size())) {
+      return false;
+    }
+
+    const auto button_flags =
+      static_cast<std::uint32_t>(util::endian::little(static_cast<std::uint16_t>(packet->buttonFlags))) |
+      (static_cast<std::uint32_t>(util::endian::little(static_cast<std::uint16_t>(packet->buttonFlags2))) << 16);
+    const auto left_trigger = packet->leftTrigger;
+    const auto right_trigger = packet->rightTrigger;
+    const auto left_stick_x = util::endian::little(packet->leftStickX);
+    const auto left_stick_y = util::endian::little(packet->leftStickY);
+    const auto right_stick_x = util::endian::little(packet->rightStickX);
+    const auto right_stick_y = util::endian::little(packet->rightStickY);
+
+    auto &state = controllers_[controller_number];
+    bool should_trigger = false;
+
+    if (!state.initialized) {
+      should_trigger =
+        button_flags != 0 ||
+        left_trigger >= TRIGGER_THRESHOLD ||
+        right_trigger >= TRIGGER_THRESHOLD ||
+        stick_outside_deadzone(left_stick_x) ||
+        stick_outside_deadzone(left_stick_y) ||
+        stick_outside_deadzone(right_stick_x) ||
+        stick_outside_deadzone(right_stick_y);
+    }
+    else {
+      should_trigger =
+        button_flags != state.button_flags ||
+        trigger_has_meaningful_change(state.left_trigger, left_trigger) ||
+        trigger_has_meaningful_change(state.right_trigger, right_trigger) ||
+        stick_has_meaningful_change(state.left_stick_x, left_stick_x) ||
+        stick_has_meaningful_change(state.left_stick_y, left_stick_y) ||
+        stick_has_meaningful_change(state.right_stick_x, right_stick_x) ||
+        stick_has_meaningful_change(state.right_stick_y, right_stick_y);
+    }
+
+    state.initialized = true;
+    state.button_flags = button_flags;
+    state.left_trigger = left_trigger;
+    state.right_trigger = right_trigger;
+    state.left_stick_x = left_stick_x;
+    state.left_stick_y = left_stick_y;
+    state.right_stick_x = right_stick_x;
+    state.right_stick_y = right_stick_y;
+
+    return should_trigger;
+  }
+
+  bool
+  tracker_t::evaluate(_NV_INPUT_HEADER *payload) {
+    switch (util::endian::little(payload->magic)) {
+      case MOUSE_MOVE_REL_MAGIC_GEN5:
+        return config::input.mouse &&
+               (util::endian::big(reinterpret_cast<PNV_REL_MOUSE_MOVE_PACKET>(payload)->deltaX) != 0 ||
+                util::endian::big(reinterpret_cast<PNV_REL_MOUSE_MOVE_PACKET>(payload)->deltaY) != 0);
+      case MOUSE_MOVE_ABS_MAGIC:
+      case MOUSE_BUTTON_DOWN_EVENT_MAGIC_GEN5:
+      case MOUSE_BUTTON_UP_EVENT_MAGIC_GEN5:
+        return config::input.mouse;
+      case KEY_DOWN_EVENT_MAGIC:
+      case KEY_UP_EVENT_MAGIC:
+      case UTF8_TEXT_EVENT_MAGIC:
+        return config::input.keyboard;
+      case SS_TOUCH_MAGIC:
+      case SS_PEN_MAGIC:
+        return config::input.mouse;
+      case SS_CONTROLLER_TOUCH_MAGIC:
+        return config::input.controller;
+      case SCROLL_MAGIC_GEN5:
+        return config::input.mouse &&
+               (util::endian::big(reinterpret_cast<PNV_SCROLL_PACKET>(payload)->scrollAmt1) != 0 ||
+                util::endian::big(reinterpret_cast<PNV_SCROLL_PACKET>(payload)->scrollAmt2) != 0);
+      case SS_HSCROLL_MAGIC:
+        return config::input.mouse && util::endian::big(reinterpret_cast<PSS_HSCROLL_PACKET>(payload)->scrollAmount) != 0;
+      case MULTI_CONTROLLER_MAGIC_GEN5:
+        return config::input.controller && evaluate_controller(reinterpret_cast<PNV_MULTI_CONTROLLER_PACKET>(payload));
+      default:
+        return false;
+    }
+  }
+
+  void
+  tracker_t::reset() {
+    for (auto &state : controllers_) {
+      state = {};
+    }
+  }
+
+}  // namespace input::activity

--- a/src/input_activity.h
+++ b/src/input_activity.h
@@ -1,0 +1,56 @@
+/**
+ * @file src/input_activity.h
+ * @brief Declarations for input activity detection used by the VRR input activity boost.
+ */
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+struct _NV_INPUT_HEADER;
+struct _NV_MULTI_CONTROLLER_PACKET;
+
+namespace input::activity {
+
+  /**
+   * @brief Decides whether an incoming input packet represents meaningful user activity.
+   * @details Filters device management/telemetry packets, zero-delta no-ops and analog
+   *          jitter/drift so the video pipeline only boosts encode cadence for input
+   *          that can plausibly produce visible feedback.
+   */
+  class tracker_t {
+  public:
+    /**
+     * @brief Evaluate an input packet.
+     * @param payload The raw input packet header.
+     * @return true if the packet should count as user activity.
+     */
+    bool
+    evaluate(_NV_INPUT_HEADER *payload);
+
+    /**
+     * @brief Reset all per-controller tracking state (e.g. on session reset).
+     */
+    void
+    reset();
+
+  private:
+    struct controller_state_t {
+      bool initialized {};
+      std::uint32_t button_flags {};
+      std::uint8_t left_trigger {};
+      std::uint8_t right_trigger {};
+      std::int16_t left_stick_x {};
+      std::int16_t left_stick_y {};
+      std::int16_t right_stick_x {};
+      std::int16_t right_stick_y {};
+    };
+
+    bool
+    evaluate_controller(_NV_MULTI_CONTROLLER_PACKET *packet);
+
+    // activeGamepadMask is 16 bits wide, so controller numbers are bounded by 16.
+    std::array<controller_state_t, 16> controllers_ {};
+  };
+
+}  // namespace input::activity

--- a/src/nvhttp/display_scale.cpp
+++ b/src/nvhttp/display_scale.cpp
@@ -51,6 +51,7 @@ namespace nvhttp::display_scale {
       node["scale_set_supported"] = false;
     }
 
+#ifndef _WIN32
     void
     add_unsupported_scale_options_fields(json &node) {
       node["current_scale_percent"] = nullptr;
@@ -58,6 +59,7 @@ namespace nvhttp::display_scale {
       node["supported_scale_percents"] = json::array();
       node["scale_set_supported"] = false;
     }
+#endif
 
 #ifdef _WIN32
     json

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -2685,17 +2685,35 @@ namespace video {
       }
     });
 
-    // set minimum frame time based on client-requested target framerate or minimum_fps_target
-    std::chrono::duration<double, std::milli> minimum_frame_time;
+    // Set the base minimum frame time based on client-requested target framerate or minimum_fps_target.
+    // This can be temporarily reduced later if VRR input activity boost is active.
+    std::chrono::duration<double, std::milli> base_minimum_frame_time;
     if (config::video.minimum_fps_target > 0) {
       // Use minimum_fps_target if specified
-      minimum_frame_time = std::chrono::duration<double, std::milli> { 1000.0 / config::video.minimum_fps_target };
-      BOOST_LOG(info) << "Minimum frame time set to "sv << minimum_frame_time.count() << "ms, based on minimum_fps_target "sv << config::video.minimum_fps_target << " fps."sv;
+      base_minimum_frame_time = std::chrono::duration<double, std::milli> { 1000.0 / config::video.minimum_fps_target };
+      BOOST_LOG(info) << "Minimum frame time set to "sv << base_minimum_frame_time.count() << "ms, based on minimum_fps_target "sv << config::video.minimum_fps_target << " fps."sv;
     }
     else {
       // Default behavior: about half the stream FPS
-      minimum_frame_time = std::chrono::duration<double, std::milli> { 2000.0 / config.framerate };
-      BOOST_LOG(info) << "Minimum frame time set to "sv << minimum_frame_time.count() << "ms, based on client-requested target framerate "sv << config.framerate << "."sv;
+      base_minimum_frame_time = std::chrono::duration<double, std::milli> { 2000.0 / config.framerate };
+      BOOST_LOG(info) << "Minimum frame time set to "sv << base_minimum_frame_time.count() << "ms, based on client-requested target framerate "sv << config.framerate << "."sv;
+    }
+
+    const bool input_activity_boost_enabled =
+      config::video.variable_refresh_rate &&
+      config::video.input_activity_boost &&
+      config::video.input_activity_boost_fps > 0 &&
+      config::video.input_activity_boost_window_ms > 0;
+
+    const auto input_activity_boost_frame_time = input_activity_boost_enabled ?
+      std::chrono::duration<double, std::milli> { 1000.0 / config::video.input_activity_boost_fps } :
+      base_minimum_frame_time;
+    const auto input_activity_boost_window = std::chrono::milliseconds { config::video.input_activity_boost_window_ms };
+
+    if (input_activity_boost_enabled) {
+      BOOST_LOG(info) << "Input activity boost enabled: floor="sv
+                      << config::video.input_activity_boost_fps
+                      << " fps, window="sv << config::video.input_activity_boost_window_ms << " ms"sv;
     }
 
     auto shutdown_event = mail->event<bool>(mail::shutdown);
@@ -2703,6 +2721,16 @@ namespace video {
     auto idr_events = mail->event<bool>(mail::idr);
     auto invalidate_ref_frames_events = mail->event<std::pair<int64_t, int64_t>>(mail::invalidate_ref_frames);
     auto dynamic_param_events_ptr = dynamic_param_events.value_or(mail::man->event<dynamic_param_t>(mail::dynamic_param_change));
+    auto input_activity_event = mail->event<std::chrono::steady_clock::time_point>(mail::input_activity);
+    auto input_boost_until = std::chrono::steady_clock::time_point::min();
+
+    auto consume_input_activity = [&]() {
+      while (input_activity_event->peek()) {
+        if (auto activity = input_activity_event->pop(0ms)) {
+          input_boost_until = std::max(input_boost_until, *activity + input_activity_boost_window);
+        }
+      }
+    };
 
     {
       // Load a dummy image into the AVFrame to ensure we have something to encode
@@ -2752,13 +2780,19 @@ namespace video {
         session->request_idr_frame();
       }
 
+      consume_input_activity();
+      auto input_boost_active = input_activity_boost_enabled && std::chrono::steady_clock::now() < input_boost_until;
+      auto effective_minimum_frame_time = input_boost_active ?
+        std::min(base_minimum_frame_time, input_activity_boost_frame_time) :
+        base_minimum_frame_time;
+
       std::optional<std::chrono::steady_clock::time_point> frame_timestamp;
       bool has_new_frame = false;
 
       // Encode at a minimum FPS to avoid image quality issues with static content
       // When variable_refresh_rate is enabled, only encode when we have a new frame
       if (!requested_idr_frame || images->peek()) {
-        if (auto img = images->pop(minimum_frame_time)) {
+        if (auto img = images->pop(effective_minimum_frame_time)) {
           frame_timestamp = img->frame_timestamp;
           if (session->convert(*img)) {
             BOOST_LOG(error) << "Could not convert image"sv;
@@ -2772,6 +2806,9 @@ namespace video {
         }
       }
 
+      consume_input_activity();
+      input_boost_active = input_activity_boost_enabled && std::chrono::steady_clock::now() < input_boost_until;
+
       // While streaming check to see if the mouse is present and enable Mouse Keys to force the cursor to appear.
       // Run this BEFORE the VRR early-continue so a KVM switch on a static screen still recovers the cursor
       // even when no new frame would be encoded.
@@ -2779,13 +2816,14 @@ namespace video {
 
       // If variable refresh rate is enabled, skip encoding when no new frame is available
       // This allows the stream framerate to match the render framerate for VRR support
-      // However, if minimum_fps_target is set, we still encode to maintain minimum FPS
+      // However, if minimum_fps_target is set, or input activity boost is active, we still encode
+      // to maintain a temporary minimum FPS floor for better visual input feedback.
       if (config::video.variable_refresh_rate && !has_new_frame && !requested_idr_frame) {
-        // Only skip if minimum_fps_target is 0 (disabled) or we've already met the minimum
-        if (config::video.minimum_fps_target == 0) {
+        // Only skip if minimum_fps_target is 0 (disabled) and input activity boost is inactive.
+        if (config::video.minimum_fps_target == 0 && !input_boost_active) {
           continue;
         }
-        // If minimum_fps_target is set, we'll encode anyway to maintain minimum FPS
+        // If minimum_fps_target is set or boost is active, we'll encode anyway to maintain minimum FPS.
       }
 
       if (encode(frame_nr++, *session, packets, channel_data, frame_timestamp)) {

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -2732,6 +2732,31 @@ namespace video {
       }
     };
 
+    using image_pop_result_t = decltype(images->pop(0ms));
+    const auto input_activity_poll_interval = std::chrono::duration<double, std::milli> { 5ms };
+    auto pop_image_interruptible = [&](const std::chrono::duration<double, std::milli> &wait_time, bool allow_input_preemption) -> image_pop_result_t {
+      if (!allow_input_preemption || wait_time <= input_activity_poll_interval) {
+        return images->pop(wait_time);
+      }
+
+      auto remaining_wait = wait_time;
+      while (images->running() && remaining_wait > 0ms) {
+        auto slice_wait = std::min(remaining_wait, input_activity_poll_interval);
+        if (auto img = images->pop(slice_wait)) {
+          return img;
+        }
+
+        consume_input_activity();
+        if (std::chrono::steady_clock::now() < input_boost_until) {
+          return {};
+        }
+
+        remaining_wait -= slice_wait;
+      }
+
+      return {};
+    };
+
     {
       // Load a dummy image into the AVFrame to ensure we have something to encode
       // even if we timeout waiting on the first frame. This is a relatively large
@@ -2792,7 +2817,7 @@ namespace video {
       // Encode at a minimum FPS to avoid image quality issues with static content
       // When variable_refresh_rate is enabled, only encode when we have a new frame
       if (!requested_idr_frame || images->peek()) {
-        if (auto img = images->pop(effective_minimum_frame_time)) {
+        if (auto img = pop_image_interruptible(effective_minimum_frame_time, input_activity_boost_enabled && !input_boost_active)) {
           frame_timestamp = img->frame_timestamp;
           if (session->convert(*img)) {
             BOOST_LOG(error) << "Could not convert image"sv;


### PR DESCRIPTION
## Summary
- add a session-local input activity signal from the input pipeline to the video pipeline
- add configurable VRR input activity boost settings for a temporary minimum encode cadence floor
- keep normal VRR idle behavior unchanged unless recent local input was observed
- guard the non-Windows display scale helper to avoid a Windows Release unused-function build failure

## Why
When VRR is enabled and the game is rendering at a very low frame rate, keyboard and mouse input can feel delayed even though the input packets themselves arrive promptly. The issue is mostly visual feedback latency: with no new frame, Sunshine can remain idle for too long. This change temporarily raises the encode cadence after recent input so visual feedback stays responsive on static or low-FPS scenes.

## Testing
- built the Windows package locally in Release
- installed and ran the packaged build locally
- manually verified the low-FPS + VRR input responsiveness improvement
- confirmed unrelated local workspace changes were not included in this PR
