### PR TITLE
fix(vdd): sync full mode list via SETMODES

### DIFF
--- a/src/display_device/session.cpp
+++ b/src/display_device/session.cpp
@@ -480,19 +480,18 @@ namespace display_device {
     const auto new_setting = to_string(*config.resolution) + "@" + to_string(*config.refresh_rate);
 
     if (last_vdd_setting == new_setting) {
-      BOOST_LOG(debug) << "VDD配置未变更: " << new_setting;
-      return;
+      BOOST_LOG(debug) << "VDD session mode unchanged; resyncing full driver mode list: " << new_setting;
     }
 
-    const auto setmodes_result = vdd_utils::set_vdd_session_mode(config);
+    const auto setmodes_result = vdd_utils::set_vdd_session_mode(config, vdd_settings);
     switch (setmodes_result) {
       case vdd_utils::set_vdd_result::ok:
         last_vdd_setting = new_setting;
-        BOOST_LOG(info) << "VDD会话模式更新完成（未写入XML）: " << new_setting;
+        BOOST_LOG(info) << "VDD会话模式列表更新完成（未写入XML）: " << new_setting;
         return;
       case vdd_utils::set_vdd_result::failed:
-        BOOST_LOG(error) << "VDD SETMODES 被驱动拒绝，跳过 XML 回退以避免运行态/持久态不一致: " << new_setting;
-        return;
+        BOOST_LOG(warning) << "VDD SETMODES 更新失败，回退 XML+reload 路径: " << new_setting;
+        break;
       case vdd_utils::set_vdd_result::invalid_config:
         BOOST_LOG(warning) << "VDD 会话模式参数无效，跳过更新: " << new_setting;
         return;
@@ -580,7 +579,7 @@ namespace display_device {
 
     // Update VDD resolution configuration
     if (auto vdd_settings = vdd_utils::prepare_vdd_settings(config);
-      vdd_settings.needs_update && config.resolution) {
+      config.resolution && config.refresh_rate) {
       update_vdd_resolution(config, vdd_settings);
     }
 

--- a/src/display_device/vdd_utils.cpp
+++ b/src/display_device/vdd_utils.cpp
@@ -17,6 +17,7 @@
 #include <cmath>
 #include <filesystem>
 #include <future>
+#include <limits>
 #include <locale>
 #include <sstream>
 #include <thread>
@@ -418,18 +419,30 @@ namespace display_device {
     }
 
     boost::optional<unsigned int>
+    rounded_vdd_refresh_hz(double refresh_hz) {
+      constexpr auto max_unsigned_refresh_hz = static_cast<double>(std::numeric_limits<unsigned int>::max());
+      constexpr auto max_lround_input = static_cast<double>(std::numeric_limits<long>::max());
+
+      if (!std::isfinite(refresh_hz) || refresh_hz <= 0.0 || refresh_hz > std::min(max_unsigned_refresh_hz, max_lround_input)) {
+        return {};
+      }
+
+      const auto rounded = std::lround(refresh_hz);
+      if (rounded <= 0 || static_cast<unsigned long>(rounded) > std::numeric_limits<unsigned int>::max()) {
+        return {};
+      }
+
+      return static_cast<unsigned int>(rounded);
+    }
+
+    boost::optional<unsigned int>
     rounded_refresh_hz(const refresh_rate_t &refresh_rate) {
       if (refresh_rate.denominator == 0) {
         return {};
       }
 
       const double refresh_hz = static_cast<double>(refresh_rate.numerator) / refresh_rate.denominator;
-      const auto rounded = static_cast<unsigned int>(std::lround(refresh_hz));
-      if (rounded == 0) {
-        return {};
-      }
-
-      return rounded;
+      return rounded_vdd_refresh_hz(refresh_hz);
     }
 
     boost::optional<unsigned int>
@@ -443,18 +456,18 @@ namespace display_device {
       try {
         std::size_t parsed_len = 0;
         const double refresh_hz = std::stod(trimmed, &parsed_len);
-        if (parsed_len != trimmed.size() || refresh_hz <= 0.0) {
+        if (parsed_len != trimmed.size()) {
           BOOST_LOG(warning) << "Skipping invalid VDD refresh-rate entry: " << value;
           return {};
         }
 
-        const auto rounded = static_cast<unsigned int>(std::lround(refresh_hz));
-        if (rounded == 0) {
+        const auto rounded = rounded_vdd_refresh_hz(refresh_hz);
+        if (!rounded) {
           BOOST_LOG(warning) << "Skipping invalid VDD refresh-rate entry: " << value;
           return {};
         }
 
-        return rounded;
+        return *rounded;
       }
       catch (const std::exception &) {
         BOOST_LOG(warning) << "Skipping invalid VDD refresh-rate entry: " << value;

--- a/src/display_device/vdd_utils.cpp
+++ b/src/display_device/vdd_utils.cpp
@@ -374,38 +374,145 @@ namespace display_device {
       return true;
     }
 
+    bool
+    same_resolution(const resolution_t &a, const resolution_t &b) {
+      return a.width == b.width && a.height == b.height;
+    }
+
+    void
+    append_unique_resolution(std::vector<resolution_t> &resolutions, const resolution_t &resolution) {
+      if (std::find_if(resolutions.begin(), resolutions.end(), [&](const auto &cached) {
+            return same_resolution(cached, resolution);
+          }) == resolutions.end()) {
+        resolutions.push_back(resolution);
+      }
+    }
+
+    void
+    append_unique_refresh_rate(std::vector<unsigned int> &refresh_rates_hz, unsigned int refresh_hz) {
+      if (refresh_hz > 0 && std::find(refresh_rates_hz.begin(), refresh_rates_hz.end(), refresh_hz) == refresh_rates_hz.end()) {
+        refresh_rates_hz.push_back(refresh_hz);
+      }
+    }
+
+    boost::optional<resolution_t>
+    parse_vdd_resolution(const std::string &value) {
+      std::string trimmed = value;
+      boost::algorithm::trim(trimmed);
+      if (trimmed.empty()) {
+        return {};
+      }
+
+      std::stringstream input(trimmed);
+      unsigned int width = 0;
+      unsigned int height = 0;
+      char separator = '\0';
+      input >> width >> separator >> height;
+
+      if (!input || !input.eof() || (separator != 'x' && separator != 'X') || width == 0 || height == 0) {
+        BOOST_LOG(warning) << "Skipping invalid VDD resolution entry: " << value;
+        return {};
+      }
+
+      return resolution_t { width, height };
+    }
+
+    boost::optional<unsigned int>
+    rounded_refresh_hz(const refresh_rate_t &refresh_rate) {
+      if (refresh_rate.denominator == 0) {
+        return {};
+      }
+
+      const double refresh_hz = static_cast<double>(refresh_rate.numerator) / refresh_rate.denominator;
+      const auto rounded = static_cast<unsigned int>(std::lround(refresh_hz));
+      if (rounded == 0) {
+        return {};
+      }
+
+      return rounded;
+    }
+
+    boost::optional<unsigned int>
+    parse_vdd_refresh_hz(const std::string &value) {
+      std::string trimmed = value;
+      boost::algorithm::trim(trimmed);
+      if (trimmed.empty()) {
+        return {};
+      }
+
+      try {
+        std::size_t parsed_len = 0;
+        const double refresh_hz = std::stod(trimmed, &parsed_len);
+        if (parsed_len != trimmed.size() || refresh_hz <= 0.0) {
+          BOOST_LOG(warning) << "Skipping invalid VDD refresh-rate entry: " << value;
+          return {};
+        }
+
+        const auto rounded = static_cast<unsigned int>(std::lround(refresh_hz));
+        if (rounded == 0) {
+          BOOST_LOG(warning) << "Skipping invalid VDD refresh-rate entry: " << value;
+          return {};
+        }
+
+        return rounded;
+      }
+      catch (const std::exception &) {
+        BOOST_LOG(warning) << "Skipping invalid VDD refresh-rate entry: " << value;
+        return {};
+      }
+    }
+
     set_vdd_result
-    set_vdd_session_mode(const parsed_config_t &config) {
+    set_vdd_session_mode(const parsed_config_t &config, const VddSettings &settings) {
       if (!config.resolution || !config.refresh_rate) {
         BOOST_LOG(debug) << "SETMODES skipped: session resolution or refresh rate is not set";
         return set_vdd_result::invalid_config;
       }
 
-      if (config.refresh_rate->denominator == 0) {
-        BOOST_LOG(warning) << "SETMODES skipped: invalid refresh rate denominator";
+      auto session_refresh_hz = rounded_refresh_hz(*config.refresh_rate);
+      if (!session_refresh_hz) {
+        BOOST_LOG(warning) << "SETMODES skipped: invalid refresh rate " << to_string(*config.refresh_rate);
         return set_vdd_result::invalid_config;
       }
 
-      const double refresh_hz = static_cast<double>(config.refresh_rate->numerator) / config.refresh_rate->denominator;
-      const auto rounded_refresh_hz = static_cast<unsigned int>(std::lround(refresh_hz));
-      if (rounded_refresh_hz == 0) {
-        BOOST_LOG(warning) << "SETMODES skipped: invalid refresh rate " << refresh_hz;
+      auto resolutions = settings.resolution_modes;
+      auto refresh_rates_hz = settings.refresh_rates_hz;
+      append_unique_resolution(resolutions, *config.resolution);
+      append_unique_refresh_rate(refresh_rates_hz, *session_refresh_hz);
+
+      if (resolutions.empty() || refresh_rates_hz.empty()) {
+        BOOST_LOG(warning) << "SETMODES skipped: full VDD mode list is empty";
         return set_vdd_result::invalid_config;
       }
 
       std::wstringstream command;
-      command << L"SETMODES "
-              << config.resolution->width << L"x"
-              << config.resolution->height << L"x"
-              << rounded_refresh_hz;
+      command << L"SETMODES ";
+      std::size_t mode_count = 0;
+      for (const auto &resolution : resolutions) {
+        for (const auto refresh_hz : refresh_rates_hz) {
+          if (mode_count > 0) {
+            command << L",";
+          }
+          command << resolution.width << L"x" << resolution.height << L"x" << refresh_hz;
+          ++mode_count;
+        }
+      }
 
-      switch (vdd_ioctl::send_command(command.str())) {
+      const auto command_string = command.str();
+      if (command_string.size() >= 2048) {
+        BOOST_LOG(warning) << "SETMODES command too large (" << command_string.size()
+                           << " wchar_t); XML fallback will be used";
+        return set_vdd_result::failed;
+      }
+
+      switch (vdd_ioctl::send_command(command_string)) {
         case vdd_ioctl::result::success:
-          BOOST_LOG(info) << "VDD live session mode updated via SETMODES: "
-                          << to_string(*config.resolution) << "@" << rounded_refresh_hz << "Hz";
+          BOOST_LOG(info) << "VDD live mode list updated via SETMODES: " << mode_count
+                          << " modes; requested " << to_string(*config.resolution)
+                          << "@" << *session_refresh_hz << "Hz";
           return set_vdd_result::ok;
         case vdd_ioctl::result::failed:
-          BOOST_LOG(warning) << "VDD SETMODES IOCTL rejected by driver; not falling back to XML to avoid partial state";
+          BOOST_LOG(warning) << "VDD SETMODES IOCTL failed; XML fallback will be used";
           return set_vdd_result::failed;
         case vdd_ioctl::result::interface_missing:
           BOOST_LOG(debug) << "VDD SETMODES unavailable: IOCTL interface missing; XML fallback will be used";
@@ -766,6 +873,8 @@ namespace display_device {
       auto is_res_cached = false;
       auto is_fps_cached = false;
       std::ostringstream res_stream, fps_stream;
+      std::vector<resolution_t> resolution_modes;
+      std::vector<unsigned int> refresh_rates_hz;
 
       res_stream << '[';
       fps_stream << '[';
@@ -773,6 +882,9 @@ namespace display_device {
       // 检查分辨率是否已缓存
       for (const auto &res : config::nvhttp.resolutions) {
         res_stream << res << ',';
+        if (const auto parsed_resolution = parse_vdd_resolution(res)) {
+          append_unique_resolution(resolution_modes, *parsed_resolution);
+        }
         if (config.resolution && res == to_string(*config.resolution)) {
           is_res_cached = true;
         }
@@ -781,19 +893,31 @@ namespace display_device {
       // 检查帧率是否已缓存
       for (const auto &fps : config::nvhttp.fps) {
         fps_stream << fps << ',';
+        if (const auto parsed_refresh_hz = parse_vdd_refresh_hz(fps)) {
+          append_unique_refresh_rate(refresh_rates_hz, *parsed_refresh_hz);
+        }
         if (config.refresh_rate && fps == to_string(*config.refresh_rate)) {
           is_fps_cached = true;
         }
       }
 
       // 如果需要更新设置
-      bool needs_update = (!is_res_cached || !is_fps_cached) && config.resolution;
+      bool needs_update = config.resolution && (!is_res_cached || (config.refresh_rate && !is_fps_cached));
       if (needs_update) {
         if (!is_res_cached) {
           res_stream << to_string(*config.resolution);
         }
         if (!is_fps_cached && config.refresh_rate) {
           fps_stream << to_string(*config.refresh_rate);
+        }
+      }
+
+      if (config.resolution) {
+        append_unique_resolution(resolution_modes, *config.resolution);
+      }
+      if (config.refresh_rate) {
+        if (const auto session_refresh_hz = rounded_refresh_hz(*config.refresh_rate)) {
+          append_unique_refresh_rate(refresh_rates_hz, *session_refresh_hz);
         }
       }
 
@@ -805,7 +929,7 @@ namespace display_device {
       res_str += ']';
       fps_str += ']';
 
-      return { res_str, fps_str, needs_update };
+      return { res_str, fps_str, resolution_modes, refresh_rates_hz, needs_update };
     }
 
     bool

--- a/src/display_device/vdd_utils.h
+++ b/src/display_device/vdd_utils.h
@@ -8,6 +8,7 @@
 #include <string_view>
 #include <thread>
 #include <unordered_set>
+#include <vector>
 #include <windows.h>
 
 #include "parsed_config.h"
@@ -51,6 +52,8 @@ namespace display_device::vdd_utils {
   struct VddSettings {
     std::string resolutions;
     std::string fps;
+    std::vector<resolution_t> resolution_modes;
+    std::vector<unsigned int> refresh_rates_hz;
     bool needs_update = false;
   };
 
@@ -87,8 +90,7 @@ namespace display_device::vdd_utils {
    * @brief Outcome of attempting a live SETMODES update.
    * @details Lets callers distinguish "driver accepted" / "driver rejected" /
    *          "feature not present" / "config is unusable" so the persistent
-   *          XML fallback only triggers when the driver genuinely lacks the
-   *          IOCTL interface.
+   *          XML fallback can be used when the live path is not available.
    */
   enum class set_vdd_result {
     ok,                 ///< Driver accepted the live mode update.
@@ -98,14 +100,15 @@ namespace display_device::vdd_utils {
   };
 
   /**
-   * @brief Push the current session mode to ZakoVDD in-memory mode list.
+   * @brief Push the complete session mode list to ZakoVDD in-memory mode list.
    * @details Uses the SETMODES IOCTL command exposed by newer ZakoVDD builds.
    *          This does not persist the session resolution to vdd_settings.xml.
-   * @param config Parsed display configuration containing resolution + refresh rate.
-   * @return Typed outcome; only ::interface_missing should trigger XML fallback.
+   * @param config Parsed display configuration containing the requested session mode.
+   * @param settings Full standard mode list plus the requested session mode.
+   * @return Typed outcome; callers can XML-fallback when the live path is unavailable.
    */
   set_vdd_result
-  set_vdd_session_mode(const parsed_config_t &config);
+  set_vdd_session_mode(const parsed_config_t &config, const VddSettings &settings);
 
   /**
    * @brief 从客户端标识符生成GUID字符串（用于驱动识别）


### PR DESCRIPTION
## 改了啥呢

- 每次 VDD session 都把完整标准分辨率/帧率列表 + 本次请求 mode 同步给驱动，`SETMODES` 现在发逗号分隔的 `WxHxR` 列表。
- 去掉相同 `last_vdd_setting` 就跳过的短路，避免驱动运行时 mode list 丢了以后不补。
- `SETMODES` 不可用或失败时回退 515 的 `vdd_settings.xml` + reload 路径。

## 为什么

ZakoVDD 0.15.7 的 `SETMODES` 是 replace live `monitorModes` list，不是 append。之前 Sunshine 只发当前 session mode，等于把 720p/1080p/4K 这些标准预置从驱动运行时列表里挤掉了；用户回退到 515 会好，是因为旧路径写 XML 后 reload 会带完整列表。杂鱼问题藏得还挺深。

## 验证

- `git diff --cached --check`
- `ninja -C build CMakeFiles/sunshine.dir/src/display_device/vdd_utils.cpp.obj CMakeFiles/sunshine.dir/src/display_device/session.cpp.obj`
- `cmake --build build --target sunshine` 继续到无关现有失败：`src/nvhttp/display_scale.cpp:55 add_unsupported_scale_options_fields(json&) defined but not used [-Werror=unused-function]`