### PR TITLE
fix(vrr): limit input boost to keyboard events

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1582,6 +1582,10 @@ namespace input {
     // Print the final input packet
     input::print((void *) payload);
 
+    const bool should_raise_input_activity =
+      config::video.input_activity_boost &&
+      input->activity_tracker.evaluate(payload);
+
     // Send the batched input to the OS
     switch (util::endian::little(payload->magic)) {
       case MOUSE_MOVE_REL_MAGIC_GEN5:
@@ -1629,6 +1633,10 @@ namespace input {
         passthrough(input, (PSS_CONTROLLER_BATTERY_PACKET) payload);
         break;
     }
+
+    if (should_raise_input_activity) {
+      input->input_activity_event->raise(std::chrono::steady_clock::now());
+    }
   }
 
   /**
@@ -1638,11 +1646,6 @@ namespace input {
    */
   void
   passthrough(std::shared_ptr<input_t> &input, std::vector<std::uint8_t> &&input_data) {
-    auto payload = input_data.empty() ? nullptr : reinterpret_cast<PNV_INPUT_HEADER>(input_data.data());
-    if (config::video.input_activity_boost && payload != nullptr && input->activity_tracker.evaluate(payload)) {
-      input->input_activity_event->raise(std::chrono::steady_clock::now());
-    }
-
     {
       std::lock_guard<std::mutex> lg(input->input_queue_lock);
       input->input_queue.push_back(std::move(input_data));
@@ -1654,8 +1657,6 @@ namespace input {
   reset(std::shared_ptr<input_t> &input) {
     task_pool.cancel(key_press_repeat_id);
     task_pool.cancel(input->mouse_left_button_timeout);
-
-    input->activity_tracker.reset();
 
     // Ensure input is synchronous, by using the task_pool
     task_pool.push([]() {

--- a/src/input_activity.cpp
+++ b/src/input_activity.cpp
@@ -2,10 +2,6 @@
  * @file src/input_activity.cpp
  * @brief Definitions for input activity detection used by the VRR input activity boost.
  */
-// standard includes
-#include <cmath>
-#include <cstdint>
-
 // lib includes
 #include <moonlight-common-c/src/Input.h>
 #include <moonlight-common-c/src/Limelight.h>
@@ -17,136 +13,15 @@
 
 namespace input::activity {
 
-  // Ignore analog jitter/drift unless the input crosses a small deadzone or changes meaningfully
-  // while active. This matches the common "edge + deadzone + hysteresis" pattern used by input systems.
-  constexpr std::int16_t STICK_DEADZONE = 2048;
-  constexpr std::int16_t STICK_DELTA = 1024;
-  constexpr std::uint8_t TRIGGER_THRESHOLD = 8;
-  constexpr std::uint8_t TRIGGER_DELTA = 4;
-
-  namespace {
-
-    bool
-    stick_outside_deadzone(std::int16_t value) {
-      return std::abs(static_cast<int>(value)) >= STICK_DEADZONE;
-    }
-
-    bool
-    trigger_has_meaningful_change(std::uint8_t previous, std::uint8_t current) {
-      const auto previous_active = previous >= TRIGGER_THRESHOLD;
-      const auto current_active = current >= TRIGGER_THRESHOLD;
-      if (previous_active != current_active) {
-        return true;
-      }
-
-      return (previous_active || current_active) &&
-             std::abs(static_cast<int>(current) - static_cast<int>(previous)) >= TRIGGER_DELTA;
-    }
-
-    bool
-    stick_has_meaningful_change(std::int16_t previous, std::int16_t current) {
-      const auto previous_active = stick_outside_deadzone(previous);
-      const auto current_active = stick_outside_deadzone(current);
-      if (previous_active != current_active) {
-        return true;
-      }
-
-      return (previous_active || current_active) &&
-             std::abs(static_cast<int>(current) - static_cast<int>(previous)) >= STICK_DELTA;
-    }
-
-  }  // namespace
-
-  bool
-  tracker_t::evaluate_controller(_NV_MULTI_CONTROLLER_PACKET *packet) {
-    const auto controller_number = util::endian::little(packet->controllerNumber);
-    if (controller_number < 0 || controller_number >= static_cast<int>(controllers_.size())) {
-      return false;
-    }
-
-    const auto button_flags =
-      static_cast<std::uint32_t>(util::endian::little(static_cast<std::uint16_t>(packet->buttonFlags))) |
-      (static_cast<std::uint32_t>(util::endian::little(static_cast<std::uint16_t>(packet->buttonFlags2))) << 16);
-    const auto left_trigger = packet->leftTrigger;
-    const auto right_trigger = packet->rightTrigger;
-    const auto left_stick_x = util::endian::little(packet->leftStickX);
-    const auto left_stick_y = util::endian::little(packet->leftStickY);
-    const auto right_stick_x = util::endian::little(packet->rightStickX);
-    const auto right_stick_y = util::endian::little(packet->rightStickY);
-
-    auto &state = controllers_[controller_number];
-    bool should_trigger = false;
-
-    if (!state.initialized) {
-      should_trigger =
-        button_flags != 0 ||
-        left_trigger >= TRIGGER_THRESHOLD ||
-        right_trigger >= TRIGGER_THRESHOLD ||
-        stick_outside_deadzone(left_stick_x) ||
-        stick_outside_deadzone(left_stick_y) ||
-        stick_outside_deadzone(right_stick_x) ||
-        stick_outside_deadzone(right_stick_y);
-    }
-    else {
-      should_trigger =
-        button_flags != state.button_flags ||
-        trigger_has_meaningful_change(state.left_trigger, left_trigger) ||
-        trigger_has_meaningful_change(state.right_trigger, right_trigger) ||
-        stick_has_meaningful_change(state.left_stick_x, left_stick_x) ||
-        stick_has_meaningful_change(state.left_stick_y, left_stick_y) ||
-        stick_has_meaningful_change(state.right_stick_x, right_stick_x) ||
-        stick_has_meaningful_change(state.right_stick_y, right_stick_y);
-    }
-
-    state.initialized = true;
-    state.button_flags = button_flags;
-    state.left_trigger = left_trigger;
-    state.right_trigger = right_trigger;
-    state.left_stick_x = left_stick_x;
-    state.left_stick_y = left_stick_y;
-    state.right_stick_x = right_stick_x;
-    state.right_stick_y = right_stick_y;
-
-    return should_trigger;
-  }
-
   bool
   tracker_t::evaluate(_NV_INPUT_HEADER *payload) {
     switch (util::endian::little(payload->magic)) {
-      case MOUSE_MOVE_REL_MAGIC_GEN5:
-        return config::input.mouse &&
-               (util::endian::big(reinterpret_cast<PNV_REL_MOUSE_MOVE_PACKET>(payload)->deltaX) != 0 ||
-                util::endian::big(reinterpret_cast<PNV_REL_MOUSE_MOVE_PACKET>(payload)->deltaY) != 0);
-      case MOUSE_MOVE_ABS_MAGIC:
-      case MOUSE_BUTTON_DOWN_EVENT_MAGIC_GEN5:
-      case MOUSE_BUTTON_UP_EVENT_MAGIC_GEN5:
-        return config::input.mouse;
       case KEY_DOWN_EVENT_MAGIC:
       case KEY_UP_EVENT_MAGIC:
       case UTF8_TEXT_EVENT_MAGIC:
         return config::input.keyboard;
-      case SS_TOUCH_MAGIC:
-      case SS_PEN_MAGIC:
-        return config::input.mouse;
-      case SS_CONTROLLER_TOUCH_MAGIC:
-        return config::input.controller;
-      case SCROLL_MAGIC_GEN5:
-        return config::input.mouse &&
-               (util::endian::big(reinterpret_cast<PNV_SCROLL_PACKET>(payload)->scrollAmt1) != 0 ||
-                util::endian::big(reinterpret_cast<PNV_SCROLL_PACKET>(payload)->scrollAmt2) != 0);
-      case SS_HSCROLL_MAGIC:
-        return config::input.mouse && util::endian::big(reinterpret_cast<PSS_HSCROLL_PACKET>(payload)->scrollAmount) != 0;
-      case MULTI_CONTROLLER_MAGIC_GEN5:
-        return config::input.controller && evaluate_controller(reinterpret_cast<PNV_MULTI_CONTROLLER_PACKET>(payload));
       default:
         return false;
-    }
-  }
-
-  void
-  tracker_t::reset() {
-    for (auto &state : controllers_) {
-      state = {};
     }
   }
 

--- a/src/input_activity.h
+++ b/src/input_activity.h
@@ -4,11 +4,7 @@
  */
 #pragma once
 
-#include <array>
-#include <cstdint>
-
 struct _NV_INPUT_HEADER;
-struct _NV_MULTI_CONTROLLER_PACKET;
 
 namespace input::activity {
 
@@ -27,30 +23,6 @@ namespace input::activity {
      */
     bool
     evaluate(_NV_INPUT_HEADER *payload);
-
-    /**
-     * @brief Reset all per-controller tracking state (e.g. on session reset).
-     */
-    void
-    reset();
-
-  private:
-    struct controller_state_t {
-      bool initialized {};
-      std::uint32_t button_flags {};
-      std::uint8_t left_trigger {};
-      std::uint8_t right_trigger {};
-      std::int16_t left_stick_x {};
-      std::int16_t left_stick_y {};
-      std::int16_t right_stick_x {};
-      std::int16_t right_stick_y {};
-    };
-
-    bool
-    evaluate_controller(_NV_MULTI_CONTROLLER_PACKET *packet);
-
-    // activeGamepadMask is 16 bits wide, so controller numbers are bounded by 16.
-    std::array<controller_state_t, 16> controllers_ {};
   };
 
 }  // namespace input::activity


### PR DESCRIPTION
## 改了啥呀

- VRR input activity boost 现在只响应键盘相关输入：`KEY_DOWN_EVENT_MAGIC`、`KEY_UP_EVENT_MAGIC`、`UTF8_TEXT_EVENT_MAGIC`。
- 鼠标移动/点击、滚轮、touch、pen、controller 都不再触发 boost，避免高频输入流把 stale-frame encode 持续拉起来。
- `activity_tracker` 已简化为无状态判断，删除了 controller 追踪状态和 reset API；之前 review 提到的 reset/evaluate 并发访问点因此不再存在。
- 仍保留 boost event 在 OS 输入派发之后触发，避免编码线程先抢到还没应用输入的旧帧。

## 为啥要改

#722 的 boost 会在 VRR 无新帧时临时 encode stale frame，用来改善静态画面下输入后的视觉反馈。但手柄实测已经证明，连续输入流触发这个机制会和 RD / 游戏渲染争资源，导致 Android / 鸿蒙客户端出现输入响应变慢、RD 帧率突然下降又恢复。

为了先拿到稳定、低风险的行为，这版只保留键盘事件触发 boost。键盘输入是离散事件，基本不会被高频流持续续命；鼠标/touch/pen/controller 这些可能高频连续的输入先全部排除，杂鱼高频事件不要再拖着编码跑呀。

## 验证

- `git diff --check -- src/input.cpp src/input_activity.cpp src/input_activity.h`
- `cmake --build build --target sunshine --parallel`
- `build/cpack_artifacts/_CPack_Packages/win64/ZIP/Sunshine/sunshine.exe --help`
- `cpack -G ZIP --config .\CPackConfig.cmake --verbose`，生成 `build/cpack_artifacts/Sunshine.zip`