### PR TITLE
fix(process): continue desktop launch when prep lacks session permission

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -244,13 +244,19 @@ namespace proc {
       auto child = platf::run_command(cmd.elevated, true, cmd.do_cmd, working_dir, _env, _pipe.get(), ec, nullptr);
 
       if (ec) {
-        BOOST_LOG(error) << "Couldn't run ["sv << cmd.do_cmd << "]: System: "sv << ec.message();
         // We don't want any prep commands failing launch of the desktop.
         // This is to prevent the issue where users reboot their PC and need to log in with Sunshine.
         // permission_denied is typically returned when the user impersonation fails, which can happen when user is not signed in yet.
         if (!(_app.cmd.empty() && ec == std::errc::permission_denied)) {
+          BOOST_LOG(error) << "Couldn't run ["sv << cmd.do_cmd << "]: System: "sv << ec.message();
           return -1;
         }
+
+        BOOST_LOG(warning) << "Skipping Desktop prep command ["sv << cmd.do_cmd
+                           << "] because Sunshine could not run it under the user's session: "sv << ec.message()
+                           << ". Desktop streaming will continue, but this prep command's effect will not be applied."sv;
+        ec.clear();
+        continue;
       }
 
       child.wait(ec);


### PR DESCRIPTION
## What changed

- Desktop prep commands that fail with `permission_denied` now log a warning and are skipped instead of failing the Desktop launch.
- The warning names the skipped command and explains that Desktop streaming will continue, but the prep command effect was not applied.
- Non-Desktop apps, other prep-command errors, and non-zero prep-command exits still fail as before.

## Why

After an RDP session is disconnected or ended, Sunshine service mode may be unable to obtain a usable user-session token. Desktop launch already intended to tolerate prep-command permission failures, but the error code was left set and the later `child.wait(ec)` path still treated the launch as failed. That made Moonlight show that the specified application could not be opened, even though the requested app was Desktop.

Tiny bug, big drama. Shoo.

## Validation

- `git diff --check HEAD~1..HEAD` passed.
- `cmake --build build --target sunshine -j 8` was attempted. The local toolchain failed while compiling multiple third-party `enet` C files and returned exit code 1 without concrete compiler diagnostics, so this could not be completed locally.
