### PR TITLE
feat(web): add high-risk settings confirmation

### DIFF
--- a/src_assets/common/assets/web/composables/useConfig.js
+++ b/src_assets/common/assets/web/composables/useConfig.js
@@ -274,6 +274,53 @@ const parseResolutions = (resStr) => {
  */
 const filterValidFps = (fps) => fps.filter((item) => +item >= 30 && +item <= 500)
 
+const RISK_SEVERITY_WEIGHT = {
+  critical: 3,
+  high: 2,
+  medium: 1,
+}
+
+const isEnabledValue = (value) => value === true || value === 'true' || value === 'enabled' || value === 1 || value === '1'
+
+const hasCommandText = (cmd) => {
+  if (!cmd) return false
+  if (typeof cmd === 'string') return cmd.trim().length > 0
+  return Boolean(String(cmd.do || cmd.cmd || cmd.undo || '').trim())
+}
+
+const hasElevatedCommand = (commands) => commands.some((cmd) => isEnabledValue(cmd?.elevated))
+
+const compactValue = (value) => {
+  if (Array.isArray(value)) return `${value.length}`
+  if (value === undefined || value === null || value === '') return ''
+  return String(value)
+}
+
+const riskLocaleKey = (id, field) => `config.risk_confirm.items.${id}.${field}`
+
+const createRisk = (
+  id,
+  severity,
+  { descriptionField = 'description', recoveryField = 'recovery', recoveryId = id, currentValue } = {},
+) => {
+  const risk = {
+    id,
+    severity,
+    titleKey: riskLocaleKey(id, 'title'),
+    descriptionKey: riskLocaleKey(id, descriptionField),
+  }
+
+  if (recoveryField) {
+    risk.recoveryKey = riskLocaleKey(recoveryId, recoveryField)
+  }
+
+  if (currentValue !== undefined && currentValue !== null && currentValue !== '') {
+    risk.currentValue = currentValue
+  }
+
+  return risk
+}
+
 /**
  * 配置管理组合式函数
  */
@@ -392,6 +439,172 @@ export function useConfig() {
     config.value.fps = serializeFps(fps.value)
     config.value.global_prep_cmd = JSON.stringify(global_prep_cmd.value)
     config.value.display_mode_remapping = JSON.stringify(display_mode_remapping.value)
+  }
+
+  /**
+   * 构建当前配置的序列化快照，不修改响应式状态。
+   */
+  const buildCurrentSnapshot = () => {
+    const currentConfig = deepClone(config.value || {})
+    currentConfig.resolutions = serializeResolutions(resolutions.value)
+    currentConfig.fps = serializeFps(filterValidFps([...fps.value]))
+    currentConfig.global_prep_cmd = JSON.stringify(global_prep_cmd.value)
+    currentConfig.display_mode_remapping = JSON.stringify(display_mode_remapping.value)
+
+    return {
+      config: currentConfig,
+      global_prep_cmd: deepClone(global_prep_cmd.value),
+      display_mode_remapping: deepClone(display_mode_remapping.value),
+    }
+  }
+
+  const addRisk = (risks, risk) => {
+    if (risks.some((item) => item.id === risk.id)) return
+    risks.push(risk)
+  }
+
+  const valueChanged = (currentConfig, key) => !isEqual(currentConfig[key], snapshots.value.config?.[key])
+
+  const listChanged = (currentList, originalList) =>
+    !isEqual(JSON.stringify(currentList), JSON.stringify(originalList || []))
+
+  /**
+   * 返回保存/应用前需要用户二次确认的风险项。
+   */
+  const getRiskyChanges = (action = 'save') => {
+    if (!config.value || !snapshots.value.config) {
+      return []
+    }
+
+    const current = buildCurrentSnapshot()
+    const currentConfig = current.config
+    const risks = []
+
+    if (action === 'apply') {
+      addRisk(risks, createRisk('restart', 'high'))
+    }
+
+    if (valueChanged(currentConfig, 'origin_web_ui_allowed') && currentConfig.origin_web_ui_allowed === 'wan') {
+      addRisk(risks, createRisk('web_ui_wan', 'critical', { currentValue: currentConfig.origin_web_ui_allowed }))
+    }
+
+    if (valueChanged(currentConfig, 'upnp') && isEnabledValue(currentConfig.upnp)) {
+      addRisk(risks, createRisk('upnp_enabled', 'high', { currentValue: currentConfig.upnp }))
+    }
+
+    if (valueChanged(currentConfig, 'wan_encryption_mode') && String(currentConfig.wan_encryption_mode) === '0') {
+      addRisk(
+        risks,
+        createRisk('wan_encryption_disabled', 'critical', { currentValue: currentConfig.wan_encryption_mode }),
+      )
+    }
+
+    if (
+      valueChanged(currentConfig, 'webhook_skip_ssl_verify') &&
+      isEnabledValue(currentConfig.webhook_skip_ssl_verify)
+    ) {
+      addRisk(
+        risks,
+        createRisk('webhook_skip_ssl_verify', 'high', { currentValue: currentConfig.webhook_skip_ssl_verify }),
+      )
+    }
+
+    if (
+      (valueChanged(currentConfig, 'webhook_enabled') || valueChanged(currentConfig, 'webhook_url')) &&
+      isEnabledValue(currentConfig.webhook_enabled) &&
+      currentConfig.webhook_url
+    ) {
+      addRisk(risks, createRisk('webhook_enabled', 'medium', { currentValue: currentConfig.webhook_url }))
+    }
+
+    if (valueChanged(currentConfig, 'pair_max_attempts') && Number(currentConfig.pair_max_attempts) === 0) {
+      addRisk(risks, createRisk('pair_limit_disabled', 'high', { currentValue: currentConfig.pair_max_attempts }))
+    }
+
+    if (listChanged(current.global_prep_cmd, snapshots.value.global_prep_cmd)) {
+      const commands = current.global_prep_cmd.filter(hasCommandText)
+      if (commands.length > 0) {
+        const elevated = hasElevatedCommand(commands)
+        addRisk(
+          risks,
+          createRisk(elevated ? 'elevated_global_commands' : 'global_prep_commands', elevated ? 'critical' : 'high', {
+            recoveryId: 'global_prep_commands',
+            currentValue: String(commands.length),
+          }),
+        )
+      }
+    }
+
+    const sensitiveFileKeys = ['credentials_file', 'pkey', 'cert', 'file_state']
+    const changedSensitiveFiles = sensitiveFileKeys.filter((key) => valueChanged(currentConfig, key))
+    if (changedSensitiveFiles.length > 0) {
+      addRisk(risks, createRisk('sensitive_files_changed', 'high', { currentValue: changedSensitiveFiles.join(', ') }))
+    }
+
+    if (
+      valueChanged(currentConfig, 'display_device_prep') &&
+      currentConfig.display_device_prep &&
+      currentConfig.display_device_prep !== 'no_operation'
+    ) {
+      const onlyDisplay = currentConfig.display_device_prep === 'ensure_only_display'
+      addRisk(
+        risks,
+        createRisk('display_device_prep', onlyDisplay ? 'critical' : 'high', {
+          descriptionField: onlyDisplay ? 'only_display_description' : 'description',
+          currentValue: currentConfig.display_device_prep,
+        }),
+      )
+    }
+
+    const displayModeKeys = ['resolution_change', 'manual_resolution', 'refresh_rate_change', 'manual_refresh_rate']
+    if (displayModeKeys.some((key) => valueChanged(currentConfig, key))) {
+      const resolutionActive = currentConfig.resolution_change && currentConfig.resolution_change !== 'no_operation'
+      const refreshActive = currentConfig.refresh_rate_change && currentConfig.refresh_rate_change !== 'no_operation'
+
+      if (resolutionActive || refreshActive) {
+        addRisk(
+          risks,
+          createRisk('display_mode_change', 'medium', {
+            currentValue: [
+              compactValue(currentConfig.resolution_change),
+              compactValue(currentConfig.manual_resolution),
+              compactValue(currentConfig.refresh_rate_change),
+              compactValue(currentConfig.manual_refresh_rate),
+            ].filter(Boolean).join(' / '),
+          }),
+        )
+      }
+    }
+
+    if (
+      listChanged(current.display_mode_remapping, snapshots.value.display_mode_remapping) &&
+      current.display_mode_remapping.length > 0
+    ) {
+      addRisk(
+        risks,
+        createRisk('display_mode_remapping', 'medium', {
+          currentValue: String(current.display_mode_remapping.length),
+        }),
+      )
+    }
+
+    if (
+      valueChanged(currentConfig, 'wgc_disable_secure_desktop') &&
+      isEnabledValue(currentConfig.wgc_disable_secure_desktop)
+    ) {
+      addRisk(
+        risks,
+        createRisk('wgc_disable_secure_desktop', 'high', {
+          currentValue: compactValue(currentConfig.wgc_disable_secure_desktop),
+        }),
+      )
+    }
+
+    if (valueChanged(currentConfig, 'capture') && ['amd', 'vdd'].includes(currentConfig.capture)) {
+      addRisk(risks, createRisk('experimental_capture', 'medium', { currentValue: currentConfig.capture }))
+    }
+
+    return risks.sort((a, b) => RISK_SEVERITY_WEIGHT[b.severity] - RISK_SEVERITY_WEIGHT[a.severity])
   }
 
   /**
@@ -560,6 +773,7 @@ export function useConfig() {
     loadConfig,
     save,
     apply,
+    getRiskyChanges,
     handleHash,
     hasUnsavedChanges,
   }

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -517,6 +517,96 @@
     "resolution_change_windows": "Resolution change",
     "resolutions": "Advertised Resolutions",
     "restart_note": "Sunshine is restarting to apply changes.",
+    "risk_confirm": {
+      "confirm_apply": "Apply and Restart",
+      "confirm_save": "Save Anyway",
+      "intro_apply": "These changes may affect security, active sessions, or host display state. Review them before Sunshine restarts.",
+      "intro_save": "These settings can affect security, host state, or commands executed by Sunshine. Review them before saving.",
+      "items": {
+        "display_device_prep": {
+          "description": "Sunshine will change the host display topology when a stream starts. This can affect the local monitor layout.",
+          "only_display_description": "Sunshine will disable other displays and keep only the selected display active. If the selected display is unavailable, the host may appear blank locally.",
+          "recovery": "If the display state is wrong, restore this option to Disabled or use the Troubleshooting page to reset display device persistence.",
+          "title": "Display topology will be changed"
+        },
+        "display_mode_change": {
+          "description": "Sunshine will change resolution or refresh rate for streaming sessions.",
+          "recovery": "Restore Resolution change and FPS change to Disabled if the monitor does not return to the expected mode.",
+          "title": "Display mode automation changed"
+        },
+        "display_mode_remapping": {
+          "description": "Client-requested display modes will be remapped before Sunshine applies them.",
+          "recovery": "Remove the remapping rules if clients receive an unexpected resolution or refresh rate.",
+          "title": "Display mode remapping changed"
+        },
+        "elevated_global_commands": {
+          "description": "Global preparation commands include elevated commands. They can change system state before or after any app launch.",
+          "title": "Elevated global commands"
+        },
+        "experimental_capture": {
+          "description": "This capture backend is experimental or has known compatibility limits on some systems.",
+          "recovery": "Switch Capture back to Autodetect, WGC, or Desktop Duplication API if capture fails.",
+          "title": "Experimental capture backend"
+        },
+        "global_prep_commands": {
+          "description": "Global preparation commands run before or after any app launch. A failed command can abort app startup.",
+          "recovery": "Remove or disable the global commands if app launch behavior becomes unexpected.",
+          "title": "Global commands will run for apps"
+        },
+        "pair_limit_disabled": {
+          "description": "Setting the pairing attempt limit to 0 removes the per-IP rate limit for pairing attempts.",
+          "recovery": "Set Pair max attempts back to a finite value such as 10.",
+          "title": "Pairing attempt limit disabled"
+        },
+        "restart": {
+          "description": "Applying configuration restarts Sunshine and terminates any active streaming sessions.",
+          "recovery": "Save without applying if you want to restart later when nobody is connected.",
+          "title": "Sunshine will restart"
+        },
+        "sensitive_files_changed": {
+          "description": "Changing credential, certificate, key, or state file paths can affect login, pairing, and stored client state.",
+          "recovery": "Restore the previous file paths if authentication, pairing, or client state behaves unexpectedly.",
+          "title": "Sensitive file paths changed"
+        },
+        "upnp_enabled": {
+          "description": "UPnP can automatically open router ports for Internet streaming.",
+          "recovery": "Disable UPnP if you do not want Sunshine to request router port mappings.",
+          "title": "UPnP port mapping enabled"
+        },
+        "wan_encryption_disabled": {
+          "description": "WAN streaming traffic may be sent without Sunshine's stream encryption.",
+          "recovery": "Use Supported clients or Force encryption for WAN streaming unless you have a specific compatibility need.",
+          "title": "WAN encryption disabled"
+        },
+        "web_ui_wan": {
+          "description": "The Web UI will be reachable from Internet-origin requests. Password protection still applies, but exposure increases attack surface.",
+          "recovery": "Use LAN or Local PC access unless you intentionally expose the Web UI through a secured network path.",
+          "title": "Web UI exposed to WAN"
+        },
+        "webhook_enabled": {
+          "description": "Sunshine will send event data to the configured webhook endpoint.",
+          "recovery": "Disable webhook notifications or remove the URL if this endpoint should not receive Sunshine events.",
+          "title": "Webhook notifications enabled"
+        },
+        "webhook_skip_ssl_verify": {
+          "description": "HTTPS webhook certificates will not be verified, which can allow interception by an untrusted endpoint.",
+          "recovery": "Disable this option after testing or use a certificate trusted by the host.",
+          "title": "Webhook SSL verification skipped"
+        },
+        "wgc_disable_secure_desktop": {
+          "description": "During WGC streaming, administrator elevation prompts can be auto-approved without a visible confirmation.",
+          "recovery": "Disable this option unless you specifically need unattended remote elevation during a trusted session.",
+          "title": "UAC secure desktop bypass enabled"
+        }
+      },
+      "recovery_label": "Recovery",
+      "severity_critical": "Critical",
+      "severity_high": "High",
+      "severity_medium": "Medium",
+      "title_apply": "Review Before Applying",
+      "title_save": "Review High-Risk Changes",
+      "value_label": "New value"
+    },
     "sleep_mode": "Sleep Mode",
     "sleep_mode_away": "Away Mode (Display Off, Instant Wake)",
     "sleep_mode_desc": "Controls what happens when the client sends a sleep command. Suspend (S3): traditional sleep, low power but requires WOL to wake. Hibernate (S4): saves to disk, very low power. Away Mode: display turns off but system stays running for instant wake - ideal for game streaming servers.",

--- a/src_assets/common/assets/web/public/assets/locale/zh.json
+++ b/src_assets/common/assets/web/public/assets/locale/zh.json
@@ -517,6 +517,96 @@
     "resolution_change_windows": "分辨率调整",
     "resolutions": "基地显示器支持的分辨率",
     "restart_note": "正在重启 Sunshine 以应用更改。",
+    "risk_confirm": {
+      "confirm_apply": "仍要应用并重启",
+      "confirm_save": "仍要保存",
+      "intro_apply": "这些变更可能影响安全性、当前会话或主机显示状态。Sunshine 重启前请先确认。",
+      "intro_save": "这些设置会影响安全性、主机状态，或 Sunshine 执行的系统命令。保存前请先确认。",
+      "items": {
+        "display_device_prep": {
+          "description": "串流开始时 Sunshine 会改动主机显示器拓扑，可能影响本机显示布局。",
+          "only_display_description": "Sunshine 会停用其他显示器，只保留指定显示器。如果目标显示器不可用，本机画面可能变黑。",
+          "recovery": "如果显示状态异常，请改回“禁用”，或到故障排除页面重置显示设备记忆。",
+          "title": "将改动显示器拓扑"
+        },
+        "display_mode_change": {
+          "description": "Sunshine 会在串流期间自动或手动切换分辨率/刷新率。",
+          "recovery": "如果显示器没有恢复到预期状态，请把分辨率变更和 FPS 变更改回“禁用”。",
+          "title": "显示模式自动化已变更"
+        },
+        "display_mode_remapping": {
+          "description": "客户端请求的显示模式会先被重映射，然后再由 Sunshine 应用。",
+          "recovery": "如果客户端拿到异常分辨率或刷新率，请删除对应重映射规则。",
+          "title": "显示模式重映射已变更"
+        },
+        "elevated_global_commands": {
+          "description": "全局准备命令包含管理员命令。它们会在任意应用启动前/后执行，可能改动系统状态。",
+          "title": "存在管理员全局命令"
+        },
+        "experimental_capture": {
+          "description": "当前捕获后端仍属实验功能，或在部分系统上存在兼容性限制。",
+          "recovery": "如果捕获失败，请改回自动检测、WGC 或 Desktop Duplication API。",
+          "title": "使用实验捕获后端"
+        },
+        "global_prep_commands": {
+          "description": "全局准备命令会在任意应用启动前/后执行。命令失败会中止应用启动。",
+          "recovery": "如果应用启动行为异常，请删除或禁用这些全局命令。",
+          "title": "全局命令将随应用执行"
+        },
+        "pair_limit_disabled": {
+          "description": "配对尝试次数设为 0 会取消每个 IP 的配对速率限制。",
+          "recovery": "建议把配对尝试次数恢复为有限值，例如 10。",
+          "title": "配对尝试限制已关闭"
+        },
+        "restart": {
+          "description": "应用配置会重启 Sunshine，并断开所有正在进行的串流会话。",
+          "recovery": "如果当前有人连接，请先只保存，稍后再手动应用。",
+          "title": "Sunshine 将重启"
+        },
+        "sensitive_files_changed": {
+          "description": "修改凭据、证书、私钥或状态文件路径，可能影响登录、配对和已保存客户端状态。",
+          "recovery": "如果认证、配对或客户端状态异常，请恢复之前的文件路径。",
+          "title": "敏感文件路径已变更"
+        },
+        "upnp_enabled": {
+          "description": "UPnP 可能自动在路由器上开放公网串流端口。",
+          "recovery": "如果不希望 Sunshine 请求路由器端口映射，请关闭 UPnP。",
+          "title": "已启用 UPnP 端口映射"
+        },
+        "wan_encryption_disabled": {
+          "description": "公网串流流量可能不再使用 Sunshine 的串流加密。",
+          "recovery": "除非有明确兼容性需求，公网串流建议使用“为支持的客户端启用”或“强制所有客户端使用”。",
+          "title": "公网加密已关闭"
+        },
+        "web_ui_wan": {
+          "description": "Web UI 将允许来自公网来源的访问。仍需要密码，但暴露面会明显增加。",
+          "recovery": "除非你已经通过可信网络路径保护它，否则建议使用“局域网”或“本机”。",
+          "title": "Web UI 将暴露到公网"
+        },
+        "webhook_enabled": {
+          "description": "Sunshine 会把事件数据发送到配置的 Webhook 地址。",
+          "recovery": "如果该地址不应接收 Sunshine 事件，请关闭 Webhook 或移除 URL。",
+          "title": "Webhook 通知已启用"
+        },
+        "webhook_skip_ssl_verify": {
+          "description": "HTTPS Webhook 的证书将不再校验，可能被不可信端点拦截。",
+          "recovery": "测试结束后请关闭此选项，或改用主机信任的证书。",
+          "title": "Webhook 跳过 SSL 校验"
+        },
+        "wgc_disable_secure_desktop": {
+          "description": "WGC 串流期间，管理员权限请求可能在没有可见确认的情况下自动通过。",
+          "recovery": "除非你明确需要在可信会话中无人值守提权，否则请关闭此选项。",
+          "title": "已启用 UAC 安全桌面绕过"
+        }
+      },
+      "recovery_label": "恢复办法",
+      "severity_critical": "高危",
+      "severity_high": "风险",
+      "severity_medium": "注意",
+      "title_apply": "应用前确认风险",
+      "title_save": "保存前确认高风险变更",
+      "value_label": "新值"
+    },
     "sleep_mode": "睡眠模式",
     "sleep_mode_away": "离开模式（关闭显示器，即时唤醒）",
     "sleep_mode_desc": "控制客户端发送睡眠命令时的行为。挂起(S3)：传统睡眠，低功耗但需要 WOL 唤醒。休眠(S4)：保存到磁盘，极低功耗。离开模式：关闭显示器但系统保持运行，可即时唤醒 - 非常适合游戏串流服务器。",

--- a/src_assets/common/assets/web/views/Config.vue
+++ b/src_assets/common/assets/web/views/Config.vue
@@ -6,6 +6,7 @@
         class="cute-btn cute-btn-primary"
         :class="{ 'has-unsaved': hasUnsaved }"
         @click="requestConfigAction('save')"
+        :disabled="riskActionRunning"
         :title="hasUnsaved ? $t('config.unsaved_changes_tooltip') : $t('_common.save')"
       >
         <i class="fas fa-save"></i>
@@ -14,6 +15,7 @@
         v-if="saved && !restarted"
         class="cute-btn cute-btn-success"
         @click="requestConfigAction('apply')"
+        :disabled="riskActionRunning"
         :title="$t('_common.apply')"
       >
         <i class="fas fa-check"></i>
@@ -69,7 +71,16 @@
     <Teleport to="body">
       <Transition name="risk-modal">
         <div v-if="showRiskConfirm" class="risk-confirm-overlay" @click.self="cancelRiskConfirm">
-          <div class="risk-confirm-modal" role="dialog" aria-modal="true" aria-labelledby="risk-confirm-title">
+          <div
+            ref="riskDialogRef"
+            class="risk-confirm-modal"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="risk-confirm-title"
+            tabindex="-1"
+            @keydown.esc.prevent="cancelRiskConfirm"
+            @keydown.tab="trapRiskFocus"
+          >
             <div class="risk-confirm-header">
               <div>
                 <h5 id="risk-confirm-title">
@@ -223,7 +234,7 @@
 </template>
 
 <script setup>
-import { ref, watch, onMounted, provide, computed, onUnmounted } from 'vue'
+import { ref, watch, onMounted, provide, computed, onUnmounted, nextTick } from 'vue'
 import Navbar from '../components/layout/Navbar.vue'
 import General from '../configs/tabs/General.vue'
 import Inputs from '../configs/tabs/Inputs.vue'
@@ -264,6 +275,8 @@ const showRiskConfirm = ref(false)
 const riskAction = ref('save')
 const riskItems = ref([])
 const riskActionRunning = ref(false)
+const riskDialogRef = ref(null)
+const lastFocusedElement = ref(null)
 
 const hasUnsaved = computed(() => {
   if (!config.value) return false
@@ -308,7 +321,65 @@ const showToast = (toastRef, duration = 5000) => {
   }, duration)
 }
 
+const getRiskFocusableElements = () => {
+  const root = riskDialogRef.value
+  if (!root) return []
+
+  return Array.from(
+    root.querySelectorAll(
+      [
+        'button:not([disabled])',
+        '[href]',
+        'input:not([disabled])',
+        'select:not([disabled])',
+        'textarea:not([disabled])',
+        '[tabindex]:not([tabindex="-1"])',
+      ].join(','),
+    ),
+  ).filter((element) => element.offsetParent !== null)
+}
+
+const focusRiskDialog = async () => {
+  await nextTick()
+  const focusable = getRiskFocusableElements()
+  const target = focusable[0] || riskDialogRef.value
+  target?.focus?.()
+}
+
+const restoreRiskFocus = () => {
+  const target = lastFocusedElement.value
+  lastFocusedElement.value = null
+
+  if (target && document.contains(target)) {
+    target.focus?.()
+  }
+}
+
+const trapRiskFocus = (event) => {
+  const focusable = getRiskFocusableElements()
+  if (!focusable.length) {
+    event.preventDefault()
+    riskDialogRef.value?.focus?.()
+    return
+  }
+
+  const currentIndex = focusable.indexOf(document.activeElement)
+  const lastIndex = focusable.length - 1
+  let nextIndex = currentIndex + 1
+
+  if (event.shiftKey) {
+    nextIndex = currentIndex <= 0 ? lastIndex : currentIndex - 1
+  } else if (currentIndex === -1 || currentIndex >= lastIndex) {
+    nextIndex = 0
+  }
+
+  event.preventDefault()
+  focusable[nextIndex].focus()
+}
+
 const runConfigAction = async (action) => {
+  if (riskActionRunning.value) return
+
   riskActionRunning.value = true
   try {
     if (action === 'apply') {
@@ -322,8 +393,11 @@ const runConfigAction = async (action) => {
 }
 
 const requestConfigAction = async (action) => {
+  if (riskActionRunning.value || showRiskConfirm.value) return
+
   const risks = getRiskyChanges(action)
   if (risks.length > 0) {
+    lastFocusedElement.value = document.activeElement
     riskAction.value = action
     riskItems.value = risks
     showRiskConfirm.value = true
@@ -340,11 +414,22 @@ const cancelRiskConfirm = () => {
 }
 
 const confirmRiskAction = async () => {
+  if (riskActionRunning.value) return
+
   const action = riskAction.value
   showRiskConfirm.value = false
   await runConfigAction(action)
   riskItems.value = []
 }
+
+watch(showRiskConfirm, async (isOpen) => {
+  if (isOpen) {
+    await focusRiskDialog()
+    return
+  }
+
+  restoreRiskFocus()
+})
 
 watch(saved, (newVal) => {
   if (newVal && !restarted.value) {
@@ -383,6 +468,7 @@ onMounted(async () => {
 onUnmounted(() => {
   window.removeEventListener('hashchange', handleHash)
   document.removeEventListener('click', handleOutsideClick)
+  lastFocusedElement.value = null
 })
 </script>
 
@@ -1048,6 +1134,22 @@ onUnmounted(() => {
 
     &:hover i {
       transform: scale(1.2) rotate(5deg);
+    }
+
+    &:disabled {
+      cursor: not-allowed;
+      opacity: 0.65;
+      transform: none;
+      box-shadow: none;
+      animation: none;
+
+      &::before {
+        opacity: 0;
+      }
+
+      i {
+        transform: none;
+      }
     }
   }
 

--- a/src_assets/common/assets/web/views/Config.vue
+++ b/src_assets/common/assets/web/views/Config.vue
@@ -5,12 +5,17 @@
       <button
         class="cute-btn cute-btn-primary"
         :class="{ 'has-unsaved': hasUnsaved }"
-        @click="save"
+        @click="requestConfigAction('save')"
         :title="hasUnsaved ? $t('config.unsaved_changes_tooltip') : $t('_common.save')"
       >
         <i class="fas fa-save"></i>
       </button>
-      <button v-if="saved && !restarted" class="cute-btn cute-btn-success" @click="apply" :title="$t('_common.apply')">
+      <button
+        v-if="saved && !restarted"
+        class="cute-btn cute-btn-success"
+        @click="requestConfigAction('apply')"
+        :title="$t('_common.apply')"
+      >
         <i class="fas fa-check"></i>
       </button>
       <div class="floating-toast-container">
@@ -60,6 +65,68 @@
         </Transition>
       </div>
     </div>
+
+    <Teleport to="body">
+      <Transition name="risk-modal">
+        <div v-if="showRiskConfirm" class="risk-confirm-overlay" @click.self="cancelRiskConfirm">
+          <div class="risk-confirm-modal" role="dialog" aria-modal="true" aria-labelledby="risk-confirm-title">
+            <div class="risk-confirm-header">
+              <div>
+                <h5 id="risk-confirm-title">
+                  <i class="fas fa-exclamation-triangle me-2"></i>
+                  {{ $t(riskAction === 'apply' ? 'config.risk_confirm.title_apply' : 'config.risk_confirm.title_save') }}
+                </h5>
+                <p>
+                  {{ $t(riskAction === 'apply' ? 'config.risk_confirm.intro_apply' : 'config.risk_confirm.intro_save') }}
+                </p>
+              </div>
+              <button type="button" class="btn-close" @click="cancelRiskConfirm" :aria-label="$t('_common.close')"></button>
+            </div>
+
+            <div class="risk-confirm-body">
+              <div
+                v-for="risk in riskItems"
+                :key="risk.id"
+                class="risk-item"
+                :class="risk.severity"
+              >
+                <div class="risk-item-header">
+                  <span class="risk-badge" :class="risk.severity">
+                    {{ $t(`config.risk_confirm.severity_${risk.severity}`) }}
+                  </span>
+                  <strong>{{ $t(risk.titleKey) }}</strong>
+                </div>
+                <p>{{ $t(risk.descriptionKey) }}</p>
+                <div v-if="risk.currentValue" class="risk-detail">
+                  <span>{{ $t('config.risk_confirm.value_label') }}</span>
+                  <code>{{ risk.currentValue }}</code>
+                </div>
+                <div v-if="risk.recoveryKey" class="risk-recovery">
+                  <span>{{ $t('config.risk_confirm.recovery_label') }}</span>
+                  <p>{{ $t(risk.recoveryKey) }}</p>
+                </div>
+              </div>
+            </div>
+
+            <div class="risk-confirm-footer">
+              <button type="button" class="btn btn-secondary" @click="cancelRiskConfirm" :disabled="riskActionRunning">
+                {{ $t('_common.cancel') }}
+              </button>
+              <button
+                type="button"
+                class="btn btn-danger"
+                @click="confirmRiskAction"
+                :disabled="riskActionRunning"
+              >
+                <i v-if="riskActionRunning" class="fas fa-spinner fa-spin me-1"></i>
+                {{ $t(riskAction === 'apply' ? 'config.risk_confirm.confirm_apply' : 'config.risk_confirm.confirm_save') }}
+              </button>
+            </div>
+          </div>
+        </div>
+      </Transition>
+    </Teleport>
+
     <div class="container">
       <h1 class="my-4 page-title">{{ $t('config.configuration') }}</h1>
 
@@ -183,8 +250,9 @@ const {
   tabs,
   initTabs,
   loadConfig,
-  save,
-  apply,
+  save: saveConfig,
+  apply: applyConfig,
+  getRiskyChanges,
   handleHash,
   hasUnsavedChanges,
 } = useConfig()
@@ -192,6 +260,10 @@ const {
 const showSaveToast = ref(false)
 const showRestartToast = ref(false)
 const expandedDropdown = ref(null)
+const showRiskConfirm = ref(false)
+const riskAction = ref('save')
+const riskItems = ref([])
+const riskActionRunning = ref(false)
 
 const hasUnsaved = computed(() => {
   if (!config.value) return false
@@ -234,6 +306,44 @@ const showToast = (toastRef, duration = 5000) => {
   setTimeout(() => {
     toastRef.value = false
   }, duration)
+}
+
+const runConfigAction = async (action) => {
+  riskActionRunning.value = true
+  try {
+    if (action === 'apply') {
+      await applyConfig()
+    } else {
+      await saveConfig()
+    }
+  } finally {
+    riskActionRunning.value = false
+  }
+}
+
+const requestConfigAction = async (action) => {
+  const risks = getRiskyChanges(action)
+  if (risks.length > 0) {
+    riskAction.value = action
+    riskItems.value = risks
+    showRiskConfirm.value = true
+    return
+  }
+
+  await runConfigAction(action)
+}
+
+const cancelRiskConfirm = () => {
+  if (riskActionRunning.value) return
+  showRiskConfirm.value = false
+  riskItems.value = []
+}
+
+const confirmRiskAction = async () => {
+  const action = riskAction.value
+  showRiskConfirm.value = false
+  await runConfigAction(action)
+  riskItems.value = []
 }
 
 watch(saved, (newVal) => {
@@ -560,6 +670,260 @@ onUnmounted(() => {
 
 .toast.show {
   opacity: 1;
+}
+
+.risk-modal-enter-active,
+.risk-modal-leave-active {
+  transition: opacity @transition-fast ease;
+
+  .risk-confirm-modal {
+    transition: transform @transition-fast @cubic-smooth, opacity @transition-fast ease;
+  }
+}
+
+.risk-modal-enter-from,
+.risk-modal-leave-to {
+  opacity: 0;
+
+  .risk-confirm-modal {
+    opacity: 0;
+    transform: translateY(16px) scale(0.98);
+  }
+}
+
+.risk-confirm-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-lg, 1.5rem);
+  background: var(--overlay-bg, rgba(0, 0, 0, 0.7));
+  backdrop-filter: blur(8px);
+
+  [data-bs-theme='light'] & {
+    background: rgba(0, 0, 0, 0.5);
+  }
+}
+
+.risk-confirm-modal {
+  width: min(720px, 100%);
+  max-height: min(760px, calc(100vh - 2.5rem));
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border-radius: var(--border-radius-xl, 1.5rem);
+  border: 1px solid var(--border-color-light, rgba(255, 255, 255, 0.2));
+  background: var(--modal-bg, rgba(30, 30, 50, 0.95));
+  backdrop-filter: blur(20px);
+  box-shadow: var(--shadow-xl, 0 25px 50px rgba(0, 0, 0, 0.5));
+  color: var(--text-primary, #fff);
+
+  [data-bs-theme='light'] & {
+    border-color: rgba(0, 0, 0, 0.15);
+    background: rgba(255, 255, 255, 0.95);
+    box-shadow: 0 25px 50px rgba(0, 0, 0, 0.2);
+    color: #000;
+  }
+}
+
+.risk-confirm-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: var(--spacing-md, 1rem) var(--spacing-lg, 1.5rem);
+  border-bottom: 1px solid var(--border-color-light, rgba(255, 255, 255, 0.1));
+
+  h5 {
+    margin: 0 0 0.35rem;
+    font-size: var(--font-size-lg, 1.25rem);
+    font-weight: 600;
+    color: var(--text-primary, #fff);
+
+    i {
+      color: var(--bs-danger);
+    }
+  }
+
+  p {
+    margin: 0;
+    color: var(--text-secondary, rgba(255, 255, 255, 0.85));
+    line-height: 1.5;
+  }
+
+  .btn-close {
+    flex: 0 0 auto;
+  }
+
+  [data-bs-theme='light'] & {
+    border-bottom-color: rgba(0, 0, 0, 0.1);
+
+    h5 {
+      color: #000;
+    }
+
+    p {
+      color: #4b5563;
+    }
+  }
+}
+
+.risk-confirm-body {
+  overflow-y: auto;
+  padding: var(--spacing-md, 1rem) var(--spacing-lg, 1.5rem);
+}
+
+.risk-item {
+  padding: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: @border-radius-md;
+  background: rgba(255, 255, 255, 0.06);
+
+  & + & {
+    margin-top: 0.75rem;
+  }
+
+  &.critical {
+    border-color: rgba(var(--bs-danger-rgb), 0.38);
+    background: rgba(var(--bs-danger-rgb), 0.1);
+  }
+
+  &.high {
+    border-color: rgba(var(--bs-warning-rgb), 0.36);
+  }
+
+  &.medium {
+    border-color: rgba(var(--bs-info-rgb), 0.32);
+  }
+
+  p {
+    margin: 0.5rem 0 0;
+    color: var(--text-primary, #fff);
+    line-height: 1.5;
+  }
+
+  [data-bs-theme='light'] & {
+    border-color: rgba(0, 0, 0, 0.1);
+    background: rgba(255, 255, 255, 0.75);
+
+    &.critical {
+      border-color: rgba(var(--bs-danger-rgb), 0.34);
+      background: rgba(var(--bs-danger-rgb), 0.08);
+    }
+
+    &.high {
+      border-color: rgba(var(--bs-warning-rgb), 0.4);
+      background: rgba(var(--bs-warning-rgb), 0.08);
+    }
+
+    &.medium {
+      border-color: rgba(var(--bs-info-rgb), 0.32);
+      background: rgba(var(--bs-info-rgb), 0.06);
+    }
+
+    p {
+      color: #000;
+    }
+  }
+}
+
+.risk-item-header {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+
+  strong {
+    font-size: 0.98rem;
+  }
+}
+
+.risk-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+
+  &.critical {
+    color: #fff;
+    background: var(--bs-danger);
+  }
+
+  &.high {
+    color: #231f20;
+    background: var(--bs-warning);
+  }
+
+  &.medium {
+    color: #fff;
+    background: var(--bs-info);
+  }
+}
+
+.risk-detail,
+.risk-recovery {
+  margin-top: 0.7rem;
+  padding-top: 0.7rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+
+  span {
+    display: block;
+    margin-bottom: 0.25rem;
+    color: var(--text-secondary, rgba(255, 255, 255, 0.85));
+    font-size: 0.8rem;
+    font-weight: 600;
+  }
+
+  code {
+    display: inline-block;
+    max-width: 100%;
+    overflow-wrap: anywhere;
+    padding: 0.2rem 0.4rem;
+    border-radius: @border-radius-sm;
+    color: var(--text-primary, #fff);
+    background: rgba(255, 255, 255, 0.1);
+  }
+
+  [data-bs-theme='light'] & {
+    border-top-color: rgba(0, 0, 0, 0.1);
+
+    span {
+      color: #4b5563;
+    }
+
+    code {
+      color: #000;
+      background: rgba(0, 0, 0, 0.06);
+    }
+  }
+}
+
+.risk-recovery p {
+  margin: 0;
+  color: var(--text-secondary, rgba(255, 255, 255, 0.85));
+
+  [data-bs-theme='light'] & {
+    color: #4b5563;
+  }
+}
+
+.risk-confirm-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: var(--spacing-md, 1rem) var(--spacing-lg, 1.5rem);
+  border-top: 1px solid var(--border-color-light, rgba(255, 255, 255, 0.1));
+
+  [data-bs-theme='light'] & {
+    border-top-color: rgba(0, 0, 0, 0.1);
+  }
 }
 
 .config-floating-buttons {


### PR DESCRIPTION
## 改了啥呀

- 给 Web UI 设置页的保存/应用流程增加高风险二次确认弹窗，杂鱼风险设置别想悄悄溜过去。
- 在 `useConfig` 里集中生成风险项，基于当前配置和加载快照做对比，不为了检测风险修改响应式状态。
- 覆盖 WAN Web UI、UPnP、公网加密关闭、跳过 webhook SSL 校验、配对限速关闭、全局/管理员命令、敏感文件路径、显示器拓扑/模式、WGC secure desktop 绕过、实验捕获后端等风险。
- 补齐 en/zh 风险确认文案，并让确认弹窗视觉跟现有 glass modal 风格保持一致。

## 为啥要改

高风险设置原来主要依赖字段说明或局部提示，用户在保存/应用时不一定能把影响串起来看。现在把风险集中到最后一步确认，尤其是会暴露公网、执行系统命令、改变显示状态、重启服务的操作，会更明确地提醒影响和恢复办法。

## 验证

- `npm run build`
- `git diff --check -- src_assets/common/assets/web/composables/useConfig.js src_assets/common/assets/web/views/Config.vue src_assets/common/assets/web/public/assets/locale/en.json src_assets/common/assets/web/public/assets/locale/zh.json`
- `node -e "const fs=require('fs'); for (const f of ['src_assets/common/assets/web/public/assets/locale/en.json','src_assets/common/assets/web/public/assets/locale/zh.json']) JSON.parse(fs.readFileSync(f,'utf8')); console.log('locale json ok')"`
- `npm run i18n:validate` 仍失败：当前仓库已有多语言缺失/未翻译项，非本 PR 新增 en/zh 风险文案导致。