### PR TITLE
perf(webui): optimize config and apps startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev-full": "node dev-server.js",
     "preview": "vite preview",
     "preview:build": "npm run build && npm run preview",
+    "test:webui": "node --test \"src_assets/common/assets/web/tests/*.test.js\"",
     "i18n:validate": "node scripts/validate-i18n.js",
     "i18n:sync": "node scripts/validate-i18n.js --sync",
     "i18n:reverse-sync": "node scripts/reverse-sync-i18n.js --sync",
@@ -26,15 +27,15 @@
     "marked": "^16.2.1",
     "nanoid": "^5.0.7",
     "qrcode": "^1.5.4",
-    "vue": "^3.5.26",
+    "vue": "^3.5.38",
     "vue-i18n": "^11.2.8",
     "vuedraggable-es": "^4.1.1"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^6.0.3",
+    "@vitejs/plugin-vue": "^6.0.7",
     "express": "^4.18.2",
     "less": "^4.4.2",
-    "vite": "^8.0.8",
+    "vite": "^8.0.16",
     "vite-plugin-ejs": "1.6.4",
     "vite-plugin-mkcert": "^1.17.8"
   }

--- a/src_assets/common/assets/web/composables/useApps.js
+++ b/src_assets/common/assets/web/composables/useApps.js
@@ -14,8 +14,8 @@ export function useApps() {
   // 状态
   const apps = ref([])
   const originalApps = ref([])
-  const filteredApps = ref([])
   const searchQuery = ref('')
+  const committedSearchQuery = ref('')
   const editingApp = ref(null)
   const platform = ref('')
   const isSaving = ref(false)
@@ -45,6 +45,8 @@ export function useApps() {
   const messageClass = computed(() => ({
     [`alert-${messageType.value}`]: true,
   }))
+
+  const filteredApps = computed(() => AppService.searchApps(apps.value, committedSearchQuery.value))
 
   // 消息图标映射
   const MESSAGE_ICONS = {
@@ -86,7 +88,6 @@ export function useApps() {
     try {
       apps.value = await AppService.getApps()
       originalApps.value = deepClone(apps.value)
-      filteredApps.value = [...apps.value]
     } catch (error) {
       console.error('加载应用失败:', error)
       showMessage('加载应用失败', APP_CONSTANTS.MESSAGE_TYPES.ERROR)
@@ -104,11 +105,12 @@ export function useApps() {
 
   // 搜索
   const performSearch = () => {
-    filteredApps.value = AppService.searchApps(apps.value, searchQuery.value)
+    committedSearchQuery.value = searchQuery.value
   }
 
   const clearSearch = () => {
     searchQuery.value = ''
+    committedSearchQuery.value = ''
     performSearch()
   }
 

--- a/src_assets/common/assets/web/composables/useConfig.js
+++ b/src_assets/common/assets/web/composables/useConfig.js
@@ -250,18 +250,18 @@ const forEachTabOption = (tabs, callback) => {
 /**
  * 序列化分辨率数组
  */
-const serializeResolutions = (resolutions) =>
+export const serializeResolutions = (resolutions) =>
   JSON.stringify(resolutions).replace(/","/g, ',').replace(/^\["/, '[').replace(/"\]$/, ']')
 
 /**
  * 序列化 FPS 数组
  */
-const serializeFps = (fps) => JSON.stringify(fps).replace(/"/g, '')
+export const serializeFps = (fps) => JSON.stringify(fps).replace(/"/g, '')
 
 /**
  * 解析分辨率字符串
  */
-const parseResolutions = (resStr) => {
+export const parseResolutions = (resStr) => {
   try {
     return JSON.parse((resStr || '').replace(/(\d+)x(\d+)/g, '"$1x$2"'))
   } catch {
@@ -272,7 +272,7 @@ const parseResolutions = (resStr) => {
 /**
  * 过滤有效的 FPS 值
  */
-const filterValidFps = (fps) => fps.filter((item) => +item >= 30 && +item <= 500)
+export const filterValidFps = (fps) => fps.filter((item) => +item >= 30 && +item <= 500)
 
 const RISK_SEVERITY_WEIGHT = {
   critical: 3,

--- a/src_assets/common/assets/web/configs/tabs/ContainerEncoders.vue
+++ b/src_assets/common/assets/web/configs/tabs/ContainerEncoders.vue
@@ -1,10 +1,11 @@
 <script setup>
-import { ref } from 'vue'
-import NvidiaNvencEncoder from './encoders/NvidiaNvencEncoder.vue'
-import IntelQuickSyncEncoder from './encoders/IntelQuickSyncEncoder.vue'
-import AmdAmfEncoder from './encoders/AmdAmfEncoder.vue'
-import VideotoolboxEncoder from './encoders/VideotoolboxEncoder.vue'
-import SoftwareEncoder from './encoders/SoftwareEncoder.vue'
+import { defineAsyncComponent, ref } from 'vue'
+
+const NvidiaNvencEncoder = defineAsyncComponent(() => import('./encoders/NvidiaNvencEncoder.vue'))
+const IntelQuickSyncEncoder = defineAsyncComponent(() => import('./encoders/IntelQuickSyncEncoder.vue'))
+const AmdAmfEncoder = defineAsyncComponent(() => import('./encoders/AmdAmfEncoder.vue'))
+const VideotoolboxEncoder = defineAsyncComponent(() => import('./encoders/VideotoolboxEncoder.vue'))
+const SoftwareEncoder = defineAsyncComponent(() => import('./encoders/SoftwareEncoder.vue'))
 
 const props = defineProps([
   'platform',

--- a/src_assets/common/assets/web/tests/appService.test.js
+++ b/src_assets/common/assets/web/tests/appService.test.js
@@ -1,0 +1,62 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { AppService } from '../services/appService.js'
+
+test('searchApps returns a shallow copy when query is empty', () => {
+  const apps = [
+    { name: 'Steam Big Picture', cmd: 'steam://open/bigpicture' },
+    { name: 'Moonlight', cmd: 'moonlight.exe' },
+  ]
+
+  const result = AppService.searchApps(apps, '   ')
+
+  assert.deepEqual(result, apps)
+  assert.notEqual(result, apps)
+})
+
+test('searchApps matches app name and command case-insensitively', () => {
+  const apps = [
+    { name: 'Steam Big Picture', cmd: 'steam://open/bigpicture' },
+    { name: 'RetroArch', cmd: 'C:/Games/retroarch.exe' },
+    { name: 'Desktop', cmd: 'mstsc.exe' },
+  ]
+
+  assert.deepEqual(AppService.searchApps(apps, 'retro'), [apps[1]])
+  assert.deepEqual(AppService.searchApps(apps, 'MSTSC'), [apps[2]])
+})
+
+test('formatAppData trims scalar fields and removes empty prep commands', () => {
+  const result = AppService.formatAppData({
+    name: '  Game  ',
+    output: '  monitor-1  ',
+    cmd: '  game.exe  ',
+    elevated: 1,
+    'auto-detach': false,
+    'wait-all': true,
+    'exit-timeout': '12',
+    'prep-cmd': [
+      { do: '  ', undo: '' },
+      { do: 'start-service', undo: '' },
+      { do: '', undo: 'stop-service' },
+    ],
+    'menu-cmd': 'not-an-array',
+    detached: ['helper.exe'],
+    'image-path': '  cover.png  ',
+    'working-dir': '  C:/Games/Game  ',
+  })
+
+  assert.equal(result.name, 'Game')
+  assert.equal(result.output, 'monitor-1')
+  assert.equal(result.cmd, 'game.exe')
+  assert.equal(result.elevated, true)
+  assert.equal(result['exit-timeout'], 12)
+  assert.deepEqual(result['prep-cmd'], [
+    { do: 'start-service', undo: '' },
+    { do: '', undo: 'stop-service' },
+  ])
+  assert.deepEqual(result['menu-cmd'], [])
+  assert.deepEqual(result.detached, ['helper.exe'])
+  assert.equal(result['image-path'], 'cover.png')
+  assert.equal(result['working-dir'], 'C:/Games/Game')
+})

--- a/src_assets/common/assets/web/tests/configSerialization.test.js
+++ b/src_assets/common/assets/web/tests/configSerialization.test.js
@@ -1,0 +1,28 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  filterValidFps,
+  parseResolutions,
+  serializeFps,
+  serializeResolutions,
+} from '../composables/useConfig.js'
+
+test('resolution config round-trips Sunshine bracket syntax', () => {
+  const parsed = parseResolutions('[1280x720,1920x1080]')
+
+  assert.deepEqual(parsed, ['1280x720', '1920x1080'])
+  assert.equal(serializeResolutions(parsed), '[1280x720,1920x1080]')
+})
+
+test('parseResolutions falls back to an empty array for invalid input', () => {
+  assert.deepEqual(parseResolutions('not valid json'), [])
+  assert.deepEqual(parseResolutions(''), [])
+})
+
+test('fps config removes invalid values before serialization', () => {
+  const valid = filterValidFps(['24', '30', 60, '500', 501])
+
+  assert.deepEqual(valid, ['30', 60, '500'])
+  assert.equal(serializeFps(valid), '[30,60,500]')
+})

--- a/src_assets/common/assets/web/views/Apps.vue
+++ b/src_assets/common/assets/web/views/Apps.vue
@@ -16,7 +16,6 @@
             class="form-control search-input"
             :placeholder="$t('apps.search_placeholder')"
             v-model="searchQuery"
-            @input="debouncedSearch"
           />
           <button v-if="searchQuery" class="btn-clear-search" @click="clearSearch">
             <i class="fas fa-times"></i>

--- a/src_assets/common/assets/web/views/Config.vue
+++ b/src_assets/common/assets/web/views/Config.vue
@@ -227,26 +227,34 @@
         <Network v-if="currentTab === 'network'" :config="config" :platform="platform" />
         <Files v-if="currentTab === 'files'" :config="config" :platform="platform" />
         <Advanced v-if="currentTab === 'advanced'" :config="config" :platform="platform" />
-        <ContainerEncoders :current-tab="currentTab" :config="config" :platform="platform" />
+        <ContainerEncoders
+          v-if="isEncoderCurrentTab"
+          :current-tab="currentTab"
+          :config="config"
+          :platform="platform"
+        />
       </div>
     </div>
   </div>
 </template>
 
 <script setup>
-import { ref, watch, onMounted, provide, computed, onUnmounted, nextTick } from 'vue'
+import { ref, watch, onMounted, provide, computed, onUnmounted, nextTick, defineAsyncComponent } from 'vue'
 import Navbar from '../components/layout/Navbar.vue'
-import General from '../configs/tabs/General.vue'
-import Inputs from '../configs/tabs/Inputs.vue'
-import Network from '../configs/tabs/Network.vue'
-import Files from '../configs/tabs/Files.vue'
-import Advanced from '../configs/tabs/Advanced.vue'
-import AudioVideo from '../configs/tabs/AudioVideo.vue'
-import ContainerEncoders from '../configs/tabs/ContainerEncoders.vue'
 import { useConfig } from '../composables/useConfig.js'
 import { initFirebase, trackEvents } from '../config/firebase.js'
 
 initFirebase()
+
+const General = defineAsyncComponent(() => import('../configs/tabs/General.vue'))
+const Inputs = defineAsyncComponent(() => import('../configs/tabs/Inputs.vue'))
+const Network = defineAsyncComponent(() => import('../configs/tabs/Network.vue'))
+const Files = defineAsyncComponent(() => import('../configs/tabs/Files.vue'))
+const Advanced = defineAsyncComponent(() => import('../configs/tabs/Advanced.vue'))
+const AudioVideo = defineAsyncComponent(() => import('../configs/tabs/AudioVideo.vue'))
+const ContainerEncoders = defineAsyncComponent(() => import('../configs/tabs/ContainerEncoders.vue'))
+
+const ENCODER_TAB_IDS = new Set(['nv', 'qsv', 'amd', 'vt', 'sw'])
 
 const {
   platform,
@@ -287,6 +295,8 @@ const hasUnsaved = computed(() => {
   void display_mode_remapping.value
   return hasUnsavedChanges()
 })
+
+const isEncoderCurrentTab = computed(() => ENCODER_TAB_IDS.has(currentTab.value))
 
 const isEncoderTabActive = (tab) => tab.type === 'group' && tab.children?.some((child) => child.id === currentTab.value)
 


### PR DESCRIPTION
## 改了啥呢

- 升级主 WebUI 稳定依赖范围到 `vue ^3.5.38`、`@vitejs/plugin-vue ^6.0.7`、`vite ^8.0.16`
- Config 页 tabs 和 encoder 面板改成 async component，首屏只加载当前需要的配置页代码
- Apps 页搜索改成防抖后的查询词 + computed 过滤结果，少维护一份列表状态，也避免输入时重复触发搜索
- 新增 WebUI Node 原生单测，覆盖 Apps 搜索/格式化和 Config 序列化逻辑

## 为啥要改

这批先走稳定升级和低风险性能优化，不碰 SPA/Vapor 那种大迁移。Config 页之前会把多个 tab 组件打进入口链路里，打开配置页时要先解析更多代码；现在主要 tab 会拆成独立 chunk，配置页入口明显变轻。

## 验证

- `npm run test:webui`：通过，6/6
- `npm run build`：通过
- `npm run i18n:validate`：失败，原因是既有 locale 缺 key/未翻译，不是本 PR 引入

备注：没有包含工作区里已有的 `Inputs.vue`、`sunshine-control-panel` 和 `tools/lsfg_d3d11_demo/` 改动。