### PR TITLE
fix(vdd): share producer probe for direct capture

### DIFF
--- a/src/display_device/vdd_utils.cpp
+++ b/src/display_device/vdd_utils.cpp
@@ -15,12 +15,14 @@
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <cmath>
+#include <cstddef>
 #include <filesystem>
 #include <future>
 #include <limits>
 #include <locale>
 #include <sstream>
 #include <thread>
+#include <type_traits>
 #include <unordered_set>
 #include <vector>
 
@@ -89,6 +91,17 @@ namespace display_device {
     };
 
     static constexpr UINT32 VDD_META_MAGIC = 0x5A564446;  // 'ZVDF'
+    static constexpr UINT32 VDD_META_VERSION = 1;
+
+    static_assert(std::is_standard_layout_v<SharedFrameMetadata>, "SharedFrameMetadata must stay standard layout");
+    static_assert(sizeof(SharedFrameMetadata) == 56, "SharedFrameMetadata layout must stay producer-compatible");
+    static_assert(offsetof(SharedFrameMetadata, Magic) == 0, "SharedFrameMetadata::Magic offset changed");
+    static_assert(offsetof(SharedFrameMetadata, Version) == 4, "SharedFrameMetadata::Version offset changed");
+    static_assert(offsetof(SharedFrameMetadata, Width) == 8, "SharedFrameMetadata::Width offset changed");
+    static_assert(offsetof(SharedFrameMetadata, Height) == 12, "SharedFrameMetadata::Height offset changed");
+    static_assert(offsetof(SharedFrameMetadata, DxgiFormat) == 16, "SharedFrameMetadata::DxgiFormat offset changed");
+    static_assert(offsetof(SharedFrameMetadata, FrameCounter) == 40, "SharedFrameMetadata::FrameCounter offset changed");
+    static_assert(offsetof(SharedFrameMetadata, LastPresentQpc) == 48, "SharedFrameMetadata::LastPresentQpc offset changed");
 
     std::chrono::milliseconds
     calculate_exponential_backoff(int attempt) {
@@ -114,7 +127,7 @@ namespace display_device {
         }
 
         auto *meta = static_cast<const SharedFrameMetadata *>(p);
-        const bool valid = meta->Magic == VDD_META_MAGIC;
+        const bool valid = meta->Magic == VDD_META_MAGIC && meta->Version == VDD_META_VERSION;
         const unsigned int mw = valid ? meta->Width : 0;
         const unsigned int mh = valid ? meta->Height : 0;
         const unsigned int mfmt = valid ? meta->DxgiFormat : 0;

--- a/src/display_device/vdd_utils.cpp
+++ b/src/display_device/vdd_utils.cpp
@@ -73,10 +73,110 @@ namespace display_device {
     // 上一次使用的客户端UUID，用于在没有提供UUID时使用
     static std::string last_used_client_uuid;
 
+    // Must stay binary-compatible with the producer-side struct in ZakoVDD.
+    struct SharedFrameMetadata {
+      UINT32 Magic;
+      UINT32 Version;
+      UINT32 Width;
+      UINT32 Height;
+      UINT32 DxgiFormat;
+      UINT32 IsHdr;
+      float MaxNits;
+      float MinNits;
+      float MaxFALL;
+      UINT64 FrameCounter;
+      UINT64 LastPresentQpc;
+    };
+
+    static constexpr UINT32 VDD_META_MAGIC = 0x5A564446;  // 'ZVDF'
+
     std::chrono::milliseconds
     calculate_exponential_backoff(int attempt) {
       auto delay = kInitialRetryDelay * (1 << attempt);
       return std::min(delay, kMaxRetryDelay);
+    }
+
+    vdd_producer_probe_t
+    probe_vdd_producer(unsigned int target_w, unsigned int target_h, unsigned int max_probe) {
+      vdd_producer_probe_t result;
+
+      for (unsigned int i = 0; i < max_probe; ++i) {
+        std::wstring meta_name = L"Global\\ZakoVDD_Meta_" + std::to_wstring(i);
+        HANDLE h = OpenFileMappingW(FILE_MAP_READ, FALSE, meta_name.c_str());
+        if (!h) {
+          continue;
+        }
+
+        void *p = MapViewOfFile(h, FILE_MAP_READ, 0, 0, sizeof(SharedFrameMetadata));
+        if (!p) {
+          CloseHandle(h);
+          continue;
+        }
+
+        auto *meta = static_cast<const SharedFrameMetadata *>(p);
+        const bool valid = meta->Magic == VDD_META_MAGIC;
+        const unsigned int mw = valid ? meta->Width : 0;
+        const unsigned int mh = valid ? meta->Height : 0;
+        const unsigned int mfmt = valid ? meta->DxgiFormat : 0;
+        const bool mhdr = valid && meta->IsHdr != 0;
+        UnmapViewOfFile(p);
+        CloseHandle(h);
+
+        if (!valid) {
+          continue;
+        }
+
+        BOOST_LOG(debug) << "[vdd] probe meta_" << i
+                         << ": " << mw << "x" << mh
+                         << " fmt=" << mfmt << " hdr=" << mhdr;
+
+        ++result.valid_count;
+        result.only_valid = static_cast<int>(i);
+        result.only_valid_width = mw;
+        result.only_valid_height = mh;
+        if (result.exact < 0 && mw == target_w && mh == target_h) {
+          result.exact = static_cast<int>(i);
+        }
+      }
+
+      if (result.exact >= 0) {
+        result.status = vdd_producer_status_e::exact_match;
+      }
+      else if (result.valid_count == 0) {
+        result.status = vdd_producer_status_e::no_valid_producer;
+      }
+      else if (result.valid_count == 1 && result.only_valid >= 0) {
+        result.status = vdd_producer_status_e::stale_sole_producer;
+      }
+      else {
+        result.status = vdd_producer_status_e::no_matching_producer;
+      }
+
+      return result;
+    }
+
+    vdd_producer_probe_t
+    wait_for_vdd_producer(unsigned int target_w, unsigned int target_h,
+      std::chrono::milliseconds retry_window,
+      std::chrono::milliseconds retry_delay,
+      unsigned int max_probe) {
+      vdd_producer_probe_t last_result;
+      const auto deadline = std::chrono::steady_clock::now() + retry_window;
+
+      for (;;) {
+        last_result = probe_vdd_producer(target_w, target_h, max_probe);
+        if (last_result.exact_match()) {
+          return last_result;
+        }
+
+        if (std::chrono::steady_clock::now() >= deadline) {
+          break;
+        }
+
+        std::this_thread::sleep_for(retry_delay);
+      }
+
+      return last_result;
     }
 
     /**

--- a/src/display_device/vdd_utils.h
+++ b/src/display_device/vdd_utils.h
@@ -57,6 +57,30 @@ namespace display_device::vdd_utils {
     bool needs_update = false;
   };
 
+  /**
+   * @brief Result of probing ZakoVDD shared-frame producer metadata.
+   */
+  enum class vdd_producer_status_e {
+    exact_match,
+    no_valid_producer,
+    stale_sole_producer,
+    no_matching_producer
+  };
+
+  struct vdd_producer_probe_t {
+    vdd_producer_status_e status = vdd_producer_status_e::no_valid_producer;
+    int exact = -1;
+    int only_valid = -1;
+    int valid_count = 0;
+    unsigned int only_valid_width = 0;
+    unsigned int only_valid_height = 0;
+
+    bool
+    exact_match() const {
+      return status == vdd_producer_status_e::exact_match && exact >= 0;
+    }
+  };
+
   // 指数退避计算
   std::chrono::milliseconds
   calculate_exponential_backoff(int attempt);
@@ -109,6 +133,21 @@ namespace display_device::vdd_utils {
    */
   set_vdd_result
   set_vdd_session_mode(const parsed_config_t &config, const VddSettings &settings);
+
+  /**
+   * @brief Probe ZakoVDD shared-frame metadata and match a producer by size.
+   */
+  vdd_producer_probe_t
+  probe_vdd_producer(unsigned int target_w, unsigned int target_h, unsigned int max_probe = 16);
+
+  /**
+   * @brief Wait until ZakoVDD publishes a producer matching the requested size.
+   */
+  vdd_producer_probe_t
+  wait_for_vdd_producer(unsigned int target_w, unsigned int target_h,
+    std::chrono::milliseconds retry_window = 2500ms,
+    std::chrono::milliseconds retry_delay = 100ms,
+    unsigned int max_probe = 16);
 
   /**
    * @brief 从客户端标识符生成GUID字符串（用于驱动识别）

--- a/src/platform/windows/display_vdd.cpp
+++ b/src/platform/windows/display_vdd.cpp
@@ -15,6 +15,7 @@
 
 #include "display.h"
 #include "misc.h"
+#include "src/display_device/vdd_utils.h"
 #include "src/main.h"
 
 #include <d3d11_1.h>
@@ -266,51 +267,6 @@ namespace platf::dxgi {
   // against the DXGI output's reported size. Then opens the shared texture
   // on the same D3D11 device as display_base_t to avoid cross-device copies.
 
-  struct vdd_probe_result_t {
-    int exact = -1;
-    int only_valid = -1;
-    int valid_count = 0;
-    unsigned int only_valid_width = 0;
-    unsigned int only_valid_height = 0;
-  };
-
-  static vdd_probe_result_t
-  probe_vdd_monitor_index(unsigned int target_w, unsigned int target_h, unsigned int max_probe) {
-    vdd_probe_result_t result;
-
-    for (unsigned int i = 0; i < max_probe; ++i) {
-      std::wstring meta_name = L"Global\\ZakoVDD_Meta_" + std::to_wstring(i);
-      HANDLE h = OpenFileMappingW(FILE_MAP_READ, FALSE, meta_name.c_str());
-      if (!h) continue;
-      void *p = MapViewOfFile(h, FILE_MAP_READ, 0, 0, sizeof(SharedFrameMetadata));
-      if (!p) {
-        CloseHandle(h);
-        continue;
-      }
-      auto *meta = static_cast<const SharedFrameMetadata *>(p);
-      bool valid = (meta->Magic == VDD_META_MAGIC);
-      unsigned mw = valid ? meta->Width : 0;
-      unsigned mh = valid ? meta->Height : 0;
-      unsigned mfmt = valid ? meta->DxgiFormat : 0;
-      bool mhdr = valid && (meta->IsHdr != 0);
-      UnmapViewOfFile(p);
-      CloseHandle(h);
-      if (!valid) continue;
-      BOOST_LOG(debug) << "[vdd] probe meta_"sv << i
-                       << ": "sv << mw << "x"sv << mh
-                       << " fmt="sv << mfmt << " hdr="sv << mhdr;
-      ++result.valid_count;
-      result.only_valid = static_cast<int>(i);
-      result.only_valid_width = mw;
-      result.only_valid_height = mh;
-      if (result.exact < 0 && mw == target_w && mh == target_h) {
-        result.exact = static_cast<int>(i);
-      }
-    }
-
-    return result;
-  }
-
   // Probes Global\ZakoVDD_Meta_<i> for valid producers and returns the index
   // whose Width/Height exactly match target. A stale sole producer is not safe:
   // the encoder and capture surfaces are already sized for the requested mode,
@@ -320,22 +276,16 @@ namespace platf::dxgi {
     constexpr auto retry_window = 2500ms;
     constexpr auto retry_delay = 100ms;
 
-    vdd_probe_result_t last_result;
-    const auto deadline = std::chrono::steady_clock::now() + retry_window;
-
-    for (;;) {
-      last_result = probe_vdd_monitor_index(target_w, target_h, max_probe);
-      if (last_result.exact >= 0) {
-        BOOST_LOG(info) << "[vdd] resolved monitor index "sv << last_result.exact
-                        << " for "sv << target_w << "x"sv << target_h << " (exact match)"sv;
-        return last_result.exact;
-      }
-
-      if (std::chrono::steady_clock::now() >= deadline) {
-        break;
-      }
-
-      std::this_thread::sleep_for(retry_delay);
+    const auto last_result = display_device::vdd_utils::wait_for_vdd_producer(
+      target_w,
+      target_h,
+      retry_window,
+      retry_delay,
+      max_probe);
+    if (last_result.exact_match()) {
+      BOOST_LOG(info) << "[vdd] resolved monitor index "sv << last_result.exact
+                      << " for "sv << target_w << "x"sv << target_h << " (exact match)"sv;
+      return last_result.exact;
     }
 
     if (last_result.valid_count == 0) {
@@ -368,10 +318,8 @@ namespace platf::dxgi {
     // Try to identify which VDD monitor backs this DXGI output by matching
     // dimensions. width/height come from DXGI DesktopCoordinates / orientation.
     // NOTE: We intentionally do NOT trigger CREATEMONITOR here. Sunshine's
-    // display-device layer (prepare_vdd) already manages monitor lifecycle, and
-    // adding a 3s NamedPipe round-trip per encoder probe wastes ~20s on every
-    // startup with no real benefit. If no producer is reachable, we just fail
-    // and let the upper layer try a different backend.
+    // display-device session layer owns VDD lifecycle. If no matching producer
+    // is reachable here, opening it would still be unsafe, so this backend fails.
     int idx = resolve_vdd_monitor_index(static_cast<unsigned>(width_before_rotation),
                                         static_cast<unsigned>(height_before_rotation));
     if (idx < 0) {


### PR DESCRIPTION
﻿## 改了啥呢
- 把 VDD shared-frame producer 的 `Meta_*` 探测结果抽到 `vdd_utils`，让 capture backend 复用同一套 `exact / stale / missing / no match` 判断。
- `display_vdd` 继续只接受尺寸精确匹配的 producer，保留 stale producer 的拒绝保护。
- 没有在 session 层自动 destroy/create 或二次 apply display config，避免为了一个杂鱼 stale metadata 把显示生命周期搅太大。

## 为啥要改
用户日志里 VDD 已经切到 `2584x1828`，但 producer metadata 还停在 `3840x2160`，于是 capture 初始化拒绝 stale producer 并结束会话。这个 PR 先把判断逻辑收口，避免后续 session/capture 各写一份探测规则，也让这个状态更容易诊断和扩展。

## 验证
- `git diff --check`
- 对 `src/display_device/vdd_utils.cpp` 和 `src/platform/windows/display_vdd.cpp` 用 CMake/Ninja 同等宏与 flags 做 `-fsyntax-only` 验证
- 用 named file mapping harness 模拟：no producer、stale sole producer、delayed producer refresh、multiple producers no match、exact match
