### PR TITLE
fix(display): guard unsafe vdd display-off prep

### DIFF
--- a/src/display_device/parsed_config.cpp
+++ b/src/display_device/parsed_config.cpp
@@ -521,7 +521,38 @@ namespace display_device {
 
   bool
   display_request_t::requires_vdd(bool requested_device_exists, bool is_vdd_device) const {
-    return use_vdd || is_vdd_device || (!requested_device_exists && allows_vdd_fallback());
+    return resolve_vdd_request(
+      *this,
+      requested_device_exists,
+      is_vdd_device,
+      parsed_config_t::device_prep_e::ensure_active
+    ) == vdd_request_decision_e::use_vdd;
+  }
+
+  bool
+  is_explicit_vdd_request(const display_request_t &request, bool is_vdd_device) {
+    return request.use_vdd || is_vdd_device;
+  }
+
+  vdd_request_decision_e
+  resolve_vdd_request(
+    const display_request_t &request,
+    bool requested_device_exists,
+    bool is_vdd_device,
+    parsed_config_t::device_prep_e device_prep) {
+    if (is_explicit_vdd_request(request, is_vdd_device)) {
+      return vdd_request_decision_e::use_vdd;
+    }
+
+    if (requested_device_exists || !request.allows_vdd_fallback()) {
+      return vdd_request_decision_e::use_requested_display;
+    }
+
+    if (device_prep == parsed_config_t::device_prep_e::no_operation) {
+      return vdd_request_decision_e::blocked_automatic_fallback;
+    }
+
+    return vdd_request_decision_e::use_vdd;
   }
 
   display_request_t
@@ -695,19 +726,20 @@ namespace display_device {
       return boost::none;
     }
 
-    const bool explicit_vdd_request = display_request.use_vdd || is_vdd_device;
-    const bool automatic_vdd_fallback =
-      !requested_device_exists && display_request.allows_vdd_fallback() && !explicit_vdd_request;
-    if (parsed_config.device_prep == parsed_config_t::device_prep_e::no_operation &&
-        automatic_vdd_fallback) {
+    const auto vdd_request_decision = resolve_vdd_request(
+      display_request,
+      requested_device_exists,
+      is_vdd_device,
+      parsed_config.device_prep
+    );
+
+    if (vdd_request_decision == vdd_request_decision_e::blocked_automatic_fallback) {
       BOOST_LOG(error) << "Requested display is unavailable and no_operation forbids automatic VDD fallback: " << parsed_config.device_id;
       return boost::none;
     }
 
-    const bool needs_vdd = explicit_vdd_request || automatic_vdd_fallback;
-
     // 不需要VDD时，使用物理模式映射
-    if (!needs_vdd) {
+    if (vdd_request_decision != vdd_request_decision_e::use_vdd) {
       BOOST_LOG(debug) << "输出设备已存在，跳过VDD准备"sv;
       parsed_config.use_vdd = false;
       parsed_config.device_prep = parsed_config_t::to_physical_device_prep(parsed_config.device_prep);
@@ -729,7 +761,10 @@ namespace display_device {
     }
 
     // 准备VDD设备
-    display_device::session_t::get().prepare_vdd(parsed_config, session);
+    if (!display_device::session_t::get().prepare_vdd(parsed_config, session)) {
+      BOOST_LOG(error) << "Failed to prepare VDD display safely.";
+      return boost::none;
+    }
 
     return parsed_config;
   }

--- a/src/display_device/parsed_config.h
+++ b/src/display_device/parsed_config.h
@@ -189,6 +189,22 @@ namespace display_device {
     requires_vdd(bool requested_device_exists, bool is_vdd_device) const;
   };
 
+  enum class vdd_request_decision_e {
+    use_requested_display,
+    use_vdd,
+    blocked_automatic_fallback
+  };
+
+  bool
+  is_explicit_vdd_request(const display_request_t &request, bool is_vdd_device);
+
+  vdd_request_decision_e
+  resolve_vdd_request(
+    const display_request_t &request,
+    bool requested_device_exists,
+    bool is_vdd_device,
+    parsed_config_t::device_prep_e device_prep);
+
   display_request_t
   resolve_display_request(const config::video_t &config, const rtsp_stream::launch_session_t &session);
 

--- a/src/display_device/session.cpp
+++ b/src/display_device/session.cpp
@@ -371,11 +371,13 @@ namespace display_device {
     const bool requested_device_exists = !requested_device_id.empty();
     const bool is_vdd_device = (display_device::get_display_friendly_name(display_request.device_id) == ZAKO_NAME);
     const auto effective_device_prep = get_effective_device_prep(config, session);
-    const bool explicit_vdd_request = display_request.use_vdd || is_vdd_device;
-    const bool automatic_vdd_fallback = !requested_device_exists && display_request.allows_vdd_fallback() && !explicit_vdd_request;
 
-    const bool needs_vdd = explicit_vdd_request ||
-      (automatic_vdd_fallback && effective_device_prep != parsed_config_t::device_prep_e::no_operation);
+    const bool needs_vdd = resolve_vdd_request(
+      display_request,
+      requested_device_exists,
+      is_vdd_device,
+      effective_device_prep
+    ) == vdd_request_decision_e::use_vdd;
 
     // - 如果不需要 VDD：跳过 VDD 相关逻辑
     // - 如果不是 SYSTEM 权限且处于 RDP 中：使用 RDP 虚拟显示器，不创建 VDD
@@ -415,7 +417,31 @@ namespace display_device {
         timer->setup_timer(nullptr);
       }
       else {
-        BOOST_LOG(debug) << "VDD already exists, skipping initial topology save (topology may be corrupted)";
+        if (vdd_will_turn_off_physical_displays) {
+          const auto current_devices = display_device::enum_available_devices();
+          if (vdd_utils::has_active_physical_display_snapshot(current_devices)) {
+            const auto current_topology = get_current_topology();
+            if (is_topology_valid(current_topology)) {
+              pre_saved_initial_topology = current_topology;
+              BOOST_LOG(debug) << "VDD already exists, but active physical displays are present; saved current topology before display_off prep: "
+                               << to_string(*pre_saved_initial_topology);
+            }
+            else {
+              BOOST_LOG(error) << "VDD already exists and physical displays are active, but current topology is invalid; refusing display_off prep.";
+              return {
+                configure_result_t::result_e::topology_fail,
+                "Current display topology is not safe for VDD display-off prep.",
+                "Disable VDD display-off prep or restore a valid physical display topology, then try again."
+              };
+            }
+          }
+          else {
+            BOOST_LOG(debug) << "VDD already exists and no active physical display baseline is available; skipping initial topology save.";
+          }
+        }
+        else {
+          BOOST_LOG(debug) << "VDD already exists, skipping initial topology save (topology may be corrupted)";
+        }
       }
     }
 
@@ -554,7 +580,7 @@ namespace display_device {
     std::this_thread::sleep_for(1200ms);
   }
 
-  void
+  bool
   session_t::prepare_vdd(parsed_config_t &config, const rtsp_stream::launch_session_t &session) {
     const std::string current_client_id = get_client_id_from_session(session);
     const vdd_utils::hdr_brightness_t hdr_brightness { session.max_nits, session.min_nits, session.max_full_nits };
@@ -575,9 +601,11 @@ namespace display_device {
 
     auto device_zako = display_device::find_device_by_friendlyname(ZAKO_NAME);
 
-    // pre_vdd_devices: 在 VDD 创建前一刻保存的物理显示器快照
-    // 延迟到 VDD 创建前才捕获，确保无论是新建还是重建都能拿到正确状态
+    // pre_vdd_devices: 在 VDD prep 前保存的显示器基线快照
+    // 延迟到 VDD 创建或 prep 前才捕获，确保能拿到可恢复的正确状态
     device_info_map_t pre_vdd_devices;
+    bool pre_vdd_devices_captured = false;
+    const bool vdd_prep_needs_snapshot = vdd_utils::vdd_prep_requires_pre_vdd_snapshot(config.vdd_prep);
 
     // Rebuild VDD device on client switch
     if (!device_zako.empty() && !current_vdd_client_id.empty() &&
@@ -628,7 +656,8 @@ namespace display_device {
       // 在创建 VDD 之前捕获物理显示器快照
       // 此时无 VDD 存在（新建 or 重建后已销毁），物理屏应处于正常状态
       pre_vdd_devices = display_device::enum_available_devices();
-      BOOST_LOG(info) << "已保存pre-VDD设备列表: " << display_device::to_string(pre_vdd_devices);
+      pre_vdd_devices_captured = true;
+      BOOST_LOG(info) << "已保存VDD prep基线设备列表: " << display_device::to_string(pre_vdd_devices);
 
       BOOST_LOG(info) << "创建虚拟显示器...";
       // 复用模式使用固定标识符，否则使用客户端ID生成唯一GUID
@@ -637,6 +666,12 @@ namespace display_device {
         : current_client_id;  // 为每个客户端生成不同GUID
       vdd_utils::create_vdd_monitor(vdd_identifier, hdr_brightness, physical_size);
       std::this_thread::sleep_for(200ms);
+    }
+    else if (vdd_prep_needs_snapshot) {
+      pre_vdd_devices = display_device::enum_available_devices();
+      pre_vdd_devices_captured = true;
+      BOOST_LOG(info) << "VDD already exists; captured current display list as VDD prep baseline: "
+                      << display_device::to_string(pre_vdd_devices);
     }
 
     // Wait for device to be ready
@@ -663,12 +698,12 @@ namespace display_device {
         else {
           BOOST_LOG(warning) << "VDD IOCTL 仍可用，跳过 disable/enable，避免制造 phantom monitor";
         }
-        return;
+        return false;
       }
     }
 
     if (device_zako.empty()) {
-      return;
+      return false;
     }
 
     if (original_output_name.empty()) {
@@ -695,9 +730,17 @@ namespace display_device {
     // VDD模式下的拓扑控制与普通模式分开处理
     if (config.vdd_prep != parsed_config_t::vdd_prep_e::no_operation) {
       // User has specified a display configuration, apply it
-      if (vdd_utils::apply_vdd_prep(device_zako, config.vdd_prep, pre_vdd_devices)) {
+      const auto vdd_prep_result = vdd_utils::apply_vdd_prep(device_zako, config.vdd_prep, pre_vdd_devices, pre_vdd_devices_captured);
+      if (vdd_prep_result == vdd_utils::vdd_prep_result_e::success) {
         BOOST_LOG(info) << "已应用VDD屏幕布局设置";
         std::this_thread::sleep_for(200ms);
+      }
+      else if (vdd_prep_result == vdd_utils::vdd_prep_result_e::topology_failed && settings.is_changing_settings_going_to_fail()) {
+        BOOST_LOG(warning) << "VDD prep topology change failed while Windows display settings are unavailable; allowing the stream to continue without applying VDD prep.";
+      }
+      else {
+        BOOST_LOG(error) << "Failed to apply VDD prep safely; aborting display configuration.";
+        return false;
       }
     }
     else {
@@ -714,6 +757,8 @@ namespace display_device {
       std::this_thread::sleep_for(500ms);
       vdd_utils::set_hdr_state(false);
     }
+
+    return true;
   }
 
   void

--- a/src/display_device/session.h
+++ b/src/display_device/session.h
@@ -212,8 +212,9 @@ namespace display_device {
 
     /**
      * @brief Prepares VDD for use
+     * @returns True when VDD prep succeeded; false when display configuration should abort.
      */
-    void
+    bool
     prepare_vdd(parsed_config_t &config, const rtsp_stream::launch_session_t &session);
 
     /**

--- a/src/display_device/vdd_utils.cpp
+++ b/src/display_device/vdd_utils.cpp
@@ -1056,42 +1056,84 @@ namespace display_device {
     }
 
     bool
+    vdd_prep_requires_pre_vdd_snapshot(parsed_config_t::vdd_prep_e vdd_prep) {
+      return vdd_prep == parsed_config_t::vdd_prep_e::display_off;
+    }
+
+    bool
+    has_active_physical_display_snapshot(const device_info_map_t &pre_vdd_devices) {
+      return std::any_of(pre_vdd_devices.begin(), pre_vdd_devices.end(), [](const auto &entry) {
+        const auto &info = entry.second;
+        return info.friendly_name != ZAKO_NAME &&
+               (info.device_state == device_state_e::active ||
+                info.device_state == device_state_e::primary);
+      });
+    }
+
+    bool
+    has_physical_display_snapshot(const device_info_map_t &pre_vdd_devices) {
+      return std::any_of(pre_vdd_devices.begin(), pre_vdd_devices.end(), [](const auto &entry) {
+        return entry.second.friendly_name != ZAKO_NAME;
+      });
+    }
+
+    vdd_prep_result_e
     apply_vdd_prep(const std::string &vdd_device_id, parsed_config_t::vdd_prep_e vdd_prep,
-      const device_info_map_t &pre_vdd_devices) {
+      const device_info_map_t &pre_vdd_devices, bool pre_vdd_devices_captured) {
       if (vdd_device_id.empty()) {
         BOOST_LOG(info) << "VDD设备ID为空，跳过vdd_prep处理";
-        return true;
+        return vdd_prep_result_e::success;
       }
 
       if (vdd_prep == parsed_config_t::vdd_prep_e::no_operation) {
         BOOST_LOG(info) << "vdd_prep设置为无操作，跳过物理显示器处理";
-        return true;
+        return vdd_prep_result_e::success;
       }
 
-      // 从 pre_vdd_devices（VDD创建前保存的设备列表）中获取物理显示器，
-      // 确保即使 VDD 创建后物理屏变 inactive 也能正确识别
+      // 从基线快照中获取物理显示器，确保即使 VDD prep 后物理屏变 inactive 也能正确识别
+      if (vdd_prep_requires_pre_vdd_snapshot(vdd_prep) && !pre_vdd_devices_captured) {
+        BOOST_LOG(error) << "Missing baseline display snapshot; refusing VDD prep "
+                         << static_cast<int>(vdd_prep)
+                         << " to avoid guessing the original physical display topology.";
+        return vdd_prep_result_e::safety_blocked;
+      }
+
+      if (vdd_prep_requires_pre_vdd_snapshot(vdd_prep) &&
+          has_physical_display_snapshot(pre_vdd_devices) &&
+          !has_active_physical_display_snapshot(pre_vdd_devices)) {
+        BOOST_LOG(error) << "Baseline display snapshot contains no active physical display; refusing VDD prep "
+                         << static_cast<int>(vdd_prep)
+                         << " because the baseline is not restorable.";
+        return vdd_prep_result_e::safety_blocked;
+      }
+
       std::vector<std::string> physical_devices;
       std::string original_primary_id;
 
-      if (!pre_vdd_devices.empty()) {
-        // 使用 VDD 创建前保存的设备信息（可靠）
+      if (pre_vdd_devices_captured) {
+        // 使用 VDD prep 前保存的基线设备信息（可靠）
         for (const auto &[device_id, info] : pre_vdd_devices) {
-          if (info.friendly_name != ZAKO_NAME) {
+          if (info.friendly_name != ZAKO_NAME &&
+              (info.device_state == device_state_e::active ||
+               info.device_state == device_state_e::primary)) {
             physical_devices.push_back(device_id);
             if (info.device_state == device_state_e::primary) {
               original_primary_id = device_id;
             }
           }
         }
-        BOOST_LOG(info) << "使用pre-VDD设备列表: " << physical_devices.size() << "个物理显示器"
+        BOOST_LOG(info) << "使用VDD prep基线设备列表: " << physical_devices.size() << "个物理显示器"
                         << (original_primary_id.empty() ? "" : ", 原主屏: " + original_primary_id);
       }
       else {
-        // 回退：从当前设备枚举中获取（VDD创建前未保存时的兜底逻辑）
-        BOOST_LOG(warning) << "未提供pre-VDD设备列表，从当前设备枚举中查找物理显示器";
+        // 回退：从当前设备枚举中获取（未保存 VDD prep 基线时的兜底逻辑）
+        BOOST_LOG(warning) << "未提供VDD prep基线设备列表，从当前设备枚举中查找物理显示器";
         const auto all_devices = enum_available_devices();
         for (const auto &[device_id, info] : all_devices) {
-          if (device_id != vdd_device_id && info.friendly_name != ZAKO_NAME) {
+          if (device_id != vdd_device_id &&
+              info.friendly_name != ZAKO_NAME &&
+              (info.device_state == device_state_e::active ||
+               info.device_state == device_state_e::primary)) {
             physical_devices.push_back(device_id);
             if (info.device_state == device_state_e::primary) {
               original_primary_id = device_id;
@@ -1110,7 +1152,7 @@ namespace display_device {
 
       if (physical_devices.empty()) {
         BOOST_LOG(debug) << "没有物理显示器需要处理";
-        return true;
+        return vdd_prep_result_e::success;
       }
 
       active_topology_t new_topology;
@@ -1149,21 +1191,21 @@ namespace display_device {
         }
 
         default:
-          return true;
+          return vdd_prep_result_e::success;
       }
 
       if (!is_topology_valid(new_topology)) {
         BOOST_LOG(error) << "新拓扑无效";
-        return false;
+        return vdd_prep_result_e::safety_blocked;
       }
 
       if (!set_topology(new_topology)) {
         BOOST_LOG(error) << "设置拓扑失败";
-        return false;
+        return vdd_prep_result_e::topology_failed;
       }
 
       BOOST_LOG(info) << "成功应用vdd_prep设置";
-      return true;
+      return vdd_prep_result_e::success;
     }
   }  // namespace vdd_utils
 }  // namespace display_device

--- a/src/display_device/vdd_utils.h
+++ b/src/display_device/vdd_utils.h
@@ -167,20 +167,37 @@ namespace display_device::vdd_utils {
   bool
   ensure_vdd_extended_mode(const std::string &device_id, const std::unordered_set<std::string> &physical_devices_to_preserve = {});
 
+  bool
+  vdd_prep_requires_pre_vdd_snapshot(parsed_config_t::vdd_prep_e vdd_prep);
+
+  bool
+  has_active_physical_display_snapshot(const device_info_map_t &pre_vdd_devices);
+
+  bool
+  has_physical_display_snapshot(const device_info_map_t &pre_vdd_devices);
+
+  enum class vdd_prep_result_e {
+    success,
+    safety_blocked,
+    topology_failed
+  };
+
   /**
    * @brief Apply VDD prep settings to handle physical displays.
    * @param vdd_device_id The VDD device ID.
    * @param vdd_prep The vdd_prep_e value specifying how to handle physical displays.
-   * @param pre_vdd_devices Physical device info captured BEFORE VDD creation.
-   *        Used to reliably identify physical displays even if VDD creation
-   *        caused them to become inactive. If empty, falls back to current device enumeration.
-   * @returns True if the operation succeeded.
+   * @param pre_vdd_devices Physical device info captured before VDD prep changes.
+   *        Used to reliably identify physical displays even if VDD creation or
+   *        prep caused them to become inactive.
+   * @param pre_vdd_devices_captured True when pre_vdd_devices is a real baseline
+   *        snapshot. Destructive topology prep is refused without this baseline.
+   * @returns Detailed result of the prep operation.
    * @note This operation modifies topology without saving/restoring state,
    *       as Windows automatically handles topology memory when displays change.
    */
-  bool
+  vdd_prep_result_e
   apply_vdd_prep(const std::string &vdd_device_id, parsed_config_t::vdd_prep_e vdd_prep,
-    const device_info_map_t &pre_vdd_devices = {});
+    const device_info_map_t &pre_vdd_devices = {}, bool pre_vdd_devices_captured = false);
 
   VddSettings
   prepare_vdd_settings(const parsed_config_t &config);

--- a/src/nvhttp_stream_start.cpp
+++ b/src/nvhttp_stream_start.cpp
@@ -242,7 +242,7 @@ namespace nvhttp::stream_start {
     explicit_vdd_requested_for_launch(const rtsp_stream::launch_session_t &launch_session) {
       const auto display_request = display_device::resolve_display_request(config::video, launch_session);
       const bool is_vdd_device = display_device::get_display_friendly_name(display_request.device_id) == ZAKO_NAME;
-      return display_request.use_vdd || is_vdd_device;
+      return display_device::is_explicit_vdd_request(display_request, is_vdd_device);
     }
 
     bool

--- a/tests/unit/test_vdd_safety.cpp
+++ b/tests/unit/test_vdd_safety.cpp
@@ -1,0 +1,119 @@
+#include "../tests_common.h"
+
+#ifdef _WIN32
+
+#include <string>
+#include <utility>
+
+#include "src/display_device/vdd_utils.h"
+#include "src/globals.h"
+
+namespace {
+  display_device::device_info_t
+  make_device(std::string friendly_name, display_device::device_state_e state) {
+    return {
+      "\\\\.\\DISPLAY1",
+      std::move(friendly_name),
+      state,
+      display_device::hdr_state_e::unknown
+    };
+  }
+}  // namespace
+
+TEST(VddPrepSafety, RequiresPreVddSnapshotForTopologyPrep) {
+  using display_device::parsed_config_t;
+
+  EXPECT_FALSE(display_device::vdd_utils::vdd_prep_requires_pre_vdd_snapshot(parsed_config_t::vdd_prep_e::no_operation));
+  EXPECT_FALSE(display_device::vdd_utils::vdd_prep_requires_pre_vdd_snapshot(parsed_config_t::vdd_prep_e::vdd_as_primary));
+  EXPECT_FALSE(display_device::vdd_utils::vdd_prep_requires_pre_vdd_snapshot(parsed_config_t::vdd_prep_e::vdd_as_secondary));
+  EXPECT_TRUE(display_device::vdd_utils::vdd_prep_requires_pre_vdd_snapshot(parsed_config_t::vdd_prep_e::display_off));
+}
+
+TEST(VddPrepSafety, DetectsRestorablePhysicalDisplaySnapshot) {
+  using namespace display_device;
+
+  EXPECT_FALSE(vdd_utils::has_active_physical_display_snapshot({}));
+  EXPECT_FALSE(vdd_utils::has_physical_display_snapshot({}));
+
+  device_info_map_t vdd_only {
+    { "vdd", make_device(ZAKO_NAME, device_state_e::primary) },
+  };
+  EXPECT_FALSE(vdd_utils::has_active_physical_display_snapshot(vdd_only));
+  EXPECT_FALSE(vdd_utils::has_physical_display_snapshot(vdd_only));
+
+  device_info_map_t inactive_physical {
+    { "physical", make_device("F32D80U", device_state_e::inactive) },
+  };
+  EXPECT_FALSE(vdd_utils::has_active_physical_display_snapshot(inactive_physical));
+  EXPECT_TRUE(vdd_utils::has_physical_display_snapshot(inactive_physical));
+
+  device_info_map_t active_physical {
+    { "physical", make_device("F32D80U", device_state_e::active) },
+  };
+  EXPECT_TRUE(vdd_utils::has_active_physical_display_snapshot(active_physical));
+  EXPECT_TRUE(vdd_utils::has_physical_display_snapshot(active_physical));
+
+  device_info_map_t primary_physical {
+    { "physical", make_device("F32D80U", device_state_e::primary) },
+  };
+  EXPECT_TRUE(vdd_utils::has_active_physical_display_snapshot(primary_physical));
+  EXPECT_TRUE(vdd_utils::has_physical_display_snapshot(primary_physical));
+}
+
+TEST(VddPrepSafety, BlocksOnlyUnsafeDisplayOffBaselines) {
+  using namespace display_device;
+  using result_e = vdd_utils::vdd_prep_result_e;
+
+  EXPECT_EQ(
+    vdd_utils::apply_vdd_prep("vdd", parsed_config_t::vdd_prep_e::display_off, {}, false),
+    result_e::safety_blocked);
+
+  device_info_map_t inactive_physical {
+    { "physical", make_device("F32D80U", device_state_e::inactive) },
+    { "vdd", make_device(ZAKO_NAME, device_state_e::primary) },
+  };
+  EXPECT_EQ(
+    vdd_utils::apply_vdd_prep("vdd", parsed_config_t::vdd_prep_e::display_off, inactive_physical, true),
+    result_e::safety_blocked);
+
+  device_info_map_t vdd_only {
+    { "vdd", make_device(ZAKO_NAME, device_state_e::primary) },
+  };
+  EXPECT_EQ(
+    vdd_utils::apply_vdd_prep("vdd", parsed_config_t::vdd_prep_e::display_off, vdd_only, true),
+    result_e::success);
+}
+
+TEST(VddRequestSafety, NoOperationBlocksOnlyAutomaticVddFallback) {
+  using namespace display_device;
+  using device_prep_e = parsed_config_t::device_prep_e;
+  using decision_e = vdd_request_decision_e;
+
+  display_request_t config_missing_display {
+    "missing",
+    display_request_t::source_e::config,
+    false
+  };
+  EXPECT_FALSE(is_explicit_vdd_request(config_missing_display, false));
+  EXPECT_EQ(resolve_vdd_request(config_missing_display, false, false, device_prep_e::no_operation), decision_e::blocked_automatic_fallback);
+  EXPECT_EQ(resolve_vdd_request(config_missing_display, false, false, device_prep_e::ensure_active), decision_e::use_vdd);
+  EXPECT_EQ(resolve_vdd_request(config_missing_display, true, false, device_prep_e::no_operation), decision_e::use_requested_display);
+
+  display_request_t explicit_vdd {
+    "missing",
+    display_request_t::source_e::config,
+    true
+  };
+  EXPECT_TRUE(is_explicit_vdd_request(explicit_vdd, false));
+  EXPECT_EQ(resolve_vdd_request(explicit_vdd, false, false, device_prep_e::no_operation), decision_e::use_vdd);
+
+  display_request_t client_physical_missing {
+    "missing",
+    display_request_t::source_e::client,
+    false
+  };
+  EXPECT_FALSE(client_physical_missing.allows_vdd_fallback());
+  EXPECT_EQ(resolve_vdd_request(client_physical_missing, false, false, device_prep_e::ensure_active), decision_e::use_requested_display);
+}
+
+#endif


### PR DESCRIPTION
## 改了啥呀

- 基于 #740 之后重新收窄 #739：保留 #740 的 `no_operation` / 副屏 / mode-HDR fallback 语义，只补 VDD `display_off` 的可恢复基线保护。
- 给 `display_off` prep 增加安全结果枚举：缺少必需 pre-VDD 快照、或物理屏存在但没有 active/primary 恢复基线时，拒绝继续猜拓扑。
- VDD 已存在但物理屏仍 active/primary 时，保存当前拓扑作为恢复基线，避免误伤常驻/复用 VDD。
- 将 #740 新增的 VDD 判定拆成共享 helper，统一 `explicit VDD`、`automatic VDD fallback`、`no_operation blocks automatic fallback` 的判断，避免 `parsed_config` / `session` / `nvhttp_stream_start` 三处后续漂移。
- 新增 VDD safety 单测，同时覆盖 #740 风险边界：显式 VDD 不会被 `no_operation` 误拦，只有自动 fallback 才会被拦。

## 为啥要改

#740 解决的是「不该自动 fallback 到 VDD」和「VDD secondary/副屏主屏关系」的问题，方向是对的；但它没有覆盖日志里 `display_off` 已经把物理屏关掉、又缺少可靠 pre-VDD 基线时的恢复风险。

这次改动把两者合并成互补关系：#740 决定什么时候该进入 VDD，我们只在真正要执行 VDD `display_off` 时检查恢复基线。这样正常锁屏 VDD 串流不被一刀切打断，小杂鱼拓扑状态也不会被当成可恢复初始状态写进去。

## 验证

- `cmake --build build --target CMakeFiles/sunshine.dir/src/display_device/parsed_config.cpp.obj CMakeFiles/sunshine.dir/src/display_device/session.cpp.obj CMakeFiles/sunshine.dir/src/display_device/vdd_utils.cpp.obj CMakeFiles/sunshine.dir/src/nvhttp_stream_start.cpp.obj CMakeFiles/sunshine.dir/src/platform/windows/display_device/settings.cpp.obj -j 8`
- `cmake -S . -B build-codex-tests -G Ninja -DBUILD_TESTS=ON -DFETCH_DRIVER_DEPS=OFF`
- `cmake --build build-codex-tests --target tests/CMakeFiles/test_sunshine.dir/unit/test_vdd_safety.cpp.obj tests/CMakeFiles/test_sunshine.dir/__/src/display_device/parsed_config.cpp.obj tests/CMakeFiles/test_sunshine.dir/__/src/display_device/session.cpp.obj tests/CMakeFiles/test_sunshine.dir/__/src/display_device/vdd_utils.cpp.obj tests/CMakeFiles/test_sunshine.dir/__/src/nvhttp_stream_start.cpp.obj -j 8`
- `git diff --check -- src/display_device/parsed_config.cpp src/display_device/parsed_config.h src/display_device/session.cpp src/display_device/session.h src/display_device/vdd_utils.cpp src/display_device/vdd_utils.h src/nvhttp_stream_start.cpp tests/unit/test_vdd_safety.cpp`

完整 `sunshine` 目标在本地临时 worktree 没有跑完：最新 `origin/master` 的 #723 touchpad 代码需要更新后的 `moonlight-common-c` 类型（`PSS_TOUCHPAD_*`），而临时 worktree 借用的本地子模块版本偏旧，失败点在 unrelated `src/input.cpp`。