### PR TITLE
fix(apps): localize remote cover art safely

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -1135,12 +1135,8 @@ namespace confighttp {
 
     std::basic_string path = coverdir + http::url_escape(key) + ".png";
     if (!url.empty()) {
-      if (http::url_get_host(url) != "images.igdb.com") {
-        outputTree.put("error", "Only images.igdb.com is allowed");
-        return;
-      }
-      if (!http::download_image_with_magic_check(url, path)) {
-        outputTree.put("error", "Failed to download cover");
+      if (!http::download_public_cover_image(url, path)) {
+        outputTree.put("error", "Failed to download public HTTPS cover");
         return;
       }
     }

--- a/src/httpcommon.cpp
+++ b/src/httpcommon.cpp
@@ -7,13 +7,17 @@
 #include "process.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cctype>
 #include <cstdint>
 #include <filesystem>
+#include <initializer_list>
 #include <utility>
+#include <vector>
 
 #include <boost/asio/ip/address.hpp>
 #include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/steady_timer.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
@@ -384,6 +388,9 @@ namespace http {
 }  // namespace http
 
 namespace {
+  constexpr auto COVER_DOWNLOAD_MAX_BYTES = static_cast<std::size_t>(10 * 1024 * 1024);
+  constexpr auto COVER_DNS_TIMEOUT = std::chrono::seconds(10);
+
   struct ParsedDownloadUrl {
     std::string scheme;
     std::string host;
@@ -477,19 +484,50 @@ namespace {
                               bytes[10] == 0xff &&
                               bytes[11] == 0xff;
     if (is_v4_mapped) {
-      const auto mapped = (static_cast<std::uint32_t>(bytes[12]) << 24) |
-                          (static_cast<std::uint32_t>(bytes[13]) << 16) |
-                          (static_cast<std::uint32_t>(bytes[14]) << 8) |
-                          static_cast<std::uint32_t>(bytes[15]);
-      return is_private_ipv4(mapped);
+      return true;
     }
 
-    return (bytes[0] & 0xfe) == 0xfc ||                         // Unique local address fc00::/7
-           (bytes[0] == 0xfe && (bytes[1] & 0xc0) == 0x80) ||    // Link-local fe80::/10
-           (bytes[0] == 0x20 && bytes[1] == 0x01 && bytes[2] == 0x0d && bytes[3] == 0xb8); // Documentation range
+    const auto has_prefix = [&bytes](std::initializer_list<unsigned char> prefix) {
+      return std::equal(prefix.begin(), prefix.end(), bytes.begin());
+    };
+    const auto is_zero_range = [&bytes](std::size_t begin, std::size_t end) {
+      return std::all_of(bytes.begin() + begin, bytes.begin() + end, [](unsigned char value) { return value == 0; });
+    };
+
+    const bool is_v4_compatible = is_zero_range(0, 12);
+    const bool is_nat64_well_known = has_prefix({0x00, 0x64, 0xff, 0x9b}) && is_zero_range(4, 12); // 64:ff9b::/96
+    const bool is_nat64_local_use = has_prefix({0x00, 0x64, 0xff, 0x9b, 0x00, 0x01}); // 64:ff9b:1::/48
+    const bool is_discard_only = has_prefix({0x01, 0x00}) && is_zero_range(2, 8); // 100::/64
+    const bool is_dummy_prefix = has_prefix({0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}); // 100:0:0:1::/64
+    const bool is_ietf_protocol_assignment = has_prefix({0x20, 0x01}) && (bytes[2] & 0xfe) == 0x00; // 2001::/23
+    const bool is_orchid_deprecated = has_prefix({0x20, 0x01, 0x00}) && (bytes[3] & 0xf0) == 0x10; // 2001:10::/28
+    const bool is_orchid_v2 = has_prefix({0x20, 0x01, 0x00}) && (bytes[3] & 0xf0) == 0x20; // 2001:20::/28
+    const bool is_documentation_2001 = has_prefix({0x20, 0x01, 0x0d, 0xb8}); // 2001:db8::/32
+    const bool is_6to4 = has_prefix({0x20, 0x02}); // 2002::/16
+    const bool is_documentation_3fff = has_prefix({0x3f, 0xff}) && (bytes[2] & 0xf0) == 0x00; // 3fff::/20
+    const bool is_srv6_sid = has_prefix({0x5f, 0x00}); // 5f00::/16
+    const bool is_unique_local = (bytes[0] & 0xfe) == 0xfc; // fc00::/7
+    const bool is_link_or_site_local = bytes[0] == 0xfe && (bytes[1] & 0xc0) != 0x00; // fe80::/10 and deprecated fec0::/10
+    const bool is_current_global_unicast = (bytes[0] & 0xe0) == 0x20; // 2000::/3
+
+    return !is_current_global_unicast ||
+           is_v4_compatible ||
+           is_nat64_well_known ||
+           is_nat64_local_use ||
+           is_discard_only ||
+           is_dummy_prefix ||
+           is_ietf_protocol_assignment ||
+           is_orchid_deprecated ||
+           is_orchid_v2 ||
+           is_documentation_2001 ||
+           is_6to4 ||
+           is_documentation_3fff ||
+           is_srv6_sid ||
+           is_unique_local ||
+           is_link_or_site_local;
   }
 
-  bool host_resolves_to_public_addresses(const std::string &host) {
+  bool resolve_host_to_public_addresses(const std::string &host, std::vector<std::string> &addresses) {
     if (host.empty() || host == "localhost" || host.ends_with(".localhost")) {
       return false;
     }
@@ -502,7 +540,28 @@ namespace {
 
     boost::asio::io_context io;
     boost::asio::ip::tcp::resolver resolver(io);
-    const auto results = resolver.resolve(host, "443", ec);
+    boost::asio::steady_timer timer(io);
+    boost::asio::ip::tcp::resolver::results_type results;
+    bool timed_out = false;
+
+    resolver.async_resolve(host, "443", [&](const boost::system::error_code &resolve_ec, const boost::asio::ip::tcp::resolver::results_type &resolve_results) {
+      ec = resolve_ec;
+      results = resolve_results;
+      timer.cancel();
+    });
+    timer.expires_after(COVER_DNS_TIMEOUT);
+    timer.async_wait([&](const boost::system::error_code &timer_ec) {
+      if (!timer_ec) {
+        timed_out = true;
+        resolver.cancel();
+      }
+    });
+    io.run();
+
+    if (timed_out) {
+      BOOST_LOG(warning) << "Cover host resolution timed out ["sv << host << ']';
+      return false;
+    }
     if (ec || results.empty()) {
       BOOST_LOG(warning) << "Cover host resolution failed or returned no addresses ["sv << host << ']';
       return false;
@@ -514,13 +573,13 @@ namespace {
         BOOST_LOG(warning) << "Cover host resolved to a blocked address ["sv << host << " -> " << address.to_string() << ']';
         return false;
       }
+      addresses.push_back(address.to_string());
     }
 
-    return true;
+    return !addresses.empty();
   }
 
-  bool is_public_https_cover_url(const std::string &url) {
-    ParsedDownloadUrl parts;
+  bool resolve_public_https_cover_url(const std::string &url, ParsedDownloadUrl &parts, std::vector<std::string> &addresses) {
     if (!parse_download_url(url, parts)) {
       return false;
     }
@@ -533,7 +592,7 @@ namespace {
       return false;
     }
 
-    return host_resolves_to_public_addresses(parts.host);
+    return resolve_host_to_public_addresses(parts.host, addresses);
   }
 
   struct ImageCheckContext {
@@ -542,6 +601,7 @@ namespace {
     FILE *fp = nullptr;
     unsigned char buffer[12]; // Buffer for magic bytes
     size_t buffer_len = 0;
+    size_t bytes_received = 0;
     bool checked = false;
     bool valid = false;
 
@@ -567,6 +627,12 @@ namespace {
       if (total_size == 0) {
         return 0;
       }
+      if (ctx->bytes_received > COVER_DOWNLOAD_MAX_BYTES || total_size > COVER_DOWNLOAD_MAX_BYTES - ctx->bytes_received) {
+        BOOST_LOG(warning) << "Image download exceeded "sv << COVER_DOWNLOAD_MAX_BYTES << " bytes [" << ctx->url << ']';
+        return 0;
+      }
+      ctx->bytes_received += total_size;
+
       const unsigned char *data = static_cast<const unsigned char *>(ptr);
 
       // If not yet checked, accumulating bytes
@@ -607,13 +673,20 @@ namespace {
           }
 
           // Flush buffer to file
-          fwrite(ctx->buffer, 1, ctx->buffer_len, ctx->fp);
+          if (fwrite(ctx->buffer, 1, ctx->buffer_len, ctx->fp) != ctx->buffer_len) {
+            BOOST_LOG(error) << "Couldn't write image data to ["sv << ctx->filename << ']';
+            return 0;
+          }
         }
         
         // If we have leftovers in this chunk that weren't part of the buffer fill
         if (total_size > to_copy) {
           if (ctx->valid && ctx->fp) {
-            fwrite(data + to_copy, 1, total_size - to_copy, ctx->fp);
+            const size_t remaining = total_size - to_copy;
+            if (fwrite(data + to_copy, 1, remaining, ctx->fp) != remaining) {
+              BOOST_LOG(error) << "Couldn't write image data to ["sv << ctx->filename << ']';
+              return 0;
+            }
           } else if (!ctx->valid && ctx->checked) {
              // Should have returned 0 above, but just in case logic flows here
              return 0;
@@ -622,7 +695,10 @@ namespace {
       } else {
         // Already checked and valid, just write
         if (ctx->valid && ctx->fp) {
-          fwrite(ptr, size, nmemb, ctx->fp);
+          if (fwrite(ptr, size, nmemb, ctx->fp) != nmemb) {
+            BOOST_LOG(error) << "Couldn't write image data to ["sv << ctx->filename << ']';
+            return 0;
+          }
         } else {
           return 0;
         }
@@ -634,10 +710,26 @@ namespace {
       return 0;
     }
   }
-}
 
-namespace http {
-  bool download_image_with_magic_check(const std::string &url, const std::string &file, long ssl_version) {
+  std::string format_curl_resolve_address(const std::string &address) {
+    boost::system::error_code ec;
+    const auto parsed = boost::asio::ip::make_address(address, ec);
+    if (!ec && parsed.is_v6()) {
+      return "["s + address + "]";
+    }
+    return address;
+  }
+
+  curl_slist *build_curl_resolve_list(const ParsedDownloadUrl &parts, const std::vector<std::string> &addresses) {
+    if (addresses.empty()) {
+      return nullptr;
+    }
+
+    std::string entry = parts.host + ":443:" + format_curl_resolve_address(addresses.front());
+    return curl_slist_append(nullptr, entry.c_str());
+  }
+
+  bool perform_image_download_with_magic_check(const std::string &url, const std::string &file, long ssl_version, const ParsedDownloadUrl *resolved_parts = nullptr, const std::vector<std::string> *resolved_addresses = nullptr) {
     BOOST_LOG(info) << "Downloading external image with magic check: " << url;
     CURL *curl = curl_easy_init();
     if (!curl) {
@@ -645,8 +737,20 @@ namespace http {
       return false;
     }
 
+    curl_slist *resolve_list = nullptr;
+    if (resolved_parts && resolved_addresses && !resolved_addresses->empty()) {
+      resolve_list = build_curl_resolve_list(*resolved_parts, *resolved_addresses);
+      if (!resolve_list) {
+        BOOST_LOG(error) << "Couldn't pin resolved cover host addresses ["sv << url << ']';
+        curl_easy_cleanup(curl);
+        return false;
+      }
+      curl_easy_setopt(curl, CURLOPT_RESOLVE, resolve_list);
+    }
+
     if (std::string file_dir = file_handler::get_parent_directory(file); !file_handler::make_directory(file_dir)) {
       BOOST_LOG(error) << "Couldn't create directory ["sv << file_dir << "] for ["sv << url << ']';
+      curl_slist_free_all(resolve_list);
       curl_easy_cleanup(curl);
       return false;
     }
@@ -659,9 +763,9 @@ namespace http {
     curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, image_write_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &ctx);
-    
+
     // Security limits
-    curl_easy_setopt(curl, CURLOPT_MAXFILESIZE_LARGE, (curl_off_t)10 * 1024 * 1024); // 10MB limit
+    curl_easy_setopt(curl, CURLOPT_MAXFILESIZE_LARGE, static_cast<curl_off_t>(COVER_DOWNLOAD_MAX_BYTES));
 
     // Disable redirects
     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 0L);
@@ -672,11 +776,12 @@ namespace http {
     long response_code = 0;
     CURLcode result = curl_easy_perform(curl);
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
-    
+
     if (ctx.fp) {
       fclose(ctx.fp);
     }
 
+    curl_slist_free_all(resolve_list);
     curl_easy_cleanup(curl);
 
     bool http_ok = (response_code == 200);
@@ -687,11 +792,11 @@ namespace http {
       } else {
         BOOST_LOG(error) << "Download failed: HTTP " << response_code << " [" << url << "]";
       }
-      
+
       // Cleanup partial file if it exists (though usually it shouldn't be much)
       if (boost::filesystem::exists(file)) {
-        boost::system::error_code ec;
-        boost::filesystem::remove(file, ec);
+        boost::system::error_code remove_ec;
+        boost::filesystem::remove(file, remove_ec);
       }
       return false;
     }
@@ -699,25 +804,44 @@ namespace http {
     // Double check: if download finished but we never got enough bytes to check?
     // Treat as failure (empty or too small file)
     if (!ctx.checked) {
-       BOOST_LOG(warning) << "Download too small to validate magic bytes ["sv << url << ']';
-       // Cleanup if file was created
-       if (boost::filesystem::exists(file)) {
-         boost::system::error_code ec;
-         boost::filesystem::remove(file, ec);
-       }
-       return false;
+      BOOST_LOG(warning) << "Download too small to validate magic bytes ["sv << url << ']';
+      // Cleanup if file was created
+      if (boost::filesystem::exists(file)) {
+        boost::system::error_code remove_ec;
+        boost::filesystem::remove(file, remove_ec);
+      }
+      return false;
     }
 
     return true;
   }
+}
+
+namespace http {
+  bool download_image_with_magic_check(const std::string &url, const std::string &file, long ssl_version) {
+    return perform_image_download_with_magic_check(url, file, ssl_version);
+  }
 
   bool download_public_cover_image(const std::string &url, const std::string &file, long ssl_version) {
-    if (!is_public_https_cover_url(url)) {
+    ParsedDownloadUrl parts;
+    std::vector<std::string> addresses;
+    if (!resolve_public_https_cover_url(url, parts, addresses)) {
       BOOST_LOG(warning) << "Blocked cover download from non-public HTTPS URL ["sv << url << ']';
       return false;
     }
 
-    return download_image_with_magic_check(url, file, ssl_version);
+    if (addresses.empty()) {
+      return perform_image_download_with_magic_check(url, file, ssl_version);
+    }
+
+    for (const auto &address : addresses) {
+      std::vector<std::string> pinned_address { address };
+      if (perform_image_download_with_magic_check(url, file, ssl_version, &parts, &pinned_address)) {
+        return true;
+      }
+    }
+
+    return false;
   }
 }
 

--- a/src/httpcommon.cpp
+++ b/src/httpcommon.cpp
@@ -397,6 +397,11 @@ namespace {
     std::string port;
   };
 
+  struct PublicHostResolution {
+    bool is_address_literal = false;
+    std::vector<std::string> addresses;
+  };
+
   std::string to_lower_ascii(std::string value) {
     std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
       return static_cast<char>(std::tolower(c));
@@ -527,7 +532,7 @@ namespace {
            is_link_or_site_local;
   }
 
-  bool resolve_host_to_public_addresses(const std::string &host, std::vector<std::string> &addresses) {
+  bool resolve_public_host(const std::string &host, PublicHostResolution &resolution) {
     if (host.empty() || host == "localhost" || host.ends_with(".localhost")) {
       return false;
     }
@@ -535,7 +540,11 @@ namespace {
     boost::system::error_code ec;
     const auto literal = boost::asio::ip::make_address(host, ec);
     if (!ec) {
-      return !is_local_or_private_address(literal);
+      if (is_local_or_private_address(literal)) {
+        return false;
+      }
+      resolution.is_address_literal = true;
+      return true;
     }
 
     boost::asio::io_context io;
@@ -573,13 +582,13 @@ namespace {
         BOOST_LOG(warning) << "Cover host resolved to a blocked address ["sv << host << " -> " << address.to_string() << ']';
         return false;
       }
-      addresses.push_back(address.to_string());
+      resolution.addresses.push_back(address.to_string());
     }
 
-    return !addresses.empty();
+    return !resolution.addresses.empty();
   }
 
-  bool resolve_public_https_cover_url(const std::string &url, ParsedDownloadUrl &parts, std::vector<std::string> &addresses) {
+  bool resolve_public_https_cover_url(const std::string &url, ParsedDownloadUrl &parts, PublicHostResolution &resolution) {
     if (!parse_download_url(url, parts)) {
       return false;
     }
@@ -592,7 +601,7 @@ namespace {
       return false;
     }
 
-    return resolve_host_to_public_addresses(parts.host, addresses);
+    return resolve_public_host(parts.host, resolution);
   }
 
   struct ImageCheckContext {
@@ -608,6 +617,26 @@ namespace {
     // Ensure buffer is large enough for our checks to avoid overflow
     static_assert(sizeof(buffer) >= 12, "Image check buffer too small");
   };
+
+  bool has_supported_image_magic(const unsigned char *magic) {
+    return (magic[0] == 0x89 && magic[1] == 0x50 && magic[2] == 0x4E && magic[3] == 0x47) || // PNG
+           (magic[0] == 0xFF && magic[1] == 0xD8 && magic[2] == 0xFF) || // JPG
+           (magic[0] == 0x42 && magic[1] == 0x4D) || // BMP
+           (memcmp(magic, "RIFF", 4) == 0 && memcmp(magic + 8, "WEBP", 4) == 0) || // WEBP
+           (magic[0] == 0x00 && magic[1] == 0x00 && magic[2] == 0x01 && magic[3] == 0x00); // ICO
+  }
+
+  bool write_image_data(ImageCheckContext &ctx, const void *data, size_t length) {
+    if (length == 0) {
+      return true;
+    }
+
+    if (fwrite(data, 1, length, ctx.fp) != length) {
+      BOOST_LOG(error) << "Couldn't write image data to ["sv << ctx.filename << ']';
+      return false;
+    }
+    return true;
+  }
 
   size_t image_write_callback(void *ptr, size_t size, size_t nmemb, void *userdata) {
     try {
@@ -646,19 +675,7 @@ namespace {
         // Have we accumulated enough?
         if (ctx->buffer_len == sizeof(ctx->buffer)) {
           ctx->checked = true;
-          unsigned char *magic = ctx->buffer;
-
-          // Perform Magic Byte Check
-          // PNG: 89 50 4E 47
-          if (magic[0] == 0x89 && magic[1] == 0x50 && magic[2] == 0x4E && magic[3] == 0x47) ctx->valid = true;
-          // JPG: FF D8 FF
-          else if (magic[0] == 0xFF && magic[1] == 0xD8 && magic[2] == 0xFF) ctx->valid = true;
-          // BMP: 42 4D
-          else if (magic[0] == 0x42 && magic[1] == 0x4D) ctx->valid = true;
-          // WEBP: RIFF ... WEBP
-          else if (memcmp(magic, "RIFF", 4) == 0 && memcmp(magic + 8, "WEBP", 4) == 0) ctx->valid = true;
-          // ICO: 00 00 01 00
-          else if (magic[0] == 0x00 && magic[1] == 0x00 && magic[2] == 0x01 && magic[3] == 0x00) ctx->valid = true;
+          ctx->valid = has_supported_image_magic(ctx->buffer);
 
           if (!ctx->valid) {
             BOOST_LOG(warning) << "Streaming validation failed: Invalid magic bytes ["sv << ctx->url << ']';
@@ -673,8 +690,7 @@ namespace {
           }
 
           // Flush buffer to file
-          if (fwrite(ctx->buffer, 1, ctx->buffer_len, ctx->fp) != ctx->buffer_len) {
-            BOOST_LOG(error) << "Couldn't write image data to ["sv << ctx->filename << ']';
+          if (!write_image_data(*ctx, ctx->buffer, ctx->buffer_len)) {
             return 0;
           }
         }
@@ -683,8 +699,7 @@ namespace {
         if (total_size > to_copy) {
           if (ctx->valid && ctx->fp) {
             const size_t remaining = total_size - to_copy;
-            if (fwrite(data + to_copy, 1, remaining, ctx->fp) != remaining) {
-              BOOST_LOG(error) << "Couldn't write image data to ["sv << ctx->filename << ']';
+            if (!write_image_data(*ctx, data + to_copy, remaining)) {
               return 0;
             }
           } else if (!ctx->valid && ctx->checked) {
@@ -695,8 +710,7 @@ namespace {
       } else {
         // Already checked and valid, just write
         if (ctx->valid && ctx->fp) {
-          if (fwrite(ptr, size, nmemb, ctx->fp) != nmemb) {
-            BOOST_LOG(error) << "Couldn't write image data to ["sv << ctx->filename << ']';
+          if (!write_image_data(*ctx, ptr, total_size)) {
             return 0;
           }
         } else {
@@ -720,16 +734,12 @@ namespace {
     return address;
   }
 
-  curl_slist *build_curl_resolve_list(const ParsedDownloadUrl &parts, const std::vector<std::string> &addresses) {
-    if (addresses.empty()) {
-      return nullptr;
-    }
-
-    std::string entry = parts.host + ":443:" + format_curl_resolve_address(addresses.front());
+  curl_slist *build_curl_resolve_list(const ParsedDownloadUrl &parts, const std::string &address) {
+    std::string entry = parts.host + ":443:" + format_curl_resolve_address(address);
     return curl_slist_append(nullptr, entry.c_str());
   }
 
-  bool perform_image_download_with_magic_check(const std::string &url, const std::string &file, long ssl_version, const ParsedDownloadUrl *resolved_parts = nullptr, const std::vector<std::string> *resolved_addresses = nullptr) {
+  bool perform_image_download_with_magic_check(const std::string &url, const std::string &file, long ssl_version, const ParsedDownloadUrl *resolved_parts = nullptr, const std::string *resolved_address = nullptr) {
     BOOST_LOG(info) << "Downloading external image with magic check: " << url;
     CURL *curl = curl_easy_init();
     if (!curl) {
@@ -738,8 +748,8 @@ namespace {
     }
 
     curl_slist *resolve_list = nullptr;
-    if (resolved_parts && resolved_addresses && !resolved_addresses->empty()) {
-      resolve_list = build_curl_resolve_list(*resolved_parts, *resolved_addresses);
+    if (resolved_parts && resolved_address) {
+      resolve_list = build_curl_resolve_list(*resolved_parts, *resolved_address);
       if (!resolve_list) {
         BOOST_LOG(error) << "Couldn't pin resolved cover host addresses ["sv << url << ']';
         curl_easy_cleanup(curl);
@@ -824,19 +834,18 @@ namespace http {
 
   bool download_public_cover_image(const std::string &url, const std::string &file, long ssl_version) {
     ParsedDownloadUrl parts;
-    std::vector<std::string> addresses;
-    if (!resolve_public_https_cover_url(url, parts, addresses)) {
+    PublicHostResolution resolution;
+    if (!resolve_public_https_cover_url(url, parts, resolution)) {
       BOOST_LOG(warning) << "Blocked cover download from non-public HTTPS URL ["sv << url << ']';
       return false;
     }
 
-    if (addresses.empty()) {
+    if (resolution.is_address_literal) {
       return perform_image_download_with_magic_check(url, file, ssl_version);
     }
 
-    for (const auto &address : addresses) {
-      std::vector<std::string> pinned_address { address };
-      if (perform_image_download_with_magic_check(url, file, ssl_version, &parts, &pinned_address)) {
+    for (const auto &address : resolution.addresses) {
+      if (perform_image_download_with_magic_check(url, file, ssl_version, &parts, &address)) {
         return true;
       }
     }

--- a/src/httpcommon.cpp
+++ b/src/httpcommon.cpp
@@ -6,9 +6,14 @@
 
 #include "process.h"
 
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
 #include <filesystem>
 #include <utility>
 
+#include <boost/asio/ip/address.hpp>
+#include <boost/asio/ip/tcp.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
@@ -379,6 +384,158 @@ namespace http {
 }  // namespace http
 
 namespace {
+  struct ParsedDownloadUrl {
+    std::string scheme;
+    std::string host;
+    std::string port;
+  };
+
+  std::string to_lower_ascii(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+      return static_cast<char>(std::tolower(c));
+    });
+    return value;
+  }
+
+  std::string normalize_host(std::string host) {
+    host = to_lower_ascii(std::move(host));
+    if (host.size() >= 2 && host.front() == '[' && host.back() == ']') {
+      host = host.substr(1, host.size() - 2);
+    }
+    while (!host.empty() && host.back() == '.') {
+      host.pop_back();
+    }
+    return host;
+  }
+
+  bool curl_url_get_string(CURLU *curlu, CURLUPart part, std::string &value, unsigned int flags = 0) {
+    char *raw = nullptr;
+    if (curl_url_get(curlu, part, &raw, flags) != CURLUE_OK) {
+      return false;
+    }
+
+    value = raw;
+    curl_free(raw);
+    return true;
+  }
+
+  bool parse_download_url(const std::string &url, ParsedDownloadUrl &parts) {
+    CURLU *curlu = curl_url();
+    if (!curlu) {
+      return false;
+    }
+
+    if (curl_url_set(curlu, CURLUPART_URL, url.c_str(), 0) != CURLUE_OK) {
+      curl_url_cleanup(curlu);
+      return false;
+    }
+
+    const bool ok = curl_url_get_string(curlu, CURLUPART_SCHEME, parts.scheme) &&
+                    curl_url_get_string(curlu, CURLUPART_HOST, parts.host);
+    curl_url_get_string(curlu, CURLUPART_PORT, parts.port);
+    curl_url_cleanup(curlu);
+
+    if (!ok) {
+      return false;
+    }
+
+    parts.scheme = to_lower_ascii(parts.scheme);
+    parts.host = normalize_host(std::move(parts.host));
+    return true;
+  }
+
+  bool is_private_ipv4(std::uint32_t address) {
+    return address == 0xffffffffu ||
+           (address & 0xff000000u) == 0x00000000u ||
+           (address & 0xff000000u) == 0x0a000000u ||
+           (address & 0xff000000u) == 0x7f000000u ||
+           (address & 0xffc00000u) == 0x64400000u ||
+           (address & 0xffff0000u) == 0xa9fe0000u ||
+           (address & 0xfff00000u) == 0xac100000u ||
+           (address & 0xffff0000u) == 0xc0a80000u ||
+           (address & 0xffffff00u) == 0xc0000000u ||
+           (address & 0xffffff00u) == 0xc0000200u ||
+           (address & 0xffffff00u) == 0xc0586300u ||
+           (address & 0xffff0000u) == 0xc6120000u ||
+           (address & 0xffffff00u) == 0xc6336400u ||
+           (address & 0xffffff00u) == 0xcb007100u ||
+           (address & 0xf0000000u) == 0xe0000000u ||
+           (address & 0xf0000000u) == 0xf0000000u;
+  }
+
+  bool is_local_or_private_address(const boost::asio::ip::address &address) {
+    if (address.is_unspecified() || address.is_loopback() || address.is_multicast()) {
+      return true;
+    }
+
+    if (address.is_v4()) {
+      return is_private_ipv4(address.to_v4().to_uint());
+    }
+
+    const auto bytes = address.to_v6().to_bytes();
+    const bool is_v4_mapped = std::all_of(bytes.begin(), bytes.begin() + 10, [](unsigned char value) { return value == 0; }) &&
+                              bytes[10] == 0xff &&
+                              bytes[11] == 0xff;
+    if (is_v4_mapped) {
+      const auto mapped = (static_cast<std::uint32_t>(bytes[12]) << 24) |
+                          (static_cast<std::uint32_t>(bytes[13]) << 16) |
+                          (static_cast<std::uint32_t>(bytes[14]) << 8) |
+                          static_cast<std::uint32_t>(bytes[15]);
+      return is_private_ipv4(mapped);
+    }
+
+    return (bytes[0] & 0xfe) == 0xfc ||                         // Unique local address fc00::/7
+           (bytes[0] == 0xfe && (bytes[1] & 0xc0) == 0x80) ||    // Link-local fe80::/10
+           (bytes[0] == 0x20 && bytes[1] == 0x01 && bytes[2] == 0x0d && bytes[3] == 0xb8); // Documentation range
+  }
+
+  bool host_resolves_to_public_addresses(const std::string &host) {
+    if (host.empty() || host == "localhost" || host.ends_with(".localhost")) {
+      return false;
+    }
+
+    boost::system::error_code ec;
+    const auto literal = boost::asio::ip::make_address(host, ec);
+    if (!ec) {
+      return !is_local_or_private_address(literal);
+    }
+
+    boost::asio::io_context io;
+    boost::asio::ip::tcp::resolver resolver(io);
+    const auto results = resolver.resolve(host, "443", ec);
+    if (ec || results.empty()) {
+      BOOST_LOG(warning) << "Cover host resolution failed or returned no addresses ["sv << host << ']';
+      return false;
+    }
+
+    for (const auto &result : results) {
+      const auto address = result.endpoint().address();
+      if (is_local_or_private_address(address)) {
+        BOOST_LOG(warning) << "Cover host resolved to a blocked address ["sv << host << " -> " << address.to_string() << ']';
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  bool is_public_https_cover_url(const std::string &url) {
+    ParsedDownloadUrl parts;
+    if (!parse_download_url(url, parts)) {
+      return false;
+    }
+
+    if (parts.scheme != "https" || parts.host.empty()) {
+      return false;
+    }
+
+    if (!parts.port.empty() && parts.port != "443") {
+      return false;
+    }
+
+    return host_resolves_to_public_addresses(parts.host);
+  }
+
   struct ImageCheckContext {
     std::string filename;
     std::string url;
@@ -552,6 +709,15 @@ namespace http {
     }
 
     return true;
+  }
+
+  bool download_public_cover_image(const std::string &url, const std::string &file, long ssl_version) {
+    if (!is_public_https_cover_url(url)) {
+      BOOST_LOG(warning) << "Blocked cover download from non-public HTTPS URL ["sv << url << ']';
+      return false;
+    }
+
+    return download_image_with_magic_check(url, file, ssl_version);
   }
 }
 

--- a/src/httpcommon.h
+++ b/src/httpcommon.h
@@ -31,6 +31,7 @@ namespace http {
   bool fetch_url(const std::string &url, std::string &content, long ssl_version = CURL_SSLVERSION_TLSv1_2);
   bool post_json(const std::string &url, const std::string &body, const std::map<std::string, std::string> &headers, std::string &response_body, long &http_code, long timeout_seconds = 120);
   bool download_image_with_magic_check(const std::string &url, const std::string &file, long ssl_version = CURL_SSLVERSION_TLSv1_2);
+  bool download_public_cover_image(const std::string &url, const std::string &file, long ssl_version = CURL_SSLVERSION_TLSv1_2);
   std::string url_escape(const std::string &url);
   std::string url_get_host(const std::string &url);
 

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -629,8 +629,7 @@ namespace proc {
         // 如果文件不存在则下载
         if (!std::filesystem::exists(local_path)) {
           BOOST_LOG(info) << "Downloading image from URL: " << original_url;
-          // 使用流式校验下载，如果Magic Byte不匹配会直接中断下载
-          if (!http::download_image_with_magic_check(original_url, local_path.string())) {
+          if (!http::download_public_cover_image(original_url, local_path.string())) {
             BOOST_LOG(warning) << "Failed to download image (or rejected by magic check) from URL: " << original_url;
             return DEFAULT_APP_IMAGE_PATH;
           }

--- a/src_assets/common/assets/web/components/CoverFinder.vue
+++ b/src_assets/common/assets/web/components/CoverFinder.vue
@@ -249,12 +249,8 @@ export default {
       this.$emit('loading', true)
 
       try {
-        if (cover.source === 'steam') {
-          this.$emit('cover-selected', { path: cover.saveUrl, source: 'steam' })
-        } else {
-          const { path } = await apiPostJson('/api/covers/upload', { key: cover.key, url: cover.saveUrl })
-          this.$emit('cover-selected', { path, source: 'igdb' })
-        }
+        const { path } = await apiPostJson('/api/covers/upload', { key: cover.key, url: cover.saveUrl })
+        this.$emit('cover-selected', { path, source: cover.source })
         this.closeFinder()
       } catch (error) {
         console.error('使用封面失败:', error)

--- a/src_assets/common/assets/web/composables/useApps.js
+++ b/src_assets/common/assets/web/composables/useApps.js
@@ -2,6 +2,7 @@ import { computed, reactive, ref } from 'vue'
 import { AppService } from '../services/appService.js'
 import { APP_CONSTANTS, ENV_VARS_CONFIG } from '../utils/constants.js'
 import { debounce, deepClone } from '../utils/helpers.js'
+import { apiPostJson } from '../utils/apiFetch.js'
 import { trackEvents } from '../config/firebase.js'
 import {
   applyGameLibraryOverrides,
@@ -18,6 +19,7 @@ import {
 
 const MESSAGE_DURATION = 3000
 const GAME_LIBRARY_SKILL_PREFS_KEY = 'sunshine-game-library-skills:v1'
+const REMOTE_IMAGE_URL_RE = /^https?:\/\//i
 
 function getStorage() {
   return typeof localStorage !== 'undefined' ? localStorage : null
@@ -805,6 +807,33 @@ export function useApps() {
   // 扫描应用字段处理
   const getScannedAppField = (app, field) => app[field] || app[field.replace(/-/g, '_')] || ''
 
+  const localizeScannedAppCover = async (scannedApp) => {
+    const imagePath = getScannedAppField(scannedApp, 'image-path')
+    if (!REMOTE_IMAGE_URL_RE.test(imagePath)) {
+      return scannedApp
+    }
+
+    try {
+      const result = await apiPostJson('/api/covers/upload', {
+        key: scannedApp.name,
+        url: imagePath,
+      })
+
+      if (result?.path) {
+        return {
+          ...scannedApp,
+          'image-path': result.path,
+          image_path: result.path,
+          'cover-localized': true,
+        }
+      }
+    } catch (error) {
+      console.warn('Failed to localize scanned cover:', scannedApp.name, error)
+    }
+
+    return scannedApp
+  }
+
   const createAppFromScanned = (scannedApp) => ({
     ...APP_CONSTANTS.DEFAULT_APP,
     name: scannedApp.name,
@@ -823,14 +852,16 @@ export function useApps() {
     }
   }
 
-  const addScannedApp = (scannedApp) => {
+  const addScannedApp = async (scannedApp) => {
+    const localizedApp = await localizeScannedAppCover(scannedApp)
+
     editingApp.value = createDefaultApp({
-      name: scannedApp.name,
-      cmd: scannedApp.cmd,
-      'working-dir': getScannedAppField(scannedApp, 'working-dir'),
-      'image-path': getScannedAppField(scannedApp, 'image-path'),
+      name: localizedApp.name,
+      cmd: localizedApp.cmd,
+      'working-dir': getScannedAppField(localizedApp, 'working-dir'),
+      'image-path': getScannedAppField(localizedApp, 'image-path'),
     })
-    scannedEditSource.value = { ...scannedApp }
+    scannedEditSource.value = { ...localizedApp }
 
     removeFromScannedList(scannedApp.source_path)
     showMessage(`正在编辑应用: ${scannedApp.name}`, APP_CONSTANTS.MESSAGE_TYPES.INFO)
@@ -839,9 +870,12 @@ export function useApps() {
 
   const quickAddScannedApp = async (scannedApp, index) => {
     try {
-      apps.value.push(createAppFromScanned(scannedApp))
+      const localizedApp = await localizeScannedAppCover(scannedApp)
+      const appToAdd = createAppFromScanned(localizedApp)
+
+      apps.value.push(appToAdd)
       await AppService.saveApps(apps.value, null)
-      rememberGameLibraryApp(scannedApp, scannedApp)
+      rememberGameLibraryApp(scannedApp, appToAdd)
       await loadApps()
 
       scannedApps.value.splice(index, 1)
@@ -862,7 +896,8 @@ export function useApps() {
 
     try {
       isSaving.value = true
-      const appsToAdd = scannedApps.value.map(createAppFromScanned)
+      const localizedScannedApps = await Promise.all(scannedApps.value.map(localizeScannedAppCover))
+      const appsToAdd = localizedScannedApps.map(createAppFromScanned)
 
       apps.value.push(...appsToAdd)
       await AppService.saveApps(apps.value, null)

--- a/src_assets/common/assets/web/composables/useApps.js
+++ b/src_assets/common/assets/web/composables/useApps.js
@@ -21,6 +21,7 @@ const MESSAGE_DURATION = 3000
 const GAME_LIBRARY_SKILL_PREFS_KEY = 'sunshine-game-library-skills:v1'
 const REMOTE_IMAGE_URL_RE = /^https?:\/\//i
 const COVER_LOCALIZATION_CONCURRENCY = 4
+const COVER_LOCALIZATION_FAILED_FIELD = 'cover-localization-failed'
 
 function getStorage() {
   return typeof localStorage !== 'undefined' ? localStorage : null
@@ -844,11 +845,15 @@ export function useApps() {
           'cover-localized': true,
         }
       }
+      console.warn('Cover localization did not return a local path:', scannedApp.name, result)
     } catch (error) {
       console.warn('Failed to localize scanned cover:', scannedApp.name, error)
     }
 
-    return scannedApp
+    return {
+      ...scannedApp,
+      [COVER_LOCALIZATION_FAILED_FIELD]: true,
+    }
   }
 
   const createAppFromScanned = (scannedApp) => ({
@@ -859,8 +864,13 @@ export function useApps() {
     'image-path': getScannedAppField(scannedApp, 'image-path'),
   })
 
-  const removeFromScannedList = (sourcePath) => {
-    const index = scannedApps.value.findIndex((a) => a.source_path === sourcePath)
+  const didCoverLocalizationFail = (scannedApp) => scannedApp?.[COVER_LOCALIZATION_FAILED_FIELD] === true
+
+  const removeScannedAppEntry = (scannedApp) => {
+    let index = scannedApps.value.indexOf(scannedApp)
+    if (index === -1 && scannedApp?.source_path) {
+      index = scannedApps.value.findIndex((a) => a.source_path === scannedApp.source_path)
+    }
     if (index !== -1) {
       scannedApps.value.splice(index, 1)
       if (scannedApps.value.length === 0) {
@@ -880,12 +890,17 @@ export function useApps() {
     })
     scannedEditSource.value = { ...localizedApp }
 
-    removeFromScannedList(scannedApp.source_path)
-    showMessage(`正在编辑应用: ${scannedApp.name}`, APP_CONSTANTS.MESSAGE_TYPES.INFO)
+    removeScannedAppEntry(scannedApp)
+    showMessage(
+      didCoverLocalizationFail(localizedApp)
+        ? `正在编辑应用: ${scannedApp.name}，但封面本地化失败，已保留原始封面地址`
+        : `正在编辑应用: ${scannedApp.name}`,
+      didCoverLocalizationFail(localizedApp) ? APP_CONSTANTS.MESSAGE_TYPES.WARNING : APP_CONSTANTS.MESSAGE_TYPES.INFO
+    )
     trackEvents.userAction('scanned_app_edit', { name: scannedApp.name })
   }
 
-  const quickAddScannedApp = async (scannedApp, index) => {
+  const quickAddScannedApp = async (scannedApp) => {
     try {
       const localizedApp = await localizeScannedAppCover(scannedApp)
       const appToAdd = createAppFromScanned(localizedApp)
@@ -895,12 +910,14 @@ export function useApps() {
       rememberGameLibraryApp(scannedApp, appToAdd)
       await loadApps()
 
-      scannedApps.value.splice(index, 1)
-      if (scannedApps.value.length === 0) {
-        showScanResult.value = false
-      }
+      removeScannedAppEntry(scannedApp)
 
-      showMessage(`已添加应用: ${scannedApp.name}`, APP_CONSTANTS.MESSAGE_TYPES.SUCCESS)
+      showMessage(
+        didCoverLocalizationFail(localizedApp)
+          ? `已添加应用: ${scannedApp.name}，但封面本地化失败，已保留原始封面地址`
+          : `已添加应用: ${scannedApp.name}`,
+        didCoverLocalizationFail(localizedApp) ? APP_CONSTANTS.MESSAGE_TYPES.WARNING : APP_CONSTANTS.MESSAGE_TYPES.SUCCESS
+      )
       trackEvents.userAction('scanned_app_quick_added', { name: scannedApp.name })
     } catch (error) {
       console.error('快速添加应用失败:', error)
@@ -926,7 +943,13 @@ export function useApps() {
       scannedAppSnapshot.forEach((scannedApp, index) => rememberGameLibraryApp(scannedApp, appsToAdd[index]))
       await loadApps()
 
-      showMessage(`已添加 ${appsToAdd.length} 个应用`, APP_CONSTANTS.MESSAGE_TYPES.SUCCESS)
+      const coverLocalizationFailureCount = localizedScannedApps.filter(didCoverLocalizationFail).length
+      showMessage(
+        coverLocalizationFailureCount > 0
+          ? `已添加 ${appsToAdd.length} 个应用，其中 ${coverLocalizationFailureCount} 个封面本地化失败，已保留原始封面地址`
+          : `已添加 ${appsToAdd.length} 个应用`,
+        coverLocalizationFailureCount > 0 ? APP_CONSTANTS.MESSAGE_TYPES.WARNING : APP_CONSTANTS.MESSAGE_TYPES.SUCCESS
+      )
       trackEvents.userAction('scanned_apps_batch_added', { count: appsToAdd.length })
 
       scannedApps.value = []

--- a/src_assets/common/assets/web/composables/useApps.js
+++ b/src_assets/common/assets/web/composables/useApps.js
@@ -866,17 +866,34 @@ export function useApps() {
 
   const didCoverLocalizationFail = (scannedApp) => scannedApp?.[COVER_LOCALIZATION_FAILED_FIELD] === true
 
-  const removeScannedAppEntry = (scannedApp) => {
-    let index = scannedApps.value.indexOf(scannedApp)
-    if (index === -1 && scannedApp?.source_path) {
-      index = scannedApps.value.findIndex((a) => a.source_path === scannedApp.source_path)
+  const findScannedAppIndex = (scannedAppOrIndex) => {
+    if (Number.isInteger(scannedAppOrIndex)) {
+      return scannedAppOrIndex
     }
-    if (index !== -1) {
+
+    let index = scannedApps.value.indexOf(scannedAppOrIndex)
+    if (index === -1 && scannedAppOrIndex?.source_path) {
+      index = scannedApps.value.findIndex((app) => app.source_path === scannedAppOrIndex.source_path)
+    }
+    return index
+  }
+
+  const removeScannedApp = (scannedAppOrIndex) => {
+    const index = findScannedAppIndex(scannedAppOrIndex)
+    if (index >= 0 && index < scannedApps.value.length) {
       scannedApps.value.splice(index, 1)
       if (scannedApps.value.length === 0) {
         showScanResult.value = false
       }
     }
+  }
+
+  const showCoverLocalizationMessage = (localizedApp, successMessage, successType) => {
+    const failed = didCoverLocalizationFail(localizedApp)
+    showMessage(
+      failed ? `${successMessage}，但封面本地化失败，已保留原始封面地址` : successMessage,
+      failed ? APP_CONSTANTS.MESSAGE_TYPES.WARNING : successType
+    )
   }
 
   const addScannedApp = async (scannedApp) => {
@@ -890,13 +907,8 @@ export function useApps() {
     })
     scannedEditSource.value = { ...localizedApp }
 
-    removeScannedAppEntry(scannedApp)
-    showMessage(
-      didCoverLocalizationFail(localizedApp)
-        ? `正在编辑应用: ${scannedApp.name}，但封面本地化失败，已保留原始封面地址`
-        : `正在编辑应用: ${scannedApp.name}`,
-      didCoverLocalizationFail(localizedApp) ? APP_CONSTANTS.MESSAGE_TYPES.WARNING : APP_CONSTANTS.MESSAGE_TYPES.INFO
-    )
+    removeScannedApp(scannedApp)
+    showCoverLocalizationMessage(localizedApp, `正在编辑应用: ${scannedApp.name}`, APP_CONSTANTS.MESSAGE_TYPES.INFO)
     trackEvents.userAction('scanned_app_edit', { name: scannedApp.name })
   }
 
@@ -910,14 +922,9 @@ export function useApps() {
       rememberGameLibraryApp(scannedApp, appToAdd)
       await loadApps()
 
-      removeScannedAppEntry(scannedApp)
+      removeScannedApp(scannedApp)
 
-      showMessage(
-        didCoverLocalizationFail(localizedApp)
-          ? `已添加应用: ${scannedApp.name}，但封面本地化失败，已保留原始封面地址`
-          : `已添加应用: ${scannedApp.name}`,
-        didCoverLocalizationFail(localizedApp) ? APP_CONSTANTS.MESSAGE_TYPES.WARNING : APP_CONSTANTS.MESSAGE_TYPES.SUCCESS
-      )
+      showCoverLocalizationMessage(localizedApp, `已添加应用: ${scannedApp.name}`, APP_CONSTANTS.MESSAGE_TYPES.SUCCESS)
       trackEvents.userAction('scanned_app_quick_added', { name: scannedApp.name })
     } catch (error) {
       console.error('快速添加应用失败:', error)
@@ -965,13 +972,6 @@ export function useApps() {
   const closeScanResult = () => {
     showScanResult.value = false
     scannedApps.value = []
-  }
-
-  const removeScannedApp = (index) => {
-    scannedApps.value.splice(index, 1)
-    if (scannedApps.value.length === 0) {
-      showScanResult.value = false
-    }
   }
 
   const handleCopySuccess = () => showMessage('复制成功', APP_CONSTANTS.MESSAGE_TYPES.SUCCESS)

--- a/src_assets/common/assets/web/composables/useApps.js
+++ b/src_assets/common/assets/web/composables/useApps.js
@@ -20,6 +20,7 @@ import {
 const MESSAGE_DURATION = 3000
 const GAME_LIBRARY_SKILL_PREFS_KEY = 'sunshine-game-library-skills:v1'
 const REMOTE_IMAGE_URL_RE = /^https?:\/\//i
+const COVER_LOCALIZATION_CONCURRENCY = 4
 
 function getStorage() {
   return typeof localStorage !== 'undefined' ? localStorage : null
@@ -58,6 +59,22 @@ function saveEnabledGameLibrarySkillIds(skillIds) {
   } catch {
     // Skill preferences are convenience state; scanning should continue if persistence fails.
   }
+}
+
+async function mapWithConcurrency(items, concurrency, mapper) {
+  const results = new Array(items.length)
+  let nextIndex = 0
+  const workerCount = Math.min(Math.max(1, concurrency), items.length)
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (nextIndex < items.length) {
+      const currentIndex = nextIndex
+      nextIndex += 1
+      results[currentIndex] = await mapper(items[currentIndex], currentIndex)
+    }
+  })
+
+  await Promise.all(workers)
+  return results
 }
 
 /**
@@ -896,12 +913,17 @@ export function useApps() {
 
     try {
       isSaving.value = true
-      const localizedScannedApps = await Promise.all(scannedApps.value.map(localizeScannedAppCover))
+      const scannedAppSnapshot = [...scannedApps.value]
+      const localizedScannedApps = await mapWithConcurrency(
+        scannedAppSnapshot,
+        COVER_LOCALIZATION_CONCURRENCY,
+        localizeScannedAppCover
+      )
       const appsToAdd = localizedScannedApps.map(createAppFromScanned)
 
       apps.value.push(...appsToAdd)
       await AppService.saveApps(apps.value, null)
-      scannedApps.value.forEach((scannedApp, index) => rememberGameLibraryApp(scannedApp, appsToAdd[index]))
+      scannedAppSnapshot.forEach((scannedApp, index) => rememberGameLibraryApp(scannedApp, appsToAdd[index]))
       await loadApps()
 
       showMessage(`已添加 ${appsToAdd.length} 个应用`, APP_CONSTANTS.MESSAGE_TYPES.SUCCESS)

--- a/src_assets/common/assets/web/tests/imageUtils.test.js
+++ b/src_assets/common/assets/web/tests/imageUtils.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { getImagePreviewUrl } from '../utils/imageUtils.js'
+
+test('getImagePreviewUrl keeps direct preview URLs unchanged', () => {
+  assert.equal(getImagePreviewUrl('https://cdn.example.com/cover.jpg'), 'https://cdn.example.com/cover.jpg')
+  assert.equal(getImagePreviewUrl('data:image/png;base64,abc'), 'data:image/png;base64,abc')
+})
+
+test('getImagePreviewUrl normalizes boxart and cover file names', () => {
+  assert.equal(getImagePreviewUrl('Half Life.png'), '/boxart/Half%20Life.png')
+  assert.equal(getImagePreviewUrl('Half%20Life.png'), '/boxart/Half%20Life.png')
+  assert.equal(getImagePreviewUrl('boxart/Half%20Life.png'), '/boxart/Half%20Life.png')
+})
+
+test('getImagePreviewUrl maps localized covers paths to boxart URLs', () => {
+  assert.equal(
+    getImagePreviewUrl('C:\\Users\\player\\AppData\\Local\\Sunshine\\covers\\Half Life.png'),
+    '/boxart/Half%20Life.png'
+  )
+  assert.equal(
+    getImagePreviewUrl('/home/player/.config/sunshine/covers/Half%20Life.png'),
+    '/boxart/Half%20Life.png'
+  )
+})

--- a/src_assets/common/assets/web/utils/imageUtils.js
+++ b/src_assets/common/assets/web/utils/imageUtils.js
@@ -11,12 +11,31 @@ export function getImagePreviewUrl(imagePath = 'box.png') {
   if (imagePath === 'desktop') {
     return '/boxart/desktop.png'
   }
+  if (/^(https?:|blob:|data:)/i.test(imagePath)) {
+    return imagePath
+  }
+  if (imagePath.startsWith('/boxart/') || imagePath.startsWith('boxart/')) {
+    return imagePath.startsWith('/') ? imagePath : `/${imagePath}`
+  }
   // 如果路径不包含分隔符,说明是boxart资源ID
   if (!/[/\\]/.test(imagePath)) {
-    return `/boxart/${encodeURIComponent(imagePath)}`
+    return `/boxart/${encodeBoxArtName(imagePath)}`
+  }
+
+  if (/[\\/]covers[\\/]/i.test(imagePath)) {
+    return `/boxart/${encodeBoxArtName(imagePath.split(/[/\\]/).pop())}`
   }
 
   return isLocalImagePath(imagePath) ? `file://${imagePath}` : imagePath
+}
+
+function encodeBoxArtName(name) {
+  const value = String(name || '')
+  try {
+    return encodeURIComponent(decodeURIComponent(value))
+  } catch {
+    return encodeURIComponent(value)
+  }
 }
 
 /**


### PR DESCRIPTION
## 改了啥呀

- 把远程封面下载收敛到 `http::download_public_cover_image()`，统一处理 HTTPS、端口、DNS/IP 地址过滤、magic byte、大小和超时。
- `/api/covers/upload` 和手写远程 `image-path` 都走同一条安全下载路径，避免入口分叉。
- 游戏扫描添加和批量添加前会先把远程封面本地化，封面搜索选择也统一上传到本地 covers。
- WebUI 预览和 GUI 大屏统一消费 `/boxart`，不再靠猜远程域名名单显示封面。
- 同步 GUI 子仓库指针，GUI 侧实现见 qiin2333/sunshine-control-panel#43。

## 为啥要改

扫描出来的封面来源可能非常分散，维护域名白名单会越来越杂鱼，而且 GUI 直接透传远程 URL 也绕不开安全和离线展示问题。现在远程 URL 只作为输入，保存前转成本地 cover，后续所有界面都读 `/boxart`，职责更清楚。

## 验证

- `node --test src_assets/common/assets/web/tests/imageUtils.test.js`
- `npm run test:webui`
- `npm run build`
- GUI 子仓库：`npm run build:renderer`
- GUI 子仓库：`cargo test --manifest-path src_assets/common/sunshine-control-panel/src-tauri/Cargo.toml proxy_server -- --nocapture`
- `git diff --check`

## 已知情况

- 本地 C++ 全量构建仍卡在 Boost 依赖对象编译；当前环境里 `c++.exe` 连最小 `int main(){}` syntax-only 都返回 1 且无诊断，因此这次没有拿到有效 C++ 编译信号。