### PR TITLE
fix(vdd): avoid persisting VDD-only restore baseline

### DIFF
--- a/src/display_device/parsed_config.cpp
+++ b/src/display_device/parsed_config.cpp
@@ -521,38 +521,7 @@ namespace display_device {
 
   bool
   display_request_t::requires_vdd(bool requested_device_exists, bool is_vdd_device) const {
-    return resolve_vdd_request(
-      *this,
-      requested_device_exists,
-      is_vdd_device,
-      parsed_config_t::device_prep_e::ensure_active
-    ) == vdd_request_decision_e::use_vdd;
-  }
-
-  bool
-  is_explicit_vdd_request(const display_request_t &request, bool is_vdd_device) {
-    return request.use_vdd || is_vdd_device;
-  }
-
-  vdd_request_decision_e
-  resolve_vdd_request(
-    const display_request_t &request,
-    bool requested_device_exists,
-    bool is_vdd_device,
-    parsed_config_t::device_prep_e device_prep) {
-    if (is_explicit_vdd_request(request, is_vdd_device)) {
-      return vdd_request_decision_e::use_vdd;
-    }
-
-    if (requested_device_exists || !request.allows_vdd_fallback()) {
-      return vdd_request_decision_e::use_requested_display;
-    }
-
-    if (device_prep == parsed_config_t::device_prep_e::no_operation) {
-      return vdd_request_decision_e::blocked_automatic_fallback;
-    }
-
-    return vdd_request_decision_e::use_vdd;
+    return use_vdd || is_vdd_device || (!requested_device_exists && allows_vdd_fallback());
   }
 
   display_request_t
@@ -726,20 +695,19 @@ namespace display_device {
       return boost::none;
     }
 
-    const auto vdd_request_decision = resolve_vdd_request(
-      display_request,
-      requested_device_exists,
-      is_vdd_device,
-      parsed_config.device_prep
-    );
-
-    if (vdd_request_decision == vdd_request_decision_e::blocked_automatic_fallback) {
+    const bool explicit_vdd_request = display_request.use_vdd || is_vdd_device;
+    const bool automatic_vdd_fallback =
+      !requested_device_exists && display_request.allows_vdd_fallback() && !explicit_vdd_request;
+    if (parsed_config.device_prep == parsed_config_t::device_prep_e::no_operation &&
+        automatic_vdd_fallback) {
       BOOST_LOG(error) << "Requested display is unavailable and no_operation forbids automatic VDD fallback: " << parsed_config.device_id;
       return boost::none;
     }
 
+    const bool needs_vdd = explicit_vdd_request || automatic_vdd_fallback;
+
     // 不需要VDD时，使用物理模式映射
-    if (vdd_request_decision != vdd_request_decision_e::use_vdd) {
+    if (!needs_vdd) {
       BOOST_LOG(debug) << "输出设备已存在，跳过VDD准备"sv;
       parsed_config.use_vdd = false;
       parsed_config.device_prep = parsed_config_t::to_physical_device_prep(parsed_config.device_prep);
@@ -761,10 +729,7 @@ namespace display_device {
     }
 
     // 准备VDD设备
-    if (!display_device::session_t::get().prepare_vdd(parsed_config, session)) {
-      BOOST_LOG(error) << "Failed to prepare VDD display safely.";
-      return boost::none;
-    }
+    display_device::session_t::get().prepare_vdd(parsed_config, session);
 
     return parsed_config;
   }

--- a/src/display_device/parsed_config.h
+++ b/src/display_device/parsed_config.h
@@ -189,22 +189,6 @@ namespace display_device {
     requires_vdd(bool requested_device_exists, bool is_vdd_device) const;
   };
 
-  enum class vdd_request_decision_e {
-    use_requested_display,
-    use_vdd,
-    blocked_automatic_fallback
-  };
-
-  bool
-  is_explicit_vdd_request(const display_request_t &request, bool is_vdd_device);
-
-  vdd_request_decision_e
-  resolve_vdd_request(
-    const display_request_t &request,
-    bool requested_device_exists,
-    bool is_vdd_device,
-    parsed_config_t::device_prep_e device_prep);
-
   display_request_t
   resolve_display_request(const config::video_t &config, const rtsp_stream::launch_session_t &session);
 

--- a/src/display_device/session.cpp
+++ b/src/display_device/session.cpp
@@ -371,13 +371,11 @@ namespace display_device {
     const bool requested_device_exists = !requested_device_id.empty();
     const bool is_vdd_device = (display_device::get_display_friendly_name(display_request.device_id) == ZAKO_NAME);
     const auto effective_device_prep = get_effective_device_prep(config, session);
+    const bool explicit_vdd_request = display_request.use_vdd || is_vdd_device;
+    const bool automatic_vdd_fallback = !requested_device_exists && display_request.allows_vdd_fallback() && !explicit_vdd_request;
 
-    const bool needs_vdd = resolve_vdd_request(
-      display_request,
-      requested_device_exists,
-      is_vdd_device,
-      effective_device_prep
-    ) == vdd_request_decision_e::use_vdd;
+    const bool needs_vdd = explicit_vdd_request ||
+      (automatic_vdd_fallback && effective_device_prep != parsed_config_t::device_prep_e::no_operation);
 
     // - 如果不需要 VDD：跳过 VDD 相关逻辑
     // - 如果不是 SYSTEM 权限且处于 RDP 中：使用 RDP 虚拟显示器，不创建 VDD
@@ -417,31 +415,7 @@ namespace display_device {
         timer->setup_timer(nullptr);
       }
       else {
-        if (vdd_will_turn_off_physical_displays) {
-          const auto current_devices = display_device::enum_available_devices();
-          if (vdd_utils::has_active_physical_display_snapshot(current_devices)) {
-            const auto current_topology = get_current_topology();
-            if (is_topology_valid(current_topology)) {
-              pre_saved_initial_topology = current_topology;
-              BOOST_LOG(debug) << "VDD already exists, but active physical displays are present; saved current topology before display_off prep: "
-                               << to_string(*pre_saved_initial_topology);
-            }
-            else {
-              BOOST_LOG(error) << "VDD already exists and physical displays are active, but current topology is invalid; refusing display_off prep.";
-              return {
-                configure_result_t::result_e::topology_fail,
-                "Current display topology is not safe for VDD display-off prep.",
-                "Disable VDD display-off prep or restore a valid physical display topology, then try again."
-              };
-            }
-          }
-          else {
-            BOOST_LOG(debug) << "VDD already exists and no active physical display baseline is available; skipping initial topology save.";
-          }
-        }
-        else {
-          BOOST_LOG(debug) << "VDD already exists, skipping initial topology save (topology may be corrupted)";
-        }
+        BOOST_LOG(debug) << "VDD already exists, skipping initial topology save (topology may be corrupted)";
       }
     }
 
@@ -580,7 +554,7 @@ namespace display_device {
     std::this_thread::sleep_for(1200ms);
   }
 
-  bool
+  void
   session_t::prepare_vdd(parsed_config_t &config, const rtsp_stream::launch_session_t &session) {
     const std::string current_client_id = get_client_id_from_session(session);
     const vdd_utils::hdr_brightness_t hdr_brightness { session.max_nits, session.min_nits, session.max_full_nits };
@@ -601,11 +575,9 @@ namespace display_device {
 
     auto device_zako = display_device::find_device_by_friendlyname(ZAKO_NAME);
 
-    // pre_vdd_devices: 在 VDD prep 前保存的显示器基线快照
-    // 延迟到 VDD 创建或 prep 前才捕获，确保能拿到可恢复的正确状态
+    // pre_vdd_devices: 在 VDD 创建前一刻保存的物理显示器快照
+    // 延迟到 VDD 创建前才捕获，确保无论是新建还是重建都能拿到正确状态
     device_info_map_t pre_vdd_devices;
-    bool pre_vdd_devices_captured = false;
-    const bool vdd_prep_needs_snapshot = vdd_utils::vdd_prep_requires_pre_vdd_snapshot(config.vdd_prep);
 
     // Rebuild VDD device on client switch
     if (!device_zako.empty() && !current_vdd_client_id.empty() &&
@@ -656,8 +628,7 @@ namespace display_device {
       // 在创建 VDD 之前捕获物理显示器快照
       // 此时无 VDD 存在（新建 or 重建后已销毁），物理屏应处于正常状态
       pre_vdd_devices = display_device::enum_available_devices();
-      pre_vdd_devices_captured = true;
-      BOOST_LOG(info) << "已保存VDD prep基线设备列表: " << display_device::to_string(pre_vdd_devices);
+      BOOST_LOG(info) << "已保存pre-VDD设备列表: " << display_device::to_string(pre_vdd_devices);
 
       BOOST_LOG(info) << "创建虚拟显示器...";
       // 复用模式使用固定标识符，否则使用客户端ID生成唯一GUID
@@ -666,12 +637,6 @@ namespace display_device {
         : current_client_id;  // 为每个客户端生成不同GUID
       vdd_utils::create_vdd_monitor(vdd_identifier, hdr_brightness, physical_size);
       std::this_thread::sleep_for(200ms);
-    }
-    else if (vdd_prep_needs_snapshot) {
-      pre_vdd_devices = display_device::enum_available_devices();
-      pre_vdd_devices_captured = true;
-      BOOST_LOG(info) << "VDD already exists; captured current display list as VDD prep baseline: "
-                      << display_device::to_string(pre_vdd_devices);
     }
 
     // Wait for device to be ready
@@ -698,12 +663,12 @@ namespace display_device {
         else {
           BOOST_LOG(warning) << "VDD IOCTL 仍可用，跳过 disable/enable，避免制造 phantom monitor";
         }
-        return false;
+        return;
       }
     }
 
     if (device_zako.empty()) {
-      return false;
+      return;
     }
 
     if (original_output_name.empty()) {
@@ -730,17 +695,9 @@ namespace display_device {
     // VDD模式下的拓扑控制与普通模式分开处理
     if (config.vdd_prep != parsed_config_t::vdd_prep_e::no_operation) {
       // User has specified a display configuration, apply it
-      const auto vdd_prep_result = vdd_utils::apply_vdd_prep(device_zako, config.vdd_prep, pre_vdd_devices, pre_vdd_devices_captured);
-      if (vdd_prep_result == vdd_utils::vdd_prep_result_e::success) {
+      if (vdd_utils::apply_vdd_prep(device_zako, config.vdd_prep, pre_vdd_devices)) {
         BOOST_LOG(info) << "已应用VDD屏幕布局设置";
         std::this_thread::sleep_for(200ms);
-      }
-      else if (vdd_prep_result == vdd_utils::vdd_prep_result_e::topology_failed && settings.is_changing_settings_going_to_fail()) {
-        BOOST_LOG(warning) << "VDD prep topology change failed while Windows display settings are unavailable; allowing the stream to continue without applying VDD prep.";
-      }
-      else {
-        BOOST_LOG(error) << "Failed to apply VDD prep safely; aborting display configuration.";
-        return false;
       }
     }
     else {
@@ -757,8 +714,6 @@ namespace display_device {
       std::this_thread::sleep_for(500ms);
       vdd_utils::set_hdr_state(false);
     }
-
-    return true;
   }
 
   void

--- a/src/display_device/session.h
+++ b/src/display_device/session.h
@@ -212,9 +212,8 @@ namespace display_device {
 
     /**
      * @brief Prepares VDD for use
-     * @returns True when VDD prep succeeded; false when display configuration should abort.
      */
-    bool
+    void
     prepare_vdd(parsed_config_t &config, const rtsp_stream::launch_session_t &session);
 
     /**

--- a/src/display_device/vdd_utils.cpp
+++ b/src/display_device/vdd_utils.cpp
@@ -1072,11 +1072,16 @@ namespace display_device {
       // 确保即使 VDD 创建后物理屏变 inactive 也能正确识别
       std::vector<std::string> physical_devices;
       std::string original_primary_id;
+      const auto is_active_physical_display = [](const device_info_t &info) {
+        return info.friendly_name != ZAKO_NAME &&
+               (info.device_state == device_state_e::active ||
+                info.device_state == device_state_e::primary);
+      };
 
       if (!pre_vdd_devices.empty()) {
         // 使用 VDD 创建前保存的设备信息（可靠）
         for (const auto &[device_id, info] : pre_vdd_devices) {
-          if (info.friendly_name != ZAKO_NAME) {
+          if (is_active_physical_display(info)) {
             physical_devices.push_back(device_id);
             if (info.device_state == device_state_e::primary) {
               original_primary_id = device_id;
@@ -1091,7 +1096,7 @@ namespace display_device {
         BOOST_LOG(warning) << "未提供pre-VDD设备列表，从当前设备枚举中查找物理显示器";
         const auto all_devices = enum_available_devices();
         for (const auto &[device_id, info] : all_devices) {
-          if (device_id != vdd_device_id && info.friendly_name != ZAKO_NAME) {
+          if (device_id != vdd_device_id && is_active_physical_display(info)) {
             physical_devices.push_back(device_id);
             if (info.device_state == device_state_e::primary) {
               original_primary_id = device_id;

--- a/src/display_device/vdd_utils.cpp
+++ b/src/display_device/vdd_utils.cpp
@@ -1056,84 +1056,42 @@ namespace display_device {
     }
 
     bool
-    vdd_prep_requires_pre_vdd_snapshot(parsed_config_t::vdd_prep_e vdd_prep) {
-      return vdd_prep == parsed_config_t::vdd_prep_e::display_off;
-    }
-
-    bool
-    has_active_physical_display_snapshot(const device_info_map_t &pre_vdd_devices) {
-      return std::any_of(pre_vdd_devices.begin(), pre_vdd_devices.end(), [](const auto &entry) {
-        const auto &info = entry.second;
-        return info.friendly_name != ZAKO_NAME &&
-               (info.device_state == device_state_e::active ||
-                info.device_state == device_state_e::primary);
-      });
-    }
-
-    bool
-    has_physical_display_snapshot(const device_info_map_t &pre_vdd_devices) {
-      return std::any_of(pre_vdd_devices.begin(), pre_vdd_devices.end(), [](const auto &entry) {
-        return entry.second.friendly_name != ZAKO_NAME;
-      });
-    }
-
-    vdd_prep_result_e
     apply_vdd_prep(const std::string &vdd_device_id, parsed_config_t::vdd_prep_e vdd_prep,
-      const device_info_map_t &pre_vdd_devices, bool pre_vdd_devices_captured) {
+      const device_info_map_t &pre_vdd_devices) {
       if (vdd_device_id.empty()) {
         BOOST_LOG(info) << "VDD设备ID为空，跳过vdd_prep处理";
-        return vdd_prep_result_e::success;
+        return true;
       }
 
       if (vdd_prep == parsed_config_t::vdd_prep_e::no_operation) {
         BOOST_LOG(info) << "vdd_prep设置为无操作，跳过物理显示器处理";
-        return vdd_prep_result_e::success;
+        return true;
       }
 
-      // 从基线快照中获取物理显示器，确保即使 VDD prep 后物理屏变 inactive 也能正确识别
-      if (vdd_prep_requires_pre_vdd_snapshot(vdd_prep) && !pre_vdd_devices_captured) {
-        BOOST_LOG(error) << "Missing baseline display snapshot; refusing VDD prep "
-                         << static_cast<int>(vdd_prep)
-                         << " to avoid guessing the original physical display topology.";
-        return vdd_prep_result_e::safety_blocked;
-      }
-
-      if (vdd_prep_requires_pre_vdd_snapshot(vdd_prep) &&
-          has_physical_display_snapshot(pre_vdd_devices) &&
-          !has_active_physical_display_snapshot(pre_vdd_devices)) {
-        BOOST_LOG(error) << "Baseline display snapshot contains no active physical display; refusing VDD prep "
-                         << static_cast<int>(vdd_prep)
-                         << " because the baseline is not restorable.";
-        return vdd_prep_result_e::safety_blocked;
-      }
-
+      // 从 pre_vdd_devices（VDD创建前保存的设备列表）中获取物理显示器，
+      // 确保即使 VDD 创建后物理屏变 inactive 也能正确识别
       std::vector<std::string> physical_devices;
       std::string original_primary_id;
 
-      if (pre_vdd_devices_captured) {
-        // 使用 VDD prep 前保存的基线设备信息（可靠）
+      if (!pre_vdd_devices.empty()) {
+        // 使用 VDD 创建前保存的设备信息（可靠）
         for (const auto &[device_id, info] : pre_vdd_devices) {
-          if (info.friendly_name != ZAKO_NAME &&
-              (info.device_state == device_state_e::active ||
-               info.device_state == device_state_e::primary)) {
+          if (info.friendly_name != ZAKO_NAME) {
             physical_devices.push_back(device_id);
             if (info.device_state == device_state_e::primary) {
               original_primary_id = device_id;
             }
           }
         }
-        BOOST_LOG(info) << "使用VDD prep基线设备列表: " << physical_devices.size() << "个物理显示器"
+        BOOST_LOG(info) << "使用pre-VDD设备列表: " << physical_devices.size() << "个物理显示器"
                         << (original_primary_id.empty() ? "" : ", 原主屏: " + original_primary_id);
       }
       else {
-        // 回退：从当前设备枚举中获取（未保存 VDD prep 基线时的兜底逻辑）
-        BOOST_LOG(warning) << "未提供VDD prep基线设备列表，从当前设备枚举中查找物理显示器";
+        // 回退：从当前设备枚举中获取（VDD创建前未保存时的兜底逻辑）
+        BOOST_LOG(warning) << "未提供pre-VDD设备列表，从当前设备枚举中查找物理显示器";
         const auto all_devices = enum_available_devices();
         for (const auto &[device_id, info] : all_devices) {
-          if (device_id != vdd_device_id &&
-              info.friendly_name != ZAKO_NAME &&
-              (info.device_state == device_state_e::active ||
-               info.device_state == device_state_e::primary)) {
+          if (device_id != vdd_device_id && info.friendly_name != ZAKO_NAME) {
             physical_devices.push_back(device_id);
             if (info.device_state == device_state_e::primary) {
               original_primary_id = device_id;
@@ -1152,7 +1110,7 @@ namespace display_device {
 
       if (physical_devices.empty()) {
         BOOST_LOG(debug) << "没有物理显示器需要处理";
-        return vdd_prep_result_e::success;
+        return true;
       }
 
       active_topology_t new_topology;
@@ -1191,21 +1149,21 @@ namespace display_device {
         }
 
         default:
-          return vdd_prep_result_e::success;
+          return true;
       }
 
       if (!is_topology_valid(new_topology)) {
         BOOST_LOG(error) << "新拓扑无效";
-        return vdd_prep_result_e::safety_blocked;
+        return false;
       }
 
       if (!set_topology(new_topology)) {
         BOOST_LOG(error) << "设置拓扑失败";
-        return vdd_prep_result_e::topology_failed;
+        return false;
       }
 
       BOOST_LOG(info) << "成功应用vdd_prep设置";
-      return vdd_prep_result_e::success;
+      return true;
     }
   }  // namespace vdd_utils
 }  // namespace display_device

--- a/src/display_device/vdd_utils.h
+++ b/src/display_device/vdd_utils.h
@@ -167,37 +167,20 @@ namespace display_device::vdd_utils {
   bool
   ensure_vdd_extended_mode(const std::string &device_id, const std::unordered_set<std::string> &physical_devices_to_preserve = {});
 
-  bool
-  vdd_prep_requires_pre_vdd_snapshot(parsed_config_t::vdd_prep_e vdd_prep);
-
-  bool
-  has_active_physical_display_snapshot(const device_info_map_t &pre_vdd_devices);
-
-  bool
-  has_physical_display_snapshot(const device_info_map_t &pre_vdd_devices);
-
-  enum class vdd_prep_result_e {
-    success,
-    safety_blocked,
-    topology_failed
-  };
-
   /**
    * @brief Apply VDD prep settings to handle physical displays.
    * @param vdd_device_id The VDD device ID.
    * @param vdd_prep The vdd_prep_e value specifying how to handle physical displays.
-   * @param pre_vdd_devices Physical device info captured before VDD prep changes.
-   *        Used to reliably identify physical displays even if VDD creation or
-   *        prep caused them to become inactive.
-   * @param pre_vdd_devices_captured True when pre_vdd_devices is a real baseline
-   *        snapshot. Destructive topology prep is refused without this baseline.
-   * @returns Detailed result of the prep operation.
+   * @param pre_vdd_devices Physical device info captured BEFORE VDD creation.
+   *        Used to reliably identify physical displays even if VDD creation
+   *        caused them to become inactive. If empty, falls back to current device enumeration.
+   * @returns True if the operation succeeded.
    * @note This operation modifies topology without saving/restoring state,
    *       as Windows automatically handles topology memory when displays change.
    */
-  vdd_prep_result_e
+  bool
   apply_vdd_prep(const std::string &vdd_device_id, parsed_config_t::vdd_prep_e vdd_prep,
-    const device_info_map_t &pre_vdd_devices = {}, bool pre_vdd_devices_captured = false);
+    const device_info_map_t &pre_vdd_devices = {});
 
   VddSettings
   prepare_vdd_settings(const parsed_config_t &config);

--- a/src/nvhttp_stream_start.cpp
+++ b/src/nvhttp_stream_start.cpp
@@ -242,7 +242,7 @@ namespace nvhttp::stream_start {
     explicit_vdd_requested_for_launch(const rtsp_stream::launch_session_t &launch_session) {
       const auto display_request = display_device::resolve_display_request(config::video, launch_session);
       const bool is_vdd_device = display_device::get_display_friendly_name(display_request.device_id) == ZAKO_NAME;
-      return display_device::is_explicit_vdd_request(display_request, is_vdd_device);
+      return display_request.use_vdd || is_vdd_device;
     }
 
     bool

--- a/src/platform/windows/display_device/settings.cpp
+++ b/src/platform/windows/display_device/settings.cpp
@@ -949,10 +949,20 @@ namespace display_device {
       // was applied.
       persistent_data_t new_settings { topology_result->pair };
       persistent_data_t &current_settings { persistent_data ? *persistent_data : new_settings };
+      const bool should_skip_new_vdd_only_persistence =
+        is_vdd_mode &&
+        !persistent_data &&
+        !pre_saved_initial_topology &&
+        is_vdd_only_topology(new_settings.topology.initial, config.device_id);
 
       const auto persist_settings = [&]() -> apply_result_t {
         if (current_settings.contains_modifications()) {
           if (!persistent_data) {
+            if (should_skip_new_vdd_only_persistence) {
+              BOOST_LOG(warning) << "VDD mode: refusing to persist current VDD-only topology as the initial restore baseline; continuing without new display restore data.";
+              return { apply_result_t::result_e::success };
+            }
+
             persistent_data = std::make_unique<persistent_data_t>(new_settings);
           }
 

--- a/src/platform/windows/display_device/settings_topology.cpp
+++ b/src/platform/windows/display_device/settings_topology.cpp
@@ -315,6 +315,16 @@ namespace display_device {
     return new_ids;
   }
 
+  bool
+  is_vdd_only_topology(const active_topology_t &topology, const std::string &vdd_device_id) {
+    if (vdd_device_id.empty()) {
+      return false;
+    }
+
+    const auto device_ids = get_device_ids_from_topology(topology);
+    return device_ids.size() == 1 && device_ids.contains(vdd_device_id);
+  }
+
   boost::optional<handled_topology_result_t>
   handle_device_topology_configuration(
     const parsed_config_t &config,

--- a/src/platform/windows/display_device/settings_topology.h
+++ b/src/platform/windows/display_device/settings_topology.h
@@ -67,6 +67,15 @@ namespace display_device {
   get_newly_enabled_devices_from_topology(const active_topology_t &previous_topology, const active_topology_t &new_topology);
 
   /**
+   * @brief Check whether the active topology contains only the supplied VDD device.
+   * @param topology Topology to inspect.
+   * @param vdd_device_id Device id of the VDD.
+   * @returns True if the topology has exactly one device and it is the VDD.
+   */
+  bool
+  is_vdd_only_topology(const active_topology_t &topology, const std::string &vdd_device_id);
+
+  /**
    * @brief Modify the topology based on the configuration and previously configured topology.
    *
    * The function performs the necessary steps for changing topology if needed.

--- a/tests/unit/test_vdd_safety.cpp
+++ b/tests/unit/test_vdd_safety.cpp
@@ -2,118 +2,16 @@
 
 #ifdef _WIN32
 
-#include <string>
-#include <utility>
+#include "src/platform/windows/display_device/settings_topology.h"
 
-#include "src/display_device/vdd_utils.h"
-#include "src/globals.h"
-
-namespace {
-  display_device::device_info_t
-  make_device(std::string friendly_name, display_device::device_state_e state) {
-    return {
-      "\\\\.\\DISPLAY1",
-      std::move(friendly_name),
-      state,
-      display_device::hdr_state_e::unknown
-    };
-  }
-}  // namespace
-
-TEST(VddPrepSafety, RequiresPreVddSnapshotForTopologyPrep) {
-  using display_device::parsed_config_t;
-
-  EXPECT_FALSE(display_device::vdd_utils::vdd_prep_requires_pre_vdd_snapshot(parsed_config_t::vdd_prep_e::no_operation));
-  EXPECT_FALSE(display_device::vdd_utils::vdd_prep_requires_pre_vdd_snapshot(parsed_config_t::vdd_prep_e::vdd_as_primary));
-  EXPECT_FALSE(display_device::vdd_utils::vdd_prep_requires_pre_vdd_snapshot(parsed_config_t::vdd_prep_e::vdd_as_secondary));
-  EXPECT_TRUE(display_device::vdd_utils::vdd_prep_requires_pre_vdd_snapshot(parsed_config_t::vdd_prep_e::display_off));
-}
-
-TEST(VddPrepSafety, DetectsRestorablePhysicalDisplaySnapshot) {
+TEST(VddBaselineSafety, DetectsVddOnlyTopology) {
   using namespace display_device;
 
-  EXPECT_FALSE(vdd_utils::has_active_physical_display_snapshot({}));
-  EXPECT_FALSE(vdd_utils::has_physical_display_snapshot({}));
-
-  device_info_map_t vdd_only {
-    { "vdd", make_device(ZAKO_NAME, device_state_e::primary) },
-  };
-  EXPECT_FALSE(vdd_utils::has_active_physical_display_snapshot(vdd_only));
-  EXPECT_FALSE(vdd_utils::has_physical_display_snapshot(vdd_only));
-
-  device_info_map_t inactive_physical {
-    { "physical", make_device("F32D80U", device_state_e::inactive) },
-  };
-  EXPECT_FALSE(vdd_utils::has_active_physical_display_snapshot(inactive_physical));
-  EXPECT_TRUE(vdd_utils::has_physical_display_snapshot(inactive_physical));
-
-  device_info_map_t active_physical {
-    { "physical", make_device("F32D80U", device_state_e::active) },
-  };
-  EXPECT_TRUE(vdd_utils::has_active_physical_display_snapshot(active_physical));
-  EXPECT_TRUE(vdd_utils::has_physical_display_snapshot(active_physical));
-
-  device_info_map_t primary_physical {
-    { "physical", make_device("F32D80U", device_state_e::primary) },
-  };
-  EXPECT_TRUE(vdd_utils::has_active_physical_display_snapshot(primary_physical));
-  EXPECT_TRUE(vdd_utils::has_physical_display_snapshot(primary_physical));
-}
-
-TEST(VddPrepSafety, BlocksOnlyUnsafeDisplayOffBaselines) {
-  using namespace display_device;
-  using result_e = vdd_utils::vdd_prep_result_e;
-
-  EXPECT_EQ(
-    vdd_utils::apply_vdd_prep("vdd", parsed_config_t::vdd_prep_e::display_off, {}, false),
-    result_e::safety_blocked);
-
-  device_info_map_t inactive_physical {
-    { "physical", make_device("F32D80U", device_state_e::inactive) },
-    { "vdd", make_device(ZAKO_NAME, device_state_e::primary) },
-  };
-  EXPECT_EQ(
-    vdd_utils::apply_vdd_prep("vdd", parsed_config_t::vdd_prep_e::display_off, inactive_physical, true),
-    result_e::safety_blocked);
-
-  device_info_map_t vdd_only {
-    { "vdd", make_device(ZAKO_NAME, device_state_e::primary) },
-  };
-  EXPECT_EQ(
-    vdd_utils::apply_vdd_prep("vdd", parsed_config_t::vdd_prep_e::display_off, vdd_only, true),
-    result_e::success);
-}
-
-TEST(VddRequestSafety, NoOperationBlocksOnlyAutomaticVddFallback) {
-  using namespace display_device;
-  using device_prep_e = parsed_config_t::device_prep_e;
-  using decision_e = vdd_request_decision_e;
-
-  display_request_t config_missing_display {
-    "missing",
-    display_request_t::source_e::config,
-    false
-  };
-  EXPECT_FALSE(is_explicit_vdd_request(config_missing_display, false));
-  EXPECT_EQ(resolve_vdd_request(config_missing_display, false, false, device_prep_e::no_operation), decision_e::blocked_automatic_fallback);
-  EXPECT_EQ(resolve_vdd_request(config_missing_display, false, false, device_prep_e::ensure_active), decision_e::use_vdd);
-  EXPECT_EQ(resolve_vdd_request(config_missing_display, true, false, device_prep_e::no_operation), decision_e::use_requested_display);
-
-  display_request_t explicit_vdd {
-    "missing",
-    display_request_t::source_e::config,
-    true
-  };
-  EXPECT_TRUE(is_explicit_vdd_request(explicit_vdd, false));
-  EXPECT_EQ(resolve_vdd_request(explicit_vdd, false, false, device_prep_e::no_operation), decision_e::use_vdd);
-
-  display_request_t client_physical_missing {
-    "missing",
-    display_request_t::source_e::client,
-    false
-  };
-  EXPECT_FALSE(client_physical_missing.allows_vdd_fallback());
-  EXPECT_EQ(resolve_vdd_request(client_physical_missing, false, false, device_prep_e::ensure_active), decision_e::use_requested_display);
+  EXPECT_FALSE(is_vdd_only_topology({}, "vdd"));
+  EXPECT_FALSE(is_vdd_only_topology({ { "vdd" } }, ""));
+  EXPECT_FALSE(is_vdd_only_topology({ { "physical" } }, "vdd"));
+  EXPECT_FALSE(is_vdd_only_topology({ { "vdd" }, { "physical" } }, "vdd"));
+  EXPECT_TRUE(is_vdd_only_topology({ { "vdd" } }, "vdd"));
 }
 
 #endif


### PR DESCRIPTION
## 改了啥呀

- Revert the hard-fail VDD display-off baseline guard from #739 so VDD resume no longer aborts when the host is already in a VDD-only topology.
- Keep the narrower safety invariant: do not persist a current VDD-only topology as a fresh initial restore baseline when there is no pre-saved physical-display topology.
- Add a small topology helper/test for detecting VDD-only active topology.

## 为啥要改

The previous guard protected restore baselines, but it also made resume fail after disconnect when physical displays were already inactive and VDD was primary. That turns a recoverable VDD-only state into a client-visible reconnect failure, 杂鱼 bug 状态自己把门锁上了。

## 验证

- `git diff --check -- src/display_device src/platform/windows/display_device src/nvhttp_stream_start.cpp tests/unit/test_vdd_safety.cpp`
- Attempted `cmake --build build --target test_sunshine --config Debug`, but the existing Ninja/MSYS2 build stops before reaching this change while compiling Boost dependency objects such as `boost_container/src/alloc_lib.c`, with no compiler diagnostic emitted.
- Attempted targeted Ninja object builds; they hit the same Boost dependency compile failure before compiling the touched objects.