### PR TITLE
perf(gui): optimize webui rendering

### DIFF
--- a/src_assets/common/assets/web/components/AppCard.vue
+++ b/src_assets/common/assets/web/components/AppCard.vue
@@ -8,6 +8,8 @@
           :src="getImageUrl()" 
           :alt="app.name"
           class="app-icon"
+          loading="lazy"
+          decoding="async"
           @error="handleImageError"
         >
         <div v-else class="app-icon-placeholder">

--- a/src_assets/common/assets/web/components/AppListItem.vue
+++ b/src_assets/common/assets/web/components/AppListItem.vue
@@ -13,6 +13,8 @@
           :src="getImageUrl()" 
           :alt="app.name"
           class="app-icon-list"
+          loading="lazy"
+          decoding="async"
           @error="handleImageError"
         >
         <div v-else class="app-icon-placeholder-list">
@@ -179,5 +181,4 @@ export default {
   }
 }
 </script>
-
 

--- a/src_assets/common/assets/web/styles/apps/app-cards.less
+++ b/src_assets/common/assets/web/styles/apps/app-cards.less
@@ -73,6 +73,8 @@
 
 .app-card-wrapper,
 .app-list-wrapper {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 220px;
   position: relative;
 
   &.selection-mode {
@@ -88,6 +90,7 @@
 }
 
 .apps-grid .app-card-wrapper {
+  contain-intrinsic-size: auto 280px;
   display: flex;
   min-width: 0;
   height: 100%;

--- a/src_assets/common/assets/web/styles/apps/list-items.less
+++ b/src_assets/common/assets/web/styles/apps/list-items.less
@@ -5,6 +5,8 @@
   background: rgba(255, 255, 255, 0.1);
   border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: var(--border-radius-lg);
+  content-visibility: auto;
+  contain-intrinsic-size: auto 96px;
   overflow: hidden;
   .glass-effect();
   .transition-default();


### PR DESCRIPTION
## 改了啥喵
- WebUI app 卡片和列表图标改为 lazy/async image decode。
- app 卡片、列表项加入 `content-visibility` 和 intrinsic size，减少离屏列表渲染压力。
- 更新 `src_assets/common/sunshine-control-panel` 子模块指针到配套的 GUI 性能优化提交。

## 配套 PR
- qiin2333/sunshine-control-panel#48

## 为啥要改
- GUI 首屏和长列表不该被离屏图片、离屏卡片、control panel 大包一起拖慢，杂鱼渲染压力该被关在视口外面。

## 量化
- control panel 日志渲染模型：1661 行 -> 26 行，渲染行数 -98.43%。
- toolbar 入口 JS：311.80kB -> 18.05kB。
- desktop 入口 JS：174.10kB -> 52.14kB。
- Element Plus 全量 JS/CSS 首屏大包已拆除。

## 验证
- `npm run build`
- `npm run build:renderer`
- `npm run test:webui`，52 passed
- `git diff --check`
- Playwright smoke：vdd 表单/下拉/toast 正常，tool-window 的 dpi/bitrate/shortcuts/rtss/pet 页面均可加载。