### PR TITLE
fix(amf): add avcodec-compatible standalone path

### DIFF
--- a/src/amf/amf_avcodec_compat.cpp
+++ b/src/amf/amf_avcodec_compat.cpp
@@ -19,13 +19,36 @@ namespace amf {
 
   namespace {
 
+    constexpr int AVCODEC_ASYNC_DEPTH_DEFAULT = 16;
+    constexpr int AVCODEC_LOOKAHEAD_DEPTH_MAX = 41;
+    constexpr int AVCODEC_ASYNC_DEPTH_MAX = AVCODEC_LOOKAHEAD_DEPTH_MAX + 1;
+
     struct avcodec_context_like_t {
       int64_t bit_rate = 0;
       int64_t rc_max_rate = 0;
       int64_t rc_buffer_size = 0;
       int gop_size = std::numeric_limits<int>::max();
-      int async_depth = 16;
+      int async_depth = AVCODEC_ASYNC_DEPTH_DEFAULT;
     };
+
+    template <class T>
+    AMF_RESULT
+    set_required_property(::amf::AMFComponent *encoder, const wchar_t *property, T value, const char *label) {
+      auto res = encoder->SetProperty(property, value);
+      if (res != AMF_OK) {
+        BOOST_LOG(error) << "AMF: AVCodec compatibility failed to set " << label << ", error: " << res;
+      }
+      return res;
+    }
+
+    template <class T>
+    void
+    set_optional_property(::amf::AMFComponent *encoder, const wchar_t *property, T value, const char *label) {
+      auto res = encoder->SetProperty(property, value);
+      if (res != AMF_OK) {
+        BOOST_LOG(warning) << "AMF: AVCodec compatibility ignored unsupported " << label << ", error: " << res;
+      }
+    }
 
     avcodec_context_like_t
     make_avcodec_context_like(const video::config_t &client_config) {
@@ -63,128 +86,164 @@ namespace amf {
       return AMF_VIDEO_ENCODER_AV1_RATE_CONTROL_METHOD_PEAK_CONSTRAINED_VBR;
     }
 
-    void
+    AMF_RESULT
     configure_h264(::amf::AMFComponent *encoder,
       const amf_config &config,
       const avcodec_context_like_t &ctx,
       const video::config_t &client_config,
       AMFRate framerate) {
-      if (config.usage) encoder->SetProperty(AMF_VIDEO_ENCODER_USAGE, (amf_int64) *config.usage);
-      if (config.quality_preset) encoder->SetProperty(AMF_VIDEO_ENCODER_QUALITY_PRESET, (amf_int64) *config.quality_preset);
+      if (config.usage) set_optional_property(encoder, AMF_VIDEO_ENCODER_USAGE, (amf_int64) *config.usage, "H.264 usage");
+      if (config.quality_preset) set_optional_property(encoder, AMF_VIDEO_ENCODER_QUALITY_PRESET, (amf_int64) *config.quality_preset, "H.264 quality_preset");
 
       const auto rc_mode = auto_rc_h264(config, ctx);
-      encoder->SetProperty(AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD, (amf_int64) rc_mode);
+      auto res = set_required_property(encoder, AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD, (amf_int64) rc_mode, "H.264 rate_control_method");
+      if (res != AMF_OK) return res;
       if (rc_mode == AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_QUALITY_VBR && config.qvbr_quality_level) {
-        encoder->SetProperty(AMF_VIDEO_ENCODER_QVBR_QUALITY_LEVEL, (amf_int64) *config.qvbr_quality_level);
+        set_optional_property(encoder, AMF_VIDEO_ENCODER_QVBR_QUALITY_LEVEL, (amf_int64) *config.qvbr_quality_level, "H.264 qvbr_quality_level");
       }
       if (config.high_motion_quality_boost_enable) {
-        encoder->SetProperty(AMF_VIDEO_ENCODER_HIGH_MOTION_QUALITY_BOOST_ENABLE, *config.high_motion_quality_boost_enable);
+        set_optional_property(encoder, AMF_VIDEO_ENCODER_HIGH_MOTION_QUALITY_BOOST_ENABLE, *config.high_motion_quality_boost_enable, "H.264 high_motion_quality_boost");
       }
-      if (ctx.rc_buffer_size) encoder->SetProperty(AMF_VIDEO_ENCODER_VBV_BUFFER_SIZE, ctx.rc_buffer_size);
-      if (ctx.bit_rate) encoder->SetProperty(AMF_VIDEO_ENCODER_TARGET_BITRATE, ctx.bit_rate);
-      if (rc_mode == AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_CBR && ctx.bit_rate) {
-        encoder->SetProperty(AMF_VIDEO_ENCODER_PEAK_BITRATE, ctx.bit_rate);
+      if (ctx.rc_buffer_size) {
+        res = set_required_property(encoder, AMF_VIDEO_ENCODER_VBV_BUFFER_SIZE, ctx.rc_buffer_size, "H.264 vbv_buffer_size");
+        if (res != AMF_OK) return res;
       }
-      if (ctx.rc_max_rate) encoder->SetProperty(AMF_VIDEO_ENCODER_PEAK_BITRATE, ctx.rc_max_rate);
+      if (ctx.bit_rate) {
+        res = set_required_property(encoder, AMF_VIDEO_ENCODER_TARGET_BITRATE, ctx.bit_rate, "H.264 target_bitrate");
+        if (res != AMF_OK) return res;
+      }
+      if (ctx.rc_max_rate) {
+        res = set_required_property(encoder, AMF_VIDEO_ENCODER_PEAK_BITRATE, ctx.rc_max_rate, "H.264 peak_bitrate");
+        if (res != AMF_OK) return res;
+      }
 
-      encoder->SetProperty(AMF_VIDEO_ENCODER_FRAMERATE, framerate);
-      if (config.enforce_hrd) encoder->SetProperty(AMF_VIDEO_ENCODER_ENFORCE_HRD, !!(*config.enforce_hrd));
-      encoder->SetProperty(AMF_VIDEO_ENCODER_IDR_PERIOD, (amf_int64) ctx.gop_size);
-      encoder->SetProperty(AMF_VIDEO_ENCODER_DE_BLOCKING_FILTER, true);
-      if (config.preanalysis) encoder->SetProperty(AMF_VIDEO_ENCODER_PRE_ANALYSIS_ENABLE, !!(*config.preanalysis));
-      if (config.vbaq) encoder->SetProperty(AMF_VIDEO_ENCODER_ENABLE_VBAQ, !!(*config.vbaq));
-      encoder->SetProperty(AMF_VIDEO_ENCODER_B_PIC_PATTERN, (amf_int64) 0);
-      if (config.lowlatency_mode) encoder->SetProperty(AMF_VIDEO_ENCODER_LOWLATENCY_MODE, !!(*config.lowlatency_mode));
-      encoder->SetProperty(AMF_VIDEO_ENCODER_QUERY_TIMEOUT, (amf_int64) 1);
+      res = set_required_property(encoder, AMF_VIDEO_ENCODER_FRAMERATE, framerate, "H.264 framerate");
+      if (res != AMF_OK) return res;
+      if (config.enforce_hrd) set_optional_property(encoder, AMF_VIDEO_ENCODER_ENFORCE_HRD, !!(*config.enforce_hrd), "H.264 enforce_hrd");
+      res = set_required_property(encoder, AMF_VIDEO_ENCODER_IDR_PERIOD, (amf_int64) ctx.gop_size, "H.264 idr_period");
+      if (res != AMF_OK) return res;
+      set_optional_property(encoder, AMF_VIDEO_ENCODER_DE_BLOCKING_FILTER, true, "H.264 deblocking_filter");
+      if (config.preanalysis) set_optional_property(encoder, AMF_VIDEO_ENCODER_PRE_ANALYSIS_ENABLE, !!(*config.preanalysis), "H.264 preanalysis");
+      if (config.vbaq) set_optional_property(encoder, AMF_VIDEO_ENCODER_ENABLE_VBAQ, !!(*config.vbaq), "H.264 vbaq");
+      set_optional_property(encoder, AMF_VIDEO_ENCODER_B_PIC_PATTERN, (amf_int64) 0, "H.264 b_pic_pattern");
+      if (config.lowlatency_mode) set_optional_property(encoder, AMF_VIDEO_ENCODER_LOWLATENCY_MODE, !!(*config.lowlatency_mode), "H.264 lowlatency_mode");
+      set_optional_property(encoder, AMF_VIDEO_ENCODER_QUERY_TIMEOUT, (amf_int64) 1, "H.264 query_timeout");
       if (config.intra_refresh_mbs) {
-        encoder->SetProperty(AMF_VIDEO_ENCODER_INTRA_REFRESH_NUM_MBS_PER_SLOT, (amf_int64) *config.intra_refresh_mbs);
+        set_optional_property(encoder, AMF_VIDEO_ENCODER_INTRA_REFRESH_NUM_MBS_PER_SLOT, (amf_int64) *config.intra_refresh_mbs, "H.264 intra_refresh_mbs");
       }
       if (client_config.slicesPerFrame > 1) {
-        encoder->SetProperty(AMF_VIDEO_ENCODER_SLICES_PER_FRAME, (amf_int64) client_config.slicesPerFrame);
+        set_optional_property(encoder, AMF_VIDEO_ENCODER_SLICES_PER_FRAME, (amf_int64) client_config.slicesPerFrame, "H.264 slices_per_frame");
       }
       if (config.h264_coding_mode && *config.h264_coding_mode != AMF_VIDEO_ENCODER_UNDEFINED) {
-        encoder->SetProperty(AMF_VIDEO_ENCODER_CABAC_ENABLE, (amf_int64) *config.h264_coding_mode);
+        set_optional_property(encoder, AMF_VIDEO_ENCODER_CABAC_ENABLE, (amf_int64) *config.h264_coding_mode, "H.264 coding_mode");
       }
+      return AMF_OK;
     }
 
-    void
+    AMF_RESULT
     configure_hevc(::amf::AMFComponent *encoder,
       const amf_config &config,
       const video::config_t &client_config,
       const video::sunshine_colorspace_t &colorspace,
       const avcodec_context_like_t &ctx,
       AMFRate framerate) {
-      if (config.usage) encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_USAGE, (amf_int64) *config.usage);
-      if (config.quality_preset) encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_QUALITY_PRESET, (amf_int64) *config.quality_preset);
+      if (config.usage) set_optional_property(encoder, AMF_VIDEO_ENCODER_HEVC_USAGE, (amf_int64) *config.usage, "HEVC usage");
+      if (config.quality_preset) set_optional_property(encoder, AMF_VIDEO_ENCODER_HEVC_QUALITY_PRESET, (amf_int64) *config.quality_preset, "HEVC quality_preset");
 
       const auto rc_mode = auto_rc_hevc(config, ctx);
-      encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD, (amf_int64) rc_mode);
+      auto res = set_required_property(encoder, AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD, (amf_int64) rc_mode, "HEVC rate_control_method");
+      if (res != AMF_OK) return res;
       if (rc_mode == AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_QUALITY_VBR && config.qvbr_quality_level) {
-        encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_QVBR_QUALITY_LEVEL, (amf_int64) *config.qvbr_quality_level);
+        set_optional_property(encoder, AMF_VIDEO_ENCODER_HEVC_QVBR_QUALITY_LEVEL, (amf_int64) *config.qvbr_quality_level, "HEVC qvbr_quality_level");
       }
       if (config.high_motion_quality_boost_enable) {
-        encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_HIGH_MOTION_QUALITY_BOOST_ENABLE, *config.high_motion_quality_boost_enable);
+        set_optional_property(encoder, AMF_VIDEO_ENCODER_HEVC_HIGH_MOTION_QUALITY_BOOST_ENABLE, *config.high_motion_quality_boost_enable, "HEVC high_motion_quality_boost");
       }
-      if (ctx.rc_buffer_size) encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_VBV_BUFFER_SIZE, ctx.rc_buffer_size);
-      if (ctx.bit_rate) encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_TARGET_BITRATE, ctx.bit_rate);
-      if (rc_mode == AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_CBR && ctx.bit_rate) {
-        encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_PEAK_BITRATE, ctx.bit_rate);
+      if (ctx.rc_buffer_size) {
+        res = set_required_property(encoder, AMF_VIDEO_ENCODER_HEVC_VBV_BUFFER_SIZE, ctx.rc_buffer_size, "HEVC vbv_buffer_size");
+        if (res != AMF_OK) return res;
       }
-      if (ctx.rc_max_rate) encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_PEAK_BITRATE, ctx.rc_max_rate);
+      if (ctx.bit_rate) {
+        res = set_required_property(encoder, AMF_VIDEO_ENCODER_HEVC_TARGET_BITRATE, ctx.bit_rate, "HEVC target_bitrate");
+        if (res != AMF_OK) return res;
+      }
+      if (ctx.rc_max_rate) {
+        res = set_required_property(encoder, AMF_VIDEO_ENCODER_HEVC_PEAK_BITRATE, ctx.rc_max_rate, "HEVC peak_bitrate");
+        if (res != AMF_OK) return res;
+      }
 
-      encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_FRAMERATE, framerate);
-      if (config.enforce_hrd) encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_ENFORCE_HRD, !!(*config.enforce_hrd));
-      encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_NUM_GOPS_PER_IDR, (amf_int64) 1);
-      encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_GOP_SIZE, (amf_int64) ctx.gop_size);
-      if (config.preanalysis) encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_PRE_ANALYSIS_ENABLE, !!(*config.preanalysis));
-      if (config.vbaq) encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_ENABLE_VBAQ, !!(*config.vbaq));
-      if (config.lowlatency_mode) encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_LOWLATENCY_MODE, !!(*config.lowlatency_mode));
-      encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_QUERY_TIMEOUT, (amf_int64) 1);
-      encoder->SetProperty(
+      res = set_required_property(encoder, AMF_VIDEO_ENCODER_HEVC_FRAMERATE, framerate, "HEVC framerate");
+      if (res != AMF_OK) return res;
+      if (config.enforce_hrd) set_optional_property(encoder, AMF_VIDEO_ENCODER_HEVC_ENFORCE_HRD, !!(*config.enforce_hrd), "HEVC enforce_hrd");
+      res = set_required_property(encoder, AMF_VIDEO_ENCODER_HEVC_NUM_GOPS_PER_IDR, (amf_int64) 1, "HEVC num_gops_per_idr");
+      if (res != AMF_OK) return res;
+      res = set_required_property(encoder, AMF_VIDEO_ENCODER_HEVC_GOP_SIZE, (amf_int64) ctx.gop_size, "HEVC gop_size");
+      if (res != AMF_OK) return res;
+      if (config.preanalysis) set_optional_property(encoder, AMF_VIDEO_ENCODER_HEVC_PRE_ANALYSIS_ENABLE, !!(*config.preanalysis), "HEVC preanalysis");
+      if (config.vbaq) set_optional_property(encoder, AMF_VIDEO_ENCODER_HEVC_ENABLE_VBAQ, !!(*config.vbaq), "HEVC vbaq");
+      if (config.lowlatency_mode) set_optional_property(encoder, AMF_VIDEO_ENCODER_HEVC_LOWLATENCY_MODE, !!(*config.lowlatency_mode), "HEVC lowlatency_mode");
+      set_optional_property(encoder, AMF_VIDEO_ENCODER_HEVC_QUERY_TIMEOUT, (amf_int64) 1, "HEVC query_timeout");
+      set_optional_property(
+        encoder,
         AMF_VIDEO_ENCODER_HEVC_PROFILE,
-        (amf_int64) (colorspace.bit_depth == 10 ? AMF_VIDEO_ENCODER_HEVC_PROFILE_MAIN_10 : AMF_VIDEO_ENCODER_HEVC_PROFILE_MAIN));
+        (amf_int64) (colorspace.bit_depth == 10 ? AMF_VIDEO_ENCODER_HEVC_PROFILE_MAIN_10 : AMF_VIDEO_ENCODER_HEVC_PROFILE_MAIN),
+        "HEVC profile");
       if (config.intra_refresh_mbs) {
-        encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_INTRA_REFRESH_NUM_CTBS_PER_SLOT, (amf_int64) *config.intra_refresh_mbs);
+        set_optional_property(encoder, AMF_VIDEO_ENCODER_HEVC_INTRA_REFRESH_NUM_CTBS_PER_SLOT, (amf_int64) *config.intra_refresh_mbs, "HEVC intra_refresh_mbs");
       }
       if (client_config.slicesPerFrame > 1) {
-        encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_SLICES_PER_FRAME, (amf_int64) client_config.slicesPerFrame);
+        set_optional_property(encoder, AMF_VIDEO_ENCODER_HEVC_SLICES_PER_FRAME, (amf_int64) client_config.slicesPerFrame, "HEVC slices_per_frame");
       }
+      return AMF_OK;
     }
 
-    void
+    AMF_RESULT
     configure_av1(::amf::AMFComponent *encoder,
       const amf_config &config,
       const avcodec_context_like_t &ctx,
       AMFRate framerate) {
-      if (config.usage) encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_USAGE, (amf_int64) *config.usage);
-      if (config.quality_preset) encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_QUALITY_PRESET, (amf_int64) *config.quality_preset);
+      if (config.usage) set_optional_property(encoder, AMF_VIDEO_ENCODER_AV1_USAGE, (amf_int64) *config.usage, "AV1 usage");
+      if (config.quality_preset) set_optional_property(encoder, AMF_VIDEO_ENCODER_AV1_QUALITY_PRESET, (amf_int64) *config.quality_preset, "AV1 quality_preset");
 
       const auto rc_mode = auto_rc_av1(config, ctx);
-      encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_RATE_CONTROL_METHOD, (amf_int64) rc_mode);
+      auto res = set_required_property(encoder, AMF_VIDEO_ENCODER_AV1_RATE_CONTROL_METHOD, (amf_int64) rc_mode, "AV1 rate_control_method");
+      if (res != AMF_OK) return res;
       if (rc_mode == AMF_VIDEO_ENCODER_AV1_RATE_CONTROL_METHOD_QUALITY_VBR && config.qvbr_quality_level) {
-        encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_QVBR_QUALITY_LEVEL, (amf_int64) *config.qvbr_quality_level);
+        set_optional_property(encoder, AMF_VIDEO_ENCODER_AV1_QVBR_QUALITY_LEVEL, (amf_int64) *config.qvbr_quality_level, "AV1 qvbr_quality_level");
       }
       if (config.high_motion_quality_boost_enable) {
-        encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_HIGH_MOTION_QUALITY_BOOST, *config.high_motion_quality_boost_enable);
+        set_optional_property(encoder, AMF_VIDEO_ENCODER_AV1_HIGH_MOTION_QUALITY_BOOST, *config.high_motion_quality_boost_enable, "AV1 high_motion_quality_boost");
       }
-      if (ctx.rc_buffer_size) encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_VBV_BUFFER_SIZE, ctx.rc_buffer_size);
-      if (ctx.bit_rate) encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_TARGET_BITRATE, ctx.bit_rate);
-      if (rc_mode == AMF_VIDEO_ENCODER_AV1_RATE_CONTROL_METHOD_CBR && ctx.bit_rate) {
-        encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_PEAK_BITRATE, ctx.bit_rate);
+      if (ctx.rc_buffer_size) {
+        res = set_required_property(encoder, AMF_VIDEO_ENCODER_AV1_VBV_BUFFER_SIZE, ctx.rc_buffer_size, "AV1 vbv_buffer_size");
+        if (res != AMF_OK) return res;
       }
-      if (ctx.rc_max_rate) encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_PEAK_BITRATE, ctx.rc_max_rate);
+      if (ctx.bit_rate) {
+        res = set_required_property(encoder, AMF_VIDEO_ENCODER_AV1_TARGET_BITRATE, ctx.bit_rate, "AV1 target_bitrate");
+        if (res != AMF_OK) return res;
+      }
+      if (ctx.rc_max_rate) {
+        res = set_required_property(encoder, AMF_VIDEO_ENCODER_AV1_PEAK_BITRATE, ctx.rc_max_rate, "AV1 peak_bitrate");
+        if (res != AMF_OK) return res;
+      }
 
-      encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_FRAMERATE, framerate);
-      if (config.enforce_hrd) encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_ENFORCE_HRD, !!(*config.enforce_hrd));
-      encoder->SetProperty(
+      res = set_required_property(encoder, AMF_VIDEO_ENCODER_AV1_FRAMERATE, framerate, "AV1 framerate");
+      if (res != AMF_OK) return res;
+      if (config.enforce_hrd) set_optional_property(encoder, AMF_VIDEO_ENCODER_AV1_ENFORCE_HRD, !!(*config.enforce_hrd), "AV1 enforce_hrd");
+      res = set_required_property(
+        encoder,
         AMF_VIDEO_ENCODER_AV1_ALIGNMENT_MODE,
-        (amf_int64) AMF_VIDEO_ENCODER_AV1_ALIGNMENT_MODE_NO_RESTRICTIONS);
-      encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_GOP_SIZE, (amf_int64) ctx.gop_size);
-      if (config.preanalysis) encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_PRE_ANALYSIS_ENABLE, !!(*config.preanalysis));
+        (amf_int64) AMF_VIDEO_ENCODER_AV1_ALIGNMENT_MODE_NO_RESTRICTIONS,
+        "AV1 alignment_mode");
+      if (res != AMF_OK) return res;
+      res = set_required_property(encoder, AMF_VIDEO_ENCODER_AV1_GOP_SIZE, (amf_int64) ctx.gop_size, "AV1 gop_size");
+      if (res != AMF_OK) return res;
+      if (config.preanalysis) set_optional_property(encoder, AMF_VIDEO_ENCODER_AV1_PRE_ANALYSIS_ENABLE, !!(*config.preanalysis), "AV1 preanalysis");
       if (config.av1_encoding_latency_mode) {
-        encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_ENCODING_LATENCY_MODE, (amf_int64) *config.av1_encoding_latency_mode);
+        set_optional_property(encoder, AMF_VIDEO_ENCODER_AV1_ENCODING_LATENCY_MODE, (amf_int64) *config.av1_encoding_latency_mode, "AV1 encoding_latency_mode");
       }
-      encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_QUERY_TIMEOUT, (amf_int64) 1);
+      set_optional_property(encoder, AMF_VIDEO_ENCODER_AV1_QUERY_TIMEOUT, (amf_int64) 1, "AV1 query_timeout");
+      return AMF_OK;
     }
 
   }  // namespace
@@ -197,23 +256,37 @@ namespace amf {
     const video::sunshine_colorspace_t &colorspace) {
     auto ctx = make_avcodec_context_like(client_config);
     auto framerate = AMFConstructRate(client_config.framerate, 1);
-    auto async_depth = config.input_queue_size.value_or(ctx.async_depth);
+    auto requested_async_depth = config.input_queue_size.value_or(ctx.async_depth);
+    auto async_depth = std::clamp(requested_async_depth, 1, AVCODEC_ASYNC_DEPTH_MAX);
 
-    if (config.pa_lookahead_depth && *config.pa_lookahead_depth >= async_depth) {
-      async_depth = *config.pa_lookahead_depth + 1;
-      BOOST_LOG(warning) << "AMF: AVCodec compatibility async_depth raised to " << async_depth
-                         << " to exceed PA lookahead depth " << *config.pa_lookahead_depth;
+    if (async_depth != requested_async_depth) {
+      BOOST_LOG(warning) << "AMF: AVCodec compatibility async_depth clamped from "
+                         << requested_async_depth << " to " << async_depth;
     }
 
+    if (config.pa_lookahead_depth) {
+      const auto lookahead_depth = std::clamp(*config.pa_lookahead_depth, 0, AVCODEC_LOOKAHEAD_DEPTH_MAX);
+      if (lookahead_depth != *config.pa_lookahead_depth) {
+        BOOST_LOG(warning) << "AMF: AVCodec compatibility PA lookahead depth clamped from "
+                           << *config.pa_lookahead_depth << " to " << lookahead_depth;
+      }
+      if (lookahead_depth >= async_depth) {
+        async_depth = std::min(lookahead_depth + 1, AVCODEC_ASYNC_DEPTH_MAX);
+        BOOST_LOG(warning) << "AMF: AVCodec compatibility async_depth raised to " << async_depth
+                           << " to exceed PA lookahead depth " << lookahead_depth;
+      }
+    }
+
+    AMF_RESULT configure_result = AMF_OK;
     switch (video_format) {
       case 0:
-        configure_h264(encoder, config, ctx, client_config, framerate);
+        configure_result = configure_h264(encoder, config, ctx, client_config, framerate);
         break;
       case 1:
-        configure_hevc(encoder, config, client_config, colorspace, ctx, framerate);
+        configure_result = configure_hevc(encoder, config, client_config, colorspace, ctx, framerate);
         break;
       default:
-        configure_av1(encoder, config, ctx, framerate);
+        configure_result = configure_av1(encoder, config, ctx, framerate);
         break;
     }
 
@@ -224,6 +297,7 @@ namespace amf {
     return {
       async_depth,
       true,
+      configure_result,
     };
   }
 

--- a/src/amf/amf_avcodec_compat.cpp
+++ b/src/amf/amf_avcodec_compat.cpp
@@ -6,8 +6,10 @@
 #include "amf_avcodec_compat.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cstdint>
 #include <limits>
+#include <thread>
 
 #include <AMF/components/VideoEncoderAV1.h>
 #include <AMF/components/VideoEncoderHEVC.h>
@@ -22,6 +24,9 @@ namespace amf {
     constexpr int AVCODEC_ASYNC_DEPTH_DEFAULT = 16;
     constexpr int AVCODEC_LOOKAHEAD_DEPTH_MAX = 41;
     constexpr int AVCODEC_ASYNC_DEPTH_MAX = AVCODEC_LOOKAHEAD_DEPTH_MAX + 1;
+    constexpr int AVCODEC_BACKPRESSURE_POLL_MAX = 20;
+    constexpr int AVCODEC_SUBMIT_RETRY_MAX = 20;
+    constexpr int AVCODEC_OUTPUT_POLL_MAX = 10;
 
     struct avcodec_context_like_t {
       int64_t bit_rate = 0;
@@ -30,6 +35,11 @@ namespace amf {
       int gop_size = std::numeric_limits<int>::max();
       int async_depth = AVCODEC_ASYNC_DEPTH_DEFAULT;
     };
+
+    bool
+    is_input_exhausted(AMF_RESULT res) {
+      return res == AMF_INPUT_FULL || res == AMF_DECODER_NO_FREE_SURFACES;
+    }
 
     template <class T>
     AMF_RESULT
@@ -247,6 +257,117 @@ namespace amf {
     }
 
   }  // namespace
+
+  void
+  amf_avcodec_scheduler::configure(int max_in_queue, bool query_timeout) {
+    hwsurfaces_in_queue_max = std::max(max_in_queue, 1);
+    query_timeout_supported = query_timeout;
+  }
+
+  void
+  amf_avcodec_scheduler::reset() {
+    output_list.clear();
+    hwsurfaces_in_queue = 0;
+  }
+
+  int
+  amf_avcodec_scheduler::in_flight() const {
+    return hwsurfaces_in_queue;
+  }
+
+  AMF_RESULT
+  amf_avcodec_scheduler::query_once(::amf::AMFComponent *encoder, ::amf::AMFDataPtr &output_data) {
+    output_data = nullptr;
+    auto res = encoder->QueryOutput(&output_data);
+    if (output_data) {
+      decrement_in_flight();
+    }
+    return res;
+  }
+
+  void
+  amf_avcodec_scheduler::sleep_if_needed(bool already_have_output) const {
+    if (!query_timeout_supported || already_have_output) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+  }
+
+  void
+  amf_avcodec_scheduler::decrement_in_flight() {
+    if (hwsurfaces_in_queue > 0) {
+      --hwsurfaces_in_queue;
+    }
+  }
+
+  amf_avcodec_scheduler_result
+  amf_avcodec_scheduler::submit_and_query(::amf::AMFComponent *encoder, const ::amf::AMFSurfacePtr &surface) {
+    amf_avcodec_scheduler_result result;
+
+    if (hwsurfaces_in_queue >= hwsurfaces_in_queue_max) {
+      for (int wait = 0; wait < AVCODEC_BACKPRESSURE_POLL_MAX && hwsurfaces_in_queue >= hwsurfaces_in_queue_max; ++wait) {
+        result.query_result = query_once(encoder, result.output_data);
+        if (result.output_data) {
+          output_list.push_back(result.output_data);
+          result.output_data = nullptr;
+          break;
+        }
+        sleep_if_needed(false);
+      }
+    }
+
+    result.submit_result = encoder->SubmitInput(surface);
+    if (is_input_exhausted(result.submit_result)) {
+      for (int retry = 0; retry < AVCODEC_SUBMIT_RETRY_MAX && is_input_exhausted(result.submit_result); ++retry) {
+        ::amf::AMFDataPtr drain_data;
+        result.query_result = query_once(encoder, drain_data);
+        if (drain_data) {
+          output_list.push_back(drain_data);
+        }
+        else {
+          sleep_if_needed(false);
+        }
+        result.submit_result = encoder->SubmitInput(surface);
+      }
+
+      if (is_input_exhausted(result.submit_result)) {
+        result.input_exhausted = true;
+        return result;
+      }
+    }
+
+    if (result.submit_result == AMF_NEED_MORE_INPUT) {
+      result.submitted = true;
+      result.need_more_input = true;
+      ++hwsurfaces_in_queue;
+      return result;
+    }
+
+    if (result.submit_result != AMF_OK) {
+      return result;
+    }
+
+    result.submitted = true;
+    ++hwsurfaces_in_queue;
+
+    if (!output_list.empty()) {
+      // Unlike libavcodec receive_packet(), Sunshine has already handed us the
+      // current input frame. Submit it first, then return previously drained
+      // output so we do not silently skip the current surface.
+      result.output_data = output_list.front();
+      output_list.pop_front();
+      return result;
+    }
+
+    for (int poll = 0; poll < AVCODEC_OUTPUT_POLL_MAX; ++poll) {
+      result.query_result = query_once(encoder, result.output_data);
+      if (result.output_data || (result.query_result != AMF_REPEAT && result.query_result != AMF_NEED_MORE_INPUT)) {
+        break;
+      }
+      sleep_if_needed(false);
+    }
+
+    return result;
+  }
 
   amf_avcodec_compat_result
   amf_avcodec_compat::configure(::amf::AMFComponent *encoder,

--- a/src/amf/amf_avcodec_compat.cpp
+++ b/src/amf/amf_avcodec_compat.cpp
@@ -1,0 +1,237 @@
+/**
+ * @file src/amf/amf_avcodec_compat.cpp
+ * @brief libavcodec AMF compatibility adapter for the standalone AMF encoder.
+ */
+
+#include "amf_avcodec_compat.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+
+#include <AMF/components/VideoEncoderAV1.h>
+#include <AMF/components/VideoEncoderHEVC.h>
+#include <AMF/components/VideoEncoderVCE.h>
+
+#include "src/logging.h"
+
+namespace amf {
+
+  namespace {
+
+    struct avcodec_context_like_t {
+      int64_t bit_rate = 0;
+      int64_t rc_max_rate = 0;
+      int64_t rc_buffer_size = 0;
+      int gop_size = std::numeric_limits<int>::max();
+      int async_depth = 16;
+    };
+
+    avcodec_context_like_t
+    make_avcodec_context_like(const video::config_t &client_config) {
+      avcodec_context_like_t ctx;
+      ctx.bit_rate = static_cast<int64_t>(client_config.bitrate) * 1000;
+      ctx.rc_max_rate = ctx.bit_rate;
+      ctx.rc_buffer_size = amf_avcodec_compat::vbv_buffer_size(client_config.bitrate, client_config);
+      return ctx;
+    }
+
+    int
+    auto_rc_h264(const amf_config &config, const avcodec_context_like_t &ctx) {
+      if (config.rc_mode) return *config.rc_mode;
+      if (ctx.bit_rate > 0 && ctx.rc_max_rate == ctx.bit_rate) {
+        return AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_CBR;
+      }
+      return AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_PEAK_CONSTRAINED_VBR;
+    }
+
+    int
+    auto_rc_hevc(const amf_config &config, const avcodec_context_like_t &ctx) {
+      if (config.rc_mode) return *config.rc_mode;
+      if (ctx.bit_rate > 0 && ctx.rc_max_rate == ctx.bit_rate) {
+        return AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_CBR;
+      }
+      return AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_PEAK_CONSTRAINED_VBR;
+    }
+
+    int
+    auto_rc_av1(const amf_config &config, const avcodec_context_like_t &ctx) {
+      if (config.rc_mode) return *config.rc_mode;
+      if (ctx.bit_rate > 0 && ctx.rc_max_rate == ctx.bit_rate) {
+        return AMF_VIDEO_ENCODER_AV1_RATE_CONTROL_METHOD_CBR;
+      }
+      return AMF_VIDEO_ENCODER_AV1_RATE_CONTROL_METHOD_PEAK_CONSTRAINED_VBR;
+    }
+
+    void
+    configure_h264(::amf::AMFComponent *encoder,
+      const amf_config &config,
+      const avcodec_context_like_t &ctx,
+      const video::config_t &client_config,
+      AMFRate framerate) {
+      if (config.usage) encoder->SetProperty(AMF_VIDEO_ENCODER_USAGE, (amf_int64) *config.usage);
+      if (config.quality_preset) encoder->SetProperty(AMF_VIDEO_ENCODER_QUALITY_PRESET, (amf_int64) *config.quality_preset);
+
+      const auto rc_mode = auto_rc_h264(config, ctx);
+      encoder->SetProperty(AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD, (amf_int64) rc_mode);
+      if (rc_mode == AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_QUALITY_VBR && config.qvbr_quality_level) {
+        encoder->SetProperty(AMF_VIDEO_ENCODER_QVBR_QUALITY_LEVEL, (amf_int64) *config.qvbr_quality_level);
+      }
+      if (config.high_motion_quality_boost_enable) {
+        encoder->SetProperty(AMF_VIDEO_ENCODER_HIGH_MOTION_QUALITY_BOOST_ENABLE, *config.high_motion_quality_boost_enable);
+      }
+      if (ctx.rc_buffer_size) encoder->SetProperty(AMF_VIDEO_ENCODER_VBV_BUFFER_SIZE, ctx.rc_buffer_size);
+      if (ctx.bit_rate) encoder->SetProperty(AMF_VIDEO_ENCODER_TARGET_BITRATE, ctx.bit_rate);
+      if (rc_mode == AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_CBR && ctx.bit_rate) {
+        encoder->SetProperty(AMF_VIDEO_ENCODER_PEAK_BITRATE, ctx.bit_rate);
+      }
+      if (ctx.rc_max_rate) encoder->SetProperty(AMF_VIDEO_ENCODER_PEAK_BITRATE, ctx.rc_max_rate);
+
+      encoder->SetProperty(AMF_VIDEO_ENCODER_FRAMERATE, framerate);
+      if (config.enforce_hrd) encoder->SetProperty(AMF_VIDEO_ENCODER_ENFORCE_HRD, !!(*config.enforce_hrd));
+      encoder->SetProperty(AMF_VIDEO_ENCODER_IDR_PERIOD, (amf_int64) ctx.gop_size);
+      encoder->SetProperty(AMF_VIDEO_ENCODER_DE_BLOCKING_FILTER, true);
+      if (config.preanalysis) encoder->SetProperty(AMF_VIDEO_ENCODER_PRE_ANALYSIS_ENABLE, !!(*config.preanalysis));
+      if (config.vbaq) encoder->SetProperty(AMF_VIDEO_ENCODER_ENABLE_VBAQ, !!(*config.vbaq));
+      encoder->SetProperty(AMF_VIDEO_ENCODER_B_PIC_PATTERN, (amf_int64) 0);
+      if (config.lowlatency_mode) encoder->SetProperty(AMF_VIDEO_ENCODER_LOWLATENCY_MODE, !!(*config.lowlatency_mode));
+      encoder->SetProperty(AMF_VIDEO_ENCODER_QUERY_TIMEOUT, (amf_int64) 1);
+      if (config.intra_refresh_mbs) {
+        encoder->SetProperty(AMF_VIDEO_ENCODER_INTRA_REFRESH_NUM_MBS_PER_SLOT, (amf_int64) *config.intra_refresh_mbs);
+      }
+      if (client_config.slicesPerFrame > 1) {
+        encoder->SetProperty(AMF_VIDEO_ENCODER_SLICES_PER_FRAME, (amf_int64) client_config.slicesPerFrame);
+      }
+      if (config.h264_coding_mode && *config.h264_coding_mode != AMF_VIDEO_ENCODER_UNDEFINED) {
+        encoder->SetProperty(AMF_VIDEO_ENCODER_CABAC_ENABLE, (amf_int64) *config.h264_coding_mode);
+      }
+    }
+
+    void
+    configure_hevc(::amf::AMFComponent *encoder,
+      const amf_config &config,
+      const video::config_t &client_config,
+      const video::sunshine_colorspace_t &colorspace,
+      const avcodec_context_like_t &ctx,
+      AMFRate framerate) {
+      if (config.usage) encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_USAGE, (amf_int64) *config.usage);
+      if (config.quality_preset) encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_QUALITY_PRESET, (amf_int64) *config.quality_preset);
+
+      const auto rc_mode = auto_rc_hevc(config, ctx);
+      encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD, (amf_int64) rc_mode);
+      if (rc_mode == AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_QUALITY_VBR && config.qvbr_quality_level) {
+        encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_QVBR_QUALITY_LEVEL, (amf_int64) *config.qvbr_quality_level);
+      }
+      if (config.high_motion_quality_boost_enable) {
+        encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_HIGH_MOTION_QUALITY_BOOST_ENABLE, *config.high_motion_quality_boost_enable);
+      }
+      if (ctx.rc_buffer_size) encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_VBV_BUFFER_SIZE, ctx.rc_buffer_size);
+      if (ctx.bit_rate) encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_TARGET_BITRATE, ctx.bit_rate);
+      if (rc_mode == AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_CBR && ctx.bit_rate) {
+        encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_PEAK_BITRATE, ctx.bit_rate);
+      }
+      if (ctx.rc_max_rate) encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_PEAK_BITRATE, ctx.rc_max_rate);
+
+      encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_FRAMERATE, framerate);
+      if (config.enforce_hrd) encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_ENFORCE_HRD, !!(*config.enforce_hrd));
+      encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_NUM_GOPS_PER_IDR, (amf_int64) 1);
+      encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_GOP_SIZE, (amf_int64) ctx.gop_size);
+      if (config.preanalysis) encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_PRE_ANALYSIS_ENABLE, !!(*config.preanalysis));
+      if (config.vbaq) encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_ENABLE_VBAQ, !!(*config.vbaq));
+      if (config.lowlatency_mode) encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_LOWLATENCY_MODE, !!(*config.lowlatency_mode));
+      encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_QUERY_TIMEOUT, (amf_int64) 1);
+      encoder->SetProperty(
+        AMF_VIDEO_ENCODER_HEVC_PROFILE,
+        (amf_int64) (colorspace.bit_depth == 10 ? AMF_VIDEO_ENCODER_HEVC_PROFILE_MAIN_10 : AMF_VIDEO_ENCODER_HEVC_PROFILE_MAIN));
+      if (config.intra_refresh_mbs) {
+        encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_INTRA_REFRESH_NUM_CTBS_PER_SLOT, (amf_int64) *config.intra_refresh_mbs);
+      }
+      if (client_config.slicesPerFrame > 1) {
+        encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_SLICES_PER_FRAME, (amf_int64) client_config.slicesPerFrame);
+      }
+    }
+
+    void
+    configure_av1(::amf::AMFComponent *encoder,
+      const amf_config &config,
+      const avcodec_context_like_t &ctx,
+      AMFRate framerate) {
+      if (config.usage) encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_USAGE, (amf_int64) *config.usage);
+      if (config.quality_preset) encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_QUALITY_PRESET, (amf_int64) *config.quality_preset);
+
+      const auto rc_mode = auto_rc_av1(config, ctx);
+      encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_RATE_CONTROL_METHOD, (amf_int64) rc_mode);
+      if (rc_mode == AMF_VIDEO_ENCODER_AV1_RATE_CONTROL_METHOD_QUALITY_VBR && config.qvbr_quality_level) {
+        encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_QVBR_QUALITY_LEVEL, (amf_int64) *config.qvbr_quality_level);
+      }
+      if (config.high_motion_quality_boost_enable) {
+        encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_HIGH_MOTION_QUALITY_BOOST, *config.high_motion_quality_boost_enable);
+      }
+      if (ctx.rc_buffer_size) encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_VBV_BUFFER_SIZE, ctx.rc_buffer_size);
+      if (ctx.bit_rate) encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_TARGET_BITRATE, ctx.bit_rate);
+      if (rc_mode == AMF_VIDEO_ENCODER_AV1_RATE_CONTROL_METHOD_CBR && ctx.bit_rate) {
+        encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_PEAK_BITRATE, ctx.bit_rate);
+      }
+      if (ctx.rc_max_rate) encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_PEAK_BITRATE, ctx.rc_max_rate);
+
+      encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_FRAMERATE, framerate);
+      if (config.enforce_hrd) encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_ENFORCE_HRD, !!(*config.enforce_hrd));
+      encoder->SetProperty(
+        AMF_VIDEO_ENCODER_AV1_ALIGNMENT_MODE,
+        (amf_int64) AMF_VIDEO_ENCODER_AV1_ALIGNMENT_MODE_NO_RESTRICTIONS);
+      encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_GOP_SIZE, (amf_int64) ctx.gop_size);
+      if (config.preanalysis) encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_PRE_ANALYSIS_ENABLE, !!(*config.preanalysis));
+      if (config.av1_encoding_latency_mode) {
+        encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_ENCODING_LATENCY_MODE, (amf_int64) *config.av1_encoding_latency_mode);
+      }
+      encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_QUERY_TIMEOUT, (amf_int64) 1);
+    }
+
+  }  // namespace
+
+  amf_avcodec_compat_result
+  amf_avcodec_compat::configure(::amf::AMFComponent *encoder,
+    int video_format,
+    const amf_config &config,
+    const video::config_t &client_config,
+    const video::sunshine_colorspace_t &colorspace) {
+    auto ctx = make_avcodec_context_like(client_config);
+    auto framerate = AMFConstructRate(client_config.framerate, 1);
+    auto async_depth = config.input_queue_size.value_or(ctx.async_depth);
+
+    if (config.pa_lookahead_depth && *config.pa_lookahead_depth >= async_depth) {
+      async_depth = *config.pa_lookahead_depth + 1;
+      BOOST_LOG(warning) << "AMF: AVCodec compatibility async_depth raised to " << async_depth
+                         << " to exceed PA lookahead depth " << *config.pa_lookahead_depth;
+    }
+
+    switch (video_format) {
+      case 0:
+        configure_h264(encoder, config, ctx, client_config, framerate);
+        break;
+      case 1:
+        configure_hevc(encoder, config, client_config, colorspace, ctx, framerate);
+        break;
+      default:
+        configure_av1(encoder, config, ctx, framerate);
+        break;
+    }
+
+    BOOST_LOG(info) << "AMF: AVCodec compatibility layer loaded"
+                    << " (async_depth=" << async_depth
+                    << ", rc_buffer=" << ctx.rc_buffer_size << ")";
+
+    return {
+      async_depth,
+      true,
+    };
+  }
+
+  int64_t
+  amf_avcodec_compat::vbv_buffer_size(int bitrate_kbps, const video::config_t &client_config) {
+    const auto bitrate = static_cast<int64_t>(bitrate_kbps) * 1000;
+    const auto effective_fps = std::max(client_config.get_effective_framerate(), 1.0);
+    return std::max<int64_t>(static_cast<int64_t>(bitrate / effective_fps), 1);
+  }
+
+}  // namespace amf

--- a/src/amf/amf_avcodec_compat.cpp
+++ b/src/amf/amf_avcodec_compat.cpp
@@ -313,6 +313,11 @@ namespace amf {
         }
         sleep_if_needed(false);
       }
+      if (hwsurfaces_in_queue >= hwsurfaces_in_queue_max) {
+        result.submit_result = AMF_INPUT_FULL;
+        result.input_exhausted = true;
+        return result;
+      }
     }
 
     result.submit_result = encoder->SubmitInput(surface);

--- a/src/amf/amf_avcodec_compat.h
+++ b/src/amf/amf_avcodec_compat.h
@@ -1,0 +1,34 @@
+/**
+ * @file src/amf/amf_avcodec_compat.h
+ * @brief libavcodec AMF compatibility adapter for the standalone AMF encoder.
+ */
+#pragma once
+
+#include "amf_config.h"
+
+#include "src/video.h"
+
+#include <AMF/components/Component.h>
+#include <AMF/core/Context.h>
+
+namespace amf {
+
+  struct amf_avcodec_compat_result {
+    int hwsurfaces_in_queue_max = 16;
+    bool manages_rate_control = true;
+  };
+
+  class amf_avcodec_compat {
+  public:
+    static amf_avcodec_compat_result
+    configure(::amf::AMFComponent *encoder,
+      int video_format,
+      const amf_config &config,
+      const video::config_t &client_config,
+      const video::sunshine_colorspace_t &colorspace);
+
+    static int64_t
+    vbv_buffer_size(int bitrate_kbps, const video::config_t &client_config);
+  };
+
+}  // namespace amf

--- a/src/amf/amf_avcodec_compat.h
+++ b/src/amf/amf_avcodec_compat.h
@@ -10,6 +10,10 @@
 
 #include <AMF/components/Component.h>
 #include <AMF/core/Context.h>
+#include <AMF/core/Data.h>
+#include <AMF/core/Surface.h>
+
+#include <deque>
 
 namespace amf {
 
@@ -17,6 +21,45 @@ namespace amf {
     int hwsurfaces_in_queue_max = 16;
     bool manages_rate_control = true;
     AMF_RESULT result = AMF_OK;
+  };
+
+  struct amf_avcodec_scheduler_result {
+    AMF_RESULT submit_result = AMF_OK;
+    AMF_RESULT query_result = AMF_OK;
+    ::amf::AMFDataPtr output_data;
+    bool submitted = false;
+    bool need_more_input = false;
+    bool input_exhausted = false;
+  };
+
+  class amf_avcodec_scheduler {
+  public:
+    void
+    configure(int hwsurfaces_in_queue_max, bool query_timeout_supported);
+
+    void
+    reset();
+
+    int
+    in_flight() const;
+
+    amf_avcodec_scheduler_result
+    submit_and_query(::amf::AMFComponent *encoder, const ::amf::AMFSurfacePtr &surface);
+
+  private:
+    AMF_RESULT
+    query_once(::amf::AMFComponent *encoder, ::amf::AMFDataPtr &output_data);
+
+    void
+    sleep_if_needed(bool already_have_output) const;
+
+    void
+    decrement_in_flight();
+
+    std::deque<::amf::AMFDataPtr> output_list;
+    int hwsurfaces_in_queue = 0;
+    int hwsurfaces_in_queue_max = 16;
+    bool query_timeout_supported = false;
   };
 
   class amf_avcodec_compat {

--- a/src/amf/amf_avcodec_compat.h
+++ b/src/amf/amf_avcodec_compat.h
@@ -16,6 +16,7 @@ namespace amf {
   struct amf_avcodec_compat_result {
     int hwsurfaces_in_queue_max = 16;
     bool manages_rate_control = true;
+    AMF_RESULT result = AMF_OK;
   };
 
   class amf_avcodec_compat {

--- a/src/amf/amf_config.h
+++ b/src/amf/amf_config.h
@@ -34,6 +34,11 @@ namespace amf {
    * Integer values correspond directly to AMF SDK enum values.
    */
   struct amf_config {
+    // Optional compatibility adapter for the standalone AMF encoder. When
+    // enabled, AMF properties are derived from AVCodecContext-like state and
+    // FFmpeg amfenc behavior; when disabled, the standalone path stays clean.
+    bool avcodec_compat = false;
+
     // Usage preset (AMF_VIDEO_ENCODER_USAGE_ENUM values)
     std::optional<int> usage;
 
@@ -49,8 +54,11 @@ namespace amf {
     // VBAQ enable
     std::optional<int> vbaq;
 
-    // H.264 entropy coding (0=CAVLC, 1=CABAC)
+    // H.264 entropy coding used by the standalone path (0=CAVLC, 1=CABAC).
     int h264_cabac = 1;
+    // H.264 AVCodec-style coding mode. Nullopt means coder=auto, so the
+    // compatibility adapter does not set AMF_VIDEO_ENCODER_CABAC_ENABLE.
+    std::optional<int> h264_coding_mode;
 
     // Enforce HRD
     std::optional<int> enforce_hrd;
@@ -125,12 +133,12 @@ namespace amf {
     // but exposing it lets users disable it as a workaround for driver bugs.
     std::optional<bool> lowlatency_mode;
 
-    // --- Input Queue Size (async_depth) ---
-    // Default nullopt = do not set the property; AMD driver default ~16,
-    // matches FFmpeg amfenc default. Sunshine historically forced 1 for
-    // minimum latency, but that is the most fragile code path inside the
-    // driver. Users can opt-in to 1 for absolute lowest latency or larger
-    // values (4/8/16) as a workaround for driver freezes.
+    // --- Input Queue Size / async_depth ---
+    // Standalone path: optional AMF INPUT_QUEUE_SIZE property.
+    // AVCodec compatibility path: FFmpeg-style async_depth / in-flight surface
+    // cap, default 16, with no AMF INPUT_QUEUE_SIZE property set. Sunshine
+    // historically forced AMF INPUT_QUEUE_SIZE=1 for minimum latency, but that
+    // is the most fragile code path inside the driver.
     std::optional<int> input_queue_size;
   };
 

--- a/src/amf/amf_d3d11.cpp
+++ b/src/amf/amf_d3d11.cpp
@@ -5,6 +5,8 @@
 
 #include "amf_d3d11.h"
 
+#include "amf_avcodec_compat.h"
+
 #include <chrono>
 #include <thread>
 
@@ -130,10 +132,9 @@ namespace amf {
     const video::sunshine_colorspace_t &colorspace) {
     auto bitrate = static_cast<int64_t>(client_config.bitrate) * 1000;
     auto framerate = AMFConstructRate(client_config.framerate, 1);
-    // Match FFmpeg's default AMF path: set only target bitrate unless the user
-    // explicitly selects a rate-control mode. In that opt-in path, keep the
-    // legacy Sunshine peak/VBV constraints paired with the selected RC mode.
+    avcodec_compat_profile = config.avcodec_compat;
     user_configured_rate_control = config.rc_mode.has_value();
+    hwsurfaces_in_queue_max = HWSURFACES_IN_QUEUE_DEFAULT;
 
     auto configure_multi_hw_instance = [&](const wchar_t *multi_hw_property,
                                            const wchar_t *sav_property,
@@ -170,7 +171,118 @@ namespace amf {
       }
     };
 
-    if (video_format == 0) {
+    auto apply_standalone_feature_overlay = [&]() {
+      max_ltr_frames = config.max_ltr_frames;
+      if (max_ltr_frames > 0) {
+        if (video_format == 0) {
+          encoder->SetProperty(AMF_VIDEO_ENCODER_MAX_LTR_FRAMES, (amf_int64) max_ltr_frames);
+          encoder->SetProperty(AMF_VIDEO_ENCODER_LTR_MODE, (amf_int64) AMF_VIDEO_ENCODER_LTR_MODE_RESET_UNUSED);
+        }
+        else if (video_format == 1) {
+          encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_MAX_LTR_FRAMES, (amf_int64) max_ltr_frames);
+          encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_LTR_MODE, (amf_int64) AMF_VIDEO_ENCODER_HEVC_LTR_MODE_RESET_UNUSED);
+        }
+        else {
+          encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_MAX_LTR_FRAMES, (amf_int64) max_ltr_frames);
+          encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_LTR_MODE, (amf_int64) AMF_VIDEO_ENCODER_AV1_LTR_MODE_RESET_UNUSED);
+        }
+      }
+
+      if (video_format == 2) {
+        if (config.av1_screen_content_tools) {
+          encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_SCREEN_CONTENT_TOOLS, *config.av1_screen_content_tools);
+        }
+        if (config.av1_palette_mode) {
+          encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_PALETTE_MODE, *config.av1_palette_mode);
+        }
+        if (config.av1_force_integer_mv) {
+          encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_FORCE_INTEGER_MV, *config.av1_force_integer_mv);
+        }
+        if (config.av1_intra_refresh_mode) {
+          encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_INTRA_REFRESH_MODE, (amf_int64) *config.av1_intra_refresh_mode);
+          if (config.av1_intra_refresh_stripes) {
+            encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_INTRAREFRESH_STRIPES, (amf_int64) *config.av1_intra_refresh_stripes);
+          }
+        }
+        if (client_config.slicesPerFrame > 1) {
+          encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_TILES_PER_FRAME, (amf_int64) client_config.slicesPerFrame);
+        }
+      }
+
+      if (config.enable_statistics_feedback) {
+        set_codec_property(
+          AMF_VIDEO_ENCODER_STATISTICS_FEEDBACK,
+          AMF_VIDEO_ENCODER_HEVC_STATISTICS_FEEDBACK,
+          AMF_VIDEO_ENCODER_AV1_STATISTICS_FEEDBACK,
+          true);
+      }
+      if (config.enable_psnr_feedback) {
+        set_codec_property(
+          AMF_VIDEO_ENCODER_PSNR_FEEDBACK,
+          AMF_VIDEO_ENCODER_HEVC_PSNR_FEEDBACK,
+          AMF_VIDEO_ENCODER_AV1_PSNR_FEEDBACK,
+          true);
+      }
+      if (config.enable_ssim_feedback) {
+        set_codec_property(
+          AMF_VIDEO_ENCODER_SSIM_FEEDBACK,
+          AMF_VIDEO_ENCODER_HEVC_SSIM_FEEDBACK,
+          AMF_VIDEO_ENCODER_AV1_SSIM_FEEDBACK,
+          true);
+      }
+    };
+
+    auto apply_avcodec_sav_latency = [&]() {
+      if (!config.multi_hw_instance_encode || !*config.multi_hw_instance_encode) return;
+
+      if (video_format == 0) {
+        encoder->SetProperty(AMF_VIDEO_ENCODER_LOWLATENCY_MODE, true);
+      }
+      else if (video_format == 1) {
+        if (!config.lowlatency_mode) {
+          encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_LOWLATENCY_MODE, true);
+        }
+      }
+      else {
+        if (!config.av1_encoding_latency_mode) {
+          encoder->SetProperty(
+            AMF_VIDEO_ENCODER_AV1_ENCODING_LATENCY_MODE,
+            (amf_int64) AMF_VIDEO_ENCODER_AV1_ENCODING_LATENCY_MODE_LOWEST_LATENCY);
+        }
+      }
+    };
+
+    if (avcodec_compat_profile) {
+      auto compat = amf_avcodec_compat::configure(encoder, video_format, config, client_config, colorspace);
+      hwsurfaces_in_queue_max = compat.hwsurfaces_in_queue_max;
+      user_configured_rate_control = compat.manages_rate_control;
+
+      if (video_format == 0) {
+        configure_multi_hw_instance(
+          nullptr,
+          AMF_VIDEO_ENCODER_ENABLE_SMART_ACCESS_VIDEO,
+          AMF_VIDEO_ENCODER_CAP_NUM_OF_HW_INSTANCES,
+          AMF_VIDEO_ENCODER_CAP_SUPPORT_SMART_ACCESS_VIDEO);
+      }
+      else if (video_format == 1) {
+        configure_multi_hw_instance(
+          AMF_VIDEO_ENCODER_HEVC_MULTI_HW_INSTANCE_ENCODE,
+          AMF_VIDEO_ENCODER_HEVC_ENABLE_SMART_ACCESS_VIDEO,
+          AMF_VIDEO_ENCODER_HEVC_CAP_NUM_OF_HW_INSTANCES,
+          AMF_VIDEO_ENCODER_HEVC_CAP_SUPPORT_SMART_ACCESS_VIDEO);
+      }
+      else {
+        configure_multi_hw_instance(
+          AMF_VIDEO_ENCODER_AV1_MULTI_HW_INSTANCE_ENCODE,
+          AMF_VIDEO_ENCODER_AV1_ENABLE_SMART_ACCESS_VIDEO,
+          AMF_VIDEO_ENCODER_AV1_CAP_NUM_OF_HW_INSTANCES,
+          AMF_VIDEO_ENCODER_AV1_CAP_SUPPORT_SMART_ACCESS_VIDEO);
+      }
+
+      apply_avcodec_sav_latency();
+      apply_standalone_feature_overlay();
+    }
+    else if (video_format == 0) {
       // H.264
       if (config.usage) encoder->SetProperty(AMF_VIDEO_ENCODER_USAGE, (amf_int64) *config.usage);
       if (config.quality_preset) encoder->SetProperty(AMF_VIDEO_ENCODER_QUALITY_PRESET, (amf_int64) *config.quality_preset);
@@ -268,15 +380,10 @@ namespace amf {
       encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_FRAMERATE, framerate);
       if (config.enforce_hrd) encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_ENFORCE_HRD, !!(*config.enforce_hrd));
       encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_NUM_GOPS_PER_IDR, (amf_int64) 1);
-      // Match FFmpeg hevc_amf default behavior (-g -1 -> AMF default GOP size 60).
-      // A GOP size of 0 disables automatic IDRs, which leaves long-running HEVC
-      // streams without periodic encoder state refresh on RDNA4.
       encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_GOP_SIZE, (amf_int64) 60);
       encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_HEADER_INSERTION_MODE, (amf_int64) AMF_VIDEO_ENCODER_HEVC_HEADER_INSERTION_MODE_IDR_ALIGNED);
       if (config.preanalysis) encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_PRE_ANALYSIS_ENABLE, !!(*config.preanalysis));
       if (config.vbaq) encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_ENABLE_VBAQ, !!(*config.vbaq));
-      // LOWLATENCY_MODE and INPUT_QUEUE_SIZE: only set when user opts in.
-      // See H.264 block above for rationale (FFmpeg-aligned default behavior).
       if (config.lowlatency_mode) encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_LOWLATENCY_MODE, !!(*config.lowlatency_mode));
       if (config.input_queue_size) encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_INPUT_QUEUE_SIZE, (amf_int64) *config.input_queue_size);
       configure_multi_hw_instance(
@@ -871,7 +978,7 @@ namespace amf {
     // path (4K144 HDR, transient VCN stall, DXGI scheduling jitter) which on
     // some AMD GPUs has been observed to wedge the pipeline until the client
     // disconnects (frame frozen, audio still flowing).
-    if (hwsurfaces_in_queue >= HWSURFACES_IN_QUEUE_MAX) {
+    if (hwsurfaces_in_queue >= hwsurfaces_in_queue_max) {
       ::amf::AMFDataPtr drain_data;
       encoder->QueryOutput(&drain_data);
       if (drain_data) {
@@ -1104,27 +1211,28 @@ namespace amf {
     if (!encoder) return;
 
     auto bitrate = static_cast<int64_t>(bitrate_kbps) * 1000;
+    auto vbv_size = avcodec_compat_profile ? amf_avcodec_compat::vbv_buffer_size(bitrate_kbps, current_config) : bitrate;
     AMF_RESULT res;
 
     if (video_format == 0) {
       res = encoder->SetProperty(AMF_VIDEO_ENCODER_TARGET_BITRATE, bitrate);
       if (user_configured_rate_control) {
         encoder->SetProperty(AMF_VIDEO_ENCODER_PEAK_BITRATE, bitrate);
-        encoder->SetProperty(AMF_VIDEO_ENCODER_VBV_BUFFER_SIZE, bitrate);
+        encoder->SetProperty(AMF_VIDEO_ENCODER_VBV_BUFFER_SIZE, vbv_size);
       }
     }
     else if (video_format == 1) {
       res = encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_TARGET_BITRATE, bitrate);
       if (user_configured_rate_control) {
         encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_PEAK_BITRATE, bitrate);
-        encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_VBV_BUFFER_SIZE, bitrate);
+        encoder->SetProperty(AMF_VIDEO_ENCODER_HEVC_VBV_BUFFER_SIZE, vbv_size);
       }
     }
     else {
       res = encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_TARGET_BITRATE, bitrate);
       if (user_configured_rate_control) {
         encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_PEAK_BITRATE, bitrate);
-        encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_VBV_BUFFER_SIZE, bitrate);
+        encoder->SetProperty(AMF_VIDEO_ENCODER_AV1_VBV_BUFFER_SIZE, vbv_size);
       }
     }
 

--- a/src/amf/amf_d3d11.cpp
+++ b/src/amf/amf_d3d11.cpp
@@ -773,6 +773,12 @@ namespace amf {
       auto qt_res = encoder->GetProperty(qt_prop, &qt_val);
       query_timeout_supported = (qt_res == AMF_OK && qt_val > 0);
       BOOST_LOG(info) << "AMF: QUERY_TIMEOUT " << (query_timeout_supported ? "supported" : "not supported") << " (value=" << qt_val << ")";
+      avcodec_scheduler.configure(hwsurfaces_in_queue_max, query_timeout_supported);
+      if (avcodec_compat_profile) {
+        BOOST_LOG(info) << "AMF: AVCodec compatibility scheduler ready"
+                        << " (hwsurfaces_in_queue_max=" << hwsurfaces_in_queue_max
+                        << ", query_timeout=" << (query_timeout_supported ? "yes" : "no") << ")";
+      }
     }
 
     // Create input texture for the rendering pipeline to write to.
@@ -827,6 +833,7 @@ namespace amf {
     current_ltr_slot = 0;
     rfi_pending = false;
     hwsurfaces_in_queue = 0;
+    avcodec_scheduler.reset();
     consecutive_submit_failures = 0;
     consecutive_empty_outputs = 0;
 
@@ -845,6 +852,7 @@ namespace amf {
     pending_outputs.clear();
     frame_rfi_flags.clear();
     hwsurfaces_in_queue = 0;
+    avcodec_scheduler.reset();
     if (encoder) {
       encoder->Terminate();
       encoder = nullptr;
@@ -977,6 +985,59 @@ namespace amf {
 
     frame_rfi_flags[frame_index] = frame_after_ref_frame_invalidation;
 
+    ::amf::AMFDataPtr output_data;
+    if (avcodec_compat_profile) {
+      auto compat = avcodec_scheduler.submit_and_query(encoder, surface);
+      res = compat.submit_result;
+
+      if (compat.input_exhausted) {
+        BOOST_LOG(warning) << "AMF: AVCodec scheduler SubmitInput still "
+                           << (res == AMF_INPUT_FULL ? "AMF_INPUT_FULL" : "AMF_DECODER_NO_FREE_SURFACES")
+                           << " after retries, dropping frame " << frame_index
+                           << " (in_flight=" << avcodec_scheduler.in_flight() << ")";
+        frame_rfi_flags.erase(frame_index);
+        if (++consecutive_submit_failures >= max_consecutive_failures) {
+          BOOST_LOG(error) << "AMF: " << consecutive_submit_failures
+                           << " consecutive frames with AVCodec scheduler input exhaustion, signaling reinit";
+          result.fatal = true;
+        }
+        return result;
+      }
+
+      if (compat.need_more_input) {
+        consecutive_submit_failures = 0;
+        return result;
+      }
+
+      if (res != AMF_OK) {
+        BOOST_LOG(error) << "AMF: AVCodec scheduler SubmitInput failed, error: " << res;
+        frame_rfi_flags.erase(frame_index);
+        if (device) {
+          auto removed_reason = device->GetDeviceRemovedReason();
+          if (removed_reason != S_OK) {
+            BOOST_LOG(error) << "AMF: D3D11 device lost after SubmitInput, reason: 0x" << util::hex(removed_reason).to_string_view();
+            result.fatal = true;
+            return result;
+          }
+        }
+        if (++consecutive_submit_failures >= max_consecutive_failures) {
+          BOOST_LOG(error) << "AMF: " << consecutive_submit_failures << " consecutive AVCodec scheduler SubmitInput failures, signaling reinit";
+          result.fatal = true;
+        }
+        return result;
+      }
+
+      consecutive_submit_failures = 0;
+      output_data = compat.output_data;
+      if (!output_data) {
+        if (++consecutive_empty_outputs >= max_consecutive_failures) {
+          BOOST_LOG(error) << "AMF: " << consecutive_empty_outputs << " consecutive frames with no AVCodec scheduler output, signaling reinit";
+          result.fatal = true;
+        }
+        return result;
+      }
+    }
+    else {
     // FFmpeg-style proactive backpressure: if we already have many surfaces
     // in flight, drain one output BEFORE SubmitInput to avoid AMF_INPUT_FULL
     // entirely. This eliminates the tight retry spin in the common overrun
@@ -1068,7 +1129,6 @@ namespace amf {
     ++hwsurfaces_in_queue;
 
     // Query output — if we already drained output during SubmitInput retry, use that
-    ::amf::AMFDataPtr output_data;
     if (!pending_outputs.empty()) {
       output_data = pending_outputs.front();
       pending_outputs.pop_front();
@@ -1097,6 +1157,7 @@ namespace amf {
         return result;
       }
       --hwsurfaces_in_queue;
+    }
     }
     consecutive_empty_outputs = 0;
 

--- a/src/amf/amf_d3d11.cpp
+++ b/src/amf/amf_d3d11.cpp
@@ -236,7 +236,9 @@ namespace amf {
       if (!config.multi_hw_instance_encode || !*config.multi_hw_instance_encode) return;
 
       if (video_format == 0) {
-        encoder->SetProperty(AMF_VIDEO_ENCODER_LOWLATENCY_MODE, true);
+        if (!config.lowlatency_mode || *config.lowlatency_mode) {
+          encoder->SetProperty(AMF_VIDEO_ENCODER_LOWLATENCY_MODE, true);
+        }
       }
       else if (video_format == 1) {
         if (!config.lowlatency_mode) {
@@ -254,6 +256,9 @@ namespace amf {
 
     if (avcodec_compat_profile) {
       auto compat = amf_avcodec_compat::configure(encoder, video_format, config, client_config, colorspace);
+      if (compat.result != AMF_OK) {
+        return false;
+      }
       hwsurfaces_in_queue_max = compat.hwsurfaces_in_queue_max;
       user_configured_rate_control = compat.manages_rate_control;
 

--- a/src/amf/amf_d3d11.h
+++ b/src/amf/amf_d3d11.h
@@ -4,6 +4,7 @@
  */
 #pragma once
 
+#include "amf_avcodec_compat.h"
 #include "amf_encoder.h"
 
 #include <d3d11.h>
@@ -121,6 +122,7 @@ namespace amf {
     int hwsurfaces_in_queue_max = HWSURFACES_IN_QUEUE_DEFAULT;
     bool user_configured_rate_control = false;
     bool avcodec_compat_profile = false;
+    amf_avcodec_scheduler avcodec_scheduler;
 
     // Statistics feedback state
     bool statistics_enabled = false;

--- a/src/amf/amf_d3d11.h
+++ b/src/amf/amf_d3d11.h
@@ -117,8 +117,10 @@ namespace amf {
     // 21 frames deep per FFmpeg's amfenc.c notes; we keep our soft cap well
     // below that to leave headroom for VCN stalls and DXGI scheduling jitter.
     int hwsurfaces_in_queue = 0;
-    static constexpr int HWSURFACES_IN_QUEUE_MAX = 16;
+    static constexpr int HWSURFACES_IN_QUEUE_DEFAULT = 16;
+    int hwsurfaces_in_queue_max = HWSURFACES_IN_QUEUE_DEFAULT;
     bool user_configured_rate_control = false;
+    bool avcodec_compat_profile = false;
 
     // Statistics feedback state
     bool statistics_enabled = false;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -432,6 +432,9 @@ namespace config {
       std::nullopt,  // vbaq: unset by default, matching FFmpeg amfenc
       (int) amd::coder_e::_auto,  // coder
       23,  // qvbr_quality (1-51, default 23)
+      0,  // ltr_frames
+      0,  // slices_per_frame
+      true,  // avcodec_compat: enable optional AVCodec-like adapter for validation
     },  // amd
 
     {
@@ -1233,6 +1236,7 @@ namespace config {
     int_between_f(vars, "amd_qvbr_quality", video.amd.amd_qvbr_quality, { 1, 51 });
     int_between_f(vars, "amd_ltr_frames", video.amd.amd_ltr_frames, { 0, 4 });
     int_between_f(vars, "amd_slices_per_frame", video.amd.amd_slices_per_frame, { 0, 4 });
+    bool_f(vars, "amd_avcodec_compat", video.amd.amd_avcodec_compat);
     bool_f(vars, "amd_multi_hw_instance", video.amd.amd_multi_hw_instance);
     // FFmpeg-aligned opt-in toggles (default nullopt = let AMD driver decide,
     // matches FFmpeg amfenc.c behavior of never setting the property unless

--- a/src/config.h
+++ b/src/config.h
@@ -77,6 +77,7 @@ namespace config {
       int amd_qvbr_quality = 23;  // QVBR quality level 1-51 (lower=better, default=23)
       int amd_ltr_frames = 0;  // LTR frames for RFI (0=disabled by default; matches FFmpeg amfenc behavior to avoid static-region color blocks)
       int amd_slices_per_frame = 0;  // Slices/tiles per frame (0=client decides, 1-4=minimum)
+      bool amd_avcodec_compat = true;  // Optional AVCodec-like AMF adapter; false keeps the clean standalone path.
       std::optional<bool> amd_multi_hw_instance;
       // The properties below historically had aggressive hardcoded defaults that
       // forced AMF code paths FFmpeg never touches (HIGH_MOTION_QUALITY_BOOST=on,
@@ -87,6 +88,7 @@ namespace config {
       // FFmpeg amfenc behavior. Users can still opt in via the WebUI.
       std::optional<bool> amd_high_motion_qb;
       std::optional<bool> amd_lowlatency_mode;
+      // Standalone: AMF INPUT_QUEUE_SIZE. AVCodec compatibility: async_depth cap.
       std::optional<int> amd_input_queue_size;   // 1-16
       std::optional<int> amd_av1_latency_mode;   // AMF_VIDEO_ENCODER_AV1_ENCODING_LATENCY_MODE_*
     } amd;

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -2574,6 +2574,7 @@ namespace platf::dxgi {
       if (!amf_d3d) return false;
 
       ::amf::amf_config amf_cfg;
+      amf_cfg.avcodec_compat = config::video.amd.amd_avcodec_compat;
 
       // Pass AMF SDK integer values directly from config
       if (client_config.videoFormat == 0) {
@@ -2605,6 +2606,9 @@ namespace platf::dxgi {
       amf_cfg.vbaq = config::video.amd.amd_vbaq;
       amf_cfg.enforce_hrd = config::video.amd.amd_enforce_hrd;
       amf_cfg.h264_cabac = (config::video.amd.amd_coder != 2);  // 2 = CAVLC
+      if (config::video.amd.amd_coder != 0) {  // 0 = auto / AMF_VIDEO_ENCODER_UNDEFINED
+        amf_cfg.h264_coding_mode = config::video.amd.amd_coder;
+      }
       amf_cfg.max_ltr_frames = config::video.amd.amd_ltr_frames;
 
       // Pre-Analysis sub-system defaults: enable PAQ + TAQ for better quality at same bitrate


### PR DESCRIPTION
﻿## 改了啥

- 新增独立 AMF AVCodec compatibility adapter，让 standalone AMF 可以按 FFmpeg/libavcodec 的 AMF 初始化习惯派生参数。
- 把 `amd_avcodec_compat` 从单纯参数开关扩到可插拔中间层：compat=true 时使用独立 AVCodec-like scheduler 管 SubmitInput / QueryOutput / in-flight surfaces / drained output list，compat=false 时继续走 native standalone 状态。
- 对齐最新 FFmpeg master `48f30aa08c473fb034f0a43313ad566a1ea7a3ed` 的 AMF 行为：`async_depth=16`、PA lookahead 队列抬升、AVCodec 风格 GOP/IDR、VBV=`bitrate/fps`、H.264 coder auto 不强制 CABAC、header/filler/skip/lowlatency 只在显式配置时写。
- compat 基础层之外，单独叠加 Sunshine standalone 新特性收益：multi-HW / Smart Access Video、LTR、AV1 screen content / palette / integer MV / intra refresh / tiles，以及 statistics/PSNR/SSIM feedback。

## 为啥要改

#763 里 Huawei P40 Pro + AMD AMF HEVC 1080p 有视频冻结但音频/手柄继续的问题。只继续调 standalone 参数很容易变成修一个设备、炸另一个设备。这里把“FFmpeg 成熟兼容性行为”和“Sunshine standalone 特性”拆成两层，减少杂鱼参数互相污染，也让后面继续补齐生命周期/调度行为有清楚落点。

## 验证

- 对照 FFmpeg master `libavcodec/amfenc*.c` 当前行为。
- 通过：`git diff --check`
- 通过：从 `build/compile_commands.json` 抽取 `src/amf/amf_avcodec_compat.cpp` 和 `src/amf/amf_d3d11.cpp` 的编译命令，并改成 `-fsyntax-only` 单独语法检查。
- 未完成本地完整 Ninja build：当前 MSYS2/GCC/Boost 环境在 unrelated Boost dependency objects 直接 code 1，没走到新增 AMF 文件。
