### PR TITLE
fix(upnp): report IGD status names

### DIFF
--- a/src/upnp.cpp
+++ b/src/upnp.cpp
@@ -3,6 +3,7 @@
  * @brief Definitions for UPnP port mapping.
  */
 #include <cstddef>
+#include <string>
 #include <miniupnpc/miniupnpc.h>
 #include <miniupnpc/upnpcommands.h>
 
@@ -31,20 +32,22 @@ namespace upnp {
     std::string description;
   };
 
-  static std::string_view
+  static std::string
   status_string(int status) {
     switch (status) {
-      case 0:
-        return "No IGD device found"sv;
-      case 1:
-        return "Valid IGD device found"sv;
-      case 2:
-        return "Valid IGD device found,  but it isn't connected"sv;
-      case 3:
-        return "A UPnP device has been found,  but it wasn't recognized as an IGD"sv;
+      case UPNP_NO_IGD:
+        return "No IGD device found"s;
+      case UPNP_CONNECTED_IGD:
+        return "Valid connected IGD device found"s;
+      case UPNP_PRIVATEIP_IGD:
+        return "Valid connected IGD device found, but its WAN address is private/non-routable"s;
+      case UPNP_DISCONNECTED_IGD:
+        return "Valid IGD device found, but it isn't connected"s;
+      case UPNP_UNKNOWN_DEVICE:
+        return "UPnP device found, but it wasn't recognized as an IGD"s;
     }
 
-    return "Unknown status"sv;
+    return "Unknown IGD status: "s + std::to_string(status);
   }
 
   /**

--- a/src/upnp.h
+++ b/src/upnp.h
@@ -33,8 +33,9 @@ namespace upnp {
    * @return The UPnP Status.
    * @retval 0 No IGD found.
    * @retval 1 A valid connected IGD has been found.
-   * @retval 2 A valid IGD has been found but it reported as not connected.
-   * @retval 3 An UPnP device has been found but was not recognized as an IGD.
+   * @retval 2 A valid connected IGD has been found but it has a private/non-routable WAN address.
+   * @retval 3 A valid IGD has been found but it reported as not connected.
+   * @retval 4 An UPnP device has been found but was not recognized as an IGD.
    */
   int
   UPNP_GetValidIGDStatus(device_t &device, urls_t *urls, IGDdatas *data, std::array<char, INET6_ADDRESS_STRLEN> &lan_addr);


### PR DESCRIPTION
## 改了啥呢

- 把 UPnP IGD 状态日志从裸的 `Unknown status` 改成 miniupnpc 状态常量对应的可读文本。
- 补上 `UPNP_PRIVATEIP_IGD` 和 `UPNP_UNKNOWN_DEVICE` 的日志说明。
- 更新 `src/upnp.h` 里 `UPNP_GetValidIGDStatus()` 的返回值注释，让 0..4 的含义和 miniupnpc 对齐。

## 为啥要改

UPnP 探测失败时只打印 `Unknown status`，看日志完全猜不出是私网 WAN、未识别 IGD，还是未来新状态码。这个杂鱼日志太会藏了，现在至少会把具体 IGD 状态讲清楚，剩下未知码也会带数字。

## 验证

- `git diff --check -- src/upnp.cpp src/upnp.h`
- 确认本机 miniupnpc 头文件存在 `UPNP_NO_IGD`、`UPNP_CONNECTED_IGD`、`UPNP_PRIVATEIP_IGD`、`UPNP_DISCONNECTED_IGD`、`UPNP_UNKNOWN_DEVICE`
- `cmake --build build --target sunshine --parallel 4` 未通过：构建在 Boost FetchContent 依赖重建阶段失败，停在 `boost_container` 对象编译，未到 Sunshine 源码目标。