### PR TITLE
fix(web): prevent setup wizard language loop

### DIFF
--- a/src_assets/common/assets/web/components/SetupWizard.vue
+++ b/src_assets/common/assets/web/components/SetupWizard.vue
@@ -458,12 +458,22 @@ import { trackEvents } from '../config/firebase.js'
 import { apiFetch, apiJson } from '../utils/apiFetch.js'
 import { openExternalUrl } from '../utils/helpers.js'
 import { detectSystemLocale } from '../config/i18n.js'
+import { SETUP_WIZARD_LANGUAGE_SAVED_KEY } from '../composables/useSetupWizard.js'
 
 // 向导第一步只暴露 简体中文(zh) / English(en) 两个选项，
 // 因此把系统语言探测结果折叠到这两者之一即可
 function detectInitialWizardLocale() {
   const sys = detectSystemLocale() // 已经过支持白名单过滤，未知语言落到 'en'
   return (sys === 'zh' || sys === 'zh_TW') ? 'zh' : 'en'
+}
+
+function markLanguageSavedForReload() {
+  try {
+    window.sessionStorage.setItem(SETUP_WIZARD_LANGUAGE_SAVED_KEY, 'true')
+  } catch (e) {
+    // If sessionStorage is unavailable, the saved locale still takes effect;
+    // the user may simply see the language step again in Chinese environments.
+  }
 }
 
 export default {
@@ -588,6 +598,7 @@ export default {
             locale: this.selectedLocale
           },
         })
+        markLanguageSavedForReload()
         // 重新加载页面以应用新语言
         window.location.reload()
       } catch (error) {

--- a/src_assets/common/assets/web/components/SetupWizard.vue
+++ b/src_assets/common/assets/web/components/SetupWizard.vue
@@ -592,12 +592,15 @@ export default {
     },
     async saveLanguage() {
       try {
-        await apiFetch('/api/config', {
+        const response = await apiFetch('/api/config', {
           method: 'POST',
           body: {
             locale: this.selectedLocale
           },
         })
+        if (!response.ok) {
+          throw new Error(`Failed to save language: HTTP ${response.status}`)
+        }
         markLanguageSavedForReload()
         // 重新加载页面以应用新语言
         window.location.reload()

--- a/src_assets/common/assets/web/composables/useSetupWizard.js
+++ b/src_assets/common/assets/web/composables/useSetupWizard.js
@@ -1,5 +1,47 @@
 import { ref } from 'vue'
 
+export const SETUP_WIZARD_LANGUAGE_SAVED_KEY = 'sunshine_setup_wizard_language_saved'
+
+function isTrue(value) {
+  return value === true || value === 'true'
+}
+
+function getSessionStorage() {
+  try {
+    return typeof window !== 'undefined' ? window.sessionStorage : globalThis.sessionStorage
+  } catch (e) {
+    return null
+  }
+}
+
+function hasSavedLanguageThisSession() {
+  return getSessionStorage()?.getItem(SETUP_WIZARD_LANGUAGE_SAVED_KEY) === 'true'
+}
+
+function clearSavedLanguageMarker() {
+  getSessionStorage()?.removeItem(SETUP_WIZARD_LANGUAGE_SAVED_KEY)
+}
+
+function isChineseBrowserLocale() {
+  try {
+    const nav = typeof navigator !== 'undefined' ? navigator : null
+    const locales = [
+      ...(Array.isArray(nav?.languages) ? nav.languages : []),
+      nav?.language,
+    ].filter(Boolean)
+
+    return locales.some((locale) => String(locale).toLowerCase().replace('-', '_').startsWith('zh'))
+  } catch (e) {
+    return false
+  }
+}
+
+function shouldSkipLanguageStep(config) {
+  if (hasSavedLanguageThisSession()) return true
+  if (!config?.locale) return false
+  return !(config.locale === 'en' && isChineseBrowserLocale())
+}
+
 /**
  * 设置向导组合式函数
  */
@@ -11,17 +53,18 @@ export function useSetupWizard() {
 
   // 检查是否需要显示设置向导
   const checkSetupWizard = (config) => {
-    const isFirstTime = config.setup_wizard_completed == true || 
-                       config.setup_wizard_completed == 'true'
+    const setupCompleted = isTrue(config.setup_wizard_completed)
     
-    if (!isFirstTime) {
-      showSetupWizard.value = true
-      adapters.value = config.adapters || []
-      displayDevices.value = config.display_devices || []
-      hasLocale.value = !!(config.locale && config.locale !== '')
-      return true
+    if (setupCompleted) {
+      clearSavedLanguageMarker()
+      return false
     }
-    return false
+
+    showSetupWizard.value = true
+    adapters.value = config.adapters || []
+    displayDevices.value = config.display_devices || []
+    hasLocale.value = shouldSkipLanguageStep(config)
+    return true
   }
 
   // 设置完成回调

--- a/src_assets/common/assets/web/tests/setupWizard.test.js
+++ b/src_assets/common/assets/web/tests/setupWizard.test.js
@@ -1,0 +1,94 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  SETUP_WIZARD_LANGUAGE_SAVED_KEY,
+  useSetupWizard,
+} from '../composables/useSetupWizard.js'
+
+function setNavigatorLanguages(languages) {
+  Object.defineProperty(globalThis, 'navigator', {
+    value: {
+      languages,
+      language: languages[0],
+    },
+    configurable: true,
+  })
+}
+
+function setSessionStorage(initial = {}) {
+  const values = new Map(Object.entries(initial))
+  Object.defineProperty(globalThis, 'sessionStorage', {
+    value: {
+      getItem: (key) => values.get(key) ?? null,
+      setItem: (key, value) => values.set(key, String(value)),
+      removeItem: (key) => values.delete(key),
+    },
+    configurable: true,
+  })
+  return values
+}
+
+test('setup wizard shows language step for default English on Chinese browsers', () => {
+  setNavigatorLanguages(['zh-CN'])
+  setSessionStorage()
+  const wizard = useSetupWizard()
+
+  assert.equal(wizard.checkSetupWizard({
+    setup_wizard_completed: false,
+    locale: 'en',
+  }), true)
+
+  assert.equal(wizard.hasLocale.value, false)
+})
+
+test('setup wizard continues after language save reload in Chinese browsers', () => {
+  setNavigatorLanguages(['zh-CN'])
+  setSessionStorage({ [SETUP_WIZARD_LANGUAGE_SAVED_KEY]: 'true' })
+  const wizard = useSetupWizard()
+
+  assert.equal(wizard.checkSetupWizard({
+    setup_wizard_completed: false,
+    locale: 'en',
+  }), true)
+
+  assert.equal(wizard.hasLocale.value, true)
+})
+
+test('setup wizard skips language step for non-English saved locales', () => {
+  setNavigatorLanguages(['zh-CN'])
+  setSessionStorage()
+  const wizard = useSetupWizard()
+
+  assert.equal(wizard.checkSetupWizard({
+    setup_wizard_completed: false,
+    locale: 'zh',
+  }), true)
+
+  assert.equal(wizard.hasLocale.value, true)
+})
+
+test('setup wizard keeps default English skip behavior outside Chinese browsers', () => {
+  setNavigatorLanguages(['en-US'])
+  setSessionStorage()
+  const wizard = useSetupWizard()
+
+  assert.equal(wizard.checkSetupWizard({
+    setup_wizard_completed: false,
+    locale: 'en',
+  }), true)
+
+  assert.equal(wizard.hasLocale.value, true)
+})
+
+test('setup wizard clears language reload marker after completion', () => {
+  setNavigatorLanguages(['zh-CN'])
+  const storage = setSessionStorage({ [SETUP_WIZARD_LANGUAGE_SAVED_KEY]: 'true' })
+  const wizard = useSetupWizard()
+
+  assert.equal(wizard.checkSetupWizard({
+    setup_wizard_completed: true,
+    locale: 'en',
+  }), false)
+
+  assert.equal(storage.has(SETUP_WIZARD_LANGUAGE_SAVED_KEY), false)
+})


### PR DESCRIPTION
## 改了啥呀

- 中文浏览器/系统环境下，首次向导遇到后端默认 `locale=en` 时不再直接跳过语言选择页。
- 保留语言保存后的页面刷新，让新语言能完整重新初始化。
- 保存语言前写入 session 级标记，刷新后继续进入第 2 步，避免这个小杂鱼循环把用户送回第 1 步。
- 增加 setup wizard 测试覆盖中文默认英文、保存后刷新继续、非中文环境行为、完成后清理标记。

## 为啥要改

后端默认 `locale=en` 会被前端当成“用户已经配置过语言”。中文环境首次进入向导时就可能跳过语言页；如果简单强制不跳过，又会和保存语言后的 reload 打架，形成保存-刷新-回第 1 步的循环。

这个改法只在前端向导里收口，不改后端 API：默认英文在中文环境下会展示语言页，用户保存后仍刷新应用语言，但同一 session 会继续向导流程。

## 验证

- `npm run test:webui`
- `npm run build`