### PR TITLE
fix(amf): default avcodec compat path off

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -434,7 +434,7 @@ namespace config {
       23,  // qvbr_quality (1-51, default 23)
       0,  // ltr_frames
       0,  // slices_per_frame
-      true,  // avcodec_compat: enable optional AVCodec-like adapter for validation
+      false,  // avcodec_compat: keep clean standalone AMF path by default
     },  // amd
 
     {

--- a/src/config.h
+++ b/src/config.h
@@ -77,7 +77,7 @@ namespace config {
       int amd_qvbr_quality = 23;  // QVBR quality level 1-51 (lower=better, default=23)
       int amd_ltr_frames = 0;  // LTR frames for RFI (0=disabled by default; matches FFmpeg amfenc behavior to avoid static-region color blocks)
       int amd_slices_per_frame = 0;  // Slices/tiles per frame (0=client decides, 1-4=minimum)
-      bool amd_avcodec_compat = true;  // Optional AVCodec-like AMF adapter; false keeps the clean standalone path.
+      bool amd_avcodec_compat = false;  // Optional AVCodec-like AMF adapter; false keeps the clean standalone path.
       std::optional<bool> amd_multi_hw_instance;
       // The properties below historically had aggressive hardcoded defaults that
       // forced AMF code paths FFmpeg never touches (HIGH_MOTION_QUALITY_BOOST=on,

--- a/src_assets/common/assets/web/composables/useConfig.js
+++ b/src_assets/common/assets/web/composables/useConfig.js
@@ -173,7 +173,7 @@ const DEFAULT_TABS = [
           amd_preanalysis: '',
           amd_vbaq: '',
           amd_coder: 'auto',
-          amd_avcodec_compat: 'enabled',
+          amd_avcodec_compat: 'disabled',
           // AMF advanced (driver workarounds): empty string = driver default
           // (FFmpeg-aligned). Users can override per-property if troubleshooting
           // freezes or tuning latency. See issue #666 (RDNA4 26.5.x).

--- a/src_assets/common/assets/web/configs/tabs/encoders/AmdAmfEncoder.vue
+++ b/src_assets/common/assets/web/configs/tabs/encoders/AmdAmfEncoder.vue
@@ -174,8 +174,8 @@ const config = ref(props.config)
     <div class="mb-3" v-if="platform === 'windows'">
       <label for="amd_avcodec_compat" class="form-label">{{ $t('config.amd_avcodec_compat') }}</label>
       <select id="amd_avcodec_compat" class="form-select" v-model="config.amd_avcodec_compat">
-        <option value="enabled">{{ $t('_common.enabled_def') }}</option>
-        <option value="disabled">{{ $t('_common.disabled') }}</option>
+        <option value="disabled">{{ $t('_common.disabled_def') }}</option>
+        <option value="enabled">{{ $t('_common.enabled') }}</option>
       </select>
       <div class="form-text">{{ $t('config.amd_avcodec_compat_desc') }}</div>
     </div>

--- a/src_assets/common/assets/web/public/assets/locale/bg.json
+++ b/src_assets/common/assets/web/public/assets/locale/bg.json
@@ -183,7 +183,7 @@
     "always_send_scancodes": "Винаги да се пращат скан-кодове",
     "always_send_scancodes_desc": "Изпращането на скан-кодове подобрява съвместимостта с игри и приложения, но може да доведе до неправилно разчетени входни сигнали от клавиатурата при някои клиенти, ако не се ползва клавиатурна подредба съвместима с английски (САЩ). Включете това, ако въвеждането от клавиатурата изобщо не работи в някои приложения. Изключете го, ако клавишите на клиента пращат грешни входни сигнали към отдалечения компютър.",
     "amd_avcodec_compat": "AVCodec-compatible AMF path",
-    "amd_avcodec_compat_desc": "Use Sunshine's AVCodec-like compatibility layer for standalone AMF. Enabled is closest to FFmpeg/upstream Sunshine behavior; disabled keeps the clean standalone AMF parameter path.",
+    "amd_avcodec_compat_desc": "Disabled by default to use Sunshine's clean standalone AMF path. Enable only if you hit device/client compatibility issues and want to try the AVCodec-like AMF compatibility layer.",
     "amd_coder": "Кодиране чрез AMF (H264)",
     "amd_coder_desc": "Позволява избирането на ентропия при кодирането, така че да се даде приоритет на качеството или скростта на кодиране. Само за H.264.",
     "amd_enforce_hrd": "Принудителна настройка на декодера с хипотетични справки (HRD) на AMF",

--- a/src_assets/common/assets/web/public/assets/locale/cs.json
+++ b/src_assets/common/assets/web/public/assets/locale/cs.json
@@ -183,7 +183,7 @@
     "always_send_scancodes": "Vždy odesílat Scancody",
     "always_send_scancodes_desc": "Odesílání scancodes zvyšuje kompatibilitu s hrami a aplikacemi, ale může mít za následek nesprávný vstup na klávesnici od určitých klientů, kteří nepoužívají americké anglické rozložení klávesnice. Povolit, pokud vstup klávesnice v některých aplikacích vůbec nefunguje. Zakázat, pokud klíče klienta generují nesprávný vstup na hostitele.",
     "amd_avcodec_compat": "AVCodec-compatible AMF path",
-    "amd_avcodec_compat_desc": "Use Sunshine's AVCodec-like compatibility layer for standalone AMF. Enabled is closest to FFmpeg/upstream Sunshine behavior; disabled keeps the clean standalone AMF parameter path.",
+    "amd_avcodec_compat_desc": "Disabled by default to use Sunshine's clean standalone AMF path. Enable only if you hit device/client compatibility issues and want to try the AVCodec-like AMF compatibility layer.",
     "amd_coder": "AMF kodér (H264)",
     "amd_coder_desc": "Umožňuje vybrat entropie kódování pro upřednostnění kvality nebo rychlosti kódování. Pouze H.264.",
     "amd_enforce_hrd": "Vymáhání hypotetického referenčního dekodéru (HRD) AMF",

--- a/src_assets/common/assets/web/public/assets/locale/de.json
+++ b/src_assets/common/assets/web/public/assets/locale/de.json
@@ -183,7 +183,7 @@
     "always_send_scancodes": "Scancodes immer senden",
     "always_send_scancodes_desc": "Das Senden von Scancodes verbessert die Kompatibilität mit Spielen und Apps, kann aber zu falschen Tastatureingaben von bestimmten Clients führen, die kein amerikanisches Tastaturlayout verwenden. Aktivieren, wenn die Eingabe der Tastatur in bestimmten Anwendungen überhaupt nicht funktioniert. Deaktivieren, wenn Schlüssel auf dem Client die falsche Eingabe auf dem Host generieren.",
     "amd_avcodec_compat": "AVCodec-compatible AMF path",
-    "amd_avcodec_compat_desc": "Use Sunshine's AVCodec-like compatibility layer for standalone AMF. Enabled is closest to FFmpeg/upstream Sunshine behavior; disabled keeps the clean standalone AMF parameter path.",
+    "amd_avcodec_compat_desc": "Disabled by default to use Sunshine's clean standalone AMF path. Enable only if you hit device/client compatibility issues and want to try the AVCodec-like AMF compatibility layer.",
     "amd_coder": "AMF Coder (H264)",
     "amd_coder_desc": "Erlaubt es Ihnen, die Entropy-Kodierung auszuwählen, um die Qualität oder die Kodierungsgeschwindigkeit zu priorisieren. H.264 nur.",
     "amd_enforce_hrd": "Hypothetische Referenz-Decodierer (HRD) durchsetzen",

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -186,7 +186,7 @@
     "amd_advanced_group_desc": "Optional driver-level AMF properties. Leaving everything blank keeps the AMD driver's default (matches FFmpeg amfenc and is recommended for most users). Tune these if you want to push for lower latency, or set them to 'disabled' to work around hardware/driver bugs such as the RX 9070 / RDNA4 + Adrenalin 26.5.x H.264/HEVC freeze (see issue #666).",
     "amd_advanced_reset": "Reset all to driver default",
     "amd_avcodec_compat": "AVCodec-compatible AMF path",
-    "amd_avcodec_compat_desc": "Use Sunshine's AVCodec-like compatibility layer for standalone AMF. Enabled is closest to FFmpeg/upstream Sunshine behavior; disabled keeps the clean standalone AMF parameter path.",
+    "amd_avcodec_compat_desc": "Disabled by default to use Sunshine's clean standalone AMF path. Enable only if you hit device/client compatibility issues and want to try the AVCodec-like AMF compatibility layer.",
     "amd_av1_latency_mode": "AMF AV1 Encoding Latency Mode",
     "amd_av1_latency_mode_desc": "AV1-only latency mode. Leave blank for driver default. Sunshine's legacy value was 'lowest latency'. If unsure, keep the driver default.",
     "amd_av1_latency_mode_lowest": "lowest latency",

--- a/src_assets/common/assets/web/public/assets/locale/en_GB.json
+++ b/src_assets/common/assets/web/public/assets/locale/en_GB.json
@@ -183,7 +183,7 @@
     "always_send_scancodes": "Always Send Scancodes",
     "always_send_scancodes_desc": "Sending scancodes enhances compatibility with games and apps but may result in incorrect keyboard input from certain clients that aren't using a US English keyboard layout. Enable if keyboard input is not working at all in certain applications. Disable if keys on the client are generating the wrong input on the host.",
     "amd_avcodec_compat": "AVCodec-compatible AMF path",
-    "amd_avcodec_compat_desc": "Use Sunshine's AVCodec-like compatibility layer for standalone AMF. Enabled is closest to FFmpeg/upstream Sunshine behavior; disabled keeps the clean standalone AMF parameter path.",
+    "amd_avcodec_compat_desc": "Disabled by default to use Sunshine's clean standalone AMF path. Enable only if you hit device/client compatibility issues and want to try the AVCodec-like AMF compatibility layer.",
     "amd_coder": "H.264 entropy coding",
     "amd_coder_desc": "Select CABAC or CAVLC entropy coding for H.264 only. Leave Auto unless debugging compatibility or performance.",
     "amd_enforce_hrd": "AMF Hypothetical Reference Decoder (HRD) Enforcement",

--- a/src_assets/common/assets/web/public/assets/locale/en_US.json
+++ b/src_assets/common/assets/web/public/assets/locale/en_US.json
@@ -183,7 +183,7 @@
     "always_send_scancodes": "Always Send Scancodes",
     "always_send_scancodes_desc": "Sending scancodes enhances compatibility with games and apps but may result in incorrect keyboard input from certain clients that aren't using a US English keyboard layout. Enable if keyboard input is not working at all in certain applications. Disable if keys on the client are generating the wrong input on the host.",
     "amd_avcodec_compat": "AVCodec-compatible AMF path",
-    "amd_avcodec_compat_desc": "Use Sunshine's AVCodec-like compatibility layer for standalone AMF. Enabled is closest to FFmpeg/upstream Sunshine behavior; disabled keeps the clean standalone AMF parameter path.",
+    "amd_avcodec_compat_desc": "Disabled by default to use Sunshine's clean standalone AMF path. Enable only if you hit device/client compatibility issues and want to try the AVCodec-like AMF compatibility layer.",
     "amd_coder": "H.264 entropy coding",
     "amd_coder_desc": "Select CABAC or CAVLC entropy coding for H.264 only. Leave Auto unless debugging compatibility or performance.",
     "amd_enforce_hrd": "AMF Hypothetical Reference Decoder (HRD) Enforcement",

--- a/src_assets/common/assets/web/public/assets/locale/es.json
+++ b/src_assets/common/assets/web/public/assets/locale/es.json
@@ -183,7 +183,7 @@
     "always_send_scancodes": "Enviar siempre códigos de escaneo",
     "always_send_scancodes_desc": "Enviar códigos de escaneo mejora la compatibilidad con juegos y aplicaciones, pero puede resultar en una entrada de teclado incorrecta de ciertos clientes que no están usando una disposición de teclado en inglés de los Estados Unidos. Activar si la entrada de teclado no funciona en absoluto en ciertas aplicaciones. Desactivar si las claves del cliente están generando una entrada incorrecta en el host.",
     "amd_avcodec_compat": "AVCodec-compatible AMF path",
-    "amd_avcodec_compat_desc": "Use Sunshine's AVCodec-like compatibility layer for standalone AMF. Enabled is closest to FFmpeg/upstream Sunshine behavior; disabled keeps the clean standalone AMF parameter path.",
+    "amd_avcodec_compat_desc": "Disabled by default to use Sunshine's clean standalone AMF path. Enable only if you hit device/client compatibility issues and want to try the AVCodec-like AMF compatibility layer.",
     "amd_coder": "Codificador AMF (H264)",
     "amd_coder_desc": "Le permite seleccionar la codificación entropía para priorizar la calidad o la velocidad de codificación. H.264 solamente.",
     "amd_enforce_hrd": "Aplicación del decodificador de referencia hipotético (HRD) AMF",

--- a/src_assets/common/assets/web/public/assets/locale/fr.json
+++ b/src_assets/common/assets/web/public/assets/locale/fr.json
@@ -183,7 +183,7 @@
     "always_send_scancodes": "Toujours envoyer les codes de balayage",
     "always_send_scancodes_desc": "L'envoi de codes de numérisation améliore la compatibilité avec les jeux et les applications, mais peut entraîner une saisie incorrecte du clavier de certains clients qui n'utilisent pas de disposition de clavier anglais américain. Activer si l'entrée du clavier ne fonctionne pas du tout dans certaines applications. Désactiver si les clés du client génèrent la mauvaise entrée sur l'hôte.",
     "amd_avcodec_compat": "AVCodec-compatible AMF path",
-    "amd_avcodec_compat_desc": "Use Sunshine's AVCodec-like compatibility layer for standalone AMF. Enabled is closest to FFmpeg/upstream Sunshine behavior; disabled keeps the clean standalone AMF parameter path.",
+    "amd_avcodec_compat_desc": "Disabled by default to use Sunshine's clean standalone AMF path. Enable only if you hit device/client compatibility issues and want to try the AVCodec-like AMF compatibility layer.",
     "amd_coder": "Codeur AMF (H264)",
     "amd_coder_desc": "Permet de sélectionner l'encodage de l'entropie pour prioriser la qualité ou la vitesse d'encodage. H.264 seulement.",
     "amd_enforce_hrd": "Enforcement du Décodeur Hypothetical Reference Decoder (HRD) de l'AMF",

--- a/src_assets/common/assets/web/public/assets/locale/it.json
+++ b/src_assets/common/assets/web/public/assets/locale/it.json
@@ -183,7 +183,7 @@
     "always_send_scancodes": "Invia sempre Scancode",
     "always_send_scancodes_desc": "L'invio di scancode migliora la compatibilità con i giochi e le applicazioni, ma può risultare in input da tastiera errati da alcuni client che non utilizzano un layout di inglese statunitense. Abilita se l' input della tastiera non funziona affatto in certe applicazioni. Disabilita se i tasti del client generano l'input errato sull'host.",
     "amd_avcodec_compat": "AVCodec-compatible AMF path",
-    "amd_avcodec_compat_desc": "Use Sunshine's AVCodec-like compatibility layer for standalone AMF. Enabled is closest to FFmpeg/upstream Sunshine behavior; disabled keeps the clean standalone AMF parameter path.",
+    "amd_avcodec_compat_desc": "Disabled by default to use Sunshine's clean standalone AMF path. Enable only if you hit device/client compatibility issues and want to try the AVCodec-like AMF compatibility layer.",
     "amd_coder": "Coder AMF (H264)",
     "amd_coder_desc": "Consente di selezionare la codifica dell'entropia per dare la priorità alla qualità o alla velocità di codifica. Solo H.264.",
     "amd_enforce_hrd": "Applica Decoder di Riferimento Ipotetico (HRD) per AMF",

--- a/src_assets/common/assets/web/public/assets/locale/ja.json
+++ b/src_assets/common/assets/web/public/assets/locale/ja.json
@@ -183,7 +183,7 @@
     "always_send_scancodes": "常にスキャンコードを送信する",
     "always_send_scancodes_desc": "スキャンコードを送信すると、ゲームやアプリとの互換性が向上しますが、米国英語のキーボードレイアウトを使用していない特定のクライアントからのキーボード入力が誤っている可能性があります。 特定のアプリケーションでキーボード入力がまったく動作しない場合に有効にします。 クライアントのキーがホストに間違った入力を生成している場合は無効にします。",
     "amd_avcodec_compat": "AVCodec-compatible AMF path",
-    "amd_avcodec_compat_desc": "Use Sunshine's AVCodec-like compatibility layer for standalone AMF. Enabled is closest to FFmpeg/upstream Sunshine behavior; disabled keeps the clean standalone AMF parameter path.",
+    "amd_avcodec_compat_desc": "Disabled by default to use Sunshine's clean standalone AMF path. Enable only if you hit device/client compatibility issues and want to try the AVCodec-like AMF compatibility layer.",
     "amd_coder": "AMFコーダー(H264)",
     "amd_coder_desc": "エントロピーエンコーディングを選択して品質やエンコーディング速度を優先することができます。H.264 のみ。",
     "amd_enforce_hrd": "AMF仮説リファレンスデコーダ(HRD) Enforcement",

--- a/src_assets/common/assets/web/public/assets/locale/ko.json
+++ b/src_assets/common/assets/web/public/assets/locale/ko.json
@@ -183,7 +183,7 @@
     "always_send_scancodes": "항상 스캔 코드 보내기",
     "always_send_scancodes_desc": "스캔코드를 전송하면 게임 및 앱과의 호환성이 향상되지만 미국식 영어 키보드 레이아웃을 사용하지 않는 특정 클라이언트에서 키보드 입력이 잘못될 수 있습니다. 특정 애플리케이션에서 키보드 입력이 전혀 작동하지 않는 경우 활성화합니다. 클라이언트의 키가 호스트에서 잘못된 입력을 생성하는 경우 비활성화합니다.",
     "amd_avcodec_compat": "AVCodec-compatible AMF path",
-    "amd_avcodec_compat_desc": "Use Sunshine's AVCodec-like compatibility layer for standalone AMF. Enabled is closest to FFmpeg/upstream Sunshine behavior; disabled keeps the clean standalone AMF parameter path.",
+    "amd_avcodec_compat_desc": "Disabled by default to use Sunshine's clean standalone AMF path. Enable only if you hit device/client compatibility issues and want to try the AVCodec-like AMF compatibility layer.",
     "amd_coder": "AMF 코더(H264)",
     "amd_coder_desc": "엔트로피 인코딩을 선택하여 품질 또는 인코딩 속도의 우선순위를 정할 수 있습니다. H.264만 해당.",
     "amd_enforce_hrd": "AMF 가상 참조 디코더(HRD) 시행",

--- a/src_assets/common/assets/web/public/assets/locale/pl.json
+++ b/src_assets/common/assets/web/public/assets/locale/pl.json
@@ -183,7 +183,7 @@
     "always_send_scancodes": "Zawsze wysyłaj kody skanowania",
     "always_send_scancodes_desc": "Wysyłanie kody skanów zwiększa kompatybilność z grami i aplikacjami, ale może powodować nieprawidłowe wprowadzanie danych z klawiatury przez niektórych klientów, którzy nie używają układu klawiatury Angielski (Stany Zjednoczone). Włącz, jeśli wprowadzanie danych z klawiatury w ogóle nie działa w niektórych aplikacjach. Wyłącz, jeśli klawisze na kliencie generują nieprawidłowe dane wejściowe na hoście.",
     "amd_avcodec_compat": "AVCodec-compatible AMF path",
-    "amd_avcodec_compat_desc": "Use Sunshine's AVCodec-like compatibility layer for standalone AMF. Enabled is closest to FFmpeg/upstream Sunshine behavior; disabled keeps the clean standalone AMF parameter path.",
+    "amd_avcodec_compat_desc": "Disabled by default to use Sunshine's clean standalone AMF path. Enable only if you hit device/client compatibility issues and want to try the AVCodec-like AMF compatibility layer.",
     "amd_coder": "AMF Coder (H264)",
     "amd_coder_desc": "Umożliwia wybór kodowania entropijnego w celu nadania priorytetu jakości lub szybkości kodowania. Tylko H.264.",
     "amd_enforce_hrd": "Wymuszanie AMF Hypothetical Reference Decoder (HRD)",

--- a/src_assets/common/assets/web/public/assets/locale/pt.json
+++ b/src_assets/common/assets/web/public/assets/locale/pt.json
@@ -183,7 +183,7 @@
     "always_send_scancodes": "Sempre enviar Scancodes",
     "always_send_scancodes_desc": "O envio de códigos de verificação melhora a compatibilidade com jogos e aplicativos, mas pode resultar em uma entrada incorreta de teclado de certos clientes que não estão usando um layout de teclado inglês dos EUA. Habilitar se a entrada de teclado não estiver funcionando em certas aplicações. Desative se as chaves no cliente estão gerando a entrada errada no host.",
     "amd_avcodec_compat": "AVCodec-compatible AMF path",
-    "amd_avcodec_compat_desc": "Use Sunshine's AVCodec-like compatibility layer for standalone AMF. Enabled is closest to FFmpeg/upstream Sunshine behavior; disabled keeps the clean standalone AMF parameter path.",
+    "amd_avcodec_compat_desc": "Disabled by default to use Sunshine's clean standalone AMF path. Enable only if you hit device/client compatibility issues and want to try the AVCodec-like AMF compatibility layer.",
     "amd_coder": "Codificador AMF (H264)",
     "amd_coder_desc": "Permite que você selecione a codificação entropia para priorizar a qualidade ou a velocidade de codificação. Somente H.264.",
     "amd_enforce_hrd": "Aplicação de Decodificador de Referência Hipotetica (HRD) AMF",

--- a/src_assets/common/assets/web/public/assets/locale/pt_BR.json
+++ b/src_assets/common/assets/web/public/assets/locale/pt_BR.json
@@ -183,7 +183,7 @@
     "always_send_scancodes": "Sempre enviar códigos de barras",
     "always_send_scancodes_desc": "O envio de códigos de barras aumenta a compatibilidade com jogos e aplicativos, mas pode resultar em entrada incorreta do teclado de determinados clientes que não estejam usando um layout de teclado em inglês dos EUA. Ative se a entrada do teclado não estiver funcionando em determinados aplicativos. Desative se as teclas do cliente estiverem gerando a entrada incorreta no host.",
     "amd_avcodec_compat": "AVCodec-compatible AMF path",
-    "amd_avcodec_compat_desc": "Use Sunshine's AVCodec-like compatibility layer for standalone AMF. Enabled is closest to FFmpeg/upstream Sunshine behavior; disabled keeps the clean standalone AMF parameter path.",
+    "amd_avcodec_compat_desc": "Disabled by default to use Sunshine's clean standalone AMF path. Enable only if you hit device/client compatibility issues and want to try the AVCodec-like AMF compatibility layer.",
     "amd_coder": "Codificador AMF (H264)",
     "amd_coder_desc": "Permite que você selecione a codificação de entropia para priorizar a qualidade ou a velocidade de codificação. Somente H.264.",
     "amd_enforce_hrd": "Aplicação do decodificador de referência hipotético (HRD) da AMF",

--- a/src_assets/common/assets/web/public/assets/locale/ru.json
+++ b/src_assets/common/assets/web/public/assets/locale/ru.json
@@ -183,7 +183,7 @@
     "always_send_scancodes": "Всегда посылать коды клавиш",
     "always_send_scancodes_desc": "Передача кодов клавиш улучшает совместимость с играми и приложениями, но может привести к неправильному вводу с клавиатуры, если клиент используют раскладку, отличную от английской США. Включите, если в каких-то приложениях ввод с клавиатуры не работает вовсе. Отключите, если клавиши клиента передают на ввод не те клавиши сервер.",
     "amd_avcodec_compat": "AVCodec-compatible AMF path",
-    "amd_avcodec_compat_desc": "Use Sunshine's AVCodec-like compatibility layer for standalone AMF. Enabled is closest to FFmpeg/upstream Sunshine behavior; disabled keeps the clean standalone AMF parameter path.",
+    "amd_avcodec_compat_desc": "Disabled by default to use Sunshine's clean standalone AMF path. Enable only if you hit device/client compatibility issues and want to try the AVCodec-like AMF compatibility layer.",
     "amd_coder": "Кодировщик AMF (H264)",
     "amd_coder_desc": "Позволяет выбрать энтропическую кодировку для приоритизации скорости или качества кодирования. Работает только с H.264.",
     "amd_enforce_hrd": "AMF Hypothetical Reference Decoder (HRD) Enforcement",

--- a/src_assets/common/assets/web/public/assets/locale/sv.json
+++ b/src_assets/common/assets/web/public/assets/locale/sv.json
@@ -183,7 +183,7 @@
     "always_send_scancodes": "Skicka alltid sökkoder",
     "always_send_scancodes_desc": "Att skicka skanningskoder förbättrar kompatibiliteten med spel och appar men kan resultera i felaktig tangentbordsinmatning från vissa klienter som inte använder en amerikansk engelsk tangentbordslayout. Aktivera om tangentbordsinmatningen inte fungerar alls i vissa program. Inaktivera om nycklar på klienten genererar fel indata på värden.",
     "amd_avcodec_compat": "AVCodec-compatible AMF path",
-    "amd_avcodec_compat_desc": "Use Sunshine's AVCodec-like compatibility layer for standalone AMF. Enabled is closest to FFmpeg/upstream Sunshine behavior; disabled keeps the clean standalone AMF parameter path.",
+    "amd_avcodec_compat_desc": "Disabled by default to use Sunshine's clean standalone AMF path. Enable only if you hit device/client compatibility issues and want to try the AVCodec-like AMF compatibility layer.",
     "amd_coder": "AMF-kod (H264)",
     "amd_coder_desc": "Låter dig välja entropi-kodning för att prioritera kvalitet eller kodningshastighet. H.264 endast.",
     "amd_enforce_hrd": "AMF Hypotetisk referensavkodare (HRD) verkställighet",

--- a/src_assets/common/assets/web/public/assets/locale/tr.json
+++ b/src_assets/common/assets/web/public/assets/locale/tr.json
@@ -183,7 +183,7 @@
     "always_send_scancodes": "Her Zaman Scancode Gönder",
     "always_send_scancodes_desc": "Scancode göndermek oyun ve uygulamalarla uyumluluğu artırır, ancak ABD İngilizcesi klavye düzeni kullanmayan bazı istemcilerden yanlış klavye girişine neden olabilir. Belirli uygulamalarda klavye girişi hiç çalışmıyorsa etkinleştirin. İstemcideki tuşlar ana bilgisayarda yanlış girdi oluşturuyorsa devre dışı bırakın.",
     "amd_avcodec_compat": "AVCodec-compatible AMF path",
-    "amd_avcodec_compat_desc": "Use Sunshine's AVCodec-like compatibility layer for standalone AMF. Enabled is closest to FFmpeg/upstream Sunshine behavior; disabled keeps the clean standalone AMF parameter path.",
+    "amd_avcodec_compat_desc": "Disabled by default to use Sunshine's clean standalone AMF path. Enable only if you hit device/client compatibility issues and want to try the AVCodec-like AMF compatibility layer.",
     "amd_coder": "AMF Kodlayıcı (H264)",
     "amd_coder_desc": "Kaliteye veya kodlama hızına öncelik vermek için entropi kodlamasını seçmenizi sağlar. Yalnızca H.264.",
     "amd_enforce_hrd": "AMF Varsayımsal Referans Kod Çözücü (HRD) Uygulaması",

--- a/src_assets/common/assets/web/public/assets/locale/uk.json
+++ b/src_assets/common/assets/web/public/assets/locale/uk.json
@@ -183,7 +183,7 @@
     "always_send_scancodes": "Завжди Надсилати Скан-коди",
     "always_send_scancodes_desc": "Надсилання скан-кодів покращує сумісність з іграми та програмами, але може призвести до некоректного введення з клавіатури деякими клієнтами, які не використовують розкладку клавіатури США. Увімкніть, якщо введення з клавіатури взагалі не працює у певних програмах. Вимкніть, якщо клавіші на клієнті генерують неправильні клавіші на хості.",
     "amd_avcodec_compat": "AVCodec-compatible AMF path",
-    "amd_avcodec_compat_desc": "Use Sunshine's AVCodec-like compatibility layer for standalone AMF. Enabled is closest to FFmpeg/upstream Sunshine behavior; disabled keeps the clean standalone AMF parameter path.",
+    "amd_avcodec_compat_desc": "Disabled by default to use Sunshine's clean standalone AMF path. Enable only if you hit device/client compatibility issues and want to try the AVCodec-like AMF compatibility layer.",
     "amd_coder": "AMF Coder (H264)",
     "amd_coder_desc": "Дозволяє вибрати ентропійне кодування, щоб надати пріоритет якості або швидкості кодування. Тільки H.264.",
     "amd_enforce_hrd": "Примусове застосування AMF Hypothetical Reference Decoder (HRD)",

--- a/src_assets/common/assets/web/public/assets/locale/zh.json
+++ b/src_assets/common/assets/web/public/assets/locale/zh.json
@@ -186,7 +186,7 @@
     "amd_advanced_group_desc": "可选的驱动级 AMF 属性。全部留空时使用 AMD 驱动默认值（与 FFmpeg amfenc 一致，对大多数用户最稳）。如需追求更低延迟可显式开启；如遇到硬件/驱动 bug（例如 RX 9070 / RDNA4 + Adrenalin 26.5.x 在 H.264/HEVC 下卡死，见 issue #666）可显式关闭对应项。",
     "amd_advanced_reset": "全部重置为驱动默认",
     "amd_avcodec_compat": "AVCodec 兼容 AMF 路径",
-    "amd_avcodec_compat_desc": "为 standalone AMF 启用 Sunshine 的 AVCodec-like 兼容层。开启时最接近 FFmpeg/上游 Sunshine 行为；关闭时保留干净的 standalone AMF 参数路径。",
+    "amd_avcodec_compat_desc": "默认关闭，使用 Sunshine 干净的 standalone AMF 路径。仅在遇到设备或客户端兼容性问题时再开启，以尝试 AVCodec-like AMF 兼容层。",
     "amd_av1_latency_mode": "AMF AV1 编码延迟模式",
     "amd_av1_latency_mode_desc": "仅 AV1 的延迟模式。留空使用驱动默认。Sunshine 旧值为 '最低延迟'。如不确定请保持驱动默认。",
     "amd_av1_latency_mode_lowest": "最低延迟",

--- a/src_assets/common/assets/web/public/assets/locale/zh_TW.json
+++ b/src_assets/common/assets/web/public/assets/locale/zh_TW.json
@@ -183,7 +183,7 @@
     "always_send_scancodes": "永遠傳送掃描碼",
     "always_send_scancodes_desc": "傳送掃描碼可以增強與遊戲和應用程式的相容性，但可能會導致某些未使用美式英語鍵盤佈局的用戶端輸入錯誤。若某些應用程式的鍵盤輸入完全無效，請啟用此選項。若用戶端的鍵盤輸入在主機端產生錯誤輸入，則請停用此選項。",
     "amd_avcodec_compat": "AVCodec 相容 AMF 路徑",
-    "amd_avcodec_compat_desc": "為 standalone AMF 啟用 Sunshine 的 AVCodec-like 相容層。啟用時最接近 FFmpeg/上游 Sunshine 行為；停用時保留乾淨的 standalone AMF 參數路徑。",
+    "amd_avcodec_compat_desc": "預設停用，使用 Sunshine 乾淨的 standalone AMF 路徑。僅在遇到裝置或用戶端相容性問題時再啟用，以嘗試 AVCodec-like AMF 相容層。",
     "amd_coder": "H.264 熵編碼模式",
     "amd_coder_desc": "僅影響 H.264 的 CABAC/CAVLC 熵編碼選擇。一般保持自動，只有排查相容性或效能問題時再調整。",
     "amd_enforce_hrd": "AMF 假想參考解碼器 (HRD) 強制執行",


### PR DESCRIPTION
## 改了啥呀

- 把 `amd_avcodec_compat` 后端默认值从开启改成关闭。
- WebUI 默认值同步改为 `disabled`，下拉项也标记 `Disabled (default)`。
- 更新 AMF 兼容路径说明：默认走干净 standalone AMF 路径，只有遇到设备或客户端兼容性问题时再开启 AVCodec-like AMF 兼容层。

## 为啥要改

- 9070 / HEVC 场景里开启兼容路径反而可能触发冻屏，所以不适合作为默认路径继续压给所有用户。
- 保留开关作为兼容性兜底，避免杂鱼兼容层把默认体验拖下水。

## 验证

- `Get-ChildItem -Path src_assets/common/assets/web/public/assets/locale -Filter *.json | ForEach-Object { try { Get-Content -Raw -Encoding UTF8 -Path $_.FullName | ConvertFrom-Json | Out-Null } catch { Write-Error "$($_.Name): $($_.Exception.Message)"; exit 1 } }; Write-Output 'locale json ok'`
- `git diff --check -- src/config.cpp src/config.h src_assets/common/assets/web/composables/useConfig.js src_assets/common/assets/web/configs/tabs/encoders/AmdAmfEncoder.vue src_assets/common/assets/web/public/assets/locale`
- `npm run test:webui`
- `npm run build`
