### PR TITLE
feat(vdd): add sealed frame channel capture

### DIFF
--- a/docs/windows_vdd_sealed_frame_channel.md
+++ b/docs/windows_vdd_sealed_frame_channel.md
@@ -1,0 +1,188 @@
+# Windows VDD Sealed Frame Channel
+
+This document defines the v2 Sunshine <-> ZakoVDD frame channel. The goal is to keep the fast producer-owned borrowed-frame path while removing the legacy globally named `Global\ZakoVDD_*` object exposure.
+
+## Goals
+
+- Keep VDD as the owner of the source frame ring.
+- Let Sunshine borrow the latest complete producer frame with no CPU readback.
+- Stop exposing predictable global names for metadata, frame-ready events, and textures.
+- Keep legacy named shared textures as an automatic fallback unless `SUNSHINE_VDD_FRAME_CHANNEL=sealed` is set.
+- Make strict mode fail closed rather than silently falling back to named objects.
+
+## Host Modes
+
+`SUNSHINE_VDD_FRAME_CHANNEL` controls host behavior:
+
+- `auto`: probe sealed support, use sealed borrow when attach succeeds, otherwise fall back to hardened legacy named objects.
+- `legacy`: skip sealed probing and use hardened legacy named objects.
+- `sealed`: require sealed caps, open, and attach to succeed. Do not fall back to legacy names.
+
+## Runtime Telemetry
+
+Sunshine logs both the transport mode and the final structured selection:
+
+```text
+[vdd_capture] opened sealed monitor ... channel=sealed_borrow selection=sealed_opened access=duplicated_handles
+[vdd] backend ready ... channel=sealed selection=sealed_opened sealed_supported=true producer_slots=3 generation=2
+```
+
+`channel` describes the active capture transport:
+
+- `sealed`: sealed IOCTL path with duplicated unnamed handles.
+- `legacy_named_hardened`: legacy named-object path with restricted access.
+- `sealed_probe_supported_legacy_capture`: sealed caps were present but host fell back to legacy capture.
+
+`selection` is the stable machine-readable reason:
+
+- `sealed_opened`: sealed caps, open, metadata attach, texture import, and keyed-mutex attach succeeded.
+- `forced_legacy`: `SUNSHINE_VDD_FRAME_CHANNEL=legacy`.
+- `caps_unsupported`: driver/interface does not expose sealed frame-channel caps.
+- `caps_failed`: capability query failed or returned unusable caps.
+- `open_unsupported`: open IOCTL was not supported by the driver.
+- `open_failed`: open IOCTL reached the driver but failed.
+- `attach_failed`: open succeeded but Sunshine rejected metadata/textures/keyed mutexes.
+- `sealed_required_failed`: `SUNSHINE_VDD_FRAME_CHANNEL=sealed` failed closed.
+- `legacy_opened`: fallback legacy named path opened successfully.
+
+Operationally, healthy sealed sessions should show:
+
+- `channel=sealed`
+- `selection=sealed_opened`
+- `sealed_supported=true`
+- `generation=N` stable during a channel lifetime
+- no `frame channel open failed`, `sealed frame channel attach failed`, or `unable to read stable metadata`
+
+## IOCTLs
+
+The authoritative ABI is `src/display_device/vdd_control_ioctl.h`.
+
+`IOCTL_VDD_QUERY_FRAME_CHANNEL_CAPS`
+
+The driver returns `VDD_FRAME_CHANNEL_CAPS` with:
+
+- `Version = VDD_FRAME_CHANNEL_CAPS_VERSION`
+- `Flags` containing all required bits:
+  - `VDD_FRAME_CHANNEL_FLAG_SEALED_BORROW`
+  - `VDD_FRAME_CHANNEL_FLAG_UNNAMED_HANDLES`
+  - `VDD_FRAME_CHANNEL_FLAG_STRICT_DACL`
+- `MaxSharedSlots <= VDD_FRAME_CHANNEL_MAX_SLOTS`
+- `MetadataSize >= sizeof(shared_frame_metadata_t)` as used by Sunshine.
+
+`IOCTL_VDD_OPEN_FRAME_CHANNEL`
+
+Sunshine sends `VDD_FRAME_CHANNEL_OPEN_REQUEST`:
+
+- `MonitorIndex`: VDD monitor index resolved by Sunshine.
+- `TargetProcessId`: Sunshine process ID. Returned handle values must be valid in this process.
+- `RequiredFlags`: security bits the driver must satisfy.
+- `DesiredSlots`: compatibility guard. `0` means driver default; nonzero must match the driver's advertised `MaxSharedSlots`.
+- `AdapterLuid*`: Sunshine D3D11 device adapter. Driver must reject mismatches.
+
+The driver returns `VDD_FRAME_CHANNEL_OPEN_RESPONSE`:
+
+- `MetadataHandle`: unnamed file mapping handle duplicated into Sunshine.
+- `FrameReadyEventHandle`: unnamed event handle duplicated into Sunshine.
+- `Slots[i].TextureHandle`: unnamed D3D11 shared texture handles duplicated into Sunshine.
+- `SlotCount`: number of valid slot handles.
+- `Flags`: must include `RequiredFlags`.
+
+Sunshine opens the current driver with `DesiredSlots=3`. The diagnostic probe defaults to `DesiredSlots=0` so operators can query the active driver without knowing the producer ring size in advance.
+
+## Metadata Consistency
+
+`shared_frame_metadata_t::MetadataSequence` is a packed compatibility field:
+
+- high 16 bits: `ChannelGeneration`
+- low 16 bits: seqlock counter
+- low bit set: producer is updating metadata
+- low bit clear: metadata is stable
+
+The field reuses the old reserved slot, so metadata remains 128 bytes. Sunshine reads metadata with a stable snapshot helper and rejects torn reads. If `ChannelGeneration` changes during capture, Sunshine requests reinitialization to avoid mixing old textures with new producer metadata.
+
+## Driver Contract
+
+The driver remains the source-frame owner.
+
+Required behavior:
+
+- Create metadata mapping, frame-ready event, and frame textures without global object names.
+- Apply a restrictive DACL before any handle duplication.
+- Validate the caller and target process before duplicating handles.
+- Duplicate handles into `TargetProcessId`; the raw numeric handle values returned in the response must be valid only in that process.
+- Use the same shared metadata layout and keyed-mutex protocol as the legacy producer-owned ring.
+- Reject adapter LUID, format, size, version, or slot-count mismatches.
+- On any partial failure, close all duplicated handles before returning an error.
+
+## Sunshine Host Contract
+
+The current host implementation:
+
+- Probes caps through `query_frame_channel_caps()`.
+- Opens the channel through `open_frame_channel()`.
+- Maps sealed metadata and opens textures with `ID3D11Device1::OpenSharedResource1()`.
+- Validates metadata, slot count, texture desc, shader-resource flags, keyed mutex, and adapter LUID.
+- Closes all returned handles after importing resources.
+- Falls back only in `auto` mode. `sealed` mode fails closed.
+
+## Validation Checklist
+
+Minimum driver-side validation before enabling sealed mode by default:
+
+- `SUNSHINE_VDD_FRAME_CHANNEL=sealed` succeeds with a current driver.
+- `SUNSHINE_VDD_FRAME_CHANNEL=legacy` still works with old drivers.
+- `SUNSHINE_VDD_FRAME_CHANNEL=auto` uses sealed on new drivers and legacy on old drivers.
+- Handle enumeration does not reveal `Global\ZakoVDD_Frame_*`, `Global\ZakoVDD_Meta_*`, or `Global\ZakoVDD_FrameReady_*` for sealed sessions.
+- Driver restart, monitor mode change, HDR format change, and Sunshine restart do not leak handles or stuck keyed-mutex slots.
+- Borrowed frame telemetry remains stable: low `consumer_acquire_timeouts`, low held-slot drops, and no persistent fallback churn.
+
+## Operator Commands
+
+Build the Sunshine host and tools:
+
+```powershell
+$env:PATH='C:\msys64\ucrt64\bin;C:\msys64\usr\bin;' + $env:PATH
+cmake --build build --target sunshine vdd-frame-channel-probe check-vdd-ioctl-abi -j 4
+```
+
+Check that the duplicated ABI header is in sync with the driver repo:
+
+```powershell
+cmake --build build --target check-vdd-ioctl-abi
+```
+
+Probe sealed caps only:
+
+```powershell
+.\build\tools\vdd-frame-channel-probe.exe
+```
+
+Open the sealed channel for monitor 0 and print a stable metadata snapshot:
+
+```powershell
+.\build\tools\vdd-frame-channel-probe.exe --open --monitor 0 --slots 3
+```
+
+Expected output includes:
+
+```text
+caps: version=1 flags=0x7 max_slots=3 metadata_size=128
+open: version=1 flags=0x7 slots=3 metadata_size=128 ...
+metadata: ... frame=... slot=.../3 meta_seq=... generation=... luid=...
+```
+
+Run a local smoke/stress pass against an active stream:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\tools\vdd_sealed_channel_stress.ps1 -Iterations 5 -RequireSunshineSealedLog
+```
+
+The stress script verifies:
+
+- sealed IOCTL open succeeds
+- metadata snapshot contains `generation` and slot telemetry
+- recent Sunshine logs contain `channel=sealed`
+- recent Sunshine logs contain `selection=sealed_opened`
+- no structured sealed failure selection is present
+
+If the probe returns `OPEN_FRAME_CHANNEL failed: 21`, the driver is installed but no active VDD producer/swapchain is currently available. Start a Moonlight stream or otherwise activate the VDD monitor, then retry.

--- a/docs/windows_vdd_sealed_frame_channel.md
+++ b/docs/windows_vdd_sealed_frame_channel.md
@@ -7,15 +7,16 @@ This document defines the v2 Sunshine <-> ZakoVDD frame channel. The goal is to 
 - Keep VDD as the owner of the source frame ring.
 - Let Sunshine borrow the latest complete producer frame with no CPU readback.
 - Stop exposing predictable global names for metadata, frame-ready events, and textures.
-- Keep legacy named shared textures as an automatic fallback unless `SUNSHINE_VDD_FRAME_CHANNEL=sealed` is set.
+- Keep Sunshine's legacy named-object consumer as a fallback for old drivers.
+- Keep new drivers sealed-only by default. Legacy named export must be explicitly enabled with `LEGACYNAMEDFRAMECHANNEL=1`.
 - Make strict mode fail closed rather than silently falling back to named objects.
 
 ## Host Modes
 
 `SUNSHINE_VDD_FRAME_CHANNEL` controls host behavior:
 
-- `auto`: probe sealed support, use sealed borrow when attach succeeds, otherwise fall back to hardened legacy named objects.
-- `legacy`: skip sealed probing and use hardened legacy named objects.
+- `auto`: probe sealed support, use sealed borrow when attach succeeds, otherwise fall back to hardened legacy named objects for old drivers or drivers with legacy export explicitly enabled.
+- `legacy`: skip sealed probing and use hardened legacy named objects. This requires an old driver or a new driver with `LEGACYNAMEDFRAMECHANNEL=1`.
 - `sealed`: require sealed caps, open, and attach to succeed. Do not fall back to legacy names.
 
 ## Runtime Telemetry
@@ -106,7 +107,8 @@ The driver remains the source-frame owner.
 
 Required behavior:
 
-- Create metadata mapping, frame-ready event, and frame textures without global object names.
+- Create metadata mapping, frame-ready event, and frame textures without global object names by default.
+- Create `Global\ZakoVDD_*` legacy named objects only when the explicit driver setting `LEGACYNAMEDFRAMECHANNEL=1` is present.
 - Apply a restrictive DACL before any handle duplication.
 - Validate the caller and target process before duplicating handles.
 - Duplicate handles into `TargetProcessId`; the raw numeric handle values returned in the response must be valid only in that process.
@@ -130,9 +132,9 @@ The current host implementation:
 Minimum driver-side validation before enabling sealed mode by default:
 
 - `SUNSHINE_VDD_FRAME_CHANNEL=sealed` succeeds with a current driver.
-- `SUNSHINE_VDD_FRAME_CHANNEL=legacy` still works with old drivers.
+- `SUNSHINE_VDD_FRAME_CHANNEL=legacy` still works with old drivers, and with new drivers only after `LEGACYNAMEDFRAMECHANNEL=1`.
 - `SUNSHINE_VDD_FRAME_CHANNEL=auto` uses sealed on new drivers and legacy on old drivers.
-- Handle enumeration does not reveal `Global\ZakoVDD_Frame_*`, `Global\ZakoVDD_Meta_*`, or `Global\ZakoVDD_FrameReady_*` for sealed sessions.
+- Handle enumeration does not reveal `Global\ZakoVDD_Frame_*`, `Global\ZakoVDD_Meta_*`, or `Global\ZakoVDD_FrameReady_*` for default new-driver sealed sessions.
 - Driver restart, monitor mode change, HDR format change, and Sunshine restart do not leak handles or stuck keyed-mutex slots.
 - Borrowed frame telemetry remains stable: low `consumer_acquire_timeouts`, low held-slot drops, and no persistent fallback churn.
 
@@ -149,6 +151,19 @@ Check that the duplicated ABI header is in sync with the driver repo:
 
 ```powershell
 cmake --build build --target check-vdd-ioctl-abi
+```
+
+Enable new-driver legacy named export only when old Sunshine builds must connect:
+
+```powershell
+New-Item -Path 'HKLM:\SOFTWARE\ZakoTech\ZakoDisplayAdapter' -Force | Out-Null
+New-ItemProperty -Path 'HKLM:\SOFTWARE\ZakoTech\ZakoDisplayAdapter' -Name LEGACYNAMEDFRAMECHANNEL -PropertyType DWord -Value 1 -Force
+```
+
+Return to sealed-only default:
+
+```powershell
+New-ItemProperty -Path 'HKLM:\SOFTWARE\ZakoTech\ZakoDisplayAdapter' -Name LEGACYNAMEDFRAMECHANNEL -PropertyType DWord -Value 0 -Force
 ```
 
 Probe sealed caps only:

--- a/docs/windows_vdd_sealed_frame_channel.md
+++ b/docs/windows_vdd_sealed_frame_channel.md
@@ -24,7 +24,7 @@ This document defines the v2 Sunshine <-> ZakoVDD frame channel. The goal is to 
 Sunshine logs both the transport mode and the final structured selection:
 
 ```text
-[vdd_capture] opened sealed monitor ... channel=sealed_borrow selection=sealed_opened access=duplicated_handles
+[vdd_capture] opened sealed monitor ... channel=sealed selection=sealed_opened access=duplicated_handles
 [vdd] backend ready ... channel=sealed selection=sealed_opened sealed_supported=true producer_slots=3 generation=2
 ```
 

--- a/src/display_device/vdd_control_ioctl.h
+++ b/src/display_device/vdd_control_ioctl.h
@@ -39,14 +39,27 @@
 
 #if defined(_WIN32) || defined(_WIN64)
 
+#if defined(INITGUID)
+#define VDD_CONTROL_RESTORE_INITGUID
+#undef INITGUID
+#endif
+
 #include <Windows.h>
 #include <winioctl.h>
+
+#if defined(VDD_CONTROL_RESTORE_INITGUID)
+#define INITGUID
+#undef VDD_CONTROL_RESTORE_INITGUID
+#endif
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 // {DA9F8C2B-7E4F-49A1-9D4E-6F2B0E1A0C4D}
+#define ZAKO_VDD_CONTROL_GUID_INIT \
+  { 0xDA9F8C2B, 0x7E4F, 0x49A1, { 0x9D, 0x4E, 0x6F, 0x2B, 0x0E, 0x1A, 0x0C, 0x4D } }
+
 DEFINE_GUID(GUID_DEVINTERFACE_ZAKO_VDD_CONTROL,
   0xDA9F8C2B, 0x7E4F, 0x49A1, 0x9D, 0x4E, 0x6F, 0x2B, 0x0E, 0x1A, 0x0C, 0x4D);
 

--- a/src/display_device/vdd_control_ioctl.h
+++ b/src/display_device/vdd_control_ioctl.h
@@ -124,6 +124,11 @@ typedef struct VDD_FRAME_CHANNEL_OPEN_RESPONSE {
 
 #ifdef __cplusplus
 }
+
+static_assert(sizeof(VDD_FRAME_CHANNEL_CAPS) == 32, "VDD_FRAME_CHANNEL_CAPS layout must stay stable");
+static_assert(sizeof(VDD_FRAME_CHANNEL_OPEN_REQUEST) == 40, "VDD_FRAME_CHANNEL_OPEN_REQUEST layout must stay stable");
+static_assert(sizeof(VDD_FRAME_CHANNEL_SLOT_HANDLE) == 16, "VDD_FRAME_CHANNEL_SLOT_HANDLE layout must stay stable");
+static_assert(sizeof(VDD_FRAME_CHANNEL_OPEN_RESPONSE) == 40 + 16 * VDD_FRAME_CHANNEL_MAX_SLOTS, "VDD_FRAME_CHANNEL_OPEN_RESPONSE layout must stay stable");
 #endif
 
 #endif  // _WIN32 || _WIN64

--- a/src/display_device/vdd_control_ioctl.h
+++ b/src/display_device/vdd_control_ioctl.h
@@ -2,10 +2,11 @@
  * @file vdd_control_ioctl.h
  * @brief Authoritative IOCTL contract between Sunshine and the ZakoVDD driver.
  *
- * This header MUST stay byte-for-byte identical with the copy that ships in
- * the Virtual-Display-Driver repository at
- *   `Common/Include/vdd_control_ioctl.h`
- * Both copies are intentionally duplicated to keep each repo self-contained.
+ * This header MUST stay byte-for-byte identical across the Sunshine and
+ * Virtual-Display-Driver repositories. The canonical copy paths are:
+ *   Sunshine: `src/display_device/vdd_control_ioctl.h`
+ *   VDD: `Common/Include/vdd_control_ioctl.h`
+ * The copies are intentionally duplicated to keep each repo self-contained.
  *
  * Transport summary:
  *   The driver exposes a custom WDF device interface
@@ -20,6 +21,18 @@
  *   re-encode anything when migrating from pipe to IOCTL.
  *
  *   `IOCTL_VDD_PING` is a cheap liveness probe (no payload).
+ *
+ *   `IOCTL_VDD_QUERY_FRAME_CHANNEL_CAPS` is the v2 frame-channel negotiation
+ *   probe. Drivers that do not implement it are treated as legacy named-object
+ *   frame producers by Sunshine.
+ *
+ *   `IOCTL_VDD_OPEN_FRAME_CHANNEL` asks the driver to duplicate an unnamed
+ *   producer-owned frame channel into the requesting Sunshine process. The
+ *   returned handle values are valid only in `TargetProcessId`.
+ *
+ *   `DesiredSlots` is a compatibility guard, not a request for the driver to
+ *   resize its producer ring. Use 0 for the driver default, or the exact
+ *   `MaxSharedSlots` value returned by `IOCTL_VDD_QUERY_FRAME_CHANNEL_CAPS`.
  */
 
 #pragma once
@@ -43,6 +56,58 @@ DEFINE_GUID(GUID_DEVINTERFACE_ZAKO_VDD_CONTROL,
 
 #define IOCTL_VDD_PING \
   CTL_CODE(FILE_DEVICE_UNKNOWN, 0x801, METHOD_BUFFERED, FILE_READ_ACCESS)
+
+#define IOCTL_VDD_QUERY_FRAME_CHANNEL_CAPS \
+  CTL_CODE(FILE_DEVICE_UNKNOWN, 0x802, METHOD_BUFFERED, FILE_READ_ACCESS)
+
+#define IOCTL_VDD_OPEN_FRAME_CHANNEL \
+  CTL_CODE(FILE_DEVICE_UNKNOWN, 0x803, METHOD_BUFFERED, FILE_READ_DATA | FILE_WRITE_DATA)
+
+#define VDD_FRAME_CHANNEL_CAPS_VERSION 1u
+#define VDD_FRAME_CHANNEL_OPEN_VERSION 1u
+#define VDD_FRAME_CHANNEL_MAX_SLOTS 8u
+#define VDD_FRAME_CHANNEL_FLAG_SEALED_BORROW 0x00000001u
+#define VDD_FRAME_CHANNEL_FLAG_UNNAMED_HANDLES 0x00000002u
+#define VDD_FRAME_CHANNEL_FLAG_STRICT_DACL 0x00000004u
+
+typedef struct VDD_FRAME_CHANNEL_CAPS {
+  UINT32 Size;
+  UINT32 Version;
+  UINT32 Flags;
+  UINT32 MaxSharedSlots;
+  UINT32 MetadataSize;
+  UINT32 Reserved0;
+  UINT64 Reserved1;
+} VDD_FRAME_CHANNEL_CAPS;
+
+typedef struct VDD_FRAME_CHANNEL_OPEN_REQUEST {
+  UINT32 Size;
+  UINT32 Version;
+  UINT32 MonitorIndex;
+  UINT32 RequiredFlags;
+  UINT32 TargetProcessId;
+  UINT32 DesiredSlots;
+  UINT32 AdapterLuidLowPart;
+  INT32 AdapterLuidHighPart;
+  UINT64 Reserved0;
+} VDD_FRAME_CHANNEL_OPEN_REQUEST;
+
+typedef struct VDD_FRAME_CHANNEL_SLOT_HANDLE {
+  UINT64 TextureHandle;
+  UINT64 Reserved0;
+} VDD_FRAME_CHANNEL_SLOT_HANDLE;
+
+typedef struct VDD_FRAME_CHANNEL_OPEN_RESPONSE {
+  UINT32 Size;
+  UINT32 Version;
+  UINT32 Flags;
+  UINT32 SlotCount;
+  UINT32 MetadataSize;
+  UINT32 Reserved0;
+  UINT64 MetadataHandle;
+  UINT64 FrameReadyEventHandle;
+  VDD_FRAME_CHANNEL_SLOT_HANDLE Slots[VDD_FRAME_CHANNEL_MAX_SLOTS];
+} VDD_FRAME_CHANNEL_OPEN_RESPONSE;
 
 #ifdef __cplusplus
 }

--- a/src/display_device/vdd_ioctl.cpp
+++ b/src/display_device/vdd_ioctl.cpp
@@ -7,16 +7,19 @@
  */
 
 #define WIN32_LEAN_AND_MEAN
-#include "vdd_ioctl.h"
+#include <Windows.h>
 
-// Emit the storage for GUID_DEVINTERFACE_ZAKO_VDD_CONTROL exactly once
-// (DEFINE_GUID expands to extern unless INITGUID is set first).
-#define INITGUID
+#include "vdd_ioctl.h"
 #include "vdd_control_ioctl.h"
 
-#include <Windows.h>
+extern "C" const GUID GUID_DEVINTERFACE_ZAKO_VDD_CONTROL = {
+  0xDA9F8C2B, 0x7E4F, 0x49A1, {0x9D, 0x4E, 0x6F, 0x2B, 0x0E, 0x1A, 0x0C, 0x4D}
+};
+
 #include <SetupAPI.h>
 
+#include <iomanip>
+#include <algorithm>
 #include <vector>
 
 #include "src/logging.h"
@@ -165,7 +168,7 @@ namespace display_device::vdd_ioctl {
           FILE_SHARE_READ | FILE_SHARE_WRITE,
           nullptr,
           OPEN_EXISTING,
-          0,
+          SECURITY_SQOS_PRESENT | SECURITY_IMPERSONATION,
           nullptr);
 
         if (m_handle == INVALID_HANDLE_VALUE) {
@@ -194,7 +197,31 @@ namespace display_device::vdd_ioctl {
       HANDLE m_handle = INVALID_HANDLE_VALUE;
     };
 
+    void
+    close_raw_frame_channel_handles(VDD_FRAME_CHANNEL_OPEN_RESPONSE &response) {
+      auto close_if_valid = [](UINT64 handle_value) {
+        if (handle_value != 0) {
+          CloseHandle(reinterpret_cast<HANDLE>(static_cast<uintptr_t>(handle_value)));
+        }
+      };
+
+      close_if_valid(response.MetadataHandle);
+      close_if_valid(response.FrameReadyEventHandle);
+      const UINT32 slot_count = std::min<UINT32>(response.SlotCount, VDD_FRAME_CHANNEL_MAX_SLOTS);
+      for (UINT32 slot = 0; slot < slot_count; ++slot) {
+        close_if_valid(response.Slots[slot].TextureHandle);
+      }
+      response = {};
+    }
+
   }  // namespace
+
+  std::uint32_t
+  required_sealed_frame_channel_flags() {
+    return VDD_FRAME_CHANNEL_FLAG_SEALED_BORROW |
+           VDD_FRAME_CHANNEL_FLAG_UNNAMED_HANDLES |
+           VDD_FRAME_CHANNEL_FLAG_STRICT_DACL;
+  }
 
   result
   send_command(const std::wstring &command) {
@@ -262,6 +289,161 @@ namespace display_device::vdd_ioctl {
       return false;
     }
     return true;
+  }
+
+  frame_channel_status
+  query_frame_channel_caps(frame_channel_caps &caps) {
+    caps = {};
+
+    device_handle dev;
+    switch (dev.open()) {
+      case device_handle::open_result::success:
+        break;
+      case device_handle::open_result::interface_missing:
+        return frame_channel_status::interface_missing;
+      case device_handle::open_result::failed:
+        return frame_channel_status::failed;
+    }
+
+    VDD_FRAME_CHANNEL_CAPS raw_caps {};
+    raw_caps.Size = sizeof(raw_caps);
+    DWORD bytes_returned = 0;
+    const BOOL ok = DeviceIoControl(
+      dev.get(),
+      IOCTL_VDD_QUERY_FRAME_CHANNEL_CAPS,
+      nullptr, 0,
+      &raw_caps, sizeof(raw_caps),
+      &bytes_returned,
+      nullptr);
+
+    if (!ok) {
+      const DWORD err = GetLastError();
+      if (err == ERROR_INVALID_FUNCTION ||
+          err == ERROR_NOT_SUPPORTED ||
+          err == ERROR_INVALID_PARAMETER) {
+        BOOST_LOG(debug) << "vdd_ioctl: frame-channel caps unsupported by driver (err=" << err << ")";
+        return frame_channel_status::unsupported;
+      }
+      BOOST_LOG(warning) << "vdd_ioctl: DeviceIoControl(IOCTL_VDD_QUERY_FRAME_CHANNEL_CAPS) failed (err=" << err << ")";
+      return frame_channel_status::failed;
+    }
+
+    if (bytes_returned < sizeof(VDD_FRAME_CHANNEL_CAPS) ||
+        raw_caps.Size < sizeof(VDD_FRAME_CHANNEL_CAPS) ||
+        raw_caps.Version != VDD_FRAME_CHANNEL_CAPS_VERSION) {
+      BOOST_LOG(warning) << "vdd_ioctl: invalid frame-channel caps response"
+                         << " bytes=" << bytes_returned
+                         << " size=" << raw_caps.Size
+                         << " version=" << raw_caps.Version;
+      return frame_channel_status::failed;
+    }
+
+    if ((raw_caps.Flags & VDD_FRAME_CHANNEL_FLAG_SEALED_BORROW) == 0 ||
+        (raw_caps.Flags & VDD_FRAME_CHANNEL_FLAG_UNNAMED_HANDLES) == 0 ||
+        (raw_caps.Flags & VDD_FRAME_CHANNEL_FLAG_STRICT_DACL) == 0) {
+      BOOST_LOG(warning) << "vdd_ioctl: frame-channel caps missing required security flags: 0x"
+                         << std::hex << raw_caps.Flags << std::dec;
+      return frame_channel_status::failed;
+    }
+
+    caps.version = raw_caps.Version;
+    caps.flags = raw_caps.Flags;
+    caps.max_shared_slots = raw_caps.MaxSharedSlots;
+    caps.metadata_size = raw_caps.MetadataSize;
+    return frame_channel_status::supported;
+  }
+
+  frame_channel_open_status
+  open_frame_channel(const frame_channel_open_request &request,
+                     frame_channel_open_response &response) {
+    response = {};
+
+    device_handle dev;
+    switch (dev.open()) {
+      case device_handle::open_result::success:
+        break;
+      case device_handle::open_result::interface_missing:
+        return frame_channel_open_status::interface_missing;
+      case device_handle::open_result::failed:
+        return frame_channel_open_status::failed;
+    }
+
+    VDD_FRAME_CHANNEL_OPEN_REQUEST raw_request {};
+    raw_request.Size = sizeof(raw_request);
+    raw_request.Version = VDD_FRAME_CHANNEL_OPEN_VERSION;
+    raw_request.MonitorIndex = request.monitor_index;
+    raw_request.RequiredFlags = request.required_flags;
+    raw_request.TargetProcessId = GetCurrentProcessId();
+    raw_request.DesiredSlots = request.desired_slots;
+    raw_request.AdapterLuidLowPart = request.adapter_luid_low_part;
+    raw_request.AdapterLuidHighPart = request.adapter_luid_high_part;
+
+    VDD_FRAME_CHANNEL_OPEN_RESPONSE raw_response {};
+    raw_response.Size = sizeof(raw_response);
+    DWORD bytes_returned = 0;
+    const BOOL ok = DeviceIoControl(
+      dev.get(),
+      IOCTL_VDD_OPEN_FRAME_CHANNEL,
+      &raw_request, sizeof(raw_request),
+      &raw_response, sizeof(raw_response),
+      &bytes_returned,
+      nullptr);
+
+    if (!ok) {
+      const DWORD err = GetLastError();
+      if (err == ERROR_INVALID_FUNCTION ||
+          err == ERROR_NOT_SUPPORTED ||
+          err == ERROR_INVALID_PARAMETER) {
+        BOOST_LOG(debug) << "vdd_ioctl: open frame-channel unsupported by driver (err=" << err << ")";
+        return frame_channel_open_status::unsupported;
+      }
+      BOOST_LOG(warning) << "vdd_ioctl: DeviceIoControl(IOCTL_VDD_OPEN_FRAME_CHANNEL) failed (err=" << err << ")";
+      return frame_channel_open_status::failed;
+    }
+
+    if (bytes_returned < sizeof(VDD_FRAME_CHANNEL_OPEN_RESPONSE) ||
+        raw_response.Size < sizeof(VDD_FRAME_CHANNEL_OPEN_RESPONSE) ||
+        raw_response.Version != VDD_FRAME_CHANNEL_OPEN_VERSION ||
+        raw_response.SlotCount == 0 ||
+        raw_response.SlotCount > VDD_FRAME_CHANNEL_MAX_SLOTS ||
+        raw_response.MetadataHandle == 0 ||
+        raw_response.FrameReadyEventHandle == 0) {
+      BOOST_LOG(warning) << "vdd_ioctl: invalid frame-channel open response"
+                         << " bytes=" << bytes_returned
+                         << " size=" << raw_response.Size
+                         << " version=" << raw_response.Version
+                         << " slots=" << raw_response.SlotCount
+                         << " meta_handle=" << raw_response.MetadataHandle
+                         << " event_handle=" << raw_response.FrameReadyEventHandle;
+      close_raw_frame_channel_handles(raw_response);
+      return frame_channel_open_status::failed;
+    }
+
+    if ((raw_response.Flags & request.required_flags) != request.required_flags) {
+      BOOST_LOG(warning) << "vdd_ioctl: frame-channel open response missing required flags"
+                         << " required=0x" << std::hex << request.required_flags
+                         << " got=0x" << raw_response.Flags << std::dec;
+      close_raw_frame_channel_handles(raw_response);
+      return frame_channel_open_status::failed;
+    }
+
+    response.version = raw_response.Version;
+    response.flags = raw_response.Flags;
+    response.slot_count = raw_response.SlotCount;
+    response.metadata_size = raw_response.MetadataSize;
+    response.metadata_handle = raw_response.MetadataHandle;
+    response.frame_ready_event_handle = raw_response.FrameReadyEventHandle;
+    response.slots.reserve(raw_response.SlotCount);
+    for (UINT32 slot = 0; slot < raw_response.SlotCount; ++slot) {
+      if (raw_response.Slots[slot].TextureHandle == 0) {
+        BOOST_LOG(warning) << "vdd_ioctl: frame-channel open response has null texture handle for slot " << slot;
+        close_raw_frame_channel_handles(raw_response);
+        response = {};
+        return frame_channel_open_status::failed;
+      }
+      response.slots.push_back(frame_channel_slot_handle { raw_response.Slots[slot].TextureHandle });
+    }
+    return frame_channel_open_status::opened;
   }
 
 }  // namespace display_device::vdd_ioctl

--- a/src/display_device/vdd_ioctl.cpp
+++ b/src/display_device/vdd_ioctl.cpp
@@ -12,9 +12,7 @@
 #include "vdd_ioctl.h"
 #include "vdd_control_ioctl.h"
 
-extern "C" const GUID GUID_DEVINTERFACE_ZAKO_VDD_CONTROL = {
-  0xDA9F8C2B, 0x7E4F, 0x49A1, {0x9D, 0x4E, 0x6F, 0x2B, 0x0E, 0x1A, 0x0C, 0x4D}
-};
+extern "C" const GUID GUID_DEVINTERFACE_ZAKO_VDD_CONTROL = ZAKO_VDD_CONTROL_GUID_INIT;
 
 #include <SetupAPI.h>
 

--- a/src/display_device/vdd_ioctl.h
+++ b/src/display_device/vdd_ioctl.h
@@ -18,7 +18,9 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
+#include <vector>
 
 namespace display_device::vdd_ioctl {
 
@@ -37,6 +39,58 @@ namespace display_device::vdd_ioctl {
     interface_missing, ///< No registered device interface (driver too old / not installed). Safe to fall back.
     failed,            ///< Driver was reached but rejected the IOCTL or returned an error. Do NOT fall back.
   };
+
+  /**
+   * @brief Host-side view of the sealed frame-channel capability probe.
+   *
+   * Kept separate from `result` because a driver can fully support the command
+   * IOCTL transport while still being an older legacy named-texture frame
+   * producer.
+   */
+  enum class frame_channel_status {
+    supported,
+    unsupported,
+    interface_missing,
+    failed,
+  };
+
+  struct frame_channel_caps {
+    std::uint32_t version = 0;
+    std::uint32_t flags = 0;
+    std::uint32_t max_shared_slots = 0;
+    std::uint32_t metadata_size = 0;
+  };
+
+  enum class frame_channel_open_status {
+    opened,
+    unsupported,
+    interface_missing,
+    failed,
+  };
+
+  struct frame_channel_open_request {
+    std::uint32_t monitor_index = 0;
+    std::uint32_t required_flags = 0;
+    std::uint32_t desired_slots = 0;
+    std::uint32_t adapter_luid_low_part = 0;
+    std::int32_t adapter_luid_high_part = 0;
+  };
+
+  struct frame_channel_slot_handle {
+    std::uint64_t texture_handle = 0;
+  };
+
+  struct frame_channel_open_response {
+    std::uint32_t version = 0;
+    std::uint32_t flags = 0;
+    std::uint32_t slot_count = 0;
+    std::uint32_t metadata_size = 0;
+    std::uint64_t metadata_handle = 0;
+    std::uint64_t frame_ready_event_handle = 0;
+    std::vector<frame_channel_slot_handle> slots;
+  };
+
+  std::uint32_t required_sealed_frame_channel_flags();
 
   /**
    * @brief Send a UTF-16 command buffer to the VDD driver via IOCTL.
@@ -59,5 +113,26 @@ namespace display_device::vdd_ioctl {
    * @return `true` if `IOCTL_VDD_PING` round-trips successfully.
    */
   bool ping();
+
+  /**
+   * @brief Probe whether the installed driver supports the v2 sealed frame
+   *        channel negotiation IOCTL.
+   *
+   * `unsupported` means the control device is present but the driver does not
+   * implement `IOCTL_VDD_QUERY_FRAME_CHANNEL_CAPS`; callers should keep using
+   * the hardened legacy named shared-texture path.
+   */
+  frame_channel_status query_frame_channel_caps(frame_channel_caps &caps);
+
+  /**
+   * @brief Ask a v2 driver to duplicate an unnamed producer-owned frame
+   *        channel into this Sunshine process.
+   *
+   * This is the host side of sealed borrow. Older drivers return
+   * `unsupported`, and callers must not treat `query_frame_channel_caps()`
+   * support as proof that this open path is usable until this call succeeds.
+   */
+  frame_channel_open_status open_frame_channel(const frame_channel_open_request &request,
+                                               frame_channel_open_response &response);
 
 }  // namespace display_device::vdd_ioctl

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -25,6 +25,12 @@
 #include "src/platform/common.h"
 #include "src/utility.h"
 #include "src/video.h"
+#include "vdd_frame_channel.h"
+
+namespace display_device::vdd_ioctl {
+  struct frame_channel_caps;
+  struct frame_channel_open_response;
+}
 
 namespace platf::dxgi {
   extern const char *format_str[];
@@ -617,11 +623,42 @@ namespace platf::dxgi {
     UINT64 dropped_acquire_failures() const { return m_droppedAcquireFailures; }
     UINT32 producer_slot_count() const { return m_slotCount; }
     UINT32 producer_slot_index() const { return m_slotIndex; }
+    UINT16 producer_channel_generation() const { return m_channelGeneration; }
     UINT64 producer_qpc_frequency() const { return m_producerQpcFrequency; }
     LUID producer_adapter_luid() const { return m_adapterLuid; }
+    UINT64 consumer_acquire_timeouts() const { return m_consumerAcquireTimeouts; }
+    bool sealed_frame_channel_supported() const { return m_sealedFrameChannelSupported; }
+    vdd_frame_channel::channel_mode frame_channel_mode() const { return m_frameChannelMode; }
+    vdd_frame_channel::channel_selection frame_channel_selection() const { return m_frameChannelSelection; }
+    bool legacy_named_channel() const { return m_legacyNamedChannel; }
 
   private:
+    enum class sealed_channel_attempt {
+      skipped,
+      opened,
+      fallback_allowed,
+      required_failed,
+    };
+
     void close();
+    void apply_metadata_snapshot(const vdd_frame_channel::shared_frame_metadata_t &meta);
+    bool attach_texture_slot(ID3D11Device1 *device,
+                             HANDLE shared_handle,
+                             const vdd_frame_channel::shared_frame_metadata_t &meta,
+                             UINT32 slot,
+                             bool close_handle,
+                             const wchar_t *debug_name = nullptr);
+    bool attach_sealed_channel(ID3D11Device1 *device,
+                               unsigned int monitor_idx,
+                               const LUID &device_luid,
+                               display_device::vdd_ioctl::frame_channel_open_response &sealed_channel);
+    bool attach_legacy_named_channel(ID3D11Device1 *device,
+                                     unsigned int monitor_idx,
+                                     const LUID &device_luid);
+    sealed_channel_attempt try_open_sealed_channel(ID3D11Device1 *device,
+                                                  unsigned int monitor_idx,
+                                                  const LUID &device_luid,
+                                                  const display_device::vdd_ioctl::frame_channel_caps &sealed_caps);
 
     HANDLE m_hMeta = nullptr;
     void  *m_pMeta = nullptr;
@@ -648,8 +685,14 @@ namespace platf::dxgi {
     UINT64 m_droppedAcquireFailures = 0;
     UINT32 m_slotCount = 1;
     UINT32 m_slotIndex = 0;
+    UINT16 m_channelGeneration = 0;
     UINT64 m_producerQpcFrequency = 0;
     LUID m_adapterLuid = {};
+    UINT64 m_consumerAcquireTimeouts = 0;
+    bool m_sealedFrameChannelSupported = false;
+    vdd_frame_channel::channel_mode m_frameChannelMode = vdd_frame_channel::channel_mode::auto_probe;
+    vdd_frame_channel::channel_selection m_frameChannelSelection = vdd_frame_channel::channel_selection::unknown;
+    bool m_legacyNamedChannel = true;
   };
 
   /**

--- a/src/platform/windows/display_vdd.cpp
+++ b/src/platform/windows/display_vdd.cpp
@@ -122,7 +122,7 @@ namespace platf::dxgi {
   probe_sealed_frame_channel(display_device::vdd_ioctl::frame_channel_caps &caps) {
     caps = {};
     switch (display_device::vdd_ioctl::query_frame_channel_caps(caps)) {
-      case display_device::vdd_ioctl::frame_channel_status::supported:
+      case display_device::vdd_ioctl::frame_channel_status::supported: {
         BOOST_LOG(info) << "[vdd_capture] sealed frame-channel caps: version="sv << caps.version
                         << " flags=0x"sv << util::hex(caps.flags).to_string_view()
                         << " max_slots="sv << caps.max_shared_slots
@@ -139,6 +139,7 @@ namespace platf::dxgi {
           return vdd_frame_channel::channel_selection::caps_failed;
         }
         return vdd_frame_channel::channel_selection::unknown;
+      }
       case display_device::vdd_ioctl::frame_channel_status::unsupported:
         BOOST_LOG(debug) << "[vdd_capture] sealed frame-channel IOCTL unsupported; using hardened legacy named channel"sv;
         return vdd_frame_channel::channel_selection::caps_unsupported;

--- a/src/platform/windows/display_vdd.cpp
+++ b/src/platform/windows/display_vdd.cpp
@@ -16,13 +16,16 @@
 #include "display.h"
 #include "misc.h"
 #include "src/config.h"
+#include "src/display_device/vdd_ioctl.h"
 #include "src/main.h"
+#include "vdd_frame_channel.h"
 
 #include <d3d11_1.h>
 #include <sddl.h>
 #include <algorithm>
 #include <cctype>
 #include <chrono>
+#include <cstdint>
 #include <cmath>
 #include <cstdlib>
 #include <optional>
@@ -35,38 +38,7 @@ namespace platf {
 
 namespace platf::dxgi {
 
-  // Must stay binary-compatible with the producer-side struct in
-  // Virtual-Display-Driver/.../ZakoVDD/Driver.cpp (SharedFrameMetadata).
-  struct SharedFrameMetadata {
-    UINT32 Magic;            // 'ZVDF' = 0x5A564446
-    UINT32 Version;          // 1
-    UINT32 Width;
-    UINT32 Height;
-    UINT32 DxgiFormat;
-    UINT32 IsHdr;
-    float  MaxNits;
-    float  MinNits;
-    float  MaxFALL;
-    UINT64 FrameCounter;
-    UINT64 LastPresentQpc;
-    UINT64 LastPublishQpc;
-    UINT32 LastPresentationFrameNumber;
-    UINT32 LastDirtyRectCount;
-    UINT64 ReplacedUnreadFrames;
-    UINT64 DroppedConsumerHeldFrames;
-    UINT64 DroppedAcquireFailures;
-    UINT32 MetadataSize;
-    UINT32 SlotCount;
-    UINT32 SlotIndex;
-    UINT32 Reserved0;
-    UINT32 AdapterLuidLowPart;
-    INT32  AdapterLuidHighPart;
-    UINT64 ProducerQpcFrequency;
-  };
-
-  static constexpr UINT32 VDD_META_MAGIC = 0x5A564446;  // 'ZVDF'
-  static constexpr UINT32 VDD_META_VERSION = 1;
-  static constexpr UINT32 VDD_MAX_SHARED_SLOTS = 8;
+  using SharedFrameMetadata = vdd_frame_channel::shared_frame_metadata_t;
 
   static std::wstring
   vdd_texture_name(unsigned int monitor_idx, UINT32 slot_idx) {
@@ -95,6 +67,217 @@ namespace platf::dxgi {
     }
     BOOST_LOG(warning) << "[vdd] ignoring invalid SUNSHINE_VDD_BORROWED_TEXTURE value: "sv << value;
     return std::nullopt;
+  }
+
+  static std::optional<vdd_frame_channel::channel_mode>
+  vdd_frame_channel_mode_env_override() {
+    const char *raw_value = std::getenv("SUNSHINE_VDD_FRAME_CHANNEL");
+    if (!raw_value || !*raw_value) {
+      return std::nullopt;
+    }
+
+    std::string value {raw_value};
+    std::transform(value.begin(), value.end(), value.begin(),
+      [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+    auto mode = vdd_frame_channel::parse_channel_mode(value);
+    if (!mode) {
+      BOOST_LOG(warning) << "[vdd] ignoring invalid SUNSHINE_VDD_FRAME_CHANNEL value: "sv << value
+                         << " (expected auto, legacy, or sealed)"sv;
+    }
+    return mode;
+  }
+
+  static std::optional<LUID>
+  vdd_device_adapter_luid(ID3D11Device *d3d_device) {
+    IDXGIDevice *dxgi_device_p = nullptr;
+    HRESULT hr = d3d_device->QueryInterface(__uuidof(IDXGIDevice), reinterpret_cast<void **>(&dxgi_device_p));
+    if (FAILED(hr) || !dxgi_device_p) {
+      BOOST_LOG(error) << "[vdd_capture] failed to query IDXGIDevice for adapter LUID: 0x"sv
+                       << util::hex(hr).to_string_view();
+      return std::nullopt;
+    }
+    dxgi_t dxgi_device {dxgi_device_p};
+
+    IDXGIAdapter *adapter_p = nullptr;
+    hr = dxgi_device->GetAdapter(&adapter_p);
+    if (FAILED(hr) || !adapter_p) {
+      BOOST_LOG(error) << "[vdd_capture] failed to query IDXGIAdapter for adapter LUID: 0x"sv
+                       << util::hex(hr).to_string_view();
+      return std::nullopt;
+    }
+    util::safe_ptr<IDXGIAdapter, Release<IDXGIAdapter>> adapter {adapter_p};
+
+    DXGI_ADAPTER_DESC desc {};
+    hr = adapter->GetDesc(&desc);
+    if (FAILED(hr)) {
+      BOOST_LOG(error) << "[vdd_capture] IDXGIAdapter::GetDesc failed: 0x"sv
+                       << util::hex(hr).to_string_view();
+      return std::nullopt;
+    }
+    return desc.AdapterLuid;
+  }
+
+  static vdd_frame_channel::channel_selection
+  probe_sealed_frame_channel(display_device::vdd_ioctl::frame_channel_caps &caps) {
+    caps = {};
+    switch (display_device::vdd_ioctl::query_frame_channel_caps(caps)) {
+      case display_device::vdd_ioctl::frame_channel_status::supported:
+        BOOST_LOG(info) << "[vdd_capture] sealed frame-channel caps: version="sv << caps.version
+                        << " flags=0x"sv << util::hex(caps.flags).to_string_view()
+                        << " max_slots="sv << caps.max_shared_slots
+                        << " metadata_size="sv << caps.metadata_size;
+        if (caps.max_shared_slots == 0) {
+          BOOST_LOG(warning) << "[vdd_capture] sealed frame-channel reported zero shared slots; using hardened legacy named channel"sv;
+          return vdd_frame_channel::channel_selection::caps_failed;
+        }
+        return vdd_frame_channel::channel_selection::unknown;
+      case display_device::vdd_ioctl::frame_channel_status::unsupported:
+        BOOST_LOG(debug) << "[vdd_capture] sealed frame-channel IOCTL unsupported; using hardened legacy named channel"sv;
+        return vdd_frame_channel::channel_selection::caps_unsupported;
+      case display_device::vdd_ioctl::frame_channel_status::interface_missing:
+        BOOST_LOG(debug) << "[vdd_capture] VDD IOCTL control interface missing; using hardened legacy named channel"sv;
+        return vdd_frame_channel::channel_selection::caps_unsupported;
+      case display_device::vdd_ioctl::frame_channel_status::failed:
+        BOOST_LOG(warning) << "[vdd_capture] sealed frame-channel capability probe failed; using hardened legacy named channel"sv;
+        return vdd_frame_channel::channel_selection::caps_failed;
+    }
+    return vdd_frame_channel::channel_selection::caps_failed;
+  }
+
+  static void
+  close_sealed_frame_channel_handles(display_device::vdd_ioctl::frame_channel_open_response &channel) {
+    auto close_if_valid = [](std::uint64_t handle_value) {
+      if (handle_value != 0) {
+        CloseHandle(reinterpret_cast<HANDLE>(static_cast<uintptr_t>(handle_value)));
+      }
+    };
+
+    close_if_valid(channel.metadata_handle);
+    close_if_valid(channel.frame_ready_event_handle);
+    for (const auto &slot : channel.slots) {
+      close_if_valid(slot.texture_handle);
+    }
+    channel = {};
+  }
+
+  static display_device::vdd_ioctl::frame_channel_open_status
+  open_sealed_frame_channel(unsigned int monitor_idx,
+                            const LUID &device_luid,
+                            UINT32 desired_slots,
+                            display_device::vdd_ioctl::frame_channel_open_response &channel) {
+    display_device::vdd_ioctl::frame_channel_open_request request {};
+    request.monitor_index = monitor_idx;
+    request.required_flags = display_device::vdd_ioctl::required_sealed_frame_channel_flags();
+    request.desired_slots = desired_slots;
+    request.adapter_luid_low_part = device_luid.LowPart;
+    request.adapter_luid_high_part = device_luid.HighPart;
+    return display_device::vdd_ioctl::open_frame_channel(request, channel);
+  }
+
+  static void
+  log_vdd_metadata_reject(const SharedFrameMetadata &meta,
+                          const LUID &device_luid,
+                          vdd_frame_channel::reject_reason reason) {
+    LUID producer_luid {};
+    producer_luid.LowPart = meta.AdapterLuidLowPart;
+    producer_luid.HighPart = meta.AdapterLuidHighPart;
+
+    switch (reason) {
+      case vdd_frame_channel::reject_reason::bad_magic:
+        BOOST_LOG(error) << "[vdd_capture] bad metadata magic: 0x"sv
+                         << util::hex(meta.Magic).to_string_view();
+        break;
+      case vdd_frame_channel::reject_reason::version_mismatch:
+        BOOST_LOG(error) << "[vdd_capture] metadata version mismatch: producer="sv
+                         << meta.Version << " consumer="sv << vdd_frame_channel::meta_version;
+        break;
+      case vdd_frame_channel::reject_reason::metadata_too_small:
+        BOOST_LOG(error) << "[vdd_capture] metadata block too small: producer="sv
+                         << meta.MetadataSize << " required="sv << vdd_frame_channel::min_metadata_size;
+        break;
+      case vdd_frame_channel::reject_reason::invalid_dimensions:
+        BOOST_LOG(warning) << "[vdd_capture] producer has invalid dimensions: "sv
+                           << meta.Width << "x"sv << meta.Height;
+        break;
+      case vdd_frame_channel::reject_reason::unsupported_format:
+        BOOST_LOG(error) << "[vdd_capture] unsupported producer DXGI format: "sv << meta.DxgiFormat;
+        break;
+      case vdd_frame_channel::reject_reason::invalid_slot_count:
+        BOOST_LOG(error) << "[vdd_capture] invalid producer slot count: "sv << meta.SlotCount
+                         << " max="sv << vdd_frame_channel::max_shared_slots;
+        break;
+      case vdd_frame_channel::reject_reason::slot_index_out_of_range:
+        BOOST_LOG(error) << "[vdd_capture] producer slot index "sv << meta.SlotIndex
+                         << " outside slot count "sv << meta.SlotCount;
+        break;
+      case vdd_frame_channel::reject_reason::zero_adapter_luid:
+        BOOST_LOG(error) << "[vdd_capture] producer adapter LUID is zero; refusing ambiguous shared texture channel"sv;
+        break;
+      case vdd_frame_channel::reject_reason::adapter_luid_mismatch:
+        BOOST_LOG(error) << "[vdd_capture] producer adapter LUID "sv
+                         << producer_luid.LowPart << ":"sv << producer_luid.HighPart
+                         << " does not match Sunshine D3D device LUID "sv
+                         << device_luid.LowPart << ":"sv << device_luid.HighPart;
+        break;
+      default:
+        BOOST_LOG(error) << "[vdd_capture] metadata rejected for reason "sv << static_cast<int>(reason);
+        break;
+    }
+  }
+
+  static bool
+  vdd_metadata_is_attachable(const SharedFrameMetadata &meta, const LUID &device_luid) {
+    const auto result = vdd_frame_channel::validate_metadata_for_attach(meta, device_luid);
+    if (!result) {
+      log_vdd_metadata_reject(meta, device_luid, result.reason);
+      return false;
+    }
+    return true;
+  }
+
+  static bool
+  vdd_metadata_is_probe_valid(const SharedFrameMetadata &meta) {
+    return static_cast<bool>(vdd_frame_channel::validate_metadata_for_probe(meta));
+  }
+
+  static bool
+  vdd_texture_desc_matches_metadata(const D3D11_TEXTURE2D_DESC &desc,
+                                    const SharedFrameMetadata &meta,
+                                    UINT32 slot) {
+    const auto result = vdd_frame_channel::validate_texture_desc(desc, meta);
+    if (result) {
+      return true;
+    }
+
+    switch (result.reason) {
+      case vdd_frame_channel::reject_reason::texture_desc_mismatch:
+        BOOST_LOG(error) << "[vdd_capture] shared texture slot "sv << slot
+                         << " desc mismatch: texture="sv << desc.Width << "x"sv << desc.Height
+                         << " fmt="sv << static_cast<int>(desc.Format)
+                         << " metadata="sv << meta.Width << "x"sv << meta.Height
+                         << " fmt="sv << meta.DxgiFormat;
+        break;
+      case vdd_frame_channel::reject_reason::texture_layout_unsupported:
+        BOOST_LOG(error) << "[vdd_capture] shared texture slot "sv << slot
+                         << " has unsupported layout: array="sv << desc.ArraySize
+                         << " mips="sv << desc.MipLevels
+                         << " samples="sv << desc.SampleDesc.Count << "/"sv << desc.SampleDesc.Quality;
+        break;
+      case vdd_frame_channel::reject_reason::texture_missing_keyed_mutex:
+        BOOST_LOG(error) << "[vdd_capture] shared texture slot "sv << slot
+                         << " is missing D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX"sv;
+        break;
+      case vdd_frame_channel::reject_reason::texture_missing_shader_resource:
+        BOOST_LOG(error) << "[vdd_capture] shared texture slot "sv << slot
+                         << " is missing D3D11_BIND_SHADER_RESOURCE"sv;
+        break;
+      default:
+        BOOST_LOG(error) << "[vdd_capture] shared texture slot "sv << slot
+                         << " rejected for reason "sv << static_cast<int>(result.reason);
+        break;
+    }
+    return false;
   }
 
   vdd_capture_t::vdd_capture_t() = default;
@@ -126,13 +309,211 @@ namespace platf::dxgi {
     }
   }
 
-  int
-  vdd_capture_t::init(ID3D11Device *d3d_device, unsigned int monitor_idx) {
-    if (!d3d_device) {
-      BOOST_LOG(error) << "[vdd_capture] init: null D3D11 device"sv;
-      return -1;
+  void
+  vdd_capture_t::apply_metadata_snapshot(const SharedFrameMetadata &meta) {
+    m_width = meta.Width;
+    m_height = meta.Height;
+    m_format = static_cast<DXGI_FORMAT>(meta.DxgiFormat);
+    m_is_hdr = (meta.IsHdr != 0);
+    m_max_nits = meta.MaxNits;
+    m_min_nits = meta.MinNits;
+    m_max_fall = meta.MaxFALL;
+    m_lastFrameCounter = meta.FrameCounter;
+    m_lastPresentQpc = meta.LastPresentQpc;
+    m_lastPublishQpc = meta.LastPublishQpc;
+    m_lastPresentationFrameNumber = meta.LastPresentationFrameNumber;
+    m_lastDirtyRectCount = meta.LastDirtyRectCount;
+    m_replacedUnreadFrames = meta.ReplacedUnreadFrames;
+    m_droppedConsumerHeldFrames = meta.DroppedConsumerHeldFrames;
+    m_droppedAcquireFailures = meta.DroppedAcquireFailures;
+    m_slotCount = meta.SlotCount;
+    m_slotIndex = meta.SlotIndex;
+    m_channelGeneration = vdd_frame_channel::metadata_channel_generation(meta.MetadataSequence);
+    m_producerQpcFrequency = meta.ProducerQpcFrequency;
+    m_adapterLuid.LowPart = meta.AdapterLuidLowPart;
+    m_adapterLuid.HighPart = meta.AdapterLuidHighPart;
+  }
+
+  bool
+  vdd_capture_t::attach_texture_slot(ID3D11Device1 *device,
+                                     HANDLE shared_handle,
+                                     const SharedFrameMetadata &meta,
+                                     UINT32 slot,
+                                     bool close_handle,
+                                     const wchar_t *debug_name) {
+    if (!device || (!shared_handle && !debug_name)) {
+      return false;
     }
 
+    ID3D11Texture2D *raw = nullptr;
+    HRESULT hr = E_FAIL;
+    if (debug_name) {
+      hr = device->OpenSharedResourceByName(debug_name,
+                                            DXGI_SHARED_RESOURCE_READ,
+                                            __uuidof(ID3D11Texture2D),
+                                            reinterpret_cast<void **>(&raw));
+    }
+    else {
+      hr = device->OpenSharedResource1(shared_handle,
+                                       __uuidof(ID3D11Texture2D),
+                                       reinterpret_cast<void **>(&raw));
+    }
+    if (close_handle) {
+      CloseHandle(shared_handle);
+    }
+    if (FAILED(hr) || !raw) {
+      BOOST_LOG(error) << "[vdd_capture] failed to open shared texture slot "sv
+                       << slot << ": 0x"sv << util::hex(hr).to_string_view()
+                       << (debug_name ? " by name" : " by duplicated handle");
+      return false;
+    }
+    m_sharedTex[slot].reset(raw);
+
+    D3D11_TEXTURE2D_DESC desc {};
+    m_sharedTex[slot]->GetDesc(&desc);
+    if (!vdd_texture_desc_matches_metadata(desc, meta, slot)) {
+      return false;
+    }
+
+    IDXGIKeyedMutex *km = nullptr;
+    hr = m_sharedTex[slot]->QueryInterface(__uuidof(IDXGIKeyedMutex), reinterpret_cast<void **>(&km));
+    if (FAILED(hr) || !km) {
+      BOOST_LOG(error) << "[vdd_capture] no IDXGIKeyedMutex on shared texture slot "sv
+                       << slot << ": 0x"sv << util::hex(hr).to_string_view();
+      return false;
+    }
+    m_keyedMutex[slot].reset(km);
+    return true;
+  }
+
+  bool
+  vdd_capture_t::attach_sealed_channel(ID3D11Device1 *device,
+                                       unsigned int monitor_idx,
+                                       const LUID &device_luid,
+                                       display_device::vdd_ioctl::frame_channel_open_response &sealed_channel) {
+    auto fail = [&]() -> bool {
+      close();
+      close_sealed_frame_channel_handles(sealed_channel);
+      return false;
+    };
+
+    m_hMeta = reinterpret_cast<HANDLE>(static_cast<uintptr_t>(sealed_channel.metadata_handle));
+    sealed_channel.metadata_handle = 0;
+    m_hEvent = reinterpret_cast<HANDLE>(static_cast<uintptr_t>(sealed_channel.frame_ready_event_handle));
+    sealed_channel.frame_ready_event_handle = 0;
+
+    m_pMeta = MapViewOfFile(m_hMeta, FILE_MAP_READ, 0, 0, sizeof(SharedFrameMetadata));
+    if (!m_pMeta) {
+      BOOST_LOG(error) << "[vdd_capture] MapViewOfFile(sealed metadata) failed: "sv << GetLastError();
+      return fail();
+    }
+
+    auto *meta = static_cast<const SharedFrameMetadata *>(m_pMeta);
+    SharedFrameMetadata meta_snapshot {};
+    if (!vdd_frame_channel::read_stable_metadata(meta, meta_snapshot)) {
+      BOOST_LOG(error) << "[vdd_capture] unable to read a stable sealed metadata snapshot"sv;
+      return fail();
+    }
+    if (!vdd_metadata_is_attachable(meta_snapshot, device_luid)) {
+      return fail();
+    }
+    if (meta_snapshot.SlotCount != sealed_channel.slot_count ||
+        sealed_channel.slots.size() < meta_snapshot.SlotCount) {
+      BOOST_LOG(error) << "[vdd_capture] sealed channel slot mismatch: metadata="sv
+                       << meta_snapshot.SlotCount << " response="sv << sealed_channel.slot_count
+                       << " handles="sv << sealed_channel.slots.size();
+      return fail();
+    }
+
+    apply_metadata_snapshot(meta_snapshot);
+
+    m_sharedTex.resize(m_slotCount);
+    m_keyedMutex.resize(m_slotCount);
+    for (UINT32 slot = 0; slot < m_slotCount; ++slot) {
+      auto &slot_handle_value = sealed_channel.slots[slot].texture_handle;
+      HANDLE slot_handle = reinterpret_cast<HANDLE>(static_cast<uintptr_t>(slot_handle_value));
+      slot_handle_value = 0;
+      if (!attach_texture_slot(device, slot_handle, meta_snapshot, slot, true)) {
+        return fail();
+      }
+    }
+
+    close_sealed_frame_channel_handles(sealed_channel);
+    m_legacyNamedChannel = false;
+    m_frameChannelSelection = vdd_frame_channel::channel_selection::sealed_opened;
+    BOOST_LOG(info) << "[vdd_capture] opened sealed monitor "sv << monitor_idx
+                    << " "sv << m_width << "x"sv << m_height
+                    << " fmt="sv << static_cast<int>(m_format)
+                    << " hdr="sv << m_is_hdr
+                    << " luid="sv << m_adapterLuid.LowPart << ":"sv << m_adapterLuid.HighPart
+                    << " slot="sv << m_slotIndex << "/"sv << m_slotCount
+                    << " meta_size="sv << meta_snapshot.MetadataSize
+                    << " meta_seq="sv << meta_snapshot.MetadataSequence
+                    << " generation="sv << m_channelGeneration
+                    << " mode="sv << vdd_frame_channel::channel_mode_name(m_frameChannelMode)
+                    << " channel=sealed_borrow"
+                    << " selection="sv << vdd_frame_channel::channel_selection_name(m_frameChannelSelection)
+                    << " access=duplicated_handles";
+    return true;
+  }
+
+  vdd_capture_t::sealed_channel_attempt
+  vdd_capture_t::try_open_sealed_channel(ID3D11Device1 *device,
+                                         unsigned int monitor_idx,
+                                         const LUID &device_luid,
+                                         const display_device::vdd_ioctl::frame_channel_caps &sealed_caps) {
+    if (m_frameChannelMode == vdd_frame_channel::channel_mode::legacy_named) {
+      return sealed_channel_attempt::skipped;
+    }
+
+    if (!m_sealedFrameChannelSupported) {
+      if (m_frameChannelMode == vdd_frame_channel::channel_mode::sealed_required) {
+        m_frameChannelSelection = vdd_frame_channel::channel_selection::sealed_required_failed;
+        BOOST_LOG(error) << "[vdd_capture] SUNSHINE_VDD_FRAME_CHANNEL=sealed requested, "
+                            "but the installed VDD driver does not expose a sealed frame channel"sv;
+        return sealed_channel_attempt::required_failed;
+      }
+      return sealed_channel_attempt::fallback_allowed;
+    }
+
+    display_device::vdd_ioctl::frame_channel_open_response sealed_channel;
+    const UINT32 desired_slots = std::min<UINT32>(vdd_frame_channel::max_shared_slots, sealed_caps.max_shared_slots);
+    const auto open_status = open_sealed_frame_channel(monitor_idx, device_luid, desired_slots, sealed_channel);
+    if (open_status == display_device::vdd_ioctl::frame_channel_open_status::opened) {
+      if (attach_sealed_channel(device, monitor_idx, device_luid, sealed_channel)) {
+        return sealed_channel_attempt::opened;
+      }
+      if (m_frameChannelMode == vdd_frame_channel::channel_mode::sealed_required) {
+        m_frameChannelSelection = vdd_frame_channel::channel_selection::sealed_required_failed;
+        return sealed_channel_attempt::required_failed;
+      }
+      m_frameChannelSelection = vdd_frame_channel::channel_selection::attach_failed;
+      BOOST_LOG(warning) << "[vdd_capture] sealed frame channel attach failed; falling back to hardened legacy named channel"sv;
+      return sealed_channel_attempt::fallback_allowed;
+    }
+
+    if (m_frameChannelMode == vdd_frame_channel::channel_mode::sealed_required) {
+      m_frameChannelSelection = vdd_frame_channel::channel_selection::sealed_required_failed;
+      BOOST_LOG(error) << "[vdd_capture] SUNSHINE_VDD_FRAME_CHANNEL=sealed requested, "
+                       << "but sealed frame channel open failed with status "sv
+                       << static_cast<int>(open_status);
+      return sealed_channel_attempt::required_failed;
+    }
+
+    m_frameChannelSelection =
+      open_status == display_device::vdd_ioctl::frame_channel_open_status::unsupported ?
+        vdd_frame_channel::channel_selection::open_unsupported :
+        vdd_frame_channel::channel_selection::open_failed;
+    BOOST_LOG(warning) << "[vdd_capture] sealed frame channel open failed with status "sv
+                       << static_cast<int>(open_status)
+                       << "; falling back to hardened legacy named channel"sv;
+    return sealed_channel_attempt::fallback_allowed;
+  }
+
+  bool
+  vdd_capture_t::attach_legacy_named_channel(ID3D11Device1 *device,
+                                             unsigned int monitor_idx,
+                                             const LUID &device_luid) {
     std::wstring meta_name = L"Global\\ZakoVDD_Meta_" + std::to_wstring(monitor_idx);
     std::wstring ev_name = L"Global\\ZakoVDD_FrameReady_" + std::to_wstring(monitor_idx);
 
@@ -144,119 +525,111 @@ namespace platf::dxgi {
       BOOST_LOG(warning) << "[vdd_capture] OpenFileMappingW failed for monitor "sv
                          << monitor_idx << " (gle="sv << err << "). "sv
                          << "VDD driver running? Monitor active?"sv;
-      return -1;
+      return false;
     }
 
     m_pMeta = MapViewOfFile(m_hMeta, FILE_MAP_READ, 0, 0, sizeof(SharedFrameMetadata));
     if (!m_pMeta) {
       BOOST_LOG(error) << "[vdd_capture] MapViewOfFile failed: "sv << GetLastError();
       close();
-      return -1;
+      return false;
     }
 
     auto *meta = static_cast<const SharedFrameMetadata *>(m_pMeta);
-    if (meta->Magic != VDD_META_MAGIC) {
-      BOOST_LOG(error) << "[vdd_capture] bad metadata magic: 0x"sv
-                       << util::hex(meta->Magic).to_string_view();
+    SharedFrameMetadata meta_snapshot {};
+    if (!vdd_frame_channel::read_stable_metadata(meta, meta_snapshot)) {
+      BOOST_LOG(error) << "[vdd_capture] unable to read a stable metadata snapshot"sv;
       close();
-      return -1;
+      return false;
     }
-    if (meta->Version != VDD_META_VERSION) {
-      BOOST_LOG(error) << "[vdd_capture] metadata version mismatch: producer="sv
-                       << meta->Version << " consumer="sv << VDD_META_VERSION;
+    if (!vdd_metadata_is_attachable(meta_snapshot, device_luid)) {
       close();
-      return -1;
+      return false;
     }
 
-    m_width = meta->Width;
-    m_height = meta->Height;
-    m_format = static_cast<DXGI_FORMAT>(meta->DxgiFormat);
-    m_is_hdr = (meta->IsHdr != 0);
-    m_max_nits = meta->MaxNits;
-    m_min_nits = meta->MinNits;
-    m_max_fall = meta->MaxFALL;
-    m_lastFrameCounter = meta->FrameCounter;
-    m_lastPresentQpc = meta->LastPresentQpc;
-    m_lastPublishQpc = meta->LastPublishQpc;
-    m_lastPresentationFrameNumber = meta->LastPresentationFrameNumber;
-    m_lastDirtyRectCount = meta->LastDirtyRectCount;
-    m_replacedUnreadFrames = meta->ReplacedUnreadFrames;
-    m_droppedConsumerHeldFrames = meta->DroppedConsumerHeldFrames;
-    m_droppedAcquireFailures = meta->DroppedAcquireFailures;
-    m_slotCount = meta->SlotCount ? std::min(meta->SlotCount, VDD_MAX_SHARED_SLOTS) : 1;
-    m_slotIndex = meta->SlotIndex;
-    m_producerQpcFrequency = meta->ProducerQpcFrequency;
-    m_adapterLuid.LowPart = meta->AdapterLuidLowPart;
-    m_adapterLuid.HighPart = meta->AdapterLuidHighPart;
-    if (meta->SlotCount > VDD_MAX_SHARED_SLOTS) {
-      BOOST_LOG(warning) << "[vdd_capture] producer advertised "sv << meta->SlotCount
-                         << " slots; clamping to "sv << VDD_MAX_SHARED_SLOTS;
-    }
+    apply_metadata_snapshot(meta_snapshot);
 
-    if (m_width == 0 || m_height == 0) {
-      BOOST_LOG(warning) << "[vdd_capture] producer has not pushed any frame yet "
-                            "(width/height = 0). Monitor may be inactive."sv;
-      // Not necessarily fatal — caller may retry — but at this point we have
-      // no shared texture either, so report failure.
-      close();
-      return -1;
-    }
-
-    m_hEvent = OpenEventW(SYNCHRONIZE | EVENT_MODIFY_STATE, FALSE, ev_name.c_str());
+    m_hEvent = OpenEventW(SYNCHRONIZE, FALSE, ev_name.c_str());
     if (!m_hEvent) {
       BOOST_LOG(error) << "[vdd_capture] OpenEventW failed: "sv << GetLastError();
       close();
-      return -1;
+      return false;
     }
 
     // Open the named shared texture using ID3D11Device1::OpenSharedResourceByName.
-    ID3D11Device1 *dev1_p = nullptr;
-    HRESULT hr = d3d_device->QueryInterface(__uuidof(ID3D11Device1), reinterpret_cast<void **>(&dev1_p));
-    if (FAILED(hr) || !dev1_p) {
-      BOOST_LOG(error) << "[vdd_capture] ID3D11Device1 not available: 0x"sv
-                       << util::hex(hr).to_string_view();
-      close();
-      return -1;
-    }
-    device1_t dev1{dev1_p};
-
     m_sharedTex.resize(m_slotCount);
     m_keyedMutex.resize(m_slotCount);
     for (UINT32 slot = 0; slot < m_slotCount; ++slot) {
-      ID3D11Texture2D *raw = nullptr;
       auto tex_name = vdd_texture_name(monitor_idx, slot);
-      hr = dev1->OpenSharedResourceByName(tex_name.c_str(),
-                                          DXGI_SHARED_RESOURCE_READ | DXGI_SHARED_RESOURCE_WRITE,
-                                          __uuidof(ID3D11Texture2D),
-                                          reinterpret_cast<void **>(&raw));
-      if (FAILED(hr) || !raw) {
-        BOOST_LOG(error) << "[vdd_capture] OpenSharedResourceByName failed for slot "sv
-                         << slot << ": 0x"sv << util::hex(hr).to_string_view()
-                         << ". LUID mismatch with VDD RenderAdapter?"sv;
+      if (!attach_texture_slot(device, nullptr, meta_snapshot, slot, false, tex_name.c_str())) {
         close();
-        return -1;
+        return false;
       }
-      m_sharedTex[slot].reset(raw);
-
-      IDXGIKeyedMutex *km = nullptr;
-      hr = m_sharedTex[slot]->QueryInterface(__uuidof(IDXGIKeyedMutex), reinterpret_cast<void **>(&km));
-      if (FAILED(hr) || !km) {
-        BOOST_LOG(error) << "[vdd_capture] no IDXGIKeyedMutex on shared texture slot "sv
-                         << slot << ": 0x"sv << util::hex(hr).to_string_view();
-        close();
-        return -1;
-      }
-      m_keyedMutex[slot].reset(km);
     }
 
+    if (m_frameChannelSelection != vdd_frame_channel::channel_selection::forced_legacy) {
+      m_frameChannelSelection = vdd_frame_channel::channel_selection::legacy_opened;
+    }
     BOOST_LOG(info) << "[vdd_capture] opened monitor "sv << monitor_idx
                     << " "sv << m_width << "x"sv << m_height
                     << " fmt="sv << static_cast<int>(m_format)
                     << " hdr="sv << m_is_hdr
                     << " luid="sv << m_adapterLuid.LowPart << ":"sv << m_adapterLuid.HighPart
                     << " slot="sv << m_slotIndex << "/"sv << m_slotCount
-                    << " meta_size="sv << meta->MetadataSize;
-    return 0;
+                    << " meta_size="sv << meta_snapshot.MetadataSize
+                    << " meta_seq="sv << meta_snapshot.MetadataSequence
+                    << " generation="sv << m_channelGeneration
+                    << " mode="sv << vdd_frame_channel::channel_mode_name(m_frameChannelMode)
+                    << " channel="sv << (m_sealedFrameChannelSupported ? "sealed_probe_supported_legacy_capture" : "legacy_named")
+                    << " selection="sv << vdd_frame_channel::channel_selection_name(m_frameChannelSelection)
+                    << " access=read_only";
+    return true;
+  }
+
+  int
+  vdd_capture_t::init(ID3D11Device *d3d_device, unsigned int monitor_idx) {
+    if (!d3d_device) {
+      BOOST_LOG(error) << "[vdd_capture] init: null D3D11 device"sv;
+      return -1;
+    }
+    const auto device_luid = vdd_device_adapter_luid(d3d_device);
+    if (!device_luid) {
+      return -1;
+    }
+    ID3D11Device1 *dev1_p = nullptr;
+    HRESULT hr = d3d_device->QueryInterface(__uuidof(ID3D11Device1), reinterpret_cast<void **>(&dev1_p));
+    if (FAILED(hr) || !dev1_p) {
+      BOOST_LOG(error) << "[vdd_capture] ID3D11Device1 not available: 0x"sv
+                       << util::hex(hr).to_string_view();
+      return -1;
+    }
+    device1_t dev1 {dev1_p};
+
+    m_frameChannelMode = vdd_frame_channel_mode_env_override().value_or(vdd_frame_channel::channel_mode::auto_probe);
+    m_frameChannelSelection = vdd_frame_channel::channel_selection::unknown;
+    display_device::vdd_ioctl::frame_channel_caps sealed_caps {};
+    if (m_frameChannelMode == vdd_frame_channel::channel_mode::legacy_named) {
+      m_sealedFrameChannelSupported = false;
+      m_frameChannelSelection = vdd_frame_channel::channel_selection::forced_legacy;
+      BOOST_LOG(info) << "[vdd_capture] frame channel mode forced to legacy_named; skipping sealed capability probe"sv;
+    }
+    else {
+      m_frameChannelSelection = probe_sealed_frame_channel(sealed_caps);
+      m_sealedFrameChannelSupported = (m_frameChannelSelection == vdd_frame_channel::channel_selection::unknown);
+    }
+    m_legacyNamedChannel = true;
+
+    switch (try_open_sealed_channel(dev1_p, monitor_idx, *device_luid, sealed_caps)) {
+      case sealed_channel_attempt::opened:
+        return 0;
+      case sealed_channel_attempt::required_failed:
+        return -1;
+      case sealed_channel_attempt::skipped:
+      case sealed_channel_attempt::fallback_allowed:
+        break;
+    }
+
+    return attach_legacy_named_channel(dev1_p, monitor_idx, *device_luid) ? 0 : -1;
   }
 
   capture_e
@@ -282,16 +655,36 @@ namespace platf::dxgi {
     }
 
     // Producer released the latest slot as key 1; consumer acquires that slot.
-    UINT32 slot = meta->SlotIndex;
+    SharedFrameMetadata meta_snapshot {};
+    if (!vdd_frame_channel::read_stable_metadata(meta, meta_snapshot)) {
+      BOOST_LOG(warning) << "[vdd_capture] unable to read stable metadata after frame-ready; requesting reinit"sv;
+      return capture_e::reinit;
+    }
+    if (!vdd_metadata_is_attachable(meta_snapshot, m_adapterLuid)) {
+      return capture_e::reinit;
+    }
+    const UINT16 frame_generation = vdd_frame_channel::metadata_channel_generation(meta_snapshot.MetadataSequence);
+    if (frame_generation != m_channelGeneration) {
+      BOOST_LOG(info) << "[vdd_capture] producer channel generation changed: old="sv
+                      << m_channelGeneration << " new="sv << frame_generation
+                      << "; requesting reinit"sv;
+      return capture_e::reinit;
+    }
+
+    UINT32 slot = meta_snapshot.SlotIndex;
     if (slot >= m_keyedMutex.size()) {
       BOOST_LOG(warning) << "[vdd_capture] producer slot "sv << slot
                          << " outside opened slot count "sv << m_keyedMutex.size()
-                         << ", falling back to slot 0"sv;
-      slot = 0;
+                         << "; requesting reinit"sv;
+      return capture_e::reinit;
     }
 
-    HRESULT hr = m_keyedMutex[slot]->AcquireSync(1, ms);
+    const DWORD acquire_ms = vdd_frame_channel::bounded_consumer_acquire_timeout_ms(ms);
+    HRESULT hr = m_keyedMutex[slot]->AcquireSync(1, acquire_ms);
     if (hr == static_cast<HRESULT>(WAIT_TIMEOUT)) {
+      ++m_consumerAcquireTimeouts;
+      BOOST_LOG(debug) << "[vdd_capture] AcquireSync(1) timeout for slot "sv << slot
+                       << " after frame-ready event (timeout_ms="sv << acquire_ms << ')';
       return capture_e::timeout;
     }
     if (FAILED(hr)) {
@@ -306,8 +699,8 @@ namespace platf::dxgi {
     // Detect producer-side resize / format change: the metadata block can change
     // any time the swap chain is re-created. If so, signal reinit so the upper
     // layer reopens the shared texture.
-    if (meta->Width != m_width || meta->Height != m_height ||
-        static_cast<DXGI_FORMAT>(meta->DxgiFormat) != m_format) {
+    if (meta_snapshot.Width != m_width || meta_snapshot.Height != m_height ||
+        static_cast<DXGI_FORMAT>(meta_snapshot.DxgiFormat) != m_format) {
       BOOST_LOG(info) << "[vdd_capture] producer resolution/format changed, requesting reinit"sv;
       m_keyedMutex[m_heldSlot]->ReleaseSync(0);
       m_holdsKey = false;
@@ -320,23 +713,8 @@ namespace platf::dxgi {
     const auto previous_acquire = m_droppedAcquireFailures;
 
     // Refresh producer metadata (cheap copy from shared mapping).
-    m_is_hdr = (meta->IsHdr != 0);
-    m_max_nits = meta->MaxNits;
-    m_min_nits = meta->MinNits;
-    m_max_fall = meta->MaxFALL;
-    m_lastFrameCounter = meta->FrameCounter;
-    m_lastPresentQpc = meta->LastPresentQpc;
-    m_lastPublishQpc = meta->LastPublishQpc;
-    m_lastPresentationFrameNumber = meta->LastPresentationFrameNumber;
-    m_lastDirtyRectCount = meta->LastDirtyRectCount;
-    m_replacedUnreadFrames = meta->ReplacedUnreadFrames;
-    m_droppedConsumerHeldFrames = meta->DroppedConsumerHeldFrames;
-    m_droppedAcquireFailures = meta->DroppedAcquireFailures;
-    m_slotCount = meta->SlotCount ? std::min(meta->SlotCount, VDD_MAX_SHARED_SLOTS) : 1;
+    apply_metadata_snapshot(meta_snapshot);
     m_slotIndex = slot;
-    m_producerQpcFrequency = meta->ProducerQpcFrequency;
-    m_adapterLuid.LowPart = meta->AdapterLuidLowPart;
-    m_adapterLuid.HighPart = meta->AdapterLuidHighPart;
     out_frame_qpc = m_lastPresentQpc ? m_lastPresentQpc : m_lastPublishQpc;
 
     if (m_replacedUnreadFrames != previous_replaced ||
@@ -425,11 +803,13 @@ namespace platf::dxgi {
         continue;
       }
       auto *meta = static_cast<const SharedFrameMetadata *>(p);
-      bool valid = (meta->Magic == VDD_META_MAGIC);
-      unsigned mw = valid ? meta->Width : 0;
-      unsigned mh = valid ? meta->Height : 0;
-      unsigned mfmt = valid ? meta->DxgiFormat : 0;
-      bool mhdr = valid && (meta->IsHdr != 0);
+      SharedFrameMetadata meta_snapshot {};
+      bool stable = vdd_frame_channel::read_stable_metadata(meta, meta_snapshot);
+      bool valid = stable && vdd_metadata_is_probe_valid(meta_snapshot);
+      unsigned mw = valid ? meta_snapshot.Width : 0;
+      unsigned mh = valid ? meta_snapshot.Height : 0;
+      unsigned mfmt = valid ? meta_snapshot.DxgiFormat : 0;
+      bool mhdr = valid && (meta_snapshot.IsHdr != 0);
       UnmapViewOfFile(p);
       CloseHandle(h);
       if (!valid) continue;
@@ -569,6 +949,12 @@ namespace platf::dxgi {
                     << " fmt="sv << dxgi_format_to_string(capture_format)
                     << " hdr="sv << dup.is_hdr()
                     << " linear_gamma="sv << capture_linear_gamma
+                    << " mode="sv << vdd_frame_channel::channel_mode_name(dup.frame_channel_mode())
+                    << " channel="sv << (dup.legacy_named_channel() ? "legacy_named_hardened" : "sealed")
+                    << " selection="sv << vdd_frame_channel::channel_selection_name(dup.frame_channel_selection())
+                    << " sealed_supported="sv << dup.sealed_frame_channel_supported()
+                    << " producer_slots="sv << dup.producer_slot_count()
+                    << " generation="sv << dup.producer_channel_generation()
                     << " borrowed_texture="sv << vdd_borrow_enabled;
     return 0;
   }

--- a/src/platform/windows/display_vdd.cpp
+++ b/src/platform/windows/display_vdd.cpp
@@ -131,6 +131,13 @@ namespace platf::dxgi {
           BOOST_LOG(warning) << "[vdd_capture] sealed frame-channel reported zero shared slots; using hardened legacy named channel"sv;
           return vdd_frame_channel::channel_selection::caps_failed;
         }
+        const auto required_flags = display_device::vdd_ioctl::required_sealed_frame_channel_flags();
+        if (caps.version != vdd_frame_channel::meta_version ||
+            caps.metadata_size < vdd_frame_channel::min_metadata_size ||
+            (caps.flags & required_flags) != required_flags) {
+          BOOST_LOG(warning) << "[vdd_capture] sealed frame-channel caps do not satisfy the required ABI/security contract; using hardened legacy named channel"sv;
+          return vdd_frame_channel::channel_selection::caps_failed;
+        }
         return vdd_frame_channel::channel_selection::unknown;
       case display_device::vdd_ioctl::frame_channel_status::unsupported:
         BOOST_LOG(debug) << "[vdd_capture] sealed frame-channel IOCTL unsupported; using hardened legacy named channel"sv;
@@ -451,7 +458,7 @@ namespace platf::dxgi {
                     << " meta_seq="sv << meta_snapshot.MetadataSequence
                     << " generation="sv << m_channelGeneration
                     << " mode="sv << vdd_frame_channel::channel_mode_name(m_frameChannelMode)
-                    << " channel=sealed_borrow"
+                    << " channel=sealed"
                     << " selection="sv << vdd_frame_channel::channel_selection_name(m_frameChannelSelection)
                     << " access=duplicated_handles";
     return true;

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -3998,6 +3998,7 @@ namespace platf::dxgi {
                      << " replaced_unread="sv << vdd_last_replaced_unread
                      << " dropped_consumer_held="sv << vdd_last_dropped_consumer_held
                      << " dropped_acquire_failures="sv << vdd_last_dropped_acquire_failures
+                     << " consumer_acquire_timeouts="sv << dup.consumer_acquire_timeouts()
                      << " deferred="sv << vdd_borrow_deferred_images.size()
                      << " deferred_frames="sv << vdd_borrow_deferred_frames
                      << " returned_deferred="sv << vdd_borrow_returned_deferred_frames

--- a/src/platform/windows/vdd_frame_channel.h
+++ b/src/platform/windows/vdd_frame_channel.h
@@ -1,0 +1,297 @@
+#pragma once
+
+#include <Windows.h>
+#include <d3d11.h>
+#include <dxgi.h>
+
+#include <cstddef>
+#include <optional>
+#include <string_view>
+#include <thread>
+
+namespace platf::dxgi::vdd_frame_channel {
+
+  // Must stay binary-compatible with the producer-side struct in
+  // Virtual-Display-Driver/.../ZakoVDD/Driver.cpp (SharedFrameMetadata).
+  struct shared_frame_metadata_t {
+    UINT32 Magic;            // 'ZVDF' = 0x5A564446
+    UINT32 Version;          // 1
+    UINT32 Width;
+    UINT32 Height;
+    UINT32 DxgiFormat;
+    UINT32 IsHdr;
+    float MaxNits;
+    float MinNits;
+    float MaxFALL;
+    UINT64 FrameCounter;
+    UINT64 LastPresentQpc;
+    UINT64 LastPublishQpc;
+    UINT32 LastPresentationFrameNumber;
+    UINT32 LastDirtyRectCount;
+    UINT64 ReplacedUnreadFrames;
+    UINT64 DroppedConsumerHeldFrames;
+    UINT64 DroppedAcquireFailures;
+    UINT32 MetadataSize;
+    UINT32 SlotCount;
+    UINT32 SlotIndex;
+    // Packed control word for metadata consistency and object identity:
+    //   bits 31..16: ChannelGeneration, incremented by the producer whenever
+    //                it recreates the exported texture channel.
+    //   bits 15..0 : MetadataSequence, a seqlock counter. Odd means the
+    //                producer is updating this block; even means stable.
+    //
+    // This intentionally reuses the old Reserved0 slot, so MetadataSize stays
+    // 128 bytes and older consumers keep reading the same prefix safely.
+    UINT32 MetadataSequence;
+    UINT32 AdapterLuidLowPart;
+    INT32 AdapterLuidHighPart;
+    UINT64 ProducerQpcFrequency;
+  };
+
+  static constexpr UINT32 meta_magic = 0x5A564446;  // 'ZVDF'
+  static constexpr UINT32 meta_version = 1;
+  static constexpr UINT32 max_shared_slots = 8;
+  static constexpr UINT32 min_metadata_size =
+    static_cast<UINT32>(offsetof(shared_frame_metadata_t, ProducerQpcFrequency) + sizeof(UINT64));
+  static constexpr DWORD consumer_acquire_wait_budget_ms = 2;
+  static constexpr UINT32 metadata_sequence_write_bit = 0x00000001u;
+
+  enum class reject_reason {
+    none,
+    bad_magic,
+    version_mismatch,
+    metadata_too_small,
+    invalid_dimensions,
+    unsupported_format,
+    invalid_slot_count,
+    slot_index_out_of_range,
+    zero_adapter_luid,
+    adapter_luid_mismatch,
+    texture_desc_mismatch,
+    texture_layout_unsupported,
+    texture_missing_keyed_mutex,
+    texture_missing_shader_resource,
+  };
+
+  enum class channel_mode {
+    auto_probe,
+    legacy_named,
+    sealed_required,
+  };
+
+  enum class channel_selection {
+    unknown,
+    sealed_opened,
+    forced_legacy,
+    caps_unsupported,
+    caps_failed,
+    open_unsupported,
+    open_failed,
+    attach_failed,
+    sealed_required_failed,
+    legacy_opened,
+  };
+
+  struct validation_result {
+    bool ok = false;
+    reject_reason reason = reject_reason::none;
+
+    explicit operator bool() const {
+      return ok;
+    }
+  };
+
+  inline bool
+  luid_equal(const LUID &a, const LUID &b) {
+    return a.LowPart == b.LowPart && a.HighPart == b.HighPart;
+  }
+
+  inline bool
+  luid_is_zero(const LUID &luid) {
+    return luid.LowPart == 0 && luid.HighPart == 0;
+  }
+
+  inline bool
+  supported_producer_format(DXGI_FORMAT format) {
+    switch (format) {
+      case DXGI_FORMAT_R16G16B16A16_FLOAT:
+      case DXGI_FORMAT_B8G8R8A8_UNORM:
+      case DXGI_FORMAT_B8G8R8X8_UNORM:
+      case DXGI_FORMAT_R8G8B8A8_UNORM:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  inline std::optional<channel_mode>
+  parse_channel_mode(std::string_view value) {
+    if (value == "auto") {
+      return channel_mode::auto_probe;
+    }
+    if (value == "legacy" || value == "legacy_named" || value == "named") {
+      return channel_mode::legacy_named;
+    }
+    if (value == "sealed" || value == "sealed_required") {
+      return channel_mode::sealed_required;
+    }
+    return std::nullopt;
+  }
+
+  inline const char *
+  channel_mode_name(channel_mode mode) {
+    switch (mode) {
+      case channel_mode::auto_probe:
+        return "auto";
+      case channel_mode::legacy_named:
+        return "legacy_named";
+      case channel_mode::sealed_required:
+        return "sealed_required";
+    }
+    return "unknown";
+  }
+
+  inline const char *
+  channel_selection_name(channel_selection selection) {
+    switch (selection) {
+      case channel_selection::unknown:
+        return "unknown";
+      case channel_selection::sealed_opened:
+        return "sealed_opened";
+      case channel_selection::forced_legacy:
+        return "forced_legacy";
+      case channel_selection::caps_unsupported:
+        return "caps_unsupported";
+      case channel_selection::caps_failed:
+        return "caps_failed";
+      case channel_selection::open_unsupported:
+        return "open_unsupported";
+      case channel_selection::open_failed:
+        return "open_failed";
+      case channel_selection::attach_failed:
+        return "attach_failed";
+      case channel_selection::sealed_required_failed:
+        return "sealed_required_failed";
+      case channel_selection::legacy_opened:
+        return "legacy_opened";
+    }
+    return "unknown";
+  }
+
+  inline DWORD
+  bounded_consumer_acquire_timeout_ms(DWORD frame_wait_timeout_ms) {
+    return frame_wait_timeout_ms < consumer_acquire_wait_budget_ms ?
+             frame_wait_timeout_ms :
+             consumer_acquire_wait_budget_ms;
+  }
+
+  inline UINT16
+  metadata_sequence_counter(UINT32 metadata_sequence) {
+    return static_cast<UINT16>(metadata_sequence & 0xFFFFu);
+  }
+
+  inline UINT16
+  metadata_channel_generation(UINT32 metadata_sequence) {
+    return static_cast<UINT16>(metadata_sequence >> 16);
+  }
+
+  inline bool
+  metadata_sequence_is_stable(UINT32 metadata_sequence) {
+    return (metadata_sequence_counter(metadata_sequence) & metadata_sequence_write_bit) == 0;
+  }
+
+  inline bool
+  read_stable_metadata(const shared_frame_metadata_t *source,
+                       shared_frame_metadata_t &snapshot,
+                       unsigned attempts = 6) {
+    if (!source) {
+      return false;
+    }
+
+    for (unsigned attempt = 0; attempt < attempts; ++attempt) {
+      const UINT32 seq_before = source->MetadataSequence;
+      if (!metadata_sequence_is_stable(seq_before)) {
+        std::this_thread::yield();
+        continue;
+      }
+
+      snapshot = *source;
+      const UINT32 seq_after = source->MetadataSequence;
+      if (seq_before == seq_after && metadata_sequence_is_stable(seq_after)) {
+        return true;
+      }
+
+      std::this_thread::yield();
+    }
+
+    return false;
+  }
+
+  inline validation_result
+  validate_metadata_for_probe(const shared_frame_metadata_t &meta) {
+    if (meta.Magic != meta_magic) {
+      return {false, reject_reason::bad_magic};
+    }
+    if (meta.Version != meta_version) {
+      return {false, reject_reason::version_mismatch};
+    }
+    if (meta.MetadataSize < min_metadata_size) {
+      return {false, reject_reason::metadata_too_small};
+    }
+    if (meta.Width == 0 || meta.Height == 0 ||
+        meta.Width > D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION ||
+        meta.Height > D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION) {
+      return {false, reject_reason::invalid_dimensions};
+    }
+    if (!supported_producer_format(static_cast<DXGI_FORMAT>(meta.DxgiFormat))) {
+      return {false, reject_reason::unsupported_format};
+    }
+    if (meta.SlotCount == 0 || meta.SlotCount > max_shared_slots) {
+      return {false, reject_reason::invalid_slot_count};
+    }
+    if (meta.SlotIndex >= meta.SlotCount) {
+      return {false, reject_reason::slot_index_out_of_range};
+    }
+    return {true, reject_reason::none};
+  }
+
+  inline validation_result
+  validate_metadata_for_attach(const shared_frame_metadata_t &meta, const LUID &device_luid) {
+    auto result = validate_metadata_for_probe(meta);
+    if (!result) {
+      return result;
+    }
+
+    LUID producer_luid {};
+    producer_luid.LowPart = meta.AdapterLuidLowPart;
+    producer_luid.HighPart = meta.AdapterLuidHighPart;
+    if (luid_is_zero(producer_luid)) {
+      return {false, reject_reason::zero_adapter_luid};
+    }
+    if (!luid_equal(producer_luid, device_luid)) {
+      return {false, reject_reason::adapter_luid_mismatch};
+    }
+    return {true, reject_reason::none};
+  }
+
+  inline validation_result
+  validate_texture_desc(const D3D11_TEXTURE2D_DESC &desc,
+                        const shared_frame_metadata_t &meta) {
+    if (desc.Width != meta.Width || desc.Height != meta.Height ||
+        desc.Format != static_cast<DXGI_FORMAT>(meta.DxgiFormat)) {
+      return {false, reject_reason::texture_desc_mismatch};
+    }
+    if (desc.ArraySize != 1 || desc.MipLevels != 1 ||
+        desc.SampleDesc.Count != 1 || desc.SampleDesc.Quality != 0) {
+      return {false, reject_reason::texture_layout_unsupported};
+    }
+    if ((desc.MiscFlags & D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX) == 0) {
+      return {false, reject_reason::texture_missing_keyed_mutex};
+    }
+    if ((desc.BindFlags & D3D11_BIND_SHADER_RESOURCE) == 0) {
+      return {false, reject_reason::texture_missing_shader_resource};
+    }
+    return {true, reject_reason::none};
+  }
+
+}  // namespace platf::dxgi::vdd_frame_channel

--- a/src/platform/windows/vdd_frame_channel.h
+++ b/src/platform/windows/vdd_frame_channel.h
@@ -48,6 +48,15 @@ namespace platf::dxgi::vdd_frame_channel {
     UINT64 ProducerQpcFrequency;
   };
 
+  static_assert(sizeof(shared_frame_metadata_t) == 128,
+                "shared_frame_metadata_t must remain ABI-compatible with the VDD producer");
+  static_assert(offsetof(shared_frame_metadata_t, MetadataSize) == 96,
+                "MetadataSize offset is part of the shared metadata ABI");
+  static_assert(offsetof(shared_frame_metadata_t, MetadataSequence) == 108,
+                "MetadataSequence offset is part of the shared metadata ABI");
+  static_assert(offsetof(shared_frame_metadata_t, ProducerQpcFrequency) == 120,
+                "ProducerQpcFrequency offset is part of the shared metadata ABI");
+
   static constexpr UINT32 meta_magic = 0x5A564446;  // 'ZVDF'
   static constexpr UINT32 meta_version = 1;
   static constexpr UINT32 max_shared_slots = 8;

--- a/tests/unit/test_vdd_safety.cpp
+++ b/tests/unit/test_vdd_safety.cpp
@@ -159,6 +159,27 @@ TEST(VddFrameChannelSafety, BoundsPostEventAcquireWait) {
             consumer_acquire_wait_budget_ms);
 }
 
+TEST(VddFrameChannelSafety, ReadsOnlyStableMetadataSnapshots) {
+  using namespace platf::dxgi::vdd_frame_channel;
+
+  auto meta = valid_vdd_metadata();
+  meta.MetadataSequence = (static_cast<UINT32>(7) << 16) | 2u;
+
+  shared_frame_metadata_t snapshot {};
+  ASSERT_TRUE(read_stable_metadata(&meta, snapshot, 1));
+  EXPECT_EQ(snapshot.FrameCounter, meta.FrameCounter);
+  EXPECT_EQ(snapshot.MetadataSequence, meta.MetadataSequence);
+  EXPECT_TRUE(metadata_sequence_is_stable(snapshot.MetadataSequence));
+  EXPECT_EQ(metadata_sequence_counter(snapshot.MetadataSequence), 2u);
+  EXPECT_EQ(metadata_channel_generation(snapshot.MetadataSequence), 7u);
+
+  meta.MetadataSequence = (static_cast<UINT32>(8) << 16) | 3u;
+  EXPECT_FALSE(metadata_sequence_is_stable(meta.MetadataSequence));
+  EXPECT_FALSE(read_stable_metadata(&meta, snapshot, 1));
+  EXPECT_EQ(metadata_sequence_counter(meta.MetadataSequence), 3u);
+  EXPECT_EQ(metadata_channel_generation(meta.MetadataSequence), 8u);
+}
+
 TEST(VddFrameChannelSafety, ParsesFrameChannelModes) {
   using namespace platf::dxgi::vdd_frame_channel;
 

--- a/tests/unit/test_vdd_safety.cpp
+++ b/tests/unit/test_vdd_safety.cpp
@@ -2,7 +2,54 @@
 
 #ifdef _WIN32
 
+#include "src/display_device/vdd_control_ioctl.h"
 #include "src/platform/windows/display_device/settings_topology.h"
+#include "src/platform/windows/vdd_frame_channel.h"
+
+namespace {
+
+  platf::dxgi::vdd_frame_channel::shared_frame_metadata_t
+  valid_vdd_metadata() {
+    platf::dxgi::vdd_frame_channel::shared_frame_metadata_t meta {};
+    meta.Magic = platf::dxgi::vdd_frame_channel::meta_magic;
+    meta.Version = platf::dxgi::vdd_frame_channel::meta_version;
+    meta.Width = 3840;
+    meta.Height = 2160;
+    meta.DxgiFormat = DXGI_FORMAT_R16G16B16A16_FLOAT;
+    meta.IsHdr = 1;
+    meta.MetadataSize = sizeof(meta);
+    meta.SlotCount = 4;
+    meta.SlotIndex = 2;
+    meta.AdapterLuidLowPart = 0x12345678;
+    meta.AdapterLuidHighPart = 0x1234;
+    meta.ProducerQpcFrequency = 10000000;
+    return meta;
+  }
+
+  LUID
+  valid_vdd_luid() {
+    LUID luid {};
+    luid.LowPart = 0x12345678;
+    luid.HighPart = 0x1234;
+    return luid;
+  }
+
+  D3D11_TEXTURE2D_DESC
+  valid_vdd_texture_desc(const platf::dxgi::vdd_frame_channel::shared_frame_metadata_t &meta) {
+    D3D11_TEXTURE2D_DESC desc {};
+    desc.Width = meta.Width;
+    desc.Height = meta.Height;
+    desc.MipLevels = 1;
+    desc.ArraySize = 1;
+    desc.Format = static_cast<DXGI_FORMAT>(meta.DxgiFormat);
+    desc.SampleDesc.Count = 1;
+    desc.SampleDesc.Quality = 0;
+    desc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+    desc.MiscFlags = D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX;
+    return desc;
+  }
+
+}  // namespace
 
 TEST(VddBaselineSafety, DetectsVddOnlyTopology) {
   using namespace display_device;
@@ -12,6 +59,183 @@ TEST(VddBaselineSafety, DetectsVddOnlyTopology) {
   EXPECT_FALSE(is_vdd_only_topology({ { "physical" } }, "vdd"));
   EXPECT_FALSE(is_vdd_only_topology({ { "vdd" }, { "physical" } }, "vdd"));
   EXPECT_TRUE(is_vdd_only_topology({ { "vdd" } }, "vdd"));
+}
+
+TEST(VddFrameChannelSafety, AcceptsValidMetadataForAttach) {
+  using namespace platf::dxgi::vdd_frame_channel;
+
+  auto meta = valid_vdd_metadata();
+  auto result = validate_metadata_for_attach(meta, valid_vdd_luid());
+
+  EXPECT_TRUE(result);
+  EXPECT_EQ(result.reason, reject_reason::none);
+}
+
+TEST(VddFrameChannelSafety, RejectsUnsafeAdapterLuid) {
+  using namespace platf::dxgi::vdd_frame_channel;
+
+  auto meta = valid_vdd_metadata();
+  meta.AdapterLuidLowPart = 0;
+  meta.AdapterLuidHighPart = 0;
+  auto result = validate_metadata_for_attach(meta, valid_vdd_luid());
+  EXPECT_FALSE(result);
+  EXPECT_EQ(result.reason, reject_reason::zero_adapter_luid);
+
+  meta = valid_vdd_metadata();
+  LUID wrong_luid {};
+  wrong_luid.LowPart = 0x87654321;
+  wrong_luid.HighPart = 0x4321;
+  result = validate_metadata_for_attach(meta, wrong_luid);
+  EXPECT_FALSE(result);
+  EXPECT_EQ(result.reason, reject_reason::adapter_luid_mismatch);
+}
+
+TEST(VddFrameChannelSafety, RejectsInvalidProbeMetadata) {
+  using namespace platf::dxgi::vdd_frame_channel;
+
+  auto meta = valid_vdd_metadata();
+  meta.MetadataSize = min_metadata_size - 1;
+  auto result = validate_metadata_for_probe(meta);
+  EXPECT_FALSE(result);
+  EXPECT_EQ(result.reason, reject_reason::metadata_too_small);
+
+  meta = valid_vdd_metadata();
+  meta.DxgiFormat = DXGI_FORMAT_R10G10B10A2_UNORM;
+  result = validate_metadata_for_probe(meta);
+  EXPECT_FALSE(result);
+  EXPECT_EQ(result.reason, reject_reason::unsupported_format);
+
+  meta = valid_vdd_metadata();
+  meta.SlotCount = max_shared_slots + 1;
+  result = validate_metadata_for_probe(meta);
+  EXPECT_FALSE(result);
+  EXPECT_EQ(result.reason, reject_reason::invalid_slot_count);
+
+  meta = valid_vdd_metadata();
+  meta.SlotIndex = meta.SlotCount;
+  result = validate_metadata_for_probe(meta);
+  EXPECT_FALSE(result);
+  EXPECT_EQ(result.reason, reject_reason::slot_index_out_of_range);
+}
+
+TEST(VddFrameChannelSafety, ValidatesTextureDescContract) {
+  using namespace platf::dxgi::vdd_frame_channel;
+
+  auto meta = valid_vdd_metadata();
+  auto desc = valid_vdd_texture_desc(meta);
+  auto result = validate_texture_desc(desc, meta);
+  EXPECT_TRUE(result);
+  EXPECT_EQ(result.reason, reject_reason::none);
+
+  desc = valid_vdd_texture_desc(meta);
+  desc.Width += 1;
+  result = validate_texture_desc(desc, meta);
+  EXPECT_FALSE(result);
+  EXPECT_EQ(result.reason, reject_reason::texture_desc_mismatch);
+
+  desc = valid_vdd_texture_desc(meta);
+  desc.MiscFlags = 0;
+  result = validate_texture_desc(desc, meta);
+  EXPECT_FALSE(result);
+  EXPECT_EQ(result.reason, reject_reason::texture_missing_keyed_mutex);
+
+  desc = valid_vdd_texture_desc(meta);
+  desc.BindFlags = 0;
+  result = validate_texture_desc(desc, meta);
+  EXPECT_FALSE(result);
+  EXPECT_EQ(result.reason, reject_reason::texture_missing_shader_resource);
+}
+
+TEST(VddFrameChannelSafety, BoundsPostEventAcquireWait) {
+  using namespace platf::dxgi::vdd_frame_channel;
+
+  EXPECT_EQ(bounded_consumer_acquire_timeout_ms(0), 0);
+  EXPECT_EQ(bounded_consumer_acquire_timeout_ms(1), 1);
+  EXPECT_EQ(bounded_consumer_acquire_timeout_ms(consumer_acquire_wait_budget_ms),
+            consumer_acquire_wait_budget_ms);
+  EXPECT_EQ(bounded_consumer_acquire_timeout_ms(16),
+            consumer_acquire_wait_budget_ms);
+  EXPECT_EQ(bounded_consumer_acquire_timeout_ms(1000),
+            consumer_acquire_wait_budget_ms);
+}
+
+TEST(VddFrameChannelSafety, ParsesFrameChannelModes) {
+  using namespace platf::dxgi::vdd_frame_channel;
+
+  auto mode = parse_channel_mode("auto");
+  ASSERT_TRUE(mode);
+  EXPECT_EQ(*mode, channel_mode::auto_probe);
+  EXPECT_STREQ(channel_mode_name(*mode), "auto");
+
+  mode = parse_channel_mode("legacy");
+  ASSERT_TRUE(mode);
+  EXPECT_EQ(*mode, channel_mode::legacy_named);
+  EXPECT_STREQ(channel_mode_name(*mode), "legacy_named");
+
+  mode = parse_channel_mode("legacy_named");
+  ASSERT_TRUE(mode);
+  EXPECT_EQ(*mode, channel_mode::legacy_named);
+
+  mode = parse_channel_mode("sealed");
+  ASSERT_TRUE(mode);
+  EXPECT_EQ(*mode, channel_mode::sealed_required);
+  EXPECT_STREQ(channel_mode_name(*mode), "sealed_required");
+
+  EXPECT_FALSE(parse_channel_mode("host_owned"));
+  EXPECT_FALSE(parse_channel_mode(""));
+}
+
+TEST(VddFrameChannelSafety, DefinesSealedChannelCapsAbi) {
+  VDD_FRAME_CHANNEL_CAPS caps {};
+  caps.Size = sizeof(caps);
+  caps.Version = VDD_FRAME_CHANNEL_CAPS_VERSION;
+  caps.Flags = VDD_FRAME_CHANNEL_FLAG_SEALED_BORROW |
+               VDD_FRAME_CHANNEL_FLAG_UNNAMED_HANDLES |
+               VDD_FRAME_CHANNEL_FLAG_STRICT_DACL;
+
+  EXPECT_EQ(caps.Size, sizeof(VDD_FRAME_CHANNEL_CAPS));
+  EXPECT_EQ(caps.Version, 1u);
+  EXPECT_NE(caps.Flags & VDD_FRAME_CHANNEL_FLAG_SEALED_BORROW, 0u);
+  EXPECT_NE(caps.Flags & VDD_FRAME_CHANNEL_FLAG_UNNAMED_HANDLES, 0u);
+  EXPECT_NE(caps.Flags & VDD_FRAME_CHANNEL_FLAG_STRICT_DACL, 0u);
+  EXPECT_NE(IOCTL_VDD_QUERY_FRAME_CHANNEL_CAPS, IOCTL_VDD_COMMAND);
+  EXPECT_NE(IOCTL_VDD_QUERY_FRAME_CHANNEL_CAPS, IOCTL_VDD_PING);
+}
+
+TEST(VddFrameChannelSafety, DefinesSealedChannelOpenAbi) {
+  VDD_FRAME_CHANNEL_OPEN_REQUEST request {};
+  request.Size = sizeof(request);
+  request.Version = VDD_FRAME_CHANNEL_OPEN_VERSION;
+  request.MonitorIndex = 2;
+  request.RequiredFlags = VDD_FRAME_CHANNEL_FLAG_SEALED_BORROW |
+                          VDD_FRAME_CHANNEL_FLAG_UNNAMED_HANDLES |
+                          VDD_FRAME_CHANNEL_FLAG_STRICT_DACL;
+  request.TargetProcessId = 1234;
+  request.DesiredSlots = VDD_FRAME_CHANNEL_MAX_SLOTS;
+  request.AdapterLuidLowPart = 0x12345678;
+  request.AdapterLuidHighPart = 0x1234;
+
+  VDD_FRAME_CHANNEL_OPEN_RESPONSE response {};
+  response.Size = sizeof(response);
+  response.Version = VDD_FRAME_CHANNEL_OPEN_VERSION;
+  response.Flags = request.RequiredFlags;
+  response.SlotCount = VDD_FRAME_CHANNEL_MAX_SLOTS;
+  response.MetadataSize = sizeof(platf::dxgi::vdd_frame_channel::shared_frame_metadata_t);
+  response.MetadataHandle = 0x1000;
+  response.FrameReadyEventHandle = 0x2000;
+  response.Slots[0].TextureHandle = 0x3000;
+
+  EXPECT_EQ(request.Size, sizeof(VDD_FRAME_CHANNEL_OPEN_REQUEST));
+  EXPECT_EQ(response.Size, sizeof(VDD_FRAME_CHANNEL_OPEN_RESPONSE));
+  EXPECT_EQ(request.Version, 1u);
+  EXPECT_EQ(response.Version, 1u);
+  EXPECT_EQ(response.SlotCount, VDD_FRAME_CHANNEL_MAX_SLOTS);
+  EXPECT_NE(response.MetadataHandle, 0u);
+  EXPECT_NE(response.FrameReadyEventHandle, 0u);
+  EXPECT_NE(response.Slots[0].TextureHandle, 0u);
+  EXPECT_NE(IOCTL_VDD_OPEN_FRAME_CHANNEL, IOCTL_VDD_COMMAND);
+  EXPECT_NE(IOCTL_VDD_OPEN_FRAME_CHANNEL, IOCTL_VDD_PING);
+  EXPECT_NE(IOCTL_VDD_OPEN_FRAME_CHANNEL, IOCTL_VDD_QUERY_FRAME_CHANNEL_CAPS);
 }
 
 #endif

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -67,7 +67,9 @@ target_compile_options(test_args PRIVATE ${SUNSHINE_COMPILE_OPTIONS})
 
 if(WIN32)
     add_executable(vdd-frame-channel-probe vdd_frame_channel_probe.cpp)
-    set_target_properties(vdd-frame-channel-probe PROPERTIES CXX_STANDARD 23)
+    set_target_properties(vdd-frame-channel-probe PROPERTIES
+            CXX_STANDARD 23
+            CXX_STANDARD_REQUIRED ON)
     target_link_libraries(vdd-frame-channel-probe
             setupapi
             ${PLATFORM_LIBRARIES})
@@ -77,5 +79,5 @@ if(WIN32)
             COMMAND powershell -NoProfile -ExecutionPolicy Bypass
                     -File "${CMAKE_CURRENT_SOURCE_DIR}/check_vdd_ioctl_abi.ps1"
             WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-            COMMENT "Checking Sunshine/VDD IOCTL ABI header sync")
+            COMMENT "Checking Sunshine/VDD IOCTL ABI header sync; set VDD_DRIVER_HEADER when DriverHeader is not passed")
 endif()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -64,3 +64,18 @@ endif()
 target_compile_options(test_args PRIVATE ${SUNSHINE_COMPILE_OPTIONS})
 # 明确标记为不安装（开发测试工具），但可以正常构建
 # 注意：不会在 cmake/packaging/windows.cmake 中安装，所以不会被打包
+
+if(WIN32)
+    add_executable(vdd-frame-channel-probe vdd_frame_channel_probe.cpp)
+    set_target_properties(vdd-frame-channel-probe PROPERTIES CXX_STANDARD 23)
+    target_link_libraries(vdd-frame-channel-probe
+            setupapi
+            ${PLATFORM_LIBRARIES})
+    target_compile_options(vdd-frame-channel-probe PRIVATE ${SUNSHINE_COMPILE_OPTIONS})
+
+    add_custom_target(check-vdd-ioctl-abi
+            COMMAND powershell -NoProfile -ExecutionPolicy Bypass
+                    -File "${CMAKE_CURRENT_SOURCE_DIR}/check_vdd_ioctl_abi.ps1"
+            WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+            COMMENT "Checking Sunshine/VDD IOCTL ABI header sync")
+endif()

--- a/tools/check_vdd_ioctl_abi.ps1
+++ b/tools/check_vdd_ioctl_abi.ps1
@@ -1,0 +1,36 @@
+param(
+  [string]$SunshineHeader = "",
+  [string]$DriverHeader = "C:\Users\mohaha\Program\github\Virtual-Display-Driver\Common\Include\vdd_control_ioctl.h"
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not $SunshineHeader) {
+  $repoRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+  $SunshineHeader = Join-Path $repoRoot "src\display_device\vdd_control_ioctl.h"
+}
+
+if (-not (Test-Path $SunshineHeader)) {
+  throw "Sunshine ABI header not found: $SunshineHeader"
+}
+if (-not (Test-Path $DriverHeader)) {
+  throw "Driver ABI header not found: $DriverHeader"
+}
+
+$sunshineText = [IO.File]::ReadAllText($SunshineHeader).Replace("`r`n", "`n")
+$driverText = [IO.File]::ReadAllText($DriverHeader).Replace("`r`n", "`n")
+$sha256 = [Security.Cryptography.SHA256]::Create()
+$sunshineHash = [BitConverter]::ToString($sha256.ComputeHash([Text.Encoding]::UTF8.GetBytes($sunshineText))).Replace("-", "")
+$driverHash = [BitConverter]::ToString($sha256.ComputeHash([Text.Encoding]::UTF8.GetBytes($driverText))).Replace("-", "")
+
+Write-Host "Sunshine ABI: $SunshineHeader"
+Write-Host "Driver ABI:   $DriverHeader"
+Write-Host "Sunshine SHA256: $sunshineHash"
+Write-Host "Driver SHA256:   $driverHash"
+
+if ($sunshineText -ne $driverText) {
+  Write-Error "VDD IOCTL ABI headers differ. Sync src/display_device/vdd_control_ioctl.h and Common/Include/vdd_control_ioctl.h."
+  exit 1
+}
+
+Write-Host "VDD IOCTL ABI headers match."

--- a/tools/check_vdd_ioctl_abi.ps1
+++ b/tools/check_vdd_ioctl_abi.ps1
@@ -1,6 +1,6 @@
 param(
   [string]$SunshineHeader = "",
-  [string]$DriverHeader = "C:\Users\mohaha\Program\github\Virtual-Display-Driver\Common\Include\vdd_control_ioctl.h"
+  [string]$DriverHeader = $env:VDD_DRIVER_HEADER
 )
 
 $ErrorActionPreference = "Stop"
@@ -8,6 +8,10 @@ $ErrorActionPreference = "Stop"
 if (-not $SunshineHeader) {
   $repoRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
   $SunshineHeader = Join-Path $repoRoot "src\display_device\vdd_control_ioctl.h"
+}
+
+if (-not $DriverHeader) {
+  throw "DriverHeader not specified. Pass -DriverHeader <path> or set `$env:VDD_DRIVER_HEADER."
 }
 
 if (-not (Test-Path $SunshineHeader)) {

--- a/tools/vdd_frame_channel_probe.cpp
+++ b/tools/vdd_frame_channel_probe.cpp
@@ -1,0 +1,261 @@
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#define INITGUID
+
+#include "src/display_device/vdd_control_ioctl.h"
+#include "src/platform/windows/vdd_frame_channel.h"
+
+#include <SetupAPI.h>
+#include <windows.h>
+
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+  using shared_frame_metadata_t = platf::dxgi::vdd_frame_channel::shared_frame_metadata_t;
+
+  struct devinfo_guard {
+    HDEVINFO handle = INVALID_HANDLE_VALUE;
+
+    ~devinfo_guard() {
+      if (handle != INVALID_HANDLE_VALUE) {
+        SetupDiDestroyDeviceInfoList(handle);
+      }
+    }
+  };
+
+  struct handle_guard {
+    HANDLE handle = INVALID_HANDLE_VALUE;
+
+    ~handle_guard() {
+      if (handle && handle != INVALID_HANDLE_VALUE) {
+        CloseHandle(handle);
+      }
+    }
+  };
+
+  void
+  close_remote_handle_value(std::uint64_t value) {
+    if (value != 0) {
+      CloseHandle(reinterpret_cast<HANDLE>(static_cast<uintptr_t>(value)));
+    }
+  }
+
+  std::wstring
+  resolve_vdd_control_path() {
+    devinfo_guard devs {
+      SetupDiGetClassDevsW(
+        &GUID_DEVINTERFACE_ZAKO_VDD_CONTROL,
+        nullptr,
+        nullptr,
+        DIGCF_DEVICEINTERFACE | DIGCF_PRESENT)
+    };
+    if (devs.handle == INVALID_HANDLE_VALUE) {
+      return {};
+    }
+
+    SP_DEVICE_INTERFACE_DATA iface {};
+    iface.cbSize = sizeof(iface);
+    if (!SetupDiEnumDeviceInterfaces(devs.handle, nullptr, &GUID_DEVINTERFACE_ZAKO_VDD_CONTROL, 0, &iface)) {
+      return {};
+    }
+
+    DWORD required = 0;
+    SetupDiGetDeviceInterfaceDetailW(devs.handle, &iface, nullptr, 0, &required, nullptr);
+    if (required == 0) {
+      return {};
+    }
+
+    std::vector<BYTE> buffer(required);
+    auto *detail = reinterpret_cast<SP_DEVICE_INTERFACE_DETAIL_DATA_W *>(buffer.data());
+    detail->cbSize = sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA_W);
+    if (!SetupDiGetDeviceInterfaceDetailW(devs.handle, &iface, detail, required, nullptr, nullptr)) {
+      return {};
+    }
+
+    return std::wstring {detail->DevicePath};
+  }
+
+  handle_guard
+  open_vdd_control() {
+    const auto path = resolve_vdd_control_path();
+    if (path.empty()) {
+      return {};
+    }
+
+    return handle_guard {
+      CreateFileW(
+        path.c_str(),
+        GENERIC_READ | GENERIC_WRITE,
+        FILE_SHARE_READ | FILE_SHARE_WRITE,
+        nullptr,
+        OPEN_EXISTING,
+        SECURITY_SQOS_PRESENT | SECURITY_IMPERSONATION,
+        nullptr)
+    };
+  }
+
+  int
+  usage() {
+    std::cout << "Usage: vdd-frame-channel-probe [--open] [--monitor N] [--slots N]\n"
+              << "  --slots 0 uses the driver default; nonzero values must match caps max_slots.\n";
+    return 2;
+  }
+
+}  // namespace
+
+int
+main(int argc, char **argv) {
+  bool do_open = false;
+  UINT32 monitor_index = 0;
+  UINT32 desired_slots = 0;
+
+  for (int i = 1; i < argc; ++i) {
+    const std::string arg = argv[i];
+    if (arg == "--open") {
+      do_open = true;
+    }
+    else if (arg == "--monitor" && i + 1 < argc) {
+      monitor_index = static_cast<UINT32>(std::stoul(argv[++i]));
+    }
+    else if (arg == "--slots" && i + 1 < argc) {
+      desired_slots = static_cast<UINT32>(std::stoul(argv[++i]));
+    }
+    else if (arg == "--help" || arg == "-h") {
+      return usage();
+    }
+    else {
+      return usage();
+    }
+  }
+
+  auto dev = open_vdd_control();
+  if (!dev.handle || dev.handle == INVALID_HANDLE_VALUE) {
+    std::cerr << "VDD control interface not found\n";
+    return 1;
+  }
+
+  VDD_FRAME_CHANNEL_CAPS caps {};
+  caps.Size = sizeof(caps);
+  DWORD bytes_returned = 0;
+  if (!DeviceIoControl(
+        dev.handle,
+        IOCTL_VDD_QUERY_FRAME_CHANNEL_CAPS,
+        nullptr, 0,
+        &caps, sizeof(caps),
+        &bytes_returned,
+        nullptr)) {
+    const DWORD err = GetLastError();
+    std::cerr << "QUERY_FRAME_CHANNEL_CAPS failed: " << err << "\n";
+    return 1;
+  }
+
+  std::cout << "caps:"
+            << " version=" << caps.Version
+            << " flags=0x" << std::hex << caps.Flags << std::dec
+            << " max_slots=" << caps.MaxSharedSlots
+            << " metadata_size=" << caps.MetadataSize
+            << "\n";
+
+  const UINT32 required_flags =
+    VDD_FRAME_CHANNEL_FLAG_SEALED_BORROW |
+    VDD_FRAME_CHANNEL_FLAG_UNNAMED_HANDLES |
+    VDD_FRAME_CHANNEL_FLAG_STRICT_DACL;
+  if ((caps.Flags & required_flags) != required_flags) {
+    std::cerr << "caps missing required sealed-channel flags\n";
+    return 1;
+  }
+
+  if (!do_open) {
+    return 0;
+  }
+
+  VDD_FRAME_CHANNEL_OPEN_REQUEST request {};
+  request.Size = sizeof(request);
+  request.Version = VDD_FRAME_CHANNEL_OPEN_VERSION;
+  request.MonitorIndex = monitor_index;
+  request.RequiredFlags = required_flags;
+  request.TargetProcessId = GetCurrentProcessId();
+  request.DesiredSlots = desired_slots;
+
+  VDD_FRAME_CHANNEL_OPEN_RESPONSE response {};
+  response.Size = sizeof(response);
+  bytes_returned = 0;
+  if (!DeviceIoControl(
+        dev.handle,
+        IOCTL_VDD_OPEN_FRAME_CHANNEL,
+        &request, sizeof(request),
+        &response, sizeof(response),
+        &bytes_returned,
+        nullptr)) {
+    const DWORD err = GetLastError();
+    std::cerr << "OPEN_FRAME_CHANNEL failed: " << err << "\n";
+    return 1;
+  }
+
+  std::cout << "open:"
+            << " version=" << response.Version
+            << " flags=0x" << std::hex << response.Flags << std::dec
+            << " slots=" << response.SlotCount
+            << " metadata_size=" << response.MetadataSize
+            << " metadata_handle=0x" << std::hex << response.MetadataHandle
+            << " event_handle=0x" << response.FrameReadyEventHandle
+            << std::dec << "\n";
+
+  if (response.MetadataHandle != 0) {
+    auto *meta = static_cast<const shared_frame_metadata_t *>(
+      MapViewOfFile(
+        reinterpret_cast<HANDLE>(static_cast<uintptr_t>(response.MetadataHandle)),
+        FILE_MAP_READ,
+        0, 0,
+        sizeof(shared_frame_metadata_t)));
+    if (!meta) {
+      std::cerr << "metadata MapViewOfFile failed: " << GetLastError() << "\n";
+    }
+    else {
+      shared_frame_metadata_t snapshot {};
+      if (!platf::dxgi::vdd_frame_channel::read_stable_metadata(meta, snapshot, 8)) {
+        std::cerr << "metadata stable snapshot failed\n";
+      }
+      else {
+        const auto generation = platf::dxgi::vdd_frame_channel::metadata_channel_generation(snapshot.MetadataSequence);
+        const auto sequence = platf::dxgi::vdd_frame_channel::metadata_sequence_counter(snapshot.MetadataSequence);
+        std::cout << "metadata:"
+                  << " magic=0x" << std::hex << snapshot.Magic << std::dec
+                  << " version=" << snapshot.Version
+                  << " size=" << snapshot.MetadataSize
+                  << " " << snapshot.Width << "x" << snapshot.Height
+                  << " fmt=" << snapshot.DxgiFormat
+                  << " hdr=" << snapshot.IsHdr
+                  << " frame=" << snapshot.FrameCounter
+                  << " slot=" << snapshot.SlotIndex << "/" << snapshot.SlotCount
+                  << " meta_seq=0x" << std::hex << snapshot.MetadataSequence << std::dec
+                  << " seq=" << sequence
+                  << " generation=" << generation
+                  << " luid=" << snapshot.AdapterLuidLowPart << ":" << snapshot.AdapterLuidHighPart
+                  << " publish_qpc=" << snapshot.LastPublishQpc
+                  << " present_qpc=" << snapshot.LastPresentQpc
+                  << " replaced_unread=" << snapshot.ReplacedUnreadFrames
+                  << " dropped_held=" << snapshot.DroppedConsumerHeldFrames
+                  << " dropped_acquire=" << snapshot.DroppedAcquireFailures
+                  << "\n";
+      }
+      UnmapViewOfFile(meta);
+    }
+  }
+
+  close_remote_handle_value(response.MetadataHandle);
+  close_remote_handle_value(response.FrameReadyEventHandle);
+  const UINT32 slot_count = response.SlotCount <= VDD_FRAME_CHANNEL_MAX_SLOTS ? response.SlotCount : VDD_FRAME_CHANNEL_MAX_SLOTS;
+  for (UINT32 slot = 0; slot < slot_count; ++slot) {
+    std::cout << "slot " << slot << " texture_handle=0x"
+              << std::hex << response.Slots[slot].TextureHandle << std::dec << "\n";
+    close_remote_handle_value(response.Slots[slot].TextureHandle);
+  }
+
+  return 0;
+}

--- a/tools/vdd_frame_channel_probe.cpp
+++ b/tools/vdd_frame_channel_probe.cpp
@@ -10,8 +10,10 @@ extern "C" const GUID GUID_DEVINTERFACE_ZAKO_VDD_CONTROL = ZAKO_VDD_CONTROL_GUID
 #include <windows.h>
 
 #include <cstdint>
+#include <exception>
 #include <iomanip>
 #include <iostream>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -107,6 +109,22 @@ namespace {
     return 2;
   }
 
+  bool
+  parse_uint32_arg(const char *text, UINT32 &value) {
+    try {
+      const std::string input { text ? text : "" };
+      std::size_t parsed_chars = 0;
+      const auto parsed = std::stoul(input, &parsed_chars, 0);
+      if (input.empty() || parsed_chars != input.size() || parsed > std::numeric_limits<UINT32>::max()) {
+        return false;
+      }
+      value = static_cast<UINT32>(parsed);
+      return true;
+    } catch (const std::exception &) {
+      return false;
+    }
+  }
+
 }  // namespace
 
 int
@@ -121,10 +139,14 @@ main(int argc, char **argv) {
       do_open = true;
     }
     else if (arg == "--monitor" && i + 1 < argc) {
-      monitor_index = static_cast<UINT32>(std::stoul(argv[++i]));
+      if (!parse_uint32_arg(argv[++i], monitor_index)) {
+        return usage();
+      }
     }
     else if (arg == "--slots" && i + 1 < argc) {
-      desired_slots = static_cast<UINT32>(std::stoul(argv[++i]));
+      if (!parse_uint32_arg(argv[++i], desired_slots)) {
+        return usage();
+      }
     }
     else if (arg == "--help" || arg == "-h") {
       return usage();

--- a/tools/vdd_frame_channel_probe.cpp
+++ b/tools/vdd_frame_channel_probe.cpp
@@ -1,9 +1,10 @@
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
-#define INITGUID
 
 #include "src/display_device/vdd_control_ioctl.h"
 #include "src/platform/windows/vdd_frame_channel.h"
+
+extern "C" const GUID GUID_DEVINTERFACE_ZAKO_VDD_CONTROL = ZAKO_VDD_CONTROL_GUID_INIT;
 
 #include <SetupAPI.h>
 #include <windows.h>

--- a/tools/vdd_sealed_channel_stress.ps1
+++ b/tools/vdd_sealed_channel_stress.ps1
@@ -1,7 +1,11 @@
 param(
+  [ValidateRange(1, 2147483647)]
   [int]$Iterations = 5,
+  [ValidateRange(0, 2147483647)]
   [int]$Monitor = 0,
+  [ValidateRange(0, 2147483647)]
   [int]$Slots = 3,
+  [ValidateRange(0, 2147483647)]
   [int]$DelaySeconds = 3,
   [string]$ProbePath = "",
   [string]$SunshineLog = "C:\Program Files\Sunshine\config\sunshine.log",
@@ -54,10 +58,15 @@ function Invoke-TriggerMonitor {
 
   if (Test-Path $TriggerMonitorScript) {
     try {
-      & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $TriggerMonitorScript *> $null
+      $triggerOutput = & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $TriggerMonitorScript 2>&1 |
+        ForEach-Object { $_.ToString() }
+      if ($LASTEXITCODE -ne 0) {
+        throw "trigger monitor exited with code $LASTEXITCODE. $($triggerOutput -join "`n")"
+      }
     }
     catch {
-      Write-Verbose "trigger monitor failed: $($_.Exception.Message)"
+      Write-Warning "trigger monitor failed: $($_.Exception.Message)"
+      throw
     }
   }
   else {
@@ -82,13 +91,42 @@ function Invoke-Probe($probe) {
   }
 }
 
+function Get-SunshineLogOffset {
+  if (-not (Test-Path $SunshineLog)) {
+    return 0
+  }
+
+  return (Get-Item $SunshineLog).Length
+}
+
 function Read-RecentSunshineSignal {
+  param(
+    [long]$StartOffset
+  )
+
   if (-not (Test-Path $SunshineLog)) {
     return ""
   }
 
   $patterns = "opened sealed monitor|backend ready|channel=sealed|selection=|meta_seq|generation=|unable to read stable metadata|frame channel open failed|sealed frame channel attach failed|requesting reinit"
-  $lines = Select-String -Path $SunshineLog -Pattern $patterns | Select-Object -Last 80
+  $file = Get-Item $SunshineLog
+  $offset = if ($file.Length -ge $StartOffset) { $StartOffset } else { 0 }
+  $stream = [System.IO.File]::Open($SunshineLog, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+  try {
+    [void]$stream.Seek($offset, [System.IO.SeekOrigin]::Begin)
+    $reader = [System.IO.StreamReader]::new($stream)
+    try {
+      $content = $reader.ReadToEnd()
+    }
+    finally {
+      $reader.Dispose()
+    }
+  }
+  finally {
+    $stream.Dispose()
+  }
+
+  $lines = $content -split "`r?`n" | Select-String -Pattern $patterns | Select-Object -Last 80
   return (($lines | ForEach-Object { $_.Line }) -join "`n")
 }
 
@@ -102,6 +140,7 @@ Write-Host "iterations=$Iterations monitor=$Monitor slots=$Slots"
 for ($i = 1; $i -le $Iterations; ++$i) {
   Write-Host ""
   Write-Host "iteration $i/$Iterations"
+  $iterationLogOffset = Get-SunshineLogOffset
 
   if ($RestartSunshineService) {
     Restart-Sunshine
@@ -124,7 +163,7 @@ for ($i = 1; $i -le $Iterations; ++$i) {
     Write-Warning "probe succeeded but metadata telemetry was incomplete"
   }
 
-  $signals = Read-RecentSunshineSignal
+  $signals = Read-RecentSunshineSignal $iterationLogOffset
   if ($signals) {
     Write-Host "recent sunshine signals:"
     Write-Host $signals

--- a/tools/vdd_sealed_channel_stress.ps1
+++ b/tools/vdd_sealed_channel_stress.ps1
@@ -1,0 +1,143 @@
+param(
+  [int]$Iterations = 5,
+  [int]$Monitor = 0,
+  [int]$Slots = 3,
+  [int]$DelaySeconds = 3,
+  [string]$ProbePath = "",
+  [string]$SunshineLog = "C:\Program Files\Sunshine\config\sunshine.log",
+  [string]$TriggerMonitorScript = "C:\Users\mohaha\Program\github\Virtual-Display-Driver\tools\vdd_capture_test\trigger_monitor.ps1",
+  [switch]$RestartSunshineService,
+  [switch]$RequireSunshineSealedLog
+)
+
+$ErrorActionPreference = "Stop"
+
+function Resolve-ProbePath {
+  if ($ProbePath) {
+    return $ProbePath
+  }
+
+  $repoRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+  $candidate = Join-Path $repoRoot "build\tools\vdd-frame-channel-probe.exe"
+  if (Test-Path $candidate) {
+    return $candidate
+  }
+
+  throw "vdd-frame-channel-probe.exe not found. Build target vdd-frame-channel-probe first, or pass -ProbePath."
+}
+
+function Test-IsAdmin {
+  $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+  $principal = [Security.Principal.WindowsPrincipal]::new($identity)
+  return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Restart-Sunshine {
+  if (-not (Test-IsAdmin)) {
+    throw "-RestartSunshineService requires an elevated PowerShell."
+  }
+
+  Restart-Service -Name SunshineService -Force -ErrorAction Stop
+  Start-Sleep -Seconds 4
+}
+
+function Invoke-TriggerMonitor {
+  if (Test-Path $TriggerMonitorScript) {
+    try {
+      & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $TriggerMonitorScript *> $null
+    }
+    catch {
+      Write-Verbose "trigger monitor failed: $($_.Exception.Message)"
+    }
+  }
+}
+
+function Invoke-Probe($probe) {
+  $oldErrorActionPreference = $ErrorActionPreference
+  $ErrorActionPreference = "Continue"
+  try {
+    $output = & $probe --open --monitor $Monitor --slots $Slots 2>&1 | ForEach-Object { $_.ToString() }
+    $exitCode = $LASTEXITCODE
+  }
+  finally {
+    $ErrorActionPreference = $oldErrorActionPreference
+  }
+
+  [pscustomobject]@{
+    ExitCode = $exitCode
+    Output = ($output -join "`n")
+  }
+}
+
+function Read-RecentSunshineSignals {
+  if (-not (Test-Path $SunshineLog)) {
+    return ""
+  }
+
+  $patterns = "opened sealed monitor|backend ready|channel=sealed|selection=|meta_seq|generation=|unable to read stable metadata|frame channel open failed|sealed frame channel attach failed|requesting reinit"
+  $lines = Select-String -Path $SunshineLog -Pattern $patterns | Select-Object -Last 80
+  return (($lines | ForEach-Object { $_.Line }) -join "`n")
+}
+
+$probe = Resolve-ProbePath
+$failures = 0
+
+Write-Host "VDD sealed channel stress"
+Write-Host "probe=$probe"
+Write-Host "iterations=$Iterations monitor=$Monitor slots=$Slots"
+
+for ($i = 1; $i -le $Iterations; ++$i) {
+  Write-Host ""
+  Write-Host "iteration $i/$Iterations"
+
+  if ($RestartSunshineService) {
+    Restart-Sunshine
+  }
+
+  Invoke-TriggerMonitor
+  Start-Sleep -Seconds $DelaySeconds
+
+  $probeResult = Invoke-Probe $probe
+  Write-Host $probeResult.Output
+
+  if ($probeResult.ExitCode -ne 0) {
+    ++$failures
+    Write-Warning "probe failed with exit code $($probeResult.ExitCode)"
+  }
+  elseif ($probeResult.Output -notmatch "metadata:" -or
+          $probeResult.Output -notmatch "generation=" -or
+          $probeResult.Output -notmatch "slot=\d+/\d+") {
+    ++$failures
+    Write-Warning "probe succeeded but metadata telemetry was incomplete"
+  }
+
+  $signals = Read-RecentSunshineSignals
+  if ($signals) {
+    Write-Host "recent sunshine signals:"
+    Write-Host $signals
+
+    if ($signals -match "unable to read stable metadata|frame channel open failed|sealed frame channel attach failed|selection=(open_failed|open_unsupported|attach_failed|sealed_required_failed|caps_failed)") {
+      ++$failures
+      Write-Warning "Sunshine log contains sealed-channel warning/error signals"
+    }
+    if ($RequireSunshineSealedLog -and $signals -notmatch "channel=sealed") {
+      ++$failures
+      Write-Warning "Sunshine log does not contain channel=sealed"
+    }
+    if ($RequireSunshineSealedLog -and $signals -notmatch "selection=sealed_opened") {
+      ++$failures
+      Write-Warning "Sunshine log does not contain selection=sealed_opened"
+    }
+  }
+  elseif ($RequireSunshineSealedLog) {
+    ++$failures
+    Write-Warning "No Sunshine sealed-channel log signals found"
+  }
+}
+
+if ($failures -ne 0) {
+  throw "VDD sealed channel stress finished with $failures failure(s)."
+}
+
+Write-Host ""
+Write-Host "VDD sealed channel stress passed."

--- a/tools/vdd_sealed_channel_stress.ps1
+++ b/tools/vdd_sealed_channel_stress.ps1
@@ -5,7 +5,7 @@ param(
   [int]$DelaySeconds = 3,
   [string]$ProbePath = "",
   [string]$SunshineLog = "C:\Program Files\Sunshine\config\sunshine.log",
-  [string]$TriggerMonitorScript = "C:\Users\mohaha\Program\github\Virtual-Display-Driver\tools\vdd_capture_test\trigger_monitor.ps1",
+  [string]$TriggerMonitorScript = $env:VDD_TRIGGER_MONITOR_SCRIPT,
   [switch]$RestartSunshineService,
   [switch]$RequireSunshineSealedLog
 )
@@ -33,15 +33,25 @@ function Test-IsAdmin {
 }
 
 function Restart-Sunshine {
+  [CmdletBinding(SupportsShouldProcess)]
+  param()
+
   if (-not (Test-IsAdmin)) {
     throw "-RestartSunshineService requires an elevated PowerShell."
   }
 
-  Restart-Service -Name SunshineService -Force -ErrorAction Stop
-  Start-Sleep -Seconds 4
+  if ($PSCmdlet.ShouldProcess("SunshineService", "Restart service")) {
+    Restart-Service -Name SunshineService -Force -ErrorAction Stop
+    Start-Sleep -Seconds 4
+  }
 }
 
 function Invoke-TriggerMonitor {
+  if (-not $TriggerMonitorScript) {
+    Write-Warning "TriggerMonitorScript not specified; monitor trigger step skipped. Pass -TriggerMonitorScript or set VDD_TRIGGER_MONITOR_SCRIPT."
+    return
+  }
+
   if (Test-Path $TriggerMonitorScript) {
     try {
       & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $TriggerMonitorScript *> $null
@@ -49,6 +59,9 @@ function Invoke-TriggerMonitor {
     catch {
       Write-Verbose "trigger monitor failed: $($_.Exception.Message)"
     }
+  }
+  else {
+    Write-Warning "TriggerMonitorScript not found at '$TriggerMonitorScript'; monitor trigger step skipped."
   }
 }
 
@@ -69,7 +82,7 @@ function Invoke-Probe($probe) {
   }
 }
 
-function Read-RecentSunshineSignals {
+function Read-RecentSunshineSignal {
   if (-not (Test-Path $SunshineLog)) {
     return ""
   }
@@ -111,7 +124,7 @@ for ($i = 1; $i -le $Iterations; ++$i) {
     Write-Warning "probe succeeded but metadata telemetry was incomplete"
   }
 
-  $signals = Read-RecentSunshineSignals
+  $signals = Read-RecentSunshineSignal
   if ($signals) {
     Write-Host "recent sunshine signals:"
     Write-Host $signals


### PR DESCRIPTION
## 改了啥呢
- 新增 Windows VDD sealed frame-channel capture path：优先用 driver duplicated unnamed handles，失败时回落 legacy named channel。
- 增加 frame metadata helper、generation/seqlock snapshot 校验、adapter LUID 校验和 channel selection telemetry。
- 新增运维工具：`vdd-frame-channel-probe`、`check-vdd-ioctl-abi.ps1`、`vdd_sealed_channel_stress.ps1`。
- 补了 sealed channel 运维文档和安全/稳定性测试，明确新 driver 默认 sealed-only；legacy named export 需要 `LEGACYNAMEDFRAMECHANNEL=1` 显式开启。

## 为啥要改
- legacy named shared texture 可用，但对象命名空间和 metadata 稳定性边界不够硬。
- sealed borrowed-frame path 保留借帧低延迟优势，同时通过 unnamed handles、strict DACL、driver-opened channel 和 metadata sequence 降低误接入风险。
- 运维侧需要明确判断当前是否真的走 sealed path，而不是只看“能出画面”。
- 新 driver 默认不创建 `Global\ZakoVDD_*`，才算把 named object 暴露面真正闭合。

## 关联
- Driver side: https://github.com/qiin2333/zako-vdd/pull/15

## 验证
- `cmake --build build --config Release --target vdd-frame-channel-probe`
- `cmake --build build --config Release --target check-vdd-ioctl-abi`
- `powershell -ExecutionPolicy Bypass -File tools\check_vdd_ioctl_abi.ps1 -DriverHeader 'C:\Users\mohaha\Program\github\Virtual-Display-Driver\Common\Include\vdd_control_ioctl.h'`
- `vdd-frame-channel-probe`: `caps: version=1 flags=0x7 max_slots=3 metadata_size=128`
- Earlier chain validation passed with Sunshine sealed logs containing `channel=sealed` and `selection=sealed_opened`.