### PR TITLE
feat(tray): unify Windows tray ownership

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -198,6 +198,7 @@ jobs:
           ninja -C build
 
       - name: Run native tests
+        shell: msys2 {0}
         run: ctest --test-dir build --output-on-failure
 
       - name: Cache Inno Setup

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -188,6 +188,7 @@ jobs:
             -G Ninja \
             -S . \
             -DBUILD_DOCS=OFF \
+            -DBUILD_TRAY_TESTS=ON \
             -DBUILD_WEB_UI=OFF \
             -DSUNSHINE_ASSETS_DIR=assets \
             -DDRIVER_DEPS_REQUIRED=${DRIVER_DEPS_REQUIRED} \
@@ -195,6 +196,9 @@ jobs:
             -DSUNSHINE_PUBLISHER_WEBSITE='https://github.com/AlkaidLab/foundation-sunshine' \
             -DSUNSHINE_PUBLISHER_ISSUE_URL='https://github.com/AlkaidLab/foundation-sunshine/issues'
           ninja -C build
+
+      - name: Run native tests
+        run: ctest --test-dir build --output-on-failure
 
       - name: Cache Inno Setup
         id: inno-cache

--- a/.gitmodules
+++ b/.gitmodules
@@ -84,4 +84,4 @@
 [submodule "src_assets/common/sunshine-control-panel"]
 	path = src_assets/common/sunshine-control-panel
 	url = https://github.com/qiin2333/sunshine-control-panel.git
-	branch = tauri
+	branch = main

--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -179,10 +179,14 @@ set(SUNSHINE_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/network.cpp"
         "${CMAKE_SOURCE_DIR}/src/network.h"
         "${CMAKE_SOURCE_DIR}/src/move_by_copy.h"
-        "${CMAKE_SOURCE_DIR}/src/system_tray.cpp"
-        "${CMAKE_SOURCE_DIR}/src/system_tray.h"
-        "${CMAKE_SOURCE_DIR}/src/system_tray_i18n.cpp"
-        "${CMAKE_SOURCE_DIR}/src/system_tray_i18n.h"
+        "${CMAKE_SOURCE_DIR}/src/tray/system_tray.cpp"
+        "${CMAKE_SOURCE_DIR}/src/tray/system_tray.h"
+        "${CMAKE_SOURCE_DIR}/src/tray/system_tray_i18n.cpp"
+        "${CMAKE_SOURCE_DIR}/src/tray/system_tray_i18n.h"
+        "${CMAKE_SOURCE_DIR}/src/tray/tray_http.cpp"
+        "${CMAKE_SOURCE_DIR}/src/tray/tray_http.h"
+        "${CMAKE_SOURCE_DIR}/src/tray/tray_state.cpp"
+        "${CMAKE_SOURCE_DIR}/src/tray/tray_state.h"
         "${CMAKE_SOURCE_DIR}/src/task_pool.h"
         "${CMAKE_SOURCE_DIR}/src/thread_pool.h"
         "${CMAKE_SOURCE_DIR}/src/thread_safe.h"
@@ -198,6 +202,7 @@ endif()
 list(APPEND SUNSHINE_DEFINITIONS SUNSHINE_ASSETS_DIR="${SUNSHINE_ASSETS_DIR_DEF}")
 
 list(APPEND SUNSHINE_DEFINITIONS SUNSHINE_TRAY=${SUNSHINE_TRAY})
+list(APPEND SUNSHINE_DEFINITIONS SUNSHINE_GUI_TRAY=${SUNSHINE_GUI_TRAY})
 
 # Publisher metadata - escape spaces for proper compilation
 string(REPLACE " " "_" SUNSHINE_PUBLISHER_NAME_SAFE "${SUNSHINE_PUBLISHER_NAME}")

--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -173,6 +173,7 @@ set(SUNSHINE_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/input_activity.h"
         "${CMAKE_SOURCE_DIR}/src/audio.cpp"
         "${CMAKE_SOURCE_DIR}/src/audio.h"
+        "${CMAKE_SOURCE_DIR}/src/http_util.h"
         "${CMAKE_SOURCE_DIR}/src/platform/common.h"
         "${CMAKE_SOURCE_DIR}/src/process.cpp"
         "${CMAKE_SOURCE_DIR}/src/process.h"

--- a/cmake/compile_definitions/windows.cmake
+++ b/cmake/compile_definitions/windows.cmake
@@ -80,7 +80,16 @@ endif()
 
 configure_file("${CMAKE_SOURCE_DIR}/src/platform/windows/windows.rc.in" windows.rc @ONLY)
 
-# set(SUNSHINE_TRAY 0)
+if(SUNSHINE_ENABLE_TRAY AND SUNSHINE_ENABLE_LEGACY_TRAY)
+    set(SUNSHINE_TRAY 1)
+    set(SUNSHINE_GUI_TRAY 0)
+elseif(SUNSHINE_ENABLE_TRAY)
+    set(SUNSHINE_TRAY 0)
+    set(SUNSHINE_GUI_TRAY 1)
+else()
+    set(SUNSHINE_TRAY 0)
+    set(SUNSHINE_GUI_TRAY 0)
+endif()
 
 set(PLATFORM_TARGET_FILES
         "${CMAKE_CURRENT_BINARY_DIR}/windows.rc"
@@ -154,7 +163,7 @@ list(PREPEND PLATFORM_LIBRARIES
         wsock32
 )
 
-if(SUNSHINE_ENABLE_TRAY)
+if(SUNSHINE_ENABLE_TRAY AND SUNSHINE_ENABLE_LEGACY_TRAY)
     list(APPEND PLATFORM_TARGET_FILES
             "${CMAKE_SOURCE_DIR}/third-party/tray/src/tray_windows.c")
 endif()

--- a/cmake/packaging/FetchGUI.cmake
+++ b/cmake/packaging/FetchGUI.cmake
@@ -19,21 +19,34 @@ if(NOT WIN32)
 endif()
 
 option(FETCH_GUI "Download pre-built GUI from GitHub Releases" ON)
+option(SUNSHINE_ALLOW_FLOATING_GUI "Allow downloading the moving latest GUI release (development only)" OFF)
 
 set(GUI_VERSION "latest" CACHE STRING "Sunshine GUI release tag (or 'latest')")
 set(GUI_REPO "qiin2333/sunshine-control-panel" CACHE STRING "GUI GitHub repository")
 
 set(GUI_DIR "${CMAKE_BINARY_DIR}/_gui" CACHE PATH "GUI binary directory" FORCE)
+set(_gui_exe_cached FALSE)
 
 if(NOT FETCH_GUI)
   message(STATUS "GUI download disabled (FETCH_GUI=OFF)")
   return()
 endif()
 
+if(GUI_VERSION STREQUAL "latest" AND NOT SUNSHINE_ALLOW_FLOATING_GUI)
+  message(FATAL_ERROR
+    "Refusing to package a floating Sunshine GUI release. Build the local GUI, "
+    "set GUI_VERSION to an explicit release tag, or opt in for development with "
+    "SUNSHINE_ALLOW_FLOATING_GUI=ON.")
+endif()
+
 # Skip if already downloaded
 if(EXISTS "${GUI_DIR}/sunshine-gui.exe")
-  message(STATUS "GUI binary already cached at ${GUI_DIR}")
-  return()
+  set(_gui_exe_cached TRUE)
+  if(EXISTS "${GUI_DIR}/WebView2Loader.dll")
+    message(STATUS "GUI binary already cached at ${GUI_DIR}")
+    return()
+  endif()
+  message(STATUS "GUI binary already cached at ${GUI_DIR}; checking for WebView2Loader.dll")
 endif()
 
 file(MAKE_DIRECTORY "${GUI_DIR}")
@@ -97,30 +110,32 @@ else()
 endif()
 
 # Download sunshine-gui.exe
-if(_gui_url)
-  message(STATUS "  Downloading sunshine-gui.exe ...")
-  execute_process(
-    COMMAND "${_CURL}" -fsSL
-      ${_auth_args}
-      -o "${GUI_DIR}/sunshine-gui.exe"
-      -L "${_gui_url}"
-    RESULT_VARIABLE _rc
-    ERROR_VARIABLE _err)
-elseif(_gui_api_url)
-  message(STATUS "  Downloading sunshine-gui.exe via API ...")
-  execute_process(
-    COMMAND "${_CURL}" -fsSL
-      ${_auth_args}
-      -H "Accept: application/octet-stream"
-      -o "${GUI_DIR}/sunshine-gui.exe"
-      "${_gui_api_url}"
-    RESULT_VARIABLE _rc
-    ERROR_VARIABLE _err)
-endif()
+if(NOT _gui_exe_cached)
+  if(_gui_url)
+    message(STATUS "  Downloading sunshine-gui.exe ...")
+    execute_process(
+      COMMAND "${_CURL}" -fsSL
+        ${_auth_args}
+        -o "${GUI_DIR}/sunshine-gui.exe"
+        -L "${_gui_url}"
+      RESULT_VARIABLE _rc
+      ERROR_VARIABLE _err)
+  elseif(_gui_api_url)
+    message(STATUS "  Downloading sunshine-gui.exe via API ...")
+    execute_process(
+      COMMAND "${_CURL}" -fsSL
+        ${_auth_args}
+        -H "Accept: application/octet-stream"
+        -o "${GUI_DIR}/sunshine-gui.exe"
+        "${_gui_api_url}"
+      RESULT_VARIABLE _rc
+      ERROR_VARIABLE _err)
+  endif()
 
-if(NOT _rc EQUAL 0)
-  message(WARNING "  Download failed (${_rc}): ${_err}")
-  file(REMOVE "${GUI_DIR}/sunshine-gui.exe")
+  if(NOT _rc EQUAL 0)
+    message(WARNING "  Download failed (${_rc}): ${_err}")
+    file(REMOVE "${GUI_DIR}/sunshine-gui.exe")
+  endif()
 endif()
 
 # Try downloading WebView2Loader.dll (optional, Tauri 2 may embed it)

--- a/cmake/packaging/FetchGUI.cmake
+++ b/cmake/packaging/FetchGUI.cmake
@@ -19,7 +19,6 @@ if(NOT WIN32)
 endif()
 
 option(FETCH_GUI "Download pre-built GUI from GitHub Releases" ON)
-option(SUNSHINE_ALLOW_FLOATING_GUI "Allow downloading the moving latest GUI release (development only)" OFF)
 
 set(GUI_VERSION "latest" CACHE STRING "Sunshine GUI release tag (or 'latest')")
 set(GUI_REPO "qiin2333/sunshine-control-panel" CACHE STRING "GUI GitHub repository")
@@ -30,13 +29,6 @@ set(_gui_exe_cached FALSE)
 if(NOT FETCH_GUI)
   message(STATUS "GUI download disabled (FETCH_GUI=OFF)")
   return()
-endif()
-
-if(GUI_VERSION STREQUAL "latest" AND NOT SUNSHINE_ALLOW_FLOATING_GUI)
-  message(FATAL_ERROR
-    "Refusing to package a floating Sunshine GUI release. Build the local GUI, "
-    "set GUI_VERSION to an explicit release tag, or opt in for development with "
-    "SUNSHINE_ALLOW_FLOATING_GUI=ON.")
 endif()
 
 # Skip if already downloaded

--- a/cmake/packaging/common.cmake
+++ b/cmake/packaging/common.cmake
@@ -40,44 +40,53 @@ install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/assets/web"
 
 # install sunshine control panel (Tauri GUI) — from pre-built download
 if(WIN32)
-    include(${CMAKE_MODULE_PATH}/packaging/FetchGUI.cmake)
+    option(SUNSHINE_PREFER_LOCAL_GUI "Prefer a locally-built Tauri GUI over the downloaded GUI binary" ON)
+
+    set(_local_gui_dir "")
+    if(SUNSHINE_PREFER_LOCAL_GUI)
+        set(TAURI_TARGET_DIR "${SUNSHINE_SOURCE_ASSETS_DIR}/common/sunshine-control-panel/src-tauri/target")
+        set(_candidate_gui_dirs
+                "${TAURI_TARGET_DIR}/release"
+                "${TAURI_TARGET_DIR}/x86_64-pc-windows-gnu/release"
+                "${TAURI_TARGET_DIR}/x86_64-pc-windows-msvc/release")
+        set(_local_gui_timestamp "")
+        foreach(_candidate_gui_dir IN LISTS _candidate_gui_dirs)
+            set(_candidate_gui_exe "${_candidate_gui_dir}/sunshine-gui.exe")
+            if(EXISTS "${_candidate_gui_exe}")
+                file(TIMESTAMP "${_candidate_gui_exe}" _candidate_gui_timestamp "%Y%m%d%H%M%S" UTC)
+                if(NOT _local_gui_dir OR _candidate_gui_timestamp STRGREATER _local_gui_timestamp)
+                    set(_local_gui_dir "${_candidate_gui_dir}")
+                    set(_local_gui_timestamp "${_candidate_gui_timestamp}")
+                endif()
+            endif()
+        endforeach()
+    endif()
+
+    if(_local_gui_dir)
+        set(GUI_DIR "${_local_gui_dir}")
+        set(GUI_DIR "${_local_gui_dir}" CACHE PATH "GUI binary directory" FORCE)
+        message(STATUS "Using local Sunshine GUI binary at ${GUI_DIR}")
+    else()
+        include(${CMAKE_MODULE_PATH}/packaging/FetchGUI.cmake)
+    endif()
 
     if(EXISTS "${GUI_DIR}/sunshine-gui.exe")
         install(PROGRAMS "${GUI_DIR}/sunshine-gui.exe"
             DESTINATION "${SUNSHINE_ASSETS_DIR}/gui"
-            COMPONENT assets)
+            COMPONENT gui)
         # WebView2Loader.dll (optional — Tauri 2 may embed it)
         if(EXISTS "${GUI_DIR}/WebView2Loader.dll")
             install(FILES "${GUI_DIR}/WebView2Loader.dll"
                 DESTINATION "${SUNSHINE_ASSETS_DIR}/gui"
-                COMPONENT assets)
+                COMPONENT gui)
         endif()
     else()
-        # Fallback: try local Tauri build output (for developers building GUI locally)
-        set(TAURI_TARGET_DIR "${SUNSHINE_SOURCE_ASSETS_DIR}/common/sunshine-control-panel/src-tauri/target")
-
-        install(PROGRAMS
-            "${TAURI_TARGET_DIR}/x86_64-pc-windows-gnu/release/sunshine-gui.exe"
-            DESTINATION "${SUNSHINE_ASSETS_DIR}/gui"
-            RENAME "sunshine-gui.exe"
-            OPTIONAL)
-        install(PROGRAMS
-            "${TAURI_TARGET_DIR}/x86_64-pc-windows-msvc/release/sunshine-gui.exe"
-            DESTINATION "${SUNSHINE_ASSETS_DIR}/gui"
-            RENAME "sunshine-gui.exe"
-            OPTIONAL)
-        install(PROGRAMS
-            "${TAURI_TARGET_DIR}/release/sunshine-gui.exe"
-            DESTINATION "${SUNSHINE_ASSETS_DIR}/gui"
-            RENAME "sunshine-gui.exe"
-            OPTIONAL)
-
-        install(FILES
-            "${TAURI_TARGET_DIR}/x86_64-pc-windows-gnu/release/WebView2Loader.dll"
-            "${TAURI_TARGET_DIR}/x86_64-pc-windows-msvc/release/WebView2Loader.dll"
-            "${TAURI_TARGET_DIR}/release/WebView2Loader.dll"
-            DESTINATION "${SUNSHINE_ASSETS_DIR}/gui"
-            OPTIONAL)
+        if(SUNSHINE_ENABLE_TRAY AND NOT SUNSHINE_ENABLE_LEGACY_TRAY)
+            message(FATAL_ERROR
+                "Sunshine GUI is required by the Windows GUI tray build, but sunshine-gui.exe is unavailable. "
+                "Build the local GUI or configure an explicit GUI release before packaging.")
+        endif()
+        message(WARNING "Sunshine GUI binary is unavailable; continuing only because the GUI tray is disabled")
     endif()
 endif()
 

--- a/cmake/packaging/sunshine.iss.in
+++ b/cmake/packaging/sunshine.iss.in
@@ -74,6 +74,7 @@ Name: "chinesesimplified"; MessagesFile: "@CMAKE_SOURCE_DIR@\cmake\packaging\Chi
 ; English custom messages
 english.ComponentApplication=Sunshine main application
 english.ComponentAssets=Required assets (shaders, web UI)
+english.ComponentGUI=Sunshine GUI and tray agent (required)
 english.ComponentVDD=Zako Virtual Display Driver (HDR)
 english.ComponentAutostart=Launch on system startup
 english.ComponentFirewall=Add firewall exclusions
@@ -114,6 +115,7 @@ english.StatusStoppingProcesses=Stopping running Sunshine processes...
 ; Chinese Simplified custom messages
 chinesesimplified.ComponentApplication=Sunshine 主程序
 chinesesimplified.ComponentAssets=必要资源（着色器、Web UI）
+chinesesimplified.ComponentGUI=Sunshine GUI 与托盘代理（必需）
 chinesesimplified.ComponentVDD=Zako 虚拟显示驱动（HDR）
 chinesesimplified.ComponentAutostart=开机自动启动
 chinesesimplified.ComponentFirewall=添加防火墙规则
@@ -160,6 +162,7 @@ Name: "custom"; Description: "{cm:TypeCustom}"; Flags: iscustom
 [Components]
 Name: "application"; Description: "{cm:ComponentApplication}"; Types: recommended full compact custom; Flags: fixed
 Name: "assets"; Description: "{cm:ComponentAssets}"; Types: recommended full compact custom; Flags: fixed
+Name: "gui"; Description: "{cm:ComponentGUI}"; Types: recommended full compact custom; Flags: fixed
 Name: "vdd"; Description: "{cm:ComponentVDD} — {cm:ComponentVDDDesc}"; Types: recommended full; ExtraDiskSpaceRequired: 2097152
 Name: "firewall"; Description: "{cm:ComponentFirewall} — {cm:ComponentFirewallDesc}"; Types: recommended full compact
 Name: "autostart"; Description: "{cm:ComponentAutostart} — {cm:ComponentAutostartDesc}"; Types: recommended full
@@ -204,8 +207,12 @@ Source: "{#MySourceDir}\scripts\IMAGE_MIGRATION.md"; DestDir: "{app}\scripts"; F
 ; PATH management
 Source: "{#MySourceDir}\scripts\update-path.bat"; DestDir: "{app}\scripts"; Flags: ignoreversion; Components: application
 
-; Assets (includes GUI, shaders, web UI, etc.)
-Source: "{#MySourceDir}\assets\*"; DestDir: "{app}\assets"; Flags: ignoreversion recursesubdirs createallsubdirs; Components: assets
+; Assets (shaders, web UI, etc.)
+Source: "{#MySourceDir}\assets\*"; DestDir: "{app}\assets"; Excludes: "gui\*"; Flags: ignoreversion recursesubdirs createallsubdirs; Components: assets
+
+; Required GUI and user-session tray agent
+Source: "{#MySourceDir}\assets\gui\{#MyAppGUIExeName}"; DestDir: "{app}\assets\gui"; Flags: ignoreversion; Components: gui
+Source: "{#MySourceDir}\assets\gui\WebView2Loader.dll"; DestDir: "{app}\assets\gui"; Flags: ignoreversion skipifsourcedoesntexist; Components: gui
 
 ; Helper tools
 Source: "{#MySourceDir}\tools\device-toggler.exe"; DestDir: "{app}\tools"; Flags: ignoreversion; Components: assets
@@ -250,13 +257,13 @@ Source: "{#MySourceDir}\tools\audio-info.exe"; DestDir: "{app}\tools"; Flags: ig
 [Icons]
 ; Start Menu shortcuts
 Name: "{group}\Sunshine"; Filename: "{app}\{#MyAppExeName}"; Parameters: "--shortcut"; IconFilename: "{app}\{#MyAppExeName}"
-Name: "{group}\Sunshine GUI"; Filename: "{app}\assets\gui\{#MyAppGUIExeName}"; IconFilename: "{app}\assets\gui\{#MyAppGUIExeName}"
+Name: "{group}\Sunshine GUI"; Filename: "{app}\assets\gui\{#MyAppGUIExeName}"; IconFilename: "{app}\assets\gui\{#MyAppGUIExeName}"; Components: gui
 Name: "{group}\Sunshine Tools"; Filename: "{app}\tools"; IconFilename: "{app}\{#MyAppExeName}"
 Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"
 
 ; Desktop shortcuts (optional, controlled by Tasks)
 Name: "{autodesktop}\Sunshine"; Filename: "{app}\{#MyAppExeName}"; Parameters: "--shortcut"; IconFilename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
-Name: "{autodesktop}\Sunshine GUI"; Filename: "{app}\assets\gui\{#MyAppGUIExeName}"; IconFilename: "{app}\assets\gui\{#MyAppGUIExeName}"; Tasks: desktopicon
+Name: "{autodesktop}\Sunshine GUI"; Filename: "{app}\assets\gui\{#MyAppGUIExeName}"; IconFilename: "{app}\assets\gui\{#MyAppGUIExeName}"; Tasks: desktopicon; Components: gui
 
 ; Install dir shortcut
 Name: "{app}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Parameters: "--shortcut"; IconFilename: "{app}\{#MyAppExeName}"
@@ -279,17 +286,10 @@ Filename: "{app}\scripts\install-service.bat"; StatusMsg: "{cm:StatusInstallServ
 Filename: "{app}\scripts\autostart-service.bat"; StatusMsg: "{cm:StatusAutostart}"; Flags: runhidden waituntilterminated; Components: autostart
 
 ; Finish page actions - user selectable
-; Use explorer.exe to launch GUI so it always runs as the non-elevated current user,
-; even though the installer itself is running with admin privileges.
-; `runascurrentuser` is required: without it Inno 6 routes postinstall items
-; through its SpawnServer to demote to the originating user. That helper
-; expects to talk to Inno's own rundll32-based child and fails with
-; "CallSpawnServer: Unexpected response: $0" the moment explorer.exe forwards
-; the request to the existing shell instance and exits. We don't need Inno's
-; demotion here anyway — the explorer.exe trick performs the de-elevation at
-; the Windows shell level on its own.
-Filename: "https://docs.qq.com/aio/DSGdQc3htbFJjSFdO?p=DXpTjzl2kZwBjN7jlRMkRJ"; Description: "{cm:FinishOpenDocs}"; Flags: postinstall shellexec runascurrentuser unchecked nowait skipifsilent
-Filename: "{win}\explorer.exe"; Parameters: """{app}\assets\gui\{#MyAppGUIExeName}"""; Description: "{cm:FinishLaunchGUI}"; Flags: postinstall nowait skipifsilent runascurrentuser
+Filename: "https://docs.qq.com/aio/DSGdQc3htbFJjSFdO?p=DXpTjzl2kZwBjN7jlRMkRJ"; Description: "{cm:FinishOpenDocs}"; Flags: postinstall shellexec runasoriginaluser unchecked nowait skipifsilent
+; Launch the user-session agent with the original desktop token. The GUI then
+; owns and reconciles its HKCU autostart entry from the correct user context.
+Filename: "{app}\assets\gui\{#MyAppGUIExeName}"; Description: "{cm:FinishLaunchGUI}"; Flags: postinstall nowait skipifsilent runasoriginaluser; Components: gui
 
 [UninstallRun]
 ; Stop running processes first. We force-kill the service binary

--- a/cmake/packaging/sunshine.iss.in
+++ b/cmake/packaging/sunshine.iss.in
@@ -293,7 +293,7 @@ Filename: "{app}\assets\gui\{#MyAppGUIExeName}"; Description: "{cm:FinishLaunchG
 
 [UninstallRun]
 ; Remove the per-user GUI startup entry before terminating the agent.
-Filename: "{app}\assets\gui\{#MyAppGUIExeName}"; Parameters: "--remove-autostart"; Flags: runhidden waituntilterminated runasoriginaluser; RunOnceId: "RemoveGUIAutoStart"; Check: FileExists(ExpandConstant('{app}\assets\gui\{#MyAppGUIExeName}'))
+Filename: "{app}\assets\gui\{#MyAppGUIExeName}"; Parameters: "--remove-autostart"; Flags: runhidden waituntilterminated; RunOnceId: "RemoveGUIAutoStart"; Check: FileExists(ExpandConstant('{app}\assets\gui\{#MyAppGUIExeName}'))
 ; Stop running processes first. We force-kill the service binary
 ; (sunshinesvc.exe) here as well, otherwise `sc stop` later may block waiting
 ; on its stop handler — which is the typical "uninstaller appears frozen" symptom.

--- a/cmake/packaging/sunshine.iss.in
+++ b/cmake/packaging/sunshine.iss.in
@@ -292,6 +292,8 @@ Filename: "https://docs.qq.com/aio/DSGdQc3htbFJjSFdO?p=DXpTjzl2kZwBjN7jlRMkRJ"; 
 Filename: "{app}\assets\gui\{#MyAppGUIExeName}"; Description: "{cm:FinishLaunchGUI}"; Flags: postinstall nowait skipifsilent runasoriginaluser; Components: gui
 
 [UninstallRun]
+; Remove the per-user GUI startup entry before terminating the agent.
+Filename: "{app}\assets\gui\{#MyAppGUIExeName}"; Parameters: "--remove-autostart"; Flags: runhidden waituntilterminated runasoriginaluser; RunOnceId: "RemoveGUIAutoStart"; Check: FileExists(ExpandConstant('{app}\assets\gui\{#MyAppGUIExeName}'))
 ; Stop running processes first. We force-kill the service binary
 ; (sunshinesvc.exe) here as well, otherwise `sc stop` later may block waiting
 ; on its stop handler — which is the typical "uninstaller appears frozen" symptom.

--- a/cmake/packaging/windows.cmake
+++ b/cmake/packaging/windows.cmake
@@ -128,7 +128,7 @@ set(CPACK_COMPONENT_APPLICATION_DISPLAY_NAME "${CMAKE_PROJECT_NAME}")
 set(CPACK_COMPONENT_APPLICATION_DESCRIPTION "${CMAKE_PROJECT_NAME} main application and required components.")
 set(CPACK_COMPONENT_APPLICATION_GROUP "Core")
 set(CPACK_COMPONENT_APPLICATION_REQUIRED true)
-set(CPACK_COMPONENT_APPLICATION_DEPENDS assets)
+set(CPACK_COMPONENT_APPLICATION_DEPENDS "assets;gui")
 
 # Virtual Display Driver
 set(CPACK_COMPONENT_VDD_DISPLAY_NAME "Zako Display Driver")
@@ -147,6 +147,12 @@ set(CPACK_COMPONENT_ASSETS_DISPLAY_NAME "Required Assets")
 set(CPACK_COMPONENT_ASSETS_DESCRIPTION "Shaders, default box art, and web UI.")
 set(CPACK_COMPONENT_ASSETS_GROUP "Core")
 set(CPACK_COMPONENT_ASSETS_REQUIRED true)
+
+# Windows user-session agent and tray owner
+set(CPACK_COMPONENT_GUI_DISPLAY_NAME "Sunshine GUI and Tray Agent")
+set(CPACK_COMPONENT_GUI_DESCRIPTION "Required Windows tray, pairing UI, and user-session services.")
+set(CPACK_COMPONENT_GUI_GROUP "Core")
+set(CPACK_COMPONENT_GUI_REQUIRED true)
 
 # audio tool
 set(CPACK_COMPONENT_AUDIO_DISPLAY_NAME "audio-info")

--- a/cmake/packaging/windows_nsis.cmake
+++ b/cmake/packaging/windows_nsis.cmake
@@ -74,17 +74,8 @@ FunctionEnd
 !define MUI_FINISHPAGE_RUN_TEXT '打开使用教程'
 !define MUI_FINISHPAGE_RUN_FUNCTION OpenDocumentation
 
-; 复选框2: 启动 Sunshine GUI（默认勾选）
-!define MUI_FINISHPAGE_SHOWREADME
-!define MUI_FINISHPAGE_SHOWREADME_TEXT '启动 Sunshine GUI'
-!define MUI_FINISHPAGE_SHOWREADME_FUNCTION LaunchGUI
-
 Function OpenDocumentation
     ExecShell 'open' 'https://docs.qq.com/aio/DSGdQc3htbFJjSFdO?p=DXpTjzl2kZwBjN7jlRMkRJ'
-FunctionEnd
-
-Function LaunchGUI
-    Exec '\$INSTDIR\\\\assets\\\\gui\\\\sunshine-gui.exe'
 FunctionEnd
 ")
 
@@ -234,6 +225,8 @@ set(CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS
         DetailPrint '恢复NVIDIA设置...'
         nsExec::ExecToLog '\\\"$INSTDIR\\\\${CMAKE_PROJECT_NAME}.exe\\\" --restore-nvprefs-undo'
         
+        DeleteRegValue HKCU 'Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Run' 'Sunshine GUI Desktop'
+
         MessageBox MB_YESNO|MB_ICONQUESTION \
             'Do you want to remove Virtual Gamepad?' \
             /SD IDNO IDNO NoGamepad

--- a/cmake/prep/constants.cmake
+++ b/cmake/prep/constants.cmake
@@ -3,3 +3,4 @@ set(SUNSHINE_SOURCE_ASSETS_DIR "${CMAKE_SOURCE_DIR}/src_assets")
 
 # enable system tray, we will disable this later if we cannot find the required package config on linux
 set(SUNSHINE_TRAY 1)
+set(SUNSHINE_GUI_TRAY 0)

--- a/cmake/prep/options.cmake
+++ b/cmake/prep/options.cmake
@@ -9,6 +9,7 @@ set(SUNSHINE_PUBLISHER_ISSUE_URL "https://github.com/qiin2333/Sunshine/issues"
 
 option(BUILD_DOCS "Build documentation" OFF)
 option(BUILD_TESTS "Build tests" OFF)
+option(BUILD_TRAY_TESTS "Build the focused tray protocol tests" OFF)
 option(NPM_OFFLINE "Use offline npm packages. You must ensure packages are in your npm cache." OFF)
 
 option(BUILD_WERROR "Enable -Werror flag." OFF)
@@ -18,6 +19,7 @@ option(SUNSHINE_CONFIGURE_ONLY "Configure special files only, then exit." OFF)
 
 option(SUNSHINE_ENABLE_TRAY "Enable system tray icon. This option will be ignored on macOS." ON)
 option(SUNSHINE_REQUIRE_TRAY "Require system tray icon. Fail the build if tray requirements are not met." ON)
+option(SUNSHINE_ENABLE_LEGACY_TRAY "Use the in-process C++ tray instead of the Windows GUI user agent." OFF)
 
 option(SUNSHINE_SYSTEM_NLOHMANN_JSON "Use system installation of nlohmann_json rather than the submodule." OFF)
 option(SUNSHINE_SYSTEM_WAYLAND_PROTOCOLS "Use system installation of wayland-protocols rather than the submodule." OFF)

--- a/cmake/targets/common.cmake
+++ b/cmake/targets/common.cmake
@@ -78,7 +78,8 @@ if(BUILD_DOCS)
 endif()
 
 # tests
-if(BUILD_TESTS)
+if(BUILD_TESTS OR BUILD_TRAY_TESTS)
+    enable_testing()
     add_subdirectory(tests)
 endif()
 

--- a/docs/tray-protocol.md
+++ b/docs/tray-protocol.md
@@ -1,0 +1,93 @@
+# Tray Provider Protocol
+
+Sunshine Core owns stream state and privileged actions. A user-session tray
+provider owns native menu presentation, notifications, language, and links into
+the desktop GUI. The provider is replaceable and is not required to be built
+with Core.
+
+## Transport and authentication
+
+- Protocol version: `1`
+- Base URL: the local Sunshine Web UI endpoint, normally
+  `https://127.0.0.1:<core-port + 1>`
+- Payloads: JSON, except the SSE endpoint
+- Access: normal Web UI authentication applies. During first configuration,
+  requests from localhost are accepted while no username exists. Remote
+  unauthenticated requests are never accepted by this exception.
+- A tray provider must not follow a remote host selected by a desktop window.
+
+`GET /api/tray/state` returns the current snapshot. `instance_id` changes when
+Core restarts and `revision` increases whenever published state changes.
+Consumers must ignore unknown fields and capabilities.
+
+`GET /api/tray/events` is an SSE stream. A `tray-state` event contains the same
+JSON object as the state endpoint. Comment frames are keepalives. Providers
+should reconnect after disconnect and may perform an infrequent state request
+as a connection health check. If `events-v1` is absent, polling the state
+endpoint is the compatibility fallback.
+
+## State capabilities
+
+- `state-v1`: state snapshot and stable instance identity
+- `events-v1`: SSE state changes
+- `actions-v1`: action endpoint
+- `operations-v1`: asynchronous operation lifecycle in state
+- `provider-lease-v1`: optional provider ownership lease
+- `notification-ack`: non-pairing notification acknowledgement
+- `pairing`: pairing notification with the `open_pin` action
+- `vdd`: virtual-display state and actions
+
+The `owner` field describes the packaged tray strategy (`gui`, `core`, or
+`disabled`). It is retained for version-1 compatibility. Active runtime
+ownership is represented separately by `provider`.
+
+## Actions and operations
+
+`POST /api/tray/action` accepts:
+
+```json
+{ "action": "vdd_create", "enabled": true, "notification_id": 12 }
+```
+
+Only fields relevant to the selected action are required. Supported actions
+are `vdd_create`, `vdd_destroy`, `vdd_toggle_keep_enabled`,
+`vdd_toggle_headless_create`, `clear_app`, `reset_display_device_config`,
+`restart`, and `notification_ack`.
+
+VDD creation is non-interactive inside Core. A graphical provider must obtain
+user confirmation before requesting it. Long-running actions return an
+`operation_id`; their current `running`, `succeeded`, or `failed` result is
+published in the state `operation` object. Operations execute serially and are
+joined during Core shutdown.
+
+## Provider lease
+
+Lease support is optional in protocol version 1 so released GUI versions remain
+compatible during migration.
+
+1. `POST /api/tray/provider/register` with `provider_id`, `version`,
+   `protocol_version`, and optional provider capabilities.
+2. Core returns a private `lease_id` and `lease_duration_ms`. The lease token is
+   never included in public state.
+3. `POST /api/tray/provider/heartbeat` with `lease_id` before expiry.
+4. `DELETE /api/tray/provider/lease` with `lease_id` for best-effort release.
+   An uncleanly terminated provider is released automatically after expiry.
+
+Only one distinct provider ID may hold an active lease. Re-registering the
+same provider ID replaces its previous lease, which supports provider restart.
+The public `provider` state contains only ID, version, and active status. Lease
+renewal does not increment the tray state revision or rebuild the provider UI.
+
+During the version-1 compatibility period, legacy clients may still read state
+and invoke actions without a lease. A future protocol version may require the
+lease for provider-owned actions after all supported packaged clients have
+migrated.
+
+## Compatibility
+
+- New provider with old Core: use state polling/SSE and actions; do not attempt
+  lease registration unless `provider-lease-v1` is advertised.
+- Old provider with new Core: existing state, event, and action behavior remains
+  available; no lease is required.
+- GUI-only installation: the provider may run independently but reports Core as
+  disconnected until a compatible local Core is installed and running.

--- a/docs/tray-protocol.md
+++ b/docs/tray-protocol.md
@@ -51,13 +51,21 @@ The `owner` field describes the packaged tray strategy (`gui`, `core`, or
 Only fields relevant to the selected action are required. Supported actions
 are `vdd_create`, `vdd_destroy`, `vdd_toggle_keep_enabled`,
 `vdd_toggle_headless_create`, `clear_app`, `reset_display_device_config`,
-`restart`, and `notification_ack`.
+`restart`, and `notification_ack`. While `vdd.awaiting_confirmation` is true,
+the GUI answers with `vdd_confirm_keep`, an `enabled` decision, and the matching
+`operation_id`.
 
 VDD creation is non-interactive inside Core. A graphical provider must obtain
-user confirmation before requesting it. Long-running actions return an
-`operation_id`; their current `running`, `succeeded`, or `failed` result is
-published in the state `operation` object. Operations execute serially and are
-joined during Core shutdown.
+user confirmation before requesting it. After creation and topology setup, Core
+starts a 20-second confirmation deadline and publishes it through tray state.
+The GUI presents the timed keep dialog in the user session. A negative decision
+or missing confirmation closes the VDD; Core owns the deadline so rollback still
+works if the GUI exits. Matching operation IDs prevent an old timer or dialog
+from closing a newer VDD.
+
+Long-running actions return an `operation_id`; their current `running`,
+`succeeded`, or `failed` result is published in the state `operation` object.
+Operations execute serially and are joined during Core shutdown.
 
 ## Future providers
 

--- a/docs/tray-protocol.md
+++ b/docs/tray-protocol.md
@@ -32,14 +32,13 @@ endpoint is the compatibility fallback.
 - `events-v1`: SSE state changes
 - `actions-v1`: action endpoint
 - `operations-v1`: asynchronous operation lifecycle in state
-- `provider-lease-v1`: optional provider ownership lease
 - `notification-ack`: non-pairing notification acknowledgement
 - `pairing`: pairing notification with the `open_pin` action
 - `vdd`: virtual-display state and actions
 
 The `owner` field describes the packaged tray strategy (`gui`, `core`, or
-`disabled`). It is retained for version-1 compatibility. Active runtime
-ownership is represented separately by `provider`.
+`disabled`). The packaged GUI uses its existing single-instance guard. Version
+1 deliberately does not add a second ownership heartbeat.
 
 ## Actions and operations
 
@@ -60,34 +59,19 @@ user confirmation before requesting it. Long-running actions return an
 published in the state `operation` object. Operations execute serially and are
 joined during Core shutdown.
 
-## Provider lease
+## Future providers
 
-Lease support is optional in protocol version 1 so released GUI versions remain
-compatible during migration.
-
-1. `POST /api/tray/provider/register` with `provider_id`, `version`,
-   `protocol_version`, and optional provider capabilities.
-2. Core returns a private `lease_id` and `lease_duration_ms`. The lease token is
-   never included in public state.
-3. `POST /api/tray/provider/heartbeat` with `lease_id` before expiry.
-4. `DELETE /api/tray/provider/lease` with `lease_id` for best-effort release.
-   An uncleanly terminated provider is released automatically after expiry.
-
-Only one distinct provider ID may hold an active lease. Re-registering the
-same provider ID replaces its previous lease, which supports provider restart.
-The public `provider` state contains only ID, version, and active status. Lease
-renewal does not increment the tray state revision or rebuild the provider UI.
-
-During the version-1 compatibility period, legacy clients may still read state
-and invoke actions without a lease. A future protocol version may require the
-lease for provider-owned actions after all supported packaged clients have
-migrated.
+Version 1 keeps runtime ownership intentionally simple: the packaged GUI is
+single-instance and Core exposes no registration or heartbeat endpoint. If a
+second tray implementation creates a real ownership conflict, introduce that
+coordination in a later protocol version with enforceable semantics. Consumers
+must not infer ownership from undocumented process or port probes.
 
 ## Compatibility
 
-- New provider with old Core: use state polling/SSE and actions; do not attempt
-  lease registration unless `provider-lease-v1` is advertised.
+- New provider with old Core: use state polling/SSE and actions according to
+  advertised capabilities.
 - Old provider with new Core: existing state, event, and action behavior remains
-  available; no lease is required.
+  available.
 - GUI-only installation: the provider may run independently but reports Core as
   disconnected until a compatible local Core is installed and running.

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -8,6 +8,7 @@
 #include <fstream>
 #include <functional>
 #include <iostream>
+#include <mutex>
 #include <thread>
 #include <unordered_map>
 #include <utility>
@@ -48,6 +49,10 @@ using namespace std::literals;
 
 #define APPS_JSON_PATH platf::appdata().string() + "/apps.json"
 namespace config {
+
+  namespace {
+    std::mutex config_file_mutex;
+  }
 
   namespace nv {
 
@@ -1750,6 +1755,7 @@ namespace config {
 
   bool
   update_config(const std::map<std::string, std::string> &updates) {
+    std::lock_guard lock { config_file_mutex };
     try {
       // 读取现有配置文件
       std::map<std::string, std::string> configMap;
@@ -1807,6 +1813,7 @@ namespace config {
 
   bool
   update_full_config(const std::map<std::string, std::string> &fullConfig) {
+    std::lock_guard lock { config_file_mutex };
     try {
       // 不需要保存到配置文件的只读字段（API响应字段，不是配置项）
       const std::set<std::string> readonlyFields = {

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -45,6 +45,7 @@
 #include "file_mapping/file_mapping_store.h"
 #include "file_handler.h"
 #include "globals.h"
+#include "http_util.h"
 #include "httpcommon.h"
 #include "logging.h"
 #include "network.h"
@@ -161,17 +162,7 @@ namespace confighttp {
       send_bad_request("Content type not provided");
       return false;
     }
-    // Extract the media type part before any parameters (e.g., charset)
-    std::string actualContentType = requestContentType->second;
-    size_t semicolonPos = actualContentType.find(';');
-    if (semicolonPos != std::string::npos) {
-      actualContentType = actualContentType.substr(0, semicolonPos);
-    }
-    boost::algorithm::trim(actualContentType);
-    boost::algorithm::to_lower(actualContentType);
-    std::string expectedContentType(contentType);
-    boost::algorithm::to_lower(expectedContentType);
-    if (actualContentType != expectedContentType) {
+    if (!http_util::content_type_matches(requestContentType->second, contentType)) {
       send_bad_request("Content type mismatch");
       return false;
     }

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -21,6 +21,7 @@
 #include <sstream>
 #include <cstdio>
 #include <ctime>
+#include <thread>
 #include <openssl/evp.h>
 #include <openssl/sha.h>
 
@@ -52,8 +53,8 @@
 #include "platform/common.h"
 #include "platform/run_command.h"
 #include "rtsp.h"
-#include "src/display_device/display_device.h"
 #include "src/display_device/to_string.h"
+#include "src/tray/tray_http.h"
 #include "stream.h"
 #include "utility.h"
 #include "uuid.h"
@@ -3190,6 +3191,17 @@ namespace confighttp {
     // basic-auth via the lambda below.
     clipboard_http::register_routes(server,
       [](clipboard_http::resp_https_t resp, clipboard_http::req_https_t req) {
+        return authenticate(std::move(resp), std::move(req));
+      });
+    tray_http::register_routes(server,
+      [](tray_http::resp_https_t resp, tray_http::req_https_t req) {
+        const auto address = net::addr_to_normalized_string(req->remote_endpoint().address());
+        if (config::sunshine.username.empty() && net::from_address(address) == net::PC) {
+          return true;
+        }
+        return authenticate(std::move(resp), std::move(req));
+      },
+      [](tray_http::resp_https_t resp, tray_http::req_https_t req) {
         return authenticate(std::move(resp), std::move(req));
       });
     server.resource["^/assets\\/.+$"]["GET"] = getNodeModules;

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -3184,17 +3184,14 @@ namespace confighttp {
       [](clipboard_http::resp_https_t resp, clipboard_http::req_https_t req) {
         return authenticate(std::move(resp), std::move(req));
       });
-    tray_http::register_routes(server,
-      [](tray_http::resp_https_t resp, tray_http::req_https_t req) {
+    tray_http::auth_fn tray_local_auth = [](tray_http::resp_https_t resp, tray_http::req_https_t req) {
         const auto address = net::addr_to_normalized_string(req->remote_endpoint().address());
         if (config::sunshine.username.empty() && net::from_address(address) == net::PC) {
           return true;
         }
         return authenticate(std::move(resp), std::move(req));
-      },
-      [](tray_http::resp_https_t resp, tray_http::req_https_t req) {
-        return authenticate(std::move(resp), std::move(req));
-      });
+      };
+    tray_http::register_routes(server, tray_local_auth, tray_local_auth);
     server.resource["^/assets\\/.+$"]["GET"] = getNodeModules;
     server.config.reuse_address = true;
     server.config.address = net::get_bind_address(address_family);

--- a/src/display_device/session.cpp
+++ b/src/display_device/session.cpp
@@ -494,6 +494,11 @@ namespace display_device {
   }
 
   bool
+  session_t::create_vdd_monitor_noninteractive() {
+    return vdd_utils::create_vdd_monitor_noninteractive();
+  }
+
+  bool
   session_t::destroy_vdd_monitor() {
     current_vdd_client_id.clear();
     return vdd_utils::destroy_vdd_monitor();

--- a/src/display_device/session.h
+++ b/src/display_device/session.h
@@ -175,6 +175,12 @@ namespace display_device {
     create_vdd_monitor(const std::string &client_name = "");
 
     /**
+     * Create a VDD without displaying Core UI. Intended for tray providers.
+     */
+    bool
+    create_vdd_monitor_noninteractive();
+
+    /**
      * @brief Destroy VDD monitor
      */
     bool

--- a/src/display_device/vdd_utils.cpp
+++ b/src/display_device/vdd_utils.cpp
@@ -30,8 +30,9 @@
 #include "src/platform/run_command.h"
 #include "src/platform/windows/display_device/windows_utils.h"
 #include "src/rtsp.h"
-#include "src/system_tray.h"
-#include "src/system_tray_i18n.h"
+#include "src/tray/system_tray.h"
+#include "src/tray/system_tray_i18n.h"
+#include "src/tray/tray_state.h"
 #include "to_string.h"
 
 namespace pt = boost::property_tree;
@@ -641,6 +642,7 @@ namespace display_device {
       // Preferred path: IOCTL device interface. On success skip pipe entirely.
       switch (vdd_ioctl::send_command(command)) {
         case vdd_ioctl::result::success:
+          tray_state::set_vdd_state(true, config::video.vdd_keep_enabled, config::video.vdd_headless_create_enabled, false);
 #if defined SUNSHINE_TRAY && SUNSHINE_TRAY >= 1
           system_tray::update_vdd_menu();
 #endif
@@ -672,6 +674,7 @@ namespace display_device {
         return false;
       }
 
+      tray_state::set_vdd_state(true, config::video.vdd_keep_enabled, config::video.vdd_headless_create_enabled, false);
 #if defined SUNSHINE_TRAY && SUNSHINE_TRAY >= 1
       system_tray::update_vdd_menu();
 #endif
@@ -713,6 +716,7 @@ namespace display_device {
       // 这是必要的，因为驱动程序卸载是异步的
       std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
+      tray_state::set_vdd_state(false, config::video.vdd_keep_enabled, config::video.vdd_headless_create_enabled, false);
 #if defined SUNSHINE_TRAY && SUNSHINE_TRAY >= 1
       system_tray::update_vdd_menu();
 #endif

--- a/src/display_device/vdd_utils.cpp
+++ b/src/display_device/vdd_utils.cpp
@@ -773,6 +773,47 @@ namespace display_device {
     }
 
     bool
+    create_vdd_monitor_noninteractive() {
+      std::unordered_set<std::string> physical_devices_before;
+      const auto topology_before = get_current_topology();
+      const auto all_devices_before = enum_available_devices();
+
+      for (const auto &group : topology_before) {
+        for (const auto &device_id : group) {
+          if (get_display_friendly_name(device_id) != ZAKO_NAME) {
+            physical_devices_before.insert(device_id);
+          }
+        }
+      }
+      if (physical_devices_before.empty()) {
+        for (const auto &[device_id, device_info] : all_devices_before) {
+          if (get_display_friendly_name(device_id) != ZAKO_NAME) {
+            physical_devices_before.insert(device_id);
+          }
+        }
+      }
+
+      if (!create_vdd_monitor("", hdr_brightness_t {}, physical_size_t {})) {
+        return false;
+      }
+
+      auto vdd_device_id = find_device_by_friendlyname(ZAKO_NAME);
+      if (vdd_device_id.empty()) {
+        std::this_thread::sleep_for(std::chrono::seconds(2));
+        vdd_device_id = find_device_by_friendlyname(ZAKO_NAME);
+      }
+      if (vdd_device_id.empty()) {
+        BOOST_LOG(warning) << "VDD was created but its display device was not found for topology setup";
+        return true;
+      }
+
+      if (!ensure_vdd_extended_mode(vdd_device_id, physical_devices_before)) {
+        BOOST_LOG(warning) << "VDD was created but extended topology setup did not complete";
+      }
+      return true;
+    }
+
+    bool
     toggle_display_power() {
       auto now = std::chrono::steady_clock::now();
 

--- a/src/display_device/vdd_utils.h
+++ b/src/display_device/vdd_utils.h
@@ -136,6 +136,13 @@ namespace display_device::vdd_utils {
   bool
   create_vdd_monitor(const std::string &client_identifier = "", const hdr_brightness_t &hdr_brightness = {}, const physical_size_t &physical_size = {});
 
+  /**
+   * Create a VDD for a user-session provider without displaying Core UI.
+   * The provider owns confirmation; Core performs bounded topology setup.
+   */
+  bool
+  create_vdd_monitor_noninteractive();
+
   bool
   destroy_vdd_monitor();
 

--- a/src/http_util.h
+++ b/src/http_util.h
@@ -4,10 +4,9 @@
  */
 #pragma once
 
+#include <algorithm>
 #include <string>
 #include <string_view>
-
-#include <boost/algorithm/string.hpp>
 
 namespace http_util {
   inline bool
@@ -16,10 +15,16 @@ namespace http_util {
       actual.erase(semicolon);
     }
 
+    const auto first = actual.find_first_not_of(" \t\r\n");
+    const auto last = actual.find_last_not_of(" \t\r\n");
+    actual = first == std::string::npos ? std::string {} : actual.substr(first, last - first + 1);
+
     auto normalized_expected = std::string { expected };
-    boost::algorithm::trim(actual);
-    boost::algorithm::to_lower(actual);
-    boost::algorithm::to_lower(normalized_expected);
+    const auto lowercase_ascii = [](unsigned char value) {
+      return static_cast<char>(value >= 'A' && value <= 'Z' ? value + ('a' - 'A') : value);
+    };
+    std::transform(actual.begin(), actual.end(), actual.begin(), lowercase_ascii);
+    std::transform(normalized_expected.begin(), normalized_expected.end(), normalized_expected.begin(), lowercase_ascii);
     return actual == normalized_expected;
   }
 }  // namespace http_util

--- a/src/http_util.h
+++ b/src/http_util.h
@@ -1,0 +1,25 @@
+/**
+ * @file src/http_util.h
+ * @brief Small shared helpers for HTTP request validation.
+ */
+#pragma once
+
+#include <string>
+#include <string_view>
+
+#include <boost/algorithm/string.hpp>
+
+namespace http_util {
+  inline bool
+  content_type_matches(std::string actual, std::string_view expected) {
+    if (const auto semicolon = actual.find(';'); semicolon != std::string::npos) {
+      actual.erase(semicolon);
+    }
+
+    auto normalized_expected = std::string { expected };
+    boost::algorithm::trim(actual);
+    boost::algorithm::to_lower(actual);
+    boost::algorithm::to_lower(normalized_expected);
+    return actual == normalized_expected;
+  }
+}  // namespace http_util

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,7 +22,7 @@
 #include "main.h"
 #include "nvhttp.h"
 #include "process.h"
-#include "system_tray.h"
+#include "tray/system_tray.h"
 #include "upnp.h"
 #include "version.h"
 #include "video.h"
@@ -445,7 +445,9 @@ main(int argc, char *argv[]) {
 
   mainThreadLoop(shutdown_event);
 
+#if defined SUNSHINE_TRAY && SUNSHINE_TRAY >= 1
   system_tray::end_tray();
+#endif
   try {
     display_device::session_t::get().restore_state();
   }

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -59,7 +59,7 @@
 #include "process.h"
 #include "rtsp.h"
 #include "stream.h"
-#include "system_tray.h"
+#include "tray/system_tray.h"
 #include "utility.h"
 #include "uuid.h"
 #include "video.h"

--- a/src/nvhttp/pairing.cpp
+++ b/src/nvhttp/pairing.cpp
@@ -26,7 +26,8 @@
 #include "src/httpcommon.h"
 #include "src/logging.h"
 #include "src/network.h"
-#include "src/system_tray.h"
+#include "src/tray/system_tray.h"
+#include "src/tray/tray_state.h"
 #include "src/utility.h"
 #include "src/uuid.h"
 
@@ -124,6 +125,7 @@ namespace nvhttp {
     static std::mutex map_id_sess_mutex;
     static std::shared_mutex client_state_mutex;
     static pair_rate_limiter_t pair_rate_limit;
+    constexpr auto pending_pin_timeout = 5min;
 
     static struct {
       std::string pin;
@@ -304,11 +306,45 @@ namespace nvhttp {
                 remove_session(ptr->second);
                 return;
               }
+              tray_state::set_pairing_required(last_pair_name);
 #if defined SUNSHINE_TRAY && SUNSHINE_TRAY >= 1
               system_tray::update_tray_require_pin(last_pair_name);
 #endif
               pending_pin_unique_id = ptr->second.client.uniqueID;
               ptr->second.async_insert_pin.response = std::move(response);
+
+              const auto pending_id = pending_pin_unique_id;
+              task_pool.pushDelayed([pending_id]() {
+                std::lock_guard<std::mutex> map_lock(map_id_sess_mutex);
+                if (pending_pin_unique_id != pending_id) {
+                  return;
+                }
+
+                const auto session = map_id_sess.find(pending_id);
+                if (session == std::end(map_id_sess)) {
+                  pending_pin_unique_id.clear();
+                  tray_state::clear_pairing_required();
+                  return;
+                }
+
+                pt::ptree timeout_tree;
+                timeout_tree.put("root.paired", 0);
+                timeout_tree.put("root.<xmlattr>.status_code", 408);
+                timeout_tree.put("root.<xmlattr>.status_message", "Pairing PIN entry timed out");
+                std::ostringstream data;
+                pt::write_xml(data, timeout_tree);
+
+                auto &async_response = session->second.async_insert_pin.response;
+                if (async_response.has_left() && async_response.left()) {
+                  async_response.left()->write(data.str());
+                }
+                else if (async_response.has_right() && async_response.right()) {
+                  async_response.right()->write(data.str());
+                }
+
+                BOOST_LOG(info) << "Pairing request timed out while waiting for PIN entry";
+                remove_session(session->second);
+              }, pending_pin_timeout);
 
               fg.disable();
               return;
@@ -462,6 +498,7 @@ namespace nvhttp {
   remove_session(const pair_session_t &sess) {
     if (pending_pin_unique_id == sess.client.uniqueID) {
       pending_pin_unique_id.clear();
+      tray_state::clear_pairing_required();
     }
     map_id_sess.erase(sess.client.uniqueID);
   }
@@ -687,6 +724,8 @@ namespace nvhttp {
     }
 
     async_response = std::decay_t<decltype(async_response.left())>();
+    pending_pin_unique_id.clear();
+    tray_state::clear_pairing_required();
     return true;
   }
 

--- a/src/platform/windows/audio.cpp
+++ b/src/platform/windows/audio.cpp
@@ -18,9 +18,11 @@
 #include "mic_write.h"
 #include "misc.h"
 #include "src/config.h"
+#include "src/globals.h"
 #include "src/logging.h"
 #include "src/platform/common.h"
-#include "src/system_tray.h"
+#include "src/tray/system_tray.h"
+#include "src/tray/tray_state.h"
 
 // Must be the last included file
 // clang-format off
@@ -952,6 +954,12 @@ namespace platf::audio {
 
       last_virtual_sink_notification = now;
       BOOST_LOG(info) << "Virtual audio sink is being kept selected for host audio streaming";
+      const auto notification_id = tray_state::set_notification(
+        "Audio device kept for streaming",
+        "Sunshine is keeping the virtual audio device selected for host audio streaming. Stop the stream before switching playback devices.");
+      task_pool.pushDelayed([notification_id]() {
+        tray_state::clear_notification_if(notification_id);
+      }, std::chrono::seconds(10));
 #if defined SUNSHINE_TRAY && SUNSHINE_TRAY >= 1
       system_tray::show_notification(
         "Audio device kept for streaming",

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -29,7 +29,9 @@
 #include "logging.h"
 #include "platform/common.h"
 #include "platform/run_command.h"
-#include "system_tray.h"
+#include "stream.h"
+#include "tray/system_tray.h"
+#include "tray/tray_state.h"
 #include "utility.h"
 
 #ifdef _WIN32
@@ -385,7 +387,8 @@ namespace proc {
     bool has_run = _app_id > 0;
     // Only show the Stopped notification if we actually have an app to stop
     // Since terminate() is always run when a new app has started
-    if (proc::proc.get_last_run_app_name().length() > 0 && has_run) {
+    if (proc::proc.get_last_run_app_name().length() > 0 && has_run && !stream::session::has_active_video_sessions()) {
+      tray_state::set_idle(proc::proc.get_last_run_app_name());
 #if defined SUNSHINE_TRAY && SUNSHINE_TRAY >= 1
       system_tray::update_tray_stopped(proc::proc.get_last_run_app_name());
 #endif

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -45,7 +45,8 @@ extern "C" {
 #include "perf_recorder.h"
 #include "stream.h"
 #include "sync.h"
-#include "system_tray.h"
+#include "tray/system_tray.h"
+#include "tray/tray_state.h"
 #include "thread_safe.h"
 #include "utility.h"
 
@@ -2998,6 +2999,11 @@ namespace stream {
       return session.state.load(std::memory_order_relaxed);
     }
 
+    bool
+    has_active_video_sessions() {
+      return running_non_control_only_sessions.load(std::memory_order_relaxed) > 0;
+    }
+
     void
     stop(session_t &session) {
       while_starting_do_nothing(session.state);
@@ -3065,12 +3071,19 @@ namespace stream {
 
           bool restore_display_state { true };
           if (proc::proc.running()) {
+            tray_state::set_paused(proc::proc.get_last_run_app_name());
 #if defined SUNSHINE_TRAY && SUNSHINE_TRAY >= 1
             system_tray::update_tray_pausing(proc::proc.get_last_run_app_name());
 #endif
 
             // TODO: make this configurable per app
             restore_display_state = false;
+          }
+          else {
+            tray_state::set_idle(proc::proc.get_last_run_app_name());
+#if defined SUNSHINE_TRAY && SUNSHINE_TRAY >= 1
+            system_tray::update_tray_stopped(proc::proc.get_last_run_app_name());
+#endif
           }
 
           if (restore_display_state) {
@@ -3187,6 +3200,7 @@ namespace stream {
           }
 
           platf::streaming_will_start();
+          tray_state::set_streaming(proc::proc.get_last_run_app_name());
 #if defined SUNSHINE_TRAY && SUNSHINE_TRAY >= 1
           system_tray::update_tray_playing(proc::proc.get_last_run_app_name());
 #endif

--- a/src/stream.h
+++ b/src/stream.h
@@ -71,6 +71,9 @@ namespace stream {
     join(session_t &session);
     state_e
     state(session_t &session);
+
+    bool
+    has_active_video_sessions();
     
 
 

--- a/src/tray/system_tray.cpp
+++ b/src/tray/system_tray.cpp
@@ -1,5 +1,5 @@
 /**
- * @file src/system_tray.cpp
+ * @file src/tray/system_tray.cpp
  * @brief Definitions for the system tray icon and notification system.
  */
 // macros
@@ -9,10 +9,8 @@
     #define WIN32_LEAN_AND_MEAN
     #include <accctrl.h>
     #include <aclapi.h>
-    #include <commdlg.h>  // 添加文件对话框支持
-    #include <shellapi.h>  // 添加 ShellExecuteW 函数声明
-    #include <shlobj.h>  // 添加 SHGetFolderPathW 函数声明
-    #include <shobjidl.h>  // 添加 IFileDialog COM接口声明
+    #include <shlobj.h>
+    #include <shobjidl.h>
     #include <tlhelp32.h>
     #include <windows.h>
     #define TRAY_ICON WEB_DIR "images/sunshine.ico"
@@ -35,30 +33,29 @@
   // standard includes
   #include <atomic>
   #include <chrono>
-  #include <csignal>
   #include <ctime>
+  #include <filesystem>
   #include <fstream>
-  #include <future>
+  #include <mutex>
   #include <string>
   #include <thread>
 
   // lib includes
   #include "tray/src/tray.h"
-  #include <boost/filesystem.hpp>
-  #include <boost/process/v1/environment.hpp>
 
   // local includes
-  #include "confighttp.h"
-  #include "display_device/session.h"
-  #include "file_handler.h"
-  #include "logging.h"
-  #include "platform/common.h"
-  #include "platform/windows/misc.h"
-  #include "process.h"
+  #include "src/confighttp.h"
+  #include "src/display_device/session.h"
+  #include "src/file_handler.h"
+  #include "src/logging.h"
+  #include "src/platform/common.h"
+  #include "src/platform/windows/misc.h"
+  #include "src/process.h"
   #include "src/display_device/display_device.h"
   #include "src/entry_handler.h"
   #include "src/globals.h"
   #include "system_tray_i18n.h"
+  #include "tray_state.h"
   #include "version.h"
 
 using namespace std::literals;
@@ -72,10 +69,19 @@ namespace system_tray {
   static std::atomic tray_thread_running = false;
   static std::atomic tray_thread_should_exit = false;
   static std::atomic<bool> end_tray_called = false;
+  static std::mutex tray_lifecycle_mutex;
 
   // 前向声明全局变量
   extern struct tray_menu tray_menus[];
   extern struct tray tray;
+  static void
+  tray_thread_worker();
+#ifdef _WIN32
+  static int
+  start_tray_instance_locked();
+  static void
+  stop_tray_instance_locked();
+#endif
 
   // 静态字符串变量用于存储本地化的菜单文本
   // 这些变量必须是静态的，以确保在 tray_menus 的生命周期内有效
@@ -209,6 +215,7 @@ namespace system_tray {
   static void update_vdd_menu_text() {
     bool vdd_active = is_vdd_active();
     bool keep_enabled = config::video.vdd_keep_enabled;
+    tray_state::set_vdd_state(vdd_active, keep_enabled, config::video.vdd_headless_create_enabled, s_vdd_in_cooldown);
     
     // 1. 创建项：启用即勾选，启用后或冷却中禁止点击
     vdd_submenu[0].checked = vdd_active ? 1 : 0;
@@ -1162,6 +1169,9 @@ namespace system_tray {
     // Wait for the shell to be initialized before registering the tray icon.
     // This ensures the tray icon works reliably after a logoff/logon cycle.
     while (GetShellWindow() == nullptr) {
+      if (tray_thread_should_exit) {
+        return 1;
+      }
       Sleep(1000);
     }
   #endif
@@ -1228,21 +1238,25 @@ namespace system_tray {
       return 0;
     }
 
+#ifdef _WIN32
+    {
+      std::lock_guard lock { tray_lifecycle_mutex };
+      try {
+        stop_tray_instance_locked();
+      }
+      catch (const std::system_error &e) {
+        BOOST_LOG(warning) << "Failed to stop tray thread: " << e.what();
+      }
+    }
+#else
     if (!tray_initialized) {
       return 0;
     }
 
     tray_initialized = false;
     tray_exit();
+#endif
 
-    if (tray_thread.joinable()) {
-      try {
-        tray_thread.join();
-      }
-      catch (const std::system_error &e) {
-        BOOST_LOG(warning) << "Failed to join tray thread: " << e.what();
-      }
-    }
     return 0;
   }
 
@@ -1402,14 +1416,72 @@ namespace system_tray {
     tray_update(&tray);
   }
 
+#ifdef _WIN32
+  static void
+  stop_tray_instance_locked() {
+    tray_thread_should_exit = true;
+
+    for (int attempts = 0; tray_thread_running && !tray_initialized && attempts < 50; ++attempts) {
+      std::this_thread::sleep_for(20ms);
+    }
+
+    if (tray_initialized.exchange(false)) {
+      tray_exit();
+    }
+
+    if (tray_thread.joinable()) {
+      tray_thread.join();
+    }
+  }
+
+  static int
+  start_tray_instance_locked() {
+    if (tray_initialized) {
+      return 0;
+    }
+
+    if (tray_thread.joinable()) {
+      tray_thread.join();
+    }
+
+    try {
+      tray_thread_should_exit = false;
+      tray_thread = std::thread(tray_thread_worker);
+
+      BOOST_LOG(info) << "System tray thread initialized successfully"sv;
+      return 0;
+    }
+    catch (const std::exception &e) {
+      BOOST_LOG(error) << "Failed to create tray thread: " << e.what();
+      return 1;
+    }
+  }
+
+#endif
+
   // Threading functions available on all platforms
   static void
   tray_thread_worker() {
+    tray_thread_running = true;
     BOOST_LOG(info) << "System tray thread started"sv;
 
     // Initialize the tray in this thread
     if (init_tray() != 0) {
-      BOOST_LOG(error) << "Failed to initialize tray in thread"sv;
+      if (tray_thread_should_exit) {
+        BOOST_LOG(debug) << "System tray initialization cancelled"sv;
+      }
+      else {
+        BOOST_LOG(error) << "Failed to initialize tray in thread"sv;
+      }
+      tray_thread_running = false;
+      return;
+    }
+
+    if (tray_thread_should_exit) {
+      tray_initialized = false;
+      tray_exit();
+      tray_thread_running = false;
+      BOOST_LOG(info) << "System tray thread stopped before entering event loop"sv;
       return;
     }
 
@@ -1417,6 +1489,7 @@ namespace system_tray {
     while (process_tray_events() == 0);
 
     BOOST_LOG(info) << "System tray thread ended"sv;
+    tray_thread_running = false;
   }
 
   int
@@ -1424,10 +1497,10 @@ namespace system_tray {
     // Reset the end_tray flag for new tray instance
     end_tray_called = false;
 
-    if (tray_thread.joinable()) {
-      tray_thread.join();
-    }
-
+#ifdef _WIN32
+    std::lock_guard lock { tray_lifecycle_mutex };
+    return start_tray_instance_locked();
+#else
     try {
       tray_thread = std::thread(tray_thread_worker);
 
@@ -1438,6 +1511,7 @@ namespace system_tray {
       BOOST_LOG(error) << "Failed to create tray thread: " << e.what();
       return 1;
     }
+#endif
   }
 
 }  // namespace system_tray

--- a/src/tray/system_tray.cpp
+++ b/src/tray/system_tray.cpp
@@ -1478,8 +1478,9 @@ namespace system_tray {
     }
 
     if (tray_thread_should_exit) {
-      tray_initialized = false;
-      tray_exit();
+      if (tray_initialized.exchange(false)) {
+        tray_exit();
+      }
       tray_thread_running = false;
       BOOST_LOG(info) << "System tray thread stopped before entering event loop"sv;
       return;

--- a/src/tray/system_tray.h
+++ b/src/tray/system_tray.h
@@ -1,5 +1,5 @@
 /**
- * @file src/system_tray.h
+ * @file src/tray/system_tray.h
  * @brief Declarations for the system tray icon and notification system.
  */
 #pragma once
@@ -10,55 +10,6 @@
  * @brief Handles the system tray icon and notification system.
  */
 namespace system_tray {
-  /**
-   * @brief Callback for opening the UI from the system tray.
-   * @param item The tray menu item.
-   */
-  void
-  tray_open_ui_cb(struct tray_menu *item);
-
-  /**
-   * @brief Callback for opening GitHub Sponsors from the system tray.
-   * @param item The tray menu item.
-   */
-  void
-  tray_donate_github_cb(struct tray_menu *item);
-
-  /**
-   * @brief Callback for opening Patreon from the system tray.
-   * @param item The tray menu item.
-   */
-  void
-  tray_donate_patreon_cb(struct tray_menu *item);
-
-  /**
-   * @brief Callback for opening PayPal donation from the system tray.
-   * @param item The tray menu item.
-   */
-  void
-  tray_donate_paypal_cb(struct tray_menu *item);
-
-  /**
-   * @brief Callback for resetting display device configuration.
-   * @param item The tray menu item.
-   */
-  void
-  tray_reset_display_device_config_cb(struct tray_menu *item);
-
-  /**
-   * @brief Callback for restarting Sunshine from the system tray.
-   * @param item The tray menu item.
-   */
-  void
-  tray_restart_cb(struct tray_menu *item);
-
-  /**
-   * @brief Callback for exiting Sunshine from the system tray.
-   * @param item The tray menu item.
-   */
-  void
-  tray_quit_cb(struct tray_menu *item);
-
   /**
    * @brief Initializes the system tray without starting a loop.
    * @return 0 if initialization was successful, non-zero otherwise.
@@ -118,13 +69,6 @@ namespace system_tray {
    * @return 0 if initialization was successful, non-zero otherwise.
    */
   int init_tray_threaded();
-
-  // Internationalization support
-  std::string get_localized_string(const std::string& key);
-  std::wstring get_localized_wstring(const std::string& key);
-  
-  // GUI process management
-  void terminate_gui_processes();
 
   // VDD menu management
   void update_vdd_menu();

--- a/src/tray/system_tray_i18n.cpp
+++ b/src/tray/system_tray_i18n.cpp
@@ -1,5 +1,7 @@
 #include "system_tray_i18n.h"
-#include "config.h"
+#include "src/config.h"
+
+#include <map>
 
 #ifdef _WIN32
   #include <windows.h>
@@ -26,7 +28,6 @@ namespace system_tray_i18n {
   const std::string KEY_VDD_CANCEL_CREATE_LOG = "vdd_cancel_create_log";
   const std::string KEY_VDD_PERSISTENT_CONFIRM_TITLE = "vdd_persistent_confirm_title";
   const std::string KEY_VDD_PERSISTENT_CONFIRM_MSG = "vdd_persistent_confirm_msg";
-  const std::string KEY_CONFIGURATION = "configuration";
   const std::string KEY_IMPORT_CONFIG = "import_config";
   const std::string KEY_EXPORT_CONFIG = "export_config";
   const std::string KEY_RESET_TO_DEFAULT = "reset_to_default";
@@ -38,10 +39,6 @@ namespace system_tray_i18n {
   const std::string KEY_VISIT_PROJECT = "visit_project";
   const std::string KEY_VISIT_PROJECT_SUNSHINE = "visit_project_sunshine";
   const std::string KEY_VISIT_PROJECT_MOONLIGHT = "visit_project_moonlight";
-  const std::string KEY_HELP_US = "help_us";
-  const std::string KEY_DEVELOPER_YUNDI339 = "developer_yundi339";
-  const std::string KEY_DEVELOPER_QIIN = "developer_qiin";
-  const std::string KEY_SPONSOR_ALKaidLab = "sponsor_alkaidlab";
   const std::string KEY_ADVANCED_SETTINGS = "advanced_settings";
   const std::string KEY_CLOSE_APP = "clear_cache";
   const std::string KEY_CLOSE_APP_CONFIRM_TITLE = "clear_cache_confirm_title";
@@ -63,13 +60,9 @@ namespace system_tray_i18n {
   const std::string KEY_CLICK_TO_COMPLETE_PAIRING = "click_to_complete_pairing";
   
   // MessageBox keys
-  const std::string KEY_ERROR_TITLE = "error_title";
-  const std::string KEY_ERROR_NO_USER_SESSION = "error_no_user_session";
   const std::string KEY_IMPORT_SUCCESS_TITLE = "import_success_title";
-  const std::string KEY_IMPORT_SUCCESS_MSG = "import_success_msg";
   const std::string KEY_IMPORT_ERROR_TITLE = "import_error_title";
   const std::string KEY_IMPORT_ERROR_WRITE = "import_error_write";
-  const std::string KEY_IMPORT_ERROR_READ = "import_error_read";
   const std::string KEY_IMPORT_ERROR_EXCEPTION = "import_error_exception";
   const std::string KEY_EXPORT_SUCCESS_TITLE = "export_success_title";
   const std::string KEY_EXPORT_SUCCESS_MSG = "export_success_msg";
@@ -87,7 +80,6 @@ namespace system_tray_i18n {
   const std::string KEY_FILE_DIALOG_SELECT_IMPORT = "file_dialog_select_import";
   const std::string KEY_FILE_DIALOG_SAVE_EXPORT = "file_dialog_save_export";
   const std::string KEY_FILE_DIALOG_CONFIG_FILES = "file_dialog_config_files";
-  const std::string KEY_FILE_DIALOG_ALL_FILES = "file_dialog_all_files";
 
   // Default English strings
   const std::map<std::string, std::string> DEFAULT_STRINGS = {
@@ -108,7 +100,6 @@ namespace system_tray_i18n {
     { KEY_VDD_CANCEL_CREATE_LOG, "User cancelled creating virtual display" },
     { KEY_VDD_PERSISTENT_CONFIRM_TITLE, "Keep Virtual Display Enabled" },
     { KEY_VDD_PERSISTENT_CONFIRM_MSG, "By enabling this option, the virtual display will NOT be closed after you stop streaming.\n\nDo you want to enable this feature?" },
-    { KEY_CONFIGURATION, "Configuration" },
     { KEY_IMPORT_CONFIG, "Import Config" },
     { KEY_EXPORT_CONFIG, "Export Config" },
     { KEY_RESET_TO_DEFAULT, "Reset Config" },
@@ -120,10 +111,6 @@ namespace system_tray_i18n {
     { KEY_VISIT_PROJECT, "Visit Project" },
     { KEY_VISIT_PROJECT_SUNSHINE, "Sunshine" },
     { KEY_VISIT_PROJECT_MOONLIGHT, "Moonlight" },
-    { KEY_HELP_US, "Sponsor Us" },
-    { KEY_DEVELOPER_YUNDI339, "Developer: Yundi339" },
-    { KEY_DEVELOPER_QIIN, "Developer: qiin2333" },
-    { KEY_SPONSOR_ALKaidLab, "Sponsor AlkaidLab" },
     { KEY_ADVANCED_SETTINGS, "Advanced Settings" },
     { KEY_CLOSE_APP, "Clear Cache" },
     { KEY_CLOSE_APP_CONFIRM_TITLE, "Clear Cache" },
@@ -141,13 +128,9 @@ namespace system_tray_i18n {
     { KEY_APPLICATION_STOPPED_MSG, "Application %s successfully stopped" },
     { KEY_INCOMING_PAIRING_REQUEST, "Incoming PIN Request From: %s" },
     { KEY_CLICK_TO_COMPLETE_PAIRING, "Click here to enter PIN" },
-    { KEY_ERROR_TITLE, "Error" },
-    { KEY_ERROR_NO_USER_SESSION, "Cannot open file dialog: No active user session found." },
     { KEY_IMPORT_SUCCESS_TITLE, "Import Success" },
-    { KEY_IMPORT_SUCCESS_MSG, "Configuration imported successfully!\nPlease restart Sunshine to apply changes." },
     { KEY_IMPORT_ERROR_TITLE, "Import Error" },
     { KEY_IMPORT_ERROR_WRITE, "Failed to import configuration file." },
-    { KEY_IMPORT_ERROR_READ, "Failed to read the selected configuration file." },
     { KEY_IMPORT_ERROR_EXCEPTION, "An error occurred while importing configuration." },
     { KEY_EXPORT_SUCCESS_TITLE, "Export Success" },
     { KEY_EXPORT_SUCCESS_MSG, "Configuration exported successfully!" },
@@ -164,8 +147,7 @@ namespace system_tray_i18n {
     { KEY_RESET_ERROR_EXCEPTION, "An error occurred while resetting configuration." },
     { KEY_FILE_DIALOG_SELECT_IMPORT, "Select Configuration File to Import" },
     { KEY_FILE_DIALOG_SAVE_EXPORT, "Save Configuration File As" },
-    { KEY_FILE_DIALOG_CONFIG_FILES, "Configuration Files" },
-    { KEY_FILE_DIALOG_ALL_FILES, "All Files" }
+    { KEY_FILE_DIALOG_CONFIG_FILES, "Configuration Files" }
   };
 
   // Chinese strings
@@ -187,7 +169,6 @@ namespace system_tray_i18n {
     { KEY_VDD_CANCEL_CREATE_LOG, "用户取消创建基地显示器" },
     { KEY_VDD_PERSISTENT_CONFIRM_TITLE, "保持开启虚拟显示器" },
     { KEY_VDD_PERSISTENT_CONFIRM_MSG, "启用此选项后，在串流结束后基地显示器将不会被自动关闭。\n\n确定要开启此功能吗？" },
-    { KEY_CONFIGURATION, "配置" },
     { KEY_IMPORT_CONFIG, "导入配置" },
     { KEY_EXPORT_CONFIG, "导出配置" },
     { KEY_RESET_TO_DEFAULT, "重置配置" },
@@ -199,10 +180,6 @@ namespace system_tray_i18n {
     { KEY_VISIT_PROJECT, "访问项目地址" },
     { KEY_VISIT_PROJECT_SUNSHINE, "Sunshine" },
     { KEY_VISIT_PROJECT_MOONLIGHT, "Moonlight" },
-    { KEY_HELP_US, "赞助我们" },
-    { KEY_DEVELOPER_YUNDI339, "开发者：Yundi339" },
-    { KEY_DEVELOPER_QIIN, "开发者：qiin2333" },
-    { KEY_SPONSOR_ALKaidLab, "赞助 AlkaidLab" },
     { KEY_ADVANCED_SETTINGS, "高级设置" },
     { KEY_CLOSE_APP, "清理缓存" },
     { KEY_CLOSE_APP_CONFIRM_TITLE, "清理缓存" },
@@ -220,13 +197,9 @@ namespace system_tray_i18n {
     { KEY_APPLICATION_STOPPED_MSG, "应用 %s 已成功停止" },
     { KEY_INCOMING_PAIRING_REQUEST, "来自 %s 的PIN请求" },
     { KEY_CLICK_TO_COMPLETE_PAIRING, "点击此处完成PIN验证" },
-    { KEY_ERROR_TITLE, "错误" },
-    { KEY_ERROR_NO_USER_SESSION, "无法打开文件对话框：未找到活动的用户会话。" },
     { KEY_IMPORT_SUCCESS_TITLE, "导入成功" },
-    { KEY_IMPORT_SUCCESS_MSG, "配置已成功导入！\n请重新启动 Sunshine 以应用更改。" },
     { KEY_IMPORT_ERROR_TITLE, "导入失败" },
     { KEY_IMPORT_ERROR_WRITE, "无法写入配置文件。" },
-    { KEY_IMPORT_ERROR_READ, "无法读取所选的配置文件。" },
     { KEY_IMPORT_ERROR_EXCEPTION, "导入配置时发生错误。" },
     { KEY_EXPORT_SUCCESS_TITLE, "导出成功" },
     { KEY_EXPORT_SUCCESS_MSG, "配置已成功导出！" },
@@ -243,8 +216,7 @@ namespace system_tray_i18n {
     { KEY_RESET_ERROR_EXCEPTION, "重置配置时发生错误。" },
     { KEY_FILE_DIALOG_SELECT_IMPORT, "选择要导入的配置文件" },
     { KEY_FILE_DIALOG_SAVE_EXPORT, "配置文件另存为" },
-    { KEY_FILE_DIALOG_CONFIG_FILES, "配置文件" },
-    { KEY_FILE_DIALOG_ALL_FILES, "所有文件" }
+    { KEY_FILE_DIALOG_CONFIG_FILES, "配置文件" }
   };
 
   const std::map<std::string, std::string> JAPANESE_STRINGS = {
@@ -265,7 +237,6 @@ namespace system_tray_i18n {
     { KEY_VDD_CANCEL_CREATE_LOG, "ユーザーが仮想ディスプレイの作成をキャンセルしました" },
     { KEY_VDD_PERSISTENT_CONFIRM_TITLE, "仮想ディスプレイを有効に保つ" },
     { KEY_VDD_PERSISTENT_CONFIRM_MSG, "このオプションを有効にすると、ストリーミング終了後に仮想ディスプレイは**自動的に閉じられません**。\n\nこの機能を有効にしますか？" },
-    { KEY_CONFIGURATION, "設定" },
     { KEY_IMPORT_CONFIG, "設定をインポート" },
     { KEY_EXPORT_CONFIG, "設定をエクスポート" },
     { KEY_RESET_TO_DEFAULT, "設定をリセット" },
@@ -277,10 +248,6 @@ namespace system_tray_i18n {
     { KEY_VISIT_PROJECT, "プロジェクトアドレスを訪問" },
     { KEY_VISIT_PROJECT_SUNSHINE, "Sunshine" },
     { KEY_VISIT_PROJECT_MOONLIGHT, "Moonlight" },
-    { KEY_HELP_US, "スポンサー" },
-    { KEY_DEVELOPER_YUNDI339, "開発者：Yundi339" },
-    { KEY_DEVELOPER_QIIN, "開発者：qiin2333" },
-    { KEY_SPONSOR_ALKaidLab, "AlkaidLabをスポンサー" },
     { KEY_ADVANCED_SETTINGS, "詳細設定" },
     { KEY_CLOSE_APP, "キャッシュをクリア" },
     { KEY_CLOSE_APP_CONFIRM_TITLE, "キャッシュをクリア" },
@@ -298,13 +265,9 @@ namespace system_tray_i18n {
     { KEY_APPLICATION_STOPPED_MSG, "アプリケーション %s が正常に停止しました" },
     { KEY_INCOMING_PAIRING_REQUEST, "%s からのPIN要求" },
     { KEY_CLICK_TO_COMPLETE_PAIRING, "クリックしてPIN認証を完了" },
-    { KEY_ERROR_TITLE, "エラー" },
-    { KEY_ERROR_NO_USER_SESSION, "ファイルダイアログを開けません：アクティブなユーザーセッションが見つかりません。" },
     { KEY_IMPORT_SUCCESS_TITLE, "インポート成功" },
-    { KEY_IMPORT_SUCCESS_MSG, "設定のインポートに成功しました！\n変更を適用するにはSunshineを再起動してください。" },
     { KEY_IMPORT_ERROR_TITLE, "インポート失敗" },
     { KEY_IMPORT_ERROR_WRITE, "設定ファイルを書き込めませんでした。" },
-    { KEY_IMPORT_ERROR_READ, "選択した設定ファイルを読み取れませんでした。" },
     { KEY_IMPORT_ERROR_EXCEPTION, "設定のインポート中にエラーが発生しました。" },
     { KEY_EXPORT_SUCCESS_TITLE, "エクスポート成功" },
     { KEY_EXPORT_SUCCESS_MSG, "設定のエクスポートに成功しました！" },
@@ -321,8 +284,7 @@ namespace system_tray_i18n {
     { KEY_RESET_ERROR_EXCEPTION, "設定のリセット中にエラーが発生しました。" },
     { KEY_FILE_DIALOG_SELECT_IMPORT, "インポートする設定ファイルを選択" },
     { KEY_FILE_DIALOG_SAVE_EXPORT, "設定ファイルに名前を付けて保存" },
-    { KEY_FILE_DIALOG_CONFIG_FILES, "設定ファイル" },
-    { KEY_FILE_DIALOG_ALL_FILES, "すべてのファイル" }
+    { KEY_FILE_DIALOG_CONFIG_FILES, "設定ファイル" }
   };
 
   // Get current locale from config

--- a/src/tray/system_tray_i18n.h
+++ b/src/tray/system_tray_i18n.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <string>
-#include <map>
 
 namespace system_tray_i18n {
   // String key constants
@@ -24,7 +23,6 @@ namespace system_tray_i18n {
   extern const std::string KEY_VDD_CANCEL_CREATE_LOG;
   extern const std::string KEY_VDD_PERSISTENT_CONFIRM_TITLE;
   extern const std::string KEY_VDD_PERSISTENT_CONFIRM_MSG;
-  extern const std::string KEY_CONFIGURATION;
   extern const std::string KEY_IMPORT_CONFIG;
   extern const std::string KEY_EXPORT_CONFIG;
   extern const std::string KEY_RESET_TO_DEFAULT;
@@ -36,10 +34,6 @@ namespace system_tray_i18n {
   extern const std::string KEY_VISIT_PROJECT;
   extern const std::string KEY_VISIT_PROJECT_SUNSHINE;
   extern const std::string KEY_VISIT_PROJECT_MOONLIGHT;
-  extern const std::string KEY_HELP_US;
-  extern const std::string KEY_DEVELOPER_YUNDI339;
-  extern const std::string KEY_DEVELOPER_QIIN;
-  extern const std::string KEY_SPONSOR_ALKaidLab;
   extern const std::string KEY_ADVANCED_SETTINGS;
   extern const std::string KEY_CLOSE_APP;
   extern const std::string KEY_CLOSE_APP_CONFIRM_TITLE;
@@ -61,13 +55,9 @@ namespace system_tray_i18n {
   extern const std::string KEY_CLICK_TO_COMPLETE_PAIRING;
   
   // MessageBox keys
-  extern const std::string KEY_ERROR_TITLE;
-  extern const std::string KEY_ERROR_NO_USER_SESSION;
   extern const std::string KEY_IMPORT_SUCCESS_TITLE;
-  extern const std::string KEY_IMPORT_SUCCESS_MSG;
   extern const std::string KEY_IMPORT_ERROR_TITLE;
   extern const std::string KEY_IMPORT_ERROR_WRITE;
-  extern const std::string KEY_IMPORT_ERROR_READ;
   extern const std::string KEY_IMPORT_ERROR_EXCEPTION;
   extern const std::string KEY_EXPORT_SUCCESS_TITLE;
   extern const std::string KEY_EXPORT_SUCCESS_MSG;
@@ -85,7 +75,6 @@ namespace system_tray_i18n {
   extern const std::string KEY_FILE_DIALOG_SELECT_IMPORT;
   extern const std::string KEY_FILE_DIALOG_SAVE_EXPORT;
   extern const std::string KEY_FILE_DIALOG_CONFIG_FILES;
-  extern const std::string KEY_FILE_DIALOG_ALL_FILES;
   
   // Get localized string
   std::string get_localized_string(const std::string& key);

--- a/src/tray/tray_http.cpp
+++ b/src/tray/tray_http.cpp
@@ -8,15 +8,18 @@
 #include <optional>
 #include <sstream>
 #include <string>
+#include <string_view>
+#include <system_error>
+#include <thread>
 #include <vector>
 
-#include <boost/algorithm/string.hpp>
 #include <nlohmann/json.hpp>
 
 #include "src/config.h"
 #include "src/display_device/display_device.h"
 #include "src/display_device/session.h"
 #include "src/globals.h"
+#include "src/http_util.h"
 #include "src/logging.h"
 #include "src/platform/common.h"
 #include "src/process.h"
@@ -27,6 +30,8 @@ namespace tray_http {
 
   namespace {
     std::atomic<bool> tray_vdd_action_cooldown { false };
+    std::atomic<bool> tray_vdd_action_running { false };
+    std::atomic<bool> tray_app_termination_running { false };
     std::mutex tray_action_mutex;
 
     struct tray_subscriber_t {
@@ -60,7 +65,8 @@ namespace tray_http {
             subscriber->alive.store(false, std::memory_order_release);
           }
         });
-      } catch (const std::exception &e) {
+      }
+      catch (const std::exception &e) {
         BOOST_LOG(debug) << "tray SSE write failed: "sv << e.what();
         subscriber->alive.store(false, std::memory_order_release);
       }
@@ -93,7 +99,8 @@ namespace tray_http {
       task_pool.pushDelayed([]() {
         publish_tray_event(": tray-keepalive\n\n");
         schedule_tray_keepalive();
-      }, 30s);
+      },
+        30s);
     }
 
     void
@@ -110,9 +117,10 @@ namespace tray_http {
       SimpleWeb::CaseInsensitiveMultimap headers;
       headers.emplace("Content-Type", "application/json");
       response->write(SimpleWeb::StatusCode::client_error_bad_request, nlohmann::json {
-        { "status", false },
-        { "error", error },
-      }.dump(),
+                                                                         { "status", false },
+                                                                         { "error", error },
+                                                                       }
+                                                                         .dump(),
         headers);
     }
 
@@ -124,14 +132,7 @@ namespace tray_http {
         return false;
       }
 
-      auto actual_content_type = request_content_type->second;
-      if (const auto semicolon_pos = actual_content_type.find(';'); semicolon_pos != std::string::npos) {
-        actual_content_type = actual_content_type.substr(0, semicolon_pos);
-      }
-
-      boost::algorithm::trim(actual_content_type);
-      boost::algorithm::to_lower(actual_content_type);
-      if (actual_content_type != "application/json") {
+      if (!http_util::content_type_matches(request_content_type->second, "application/json")) {
         send_bad_request(std::move(response), "Content type mismatch");
         return false;
       }
@@ -150,46 +151,102 @@ namespace tray_http {
         tray_vdd_active(),
         config::video.vdd_keep_enabled,
         config::video.vdd_headless_create_enabled,
-        tray_vdd_action_cooldown.load());
+        tray_vdd_action_running.load() || tray_vdd_action_cooldown.load());
     }
 
     void
-    start_tray_vdd_action_cooldown() {
+    finish_tray_vdd_action(bool success, std::string_view error) {
       tray_vdd_action_cooldown = true;
+      tray_vdd_action_running = false;
       update_tray_vdd_state();
+
+      if (!success) {
+        tray_state::set_notification("Virtual display", std::string { error }, "default");
+      }
 
       task_pool.pushDelayed([]() {
         tray_vdd_action_cooldown = false;
         update_tray_vdd_state();
-      }, 10s);
+      },
+        10s);
+    }
+
+    bool
+    dispatch_tray_vdd_action(bool create) {
+      try {
+        std::thread([create]() {
+          const auto action_name = create ? "create"sv : "close"sv;
+          BOOST_LOG(info) << (create ? "Creating"sv : "Closing"sv) << " VDD from GUI tray"sv;
+
+          try {
+            const bool success = create ?
+                                   display_device::session_t::get().toggle_display_power() :
+                                   display_device::session_t::get().destroy_vdd_monitor();
+            finish_tray_vdd_action(success, create ? "Failed to create virtual display"sv : "Failed to close virtual display"sv);
+          }
+          catch (const std::exception &e) {
+            BOOST_LOG(error) << "VDD "sv << action_name << " action failed: "sv << e.what();
+            finish_tray_vdd_action(false, create ? "Failed to create virtual display"sv : "Failed to close virtual display"sv);
+          }
+        }).detach();
+        return true;
+      }
+      catch (const std::system_error &e) {
+        BOOST_LOG(error) << "Failed to dispatch VDD action: "sv << e.what();
+        return false;
+      }
+    }
+
+    bool
+    dispatch_app_termination() {
+      try {
+        std::thread([]() {
+          BOOST_LOG(info) << "Clearing cache by terminating application from GUI tray"sv;
+          try {
+            proc::proc.terminate();
+          }
+          catch (const std::exception &e) {
+            BOOST_LOG(error) << "Application termination failed: "sv << e.what();
+            tray_state::set_notification("Sunshine", "Failed to terminate the running application", "default");
+          }
+          tray_app_termination_running = false;
+        }).detach();
+        return true;
+      }
+      catch (const std::system_error &e) {
+        BOOST_LOG(error) << "Failed to dispatch application termination: "sv << e.what();
+        return false;
+      }
     }
 
     nlohmann::json
     run_tray_action(const std::string &action, const std::optional<bool> enabled, const std::optional<std::uint64_t> notification_id) {
-      std::lock_guard lock { tray_action_mutex };
+      std::unique_lock lock { tray_action_mutex };
 
       if (action == "vdd_create") {
-        if (tray_vdd_action_cooldown.load()) {
-          return { { "status", false }, { "error", "VDD action is cooling down" } };
+        if (tray_vdd_action_running.load() || tray_vdd_action_cooldown.load()) {
+          return { { "status", false }, { "error", "VDD action is already in progress or cooling down" } };
         }
         if (tray_vdd_active()) {
           update_tray_vdd_state();
           return { { "status", false }, { "error", "VDD is already active" } };
         }
 
-        BOOST_LOG(info) << "Creating VDD from GUI tray"sv;
-        if (!display_device::session_t::get().toggle_display_power()) {
+        tray_vdd_action_running = true;
+        lock.unlock();
+        update_tray_vdd_state();
+        if (!dispatch_tray_vdd_action(true)) {
+          tray_vdd_action_running = false;
           update_tray_vdd_state();
-          return { { "status", false }, { "error", "Failed to create VDD" } };
+          return { { "status", false }, { "error", "Failed to start VDD create action" } };
         }
 
-        start_tray_vdd_action_cooldown();
         return { { "status", true }, { "message", "VDD create requested" } };
       }
 
       if (action == "vdd_destroy") {
-        if (tray_vdd_action_cooldown.load()) {
-          return { { "status", false }, { "error", "VDD action is cooling down" } };
+        if (tray_vdd_action_running.load() || tray_vdd_action_cooldown.load()) {
+          return { { "status", false }, { "error", "VDD action is already in progress or cooling down" } };
         }
         if (!tray_vdd_active()) {
           update_tray_vdd_state();
@@ -200,13 +257,15 @@ namespace tray_http {
           return { { "status", false }, { "error", "VDD keep-enabled mode is active" } };
         }
 
-        BOOST_LOG(info) << "Closing VDD from GUI tray"sv;
-        if (!display_device::session_t::get().destroy_vdd_monitor()) {
+        tray_vdd_action_running = true;
+        lock.unlock();
+        update_tray_vdd_state();
+        if (!dispatch_tray_vdd_action(false)) {
+          tray_vdd_action_running = false;
           update_tray_vdd_state();
-          return { { "status", false }, { "error", "Failed to close VDD" } };
+          return { { "status", false }, { "error", "Failed to start VDD close action" } };
         }
 
-        start_tray_vdd_action_cooldown();
         return { { "status", true }, { "message", "VDD close requested" } };
       }
 
@@ -231,8 +290,15 @@ namespace tray_http {
       }
 
       if (action == "clear_app") {
-        BOOST_LOG(info) << "Clearing cache by terminating application from GUI tray"sv;
-        proc::proc.terminate();
+        if (tray_app_termination_running.exchange(true)) {
+          return { { "status", false }, { "error", "Application termination is already in progress" } };
+        }
+
+        lock.unlock();
+        if (!dispatch_app_termination()) {
+          tray_app_termination_running = false;
+          return { { "status", false }, { "error", "Failed to start application termination" } };
+        }
         return { { "status", true }, { "message", "Application termination requested" } };
       }
 
@@ -324,10 +390,10 @@ namespace tray_http {
       }
       catch (const std::exception &e) {
         send_json(std::move(response), {
-          { "status", false },
-          { "error", e.what() },
-          { "tray_state", tray_state::to_json() },
-        });
+                                         { "status", false },
+                                         { "error", e.what() },
+                                         { "tray_state", tray_state::to_json() },
+                                       });
       }
     }
 

--- a/src/tray/tray_http.cpp
+++ b/src/tray/tray_http.cpp
@@ -1,0 +1,354 @@
+#include "tray_http.h"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <boost/algorithm/string.hpp>
+#include <nlohmann/json.hpp>
+
+#include "src/config.h"
+#include "src/display_device/display_device.h"
+#include "src/display_device/session.h"
+#include "src/globals.h"
+#include "src/logging.h"
+#include "src/platform/common.h"
+#include "src/process.h"
+#include "tray_state.h"
+
+namespace tray_http {
+  using namespace std::literals;
+
+  namespace {
+    std::atomic<bool> tray_vdd_action_cooldown { false };
+    std::mutex tray_action_mutex;
+
+    struct tray_subscriber_t {
+      resp_https_t response;
+      std::atomic_bool alive { true };
+      std::mutex send_mutex;
+    };
+
+    std::mutex tray_subscribers_mutex;
+    std::vector<std::shared_ptr<tray_subscriber_t>> tray_subscribers;
+    std::atomic_bool tray_keepalive_started { false };
+
+    std::string
+    tray_state_event() {
+      return "event: tray-state\ndata: " + tray_state::to_json().dump() + "\n\n";
+    }
+
+    void
+    send_tray_event(const std::shared_ptr<tray_subscriber_t> &subscriber, const std::string &event) {
+      if (!subscriber->alive.load(std::memory_order_acquire)) {
+        return;
+      }
+      try {
+        std::lock_guard lock { subscriber->send_mutex };
+        if (!subscriber->alive.load(std::memory_order_acquire)) {
+          return;
+        }
+        *subscriber->response << event;
+        subscriber->response->send([subscriber](const SimpleWeb::error_code &error) {
+          if (error) {
+            subscriber->alive.store(false, std::memory_order_release);
+          }
+        });
+      } catch (const std::exception &e) {
+        BOOST_LOG(debug) << "tray SSE write failed: "sv << e.what();
+        subscriber->alive.store(false, std::memory_order_release);
+      }
+    }
+
+    void
+    publish_tray_event(const std::string &event) {
+      std::vector<std::shared_ptr<tray_subscriber_t>> subscribers;
+      {
+        std::lock_guard lock { tray_subscribers_mutex };
+        tray_subscribers.erase(
+          std::remove_if(tray_subscribers.begin(), tray_subscribers.end(), [](const auto &subscriber) {
+            return !subscriber->alive.load(std::memory_order_acquire);
+          }),
+          tray_subscribers.end());
+        subscribers = tray_subscribers;
+      }
+      for (const auto &subscriber : subscribers) {
+        send_tray_event(subscriber, event);
+      }
+    }
+
+    void
+    publish_tray_state() {
+      publish_tray_event(tray_state_event());
+    }
+
+    void
+    schedule_tray_keepalive() {
+      task_pool.pushDelayed([]() {
+        publish_tray_event(": tray-keepalive\n\n");
+        schedule_tray_keepalive();
+      }, 30s);
+    }
+
+    void
+    send_json(resp_https_t response, const nlohmann::json &body) {
+      SimpleWeb::CaseInsensitiveMultimap headers;
+      headers.emplace("Content-Type", "application/json");
+      headers.emplace("X-Frame-Options", "DENY");
+      headers.emplace("Content-Security-Policy", "frame-ancestors 'none';");
+      response->write(body.dump(), headers);
+    }
+
+    void
+    send_bad_request(resp_https_t response, const std::string &error) {
+      SimpleWeb::CaseInsensitiveMultimap headers;
+      headers.emplace("Content-Type", "application/json");
+      response->write(SimpleWeb::StatusCode::client_error_bad_request, nlohmann::json {
+        { "status", false },
+        { "error", error },
+      }.dump(),
+        headers);
+    }
+
+    bool
+    check_json_content_type(resp_https_t response, req_https_t request) {
+      const auto request_content_type = request->header.find("content-type");
+      if (request_content_type == request->header.end()) {
+        send_bad_request(std::move(response), "Content type not provided");
+        return false;
+      }
+
+      auto actual_content_type = request_content_type->second;
+      if (const auto semicolon_pos = actual_content_type.find(';'); semicolon_pos != std::string::npos) {
+        actual_content_type = actual_content_type.substr(0, semicolon_pos);
+      }
+
+      boost::algorithm::trim(actual_content_type);
+      boost::algorithm::to_lower(actual_content_type);
+      if (actual_content_type != "application/json") {
+        send_bad_request(std::move(response), "Content type mismatch");
+        return false;
+      }
+
+      return true;
+    }
+
+    bool
+    tray_vdd_active() {
+      return !display_device::find_device_by_friendlyname(ZAKO_NAME).empty();
+    }
+
+    void
+    update_tray_vdd_state() {
+      tray_state::set_vdd_state(
+        tray_vdd_active(),
+        config::video.vdd_keep_enabled,
+        config::video.vdd_headless_create_enabled,
+        tray_vdd_action_cooldown.load());
+    }
+
+    void
+    start_tray_vdd_action_cooldown() {
+      tray_vdd_action_cooldown = true;
+      update_tray_vdd_state();
+
+      task_pool.pushDelayed([]() {
+        tray_vdd_action_cooldown = false;
+        update_tray_vdd_state();
+      }, 10s);
+    }
+
+    nlohmann::json
+    run_tray_action(const std::string &action, const std::optional<bool> enabled, const std::optional<std::uint64_t> notification_id) {
+      std::lock_guard lock { tray_action_mutex };
+
+      if (action == "vdd_create") {
+        if (tray_vdd_action_cooldown.load()) {
+          return { { "status", false }, { "error", "VDD action is cooling down" } };
+        }
+        if (tray_vdd_active()) {
+          update_tray_vdd_state();
+          return { { "status", false }, { "error", "VDD is already active" } };
+        }
+
+        BOOST_LOG(info) << "Creating VDD from GUI tray"sv;
+        if (!display_device::session_t::get().toggle_display_power()) {
+          update_tray_vdd_state();
+          return { { "status", false }, { "error", "Failed to create VDD" } };
+        }
+
+        start_tray_vdd_action_cooldown();
+        return { { "status", true }, { "message", "VDD create requested" } };
+      }
+
+      if (action == "vdd_destroy") {
+        if (tray_vdd_action_cooldown.load()) {
+          return { { "status", false }, { "error", "VDD action is cooling down" } };
+        }
+        if (!tray_vdd_active()) {
+          update_tray_vdd_state();
+          return { { "status", false }, { "error", "VDD is not active" } };
+        }
+        if (config::video.vdd_keep_enabled) {
+          update_tray_vdd_state();
+          return { { "status", false }, { "error", "VDD keep-enabled mode is active" } };
+        }
+
+        BOOST_LOG(info) << "Closing VDD from GUI tray"sv;
+        if (!display_device::session_t::get().destroy_vdd_monitor()) {
+          update_tray_vdd_state();
+          return { { "status", false }, { "error", "Failed to close VDD" } };
+        }
+
+        start_tray_vdd_action_cooldown();
+        return { { "status", true }, { "message", "VDD close requested" } };
+      }
+
+      if (action == "vdd_toggle_keep_enabled") {
+        config::video.vdd_keep_enabled = enabled.value_or(!config::video.vdd_keep_enabled);
+        config::update_config({ { "vdd_keep_enabled", config::video.vdd_keep_enabled ? "true" : "false" } });
+        update_tray_vdd_state();
+        return {
+          { "status", true },
+          { "message", config::video.vdd_keep_enabled ? "VDD keep-enabled mode enabled" : "VDD keep-enabled mode disabled" },
+        };
+      }
+
+      if (action == "vdd_toggle_headless_create") {
+        config::video.vdd_headless_create_enabled = enabled.value_or(!config::video.vdd_headless_create_enabled);
+        config::update_config({ { "vdd_headless_create", config::video.vdd_headless_create_enabled ? "true" : "false" } });
+        update_tray_vdd_state();
+        return {
+          { "status", true },
+          { "message", config::video.vdd_headless_create_enabled ? "Headless VDD auto-create enabled" : "Headless VDD auto-create disabled" },
+        };
+      }
+
+      if (action == "clear_app") {
+        BOOST_LOG(info) << "Clearing cache by terminating application from GUI tray"sv;
+        proc::proc.terminate();
+        return { { "status", true }, { "message", "Application termination requested" } };
+      }
+
+      if (action == "reset_display_device_config") {
+        BOOST_LOG(info) << "Resetting display device config from GUI tray"sv;
+        display_device::session_t::get().reset_persistence();
+        update_tray_vdd_state();
+        return { { "status", true }, { "message", "Display device config reset" } };
+      }
+
+      if (action == "restart") {
+        BOOST_LOG(info) << "Restarting from GUI tray"sv;
+        platf::restart();
+        return { { "status", true }, { "message", "Restart requested" } };
+      }
+
+      if (action == "notification_ack") {
+        if (!notification_id || *notification_id == 0) {
+          return { { "status", false }, { "error", "notification_id is required" } };
+        }
+        if (!tray_state::acknowledge_notification(*notification_id)) {
+          return { { "status", false }, { "error", "Notification is stale or still actionable" } };
+        }
+        return { { "status", true }, { "message", "Notification acknowledged" } };
+      }
+
+      return { { "status", false }, { "error", "Unknown tray action" } };
+    }
+
+    void
+    get_tray_state(resp_https_t response, req_https_t request, const auth_fn &auth) {
+      if (!auth(response, request)) return;
+
+      send_json(std::move(response), tray_state::to_json());
+    }
+
+    void
+    subscribe_tray_state(resp_https_t response, req_https_t request, const auth_fn &auth) {
+      if (!auth(response, request)) return;
+
+      auto subscriber = std::make_shared<tray_subscriber_t>();
+      subscriber->response = std::move(response);
+      subscriber->response->close_connection_after_response = true;
+
+      SimpleWeb::CaseInsensitiveMultimap headers;
+      headers.emplace("Content-Type", "text/event-stream");
+      headers.emplace("Cache-Control", "no-cache");
+      headers.emplace("Connection", "keep-alive");
+      headers.emplace("X-Accel-Buffering", "no");
+      subscriber->response->write(headers);
+      subscriber->response->send();
+
+      {
+        std::lock_guard lock { tray_subscribers_mutex };
+        tray_subscribers.push_back(subscriber);
+      }
+      send_tray_event(subscriber, tray_state_event());
+    }
+
+    void
+    tray_action(resp_https_t response, req_https_t request, const auth_fn &auth) {
+      if (!check_json_content_type(response, request)) return;
+      if (!auth(response, request)) return;
+
+      std::stringstream ss;
+      ss << request->content.rdbuf();
+
+      try {
+        const auto body = nlohmann::json::parse(ss.str());
+        const auto action = body.value("action", ""s);
+        std::optional<bool> enabled;
+        if (body.contains("enabled")) {
+          if (!body.at("enabled").is_boolean()) {
+            throw std::invalid_argument("enabled must be a boolean");
+          }
+          enabled = body.at("enabled").get<bool>();
+        }
+        std::optional<std::uint64_t> notification_id;
+        if (body.contains("notification_id")) {
+          if (!body.at("notification_id").is_number_unsigned()) {
+            throw std::invalid_argument("notification_id must be an unsigned integer");
+          }
+          notification_id = body.at("notification_id").get<std::uint64_t>();
+        }
+        auto result = run_tray_action(action, enabled, notification_id);
+        result["action"] = action;
+        result["tray_state"] = tray_state::to_json();
+        send_json(std::move(response), result);
+      }
+      catch (const std::exception &e) {
+        send_json(std::move(response), {
+          { "status", false },
+          { "error", e.what() },
+          { "tray_state", tray_state::to_json() },
+        });
+      }
+    }
+
+  }  // namespace
+
+  void
+  register_routes(https_server_t &server, auth_fn state_auth, auth_fn action_auth) {
+    update_tray_vdd_state();
+    tray_state::set_change_sink(&publish_tray_state);
+    if (!tray_keepalive_started.exchange(true)) {
+      schedule_tray_keepalive();
+    }
+    server.resource["^/api/tray/state$"]["GET"] = [state_auth](resp_https_t response, req_https_t request) {
+      get_tray_state(std::move(response), std::move(request), state_auth);
+    };
+    server.resource["^/api/tray/events$"]["GET"] = [state_auth](resp_https_t response, req_https_t request) {
+      subscribe_tray_state(std::move(response), std::move(request), state_auth);
+    };
+    server.resource["^/api/tray/action$"]["POST"] = [action_auth](resp_https_t response, req_https_t request) {
+      tray_action(std::move(response), std::move(request), action_auth);
+    };
+  }
+
+}  // namespace tray_http

--- a/src/tray/tray_http.cpp
+++ b/src/tray/tray_http.cpp
@@ -6,11 +6,10 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <random>
 #include <sstream>
 #include <string>
 #include <string_view>
-#include <system_error>
-#include <thread>
 #include <vector>
 
 #include <nlohmann/json.hpp>
@@ -23,6 +22,7 @@
 #include "src/logging.h"
 #include "src/platform/common.h"
 #include "src/process.h"
+#include "src/thread_pool.h"
 #include "tray_state.h"
 
 namespace tray_http {
@@ -34,6 +34,12 @@ namespace tray_http {
     std::atomic<bool> tray_app_termination_running { false };
     std::mutex tray_action_mutex;
 
+    thread_pool_util::ThreadPool &
+    tray_action_executor() {
+      static thread_pool_util::ThreadPool executor { 1 };
+      return executor;
+    }
+
     struct tray_subscriber_t {
       resp_https_t response;
       std::atomic_bool alive { true };
@@ -43,6 +49,24 @@ namespace tray_http {
     std::mutex tray_subscribers_mutex;
     std::vector<std::shared_ptr<tray_subscriber_t>> tray_subscribers;
     std::atomic_bool tray_keepalive_started { false };
+
+    constexpr auto provider_lease_duration = 45s;
+    struct provider_lease_t {
+      std::string lease_id;
+      std::string provider_id;
+      std::string version;
+      std::chrono::steady_clock::time_point expires_at;
+    };
+    std::mutex provider_lease_mutex;
+    std::optional<provider_lease_t> provider_lease;
+
+    std::string
+    new_lease_id() {
+      std::random_device random;
+      std::ostringstream id;
+      id << std::hex << random() << random() << random() << random();
+      return id.str();
+    }
 
     std::string
     tray_state_event() {
@@ -113,6 +137,15 @@ namespace tray_http {
     }
 
     void
+    send_json(resp_https_t response, const SimpleWeb::StatusCode status, const nlohmann::json &body) {
+      SimpleWeb::CaseInsensitiveMultimap headers;
+      headers.emplace("Content-Type", "application/json");
+      headers.emplace("X-Frame-Options", "DENY");
+      headers.emplace("Content-Security-Policy", "frame-ancestors 'none';");
+      response->write(status, body.dump(), headers);
+    }
+
+    void
     send_bad_request(resp_https_t response, const std::string &error) {
       SimpleWeb::CaseInsensitiveMultimap headers;
       headers.emplace("Content-Type", "application/json");
@@ -140,6 +173,137 @@ namespace tray_http {
       return true;
     }
 
+    nlohmann::json
+    read_json_body(const req_https_t &request) {
+      std::stringstream content;
+      content << request->content.rdbuf();
+      return nlohmann::json::parse(content.str());
+    }
+
+    void
+    clear_provider_lease_if_expired(const std::optional<std::string_view> expected_lease = std::nullopt) {
+      std::lock_guard lock { provider_lease_mutex };
+      if (provider_lease &&
+          (!expected_lease || provider_lease->lease_id == *expected_lease) &&
+          provider_lease->expires_at <= std::chrono::steady_clock::now()) {
+        provider_lease.reset();
+        tray_state::clear_provider();
+      }
+    }
+
+    void
+    schedule_provider_lease_expiry(const std::string &lease_id) {
+      task_pool.pushDelayed([lease_id]() {
+        clear_provider_lease_if_expired(lease_id);
+      },
+        provider_lease_duration + 1s);
+    }
+
+    void
+    register_provider(resp_https_t response, req_https_t request, const auth_fn &auth) {
+      if (!check_json_content_type(response, request)) return;
+      if (!auth(response, request)) return;
+
+      try {
+        const auto body = read_json_body(request);
+        const auto provider_id = body.value("provider_id", ""s);
+        const auto version = body.value("version", ""s);
+        const auto requested_protocol = body.value("protocol_version", 0U);
+        if (provider_id.empty()) {
+          throw std::invalid_argument("provider_id is required");
+        }
+        if (requested_protocol != tray_state::protocol_version) {
+          throw std::invalid_argument("unsupported tray protocol version");
+        }
+
+        clear_provider_lease_if_expired();
+        provider_lease_t lease;
+        {
+          std::lock_guard lock { provider_lease_mutex };
+          if (provider_lease && provider_lease->provider_id != provider_id) {
+            send_json(std::move(response), SimpleWeb::StatusCode::client_error_conflict, {
+                                                                                           { "status", false },
+                                                                                           { "error", "Another tray provider owns the active lease" },
+                                                                                         });
+            return;
+          }
+          lease = { new_lease_id(), provider_id, version, std::chrono::steady_clock::now() + provider_lease_duration };
+          provider_lease = lease;
+          tray_state::set_provider(provider_id, version);
+        }
+
+        schedule_provider_lease_expiry(lease.lease_id);
+        send_json(std::move(response), {
+                                         { "status", true },
+                                         { "lease_id", lease.lease_id },
+                                         { "lease_duration_ms", std::chrono::duration_cast<std::chrono::milliseconds>(provider_lease_duration).count() },
+                                       });
+      }
+      catch (const std::exception &e) {
+        send_bad_request(std::move(response), e.what());
+      }
+    }
+
+    void
+    heartbeat_provider(resp_https_t response, req_https_t request, const auth_fn &auth) {
+      if (!check_json_content_type(response, request)) return;
+      if (!auth(response, request)) return;
+
+      try {
+        const auto lease_id = read_json_body(request).value("lease_id", ""s);
+        std::string provider_id;
+        std::string version;
+        {
+          std::lock_guard lock { provider_lease_mutex };
+          if (!provider_lease || provider_lease->lease_id != lease_id || provider_lease->expires_at <= std::chrono::steady_clock::now()) {
+            provider_lease.reset();
+            tray_state::clear_provider();
+          }
+          else {
+            provider_lease->expires_at = std::chrono::steady_clock::now() + provider_lease_duration;
+            provider_id = provider_lease->provider_id;
+            version = provider_lease->version;
+          }
+        }
+        if (provider_id.empty()) {
+          send_json(std::move(response), SimpleWeb::StatusCode::client_error_conflict, {
+                                                                                         { "status", false },
+                                                                                         { "error", "Provider lease is missing or expired" },
+                                                                                       });
+          return;
+        }
+
+        schedule_provider_lease_expiry(lease_id);
+        send_json(std::move(response), { { "status", true }, { "lease_duration_ms", std::chrono::duration_cast<std::chrono::milliseconds>(provider_lease_duration).count() } });
+      }
+      catch (const std::exception &e) {
+        send_bad_request(std::move(response), e.what());
+      }
+    }
+
+    void
+    release_provider(resp_https_t response, req_https_t request, const auth_fn &auth) {
+      if (!check_json_content_type(response, request)) return;
+      if (!auth(response, request)) return;
+
+      try {
+        const auto lease_id = read_json_body(request).value("lease_id", ""s);
+        bool released = false;
+        {
+          std::lock_guard lock { provider_lease_mutex };
+          if (provider_lease && provider_lease->lease_id == lease_id) {
+            provider_lease.reset();
+            tray_state::clear_provider();
+            released = true;
+          }
+        }
+        send_json(std::move(response), { { "status", released } });
+      }
+      catch (const std::exception &e) {
+        send_bad_request(std::move(response), e.what());
+      }
+    }
+
     bool
     tray_vdd_active() {
       return !display_device::find_device_by_friendlyname(ZAKO_NAME).empty();
@@ -155,7 +319,7 @@ namespace tray_http {
     }
 
     void
-    finish_tray_vdd_action(bool success, std::string_view error) {
+    finish_tray_vdd_action(const std::uint64_t operation_id, bool success, std::string_view error) {
       tray_vdd_action_cooldown = true;
       tray_vdd_action_running = false;
       update_tray_vdd_state();
@@ -163,6 +327,11 @@ namespace tray_http {
       if (!success) {
         tray_state::set_notification("Virtual display", std::string { error }, "default");
       }
+      tray_state::complete_operation(
+        operation_id,
+        success,
+        success ? "Virtual display action completed" : "",
+        success ? "" : std::string { error });
 
       task_pool.pushDelayed([]() {
         tray_vdd_action_cooldown = false;
@@ -172,48 +341,53 @@ namespace tray_http {
     }
 
     bool
-    dispatch_tray_vdd_action(bool create) {
+    dispatch_tray_vdd_action(bool create, const std::uint64_t operation_id) {
       try {
-        std::thread([create]() {
+        tray_action_executor().push([create, operation_id]() {
           const auto action_name = create ? "create"sv : "close"sv;
           BOOST_LOG(info) << (create ? "Creating"sv : "Closing"sv) << " VDD from GUI tray"sv;
 
           try {
             const bool success = create ?
-                                   display_device::session_t::get().toggle_display_power() :
+                                   display_device::session_t::get().create_vdd_monitor_noninteractive() :
                                    display_device::session_t::get().destroy_vdd_monitor();
-            finish_tray_vdd_action(success, create ? "Failed to create virtual display"sv : "Failed to close virtual display"sv);
+            finish_tray_vdd_action(operation_id, success, create ? "Failed to create virtual display"sv : "Failed to close virtual display"sv);
           }
           catch (const std::exception &e) {
             BOOST_LOG(error) << "VDD "sv << action_name << " action failed: "sv << e.what();
-            finish_tray_vdd_action(false, create ? "Failed to create virtual display"sv : "Failed to close virtual display"sv);
+            finish_tray_vdd_action(operation_id, false, create ? "Failed to create virtual display"sv : "Failed to close virtual display"sv);
           }
-        }).detach();
+        });
         return true;
       }
-      catch (const std::system_error &e) {
+      catch (const std::exception &e) {
         BOOST_LOG(error) << "Failed to dispatch VDD action: "sv << e.what();
         return false;
       }
     }
 
     bool
-    dispatch_app_termination() {
+    dispatch_app_termination(const std::uint64_t operation_id) {
       try {
-        std::thread([]() {
+        tray_action_executor().push([operation_id]() {
           BOOST_LOG(info) << "Clearing cache by terminating application from GUI tray"sv;
+          bool success = true;
+          std::string operation_error;
           try {
             proc::proc.terminate();
           }
           catch (const std::exception &e) {
             BOOST_LOG(error) << "Application termination failed: "sv << e.what();
             tray_state::set_notification("Sunshine", "Failed to terminate the running application", "default");
+            success = false;
+            operation_error = "Failed to terminate the running application";
           }
           tray_app_termination_running = false;
-        }).detach();
+          tray_state::complete_operation(operation_id, success, success ? "Application terminated" : "", operation_error);
+        });
         return true;
       }
-      catch (const std::system_error &e) {
+      catch (const std::exception &e) {
         BOOST_LOG(error) << "Failed to dispatch application termination: "sv << e.what();
         return false;
       }
@@ -224,8 +398,8 @@ namespace tray_http {
       std::unique_lock lock { tray_action_mutex };
 
       if (action == "vdd_create") {
-        if (tray_vdd_action_running.load() || tray_vdd_action_cooldown.load()) {
-          return { { "status", false }, { "error", "VDD action is already in progress or cooling down" } };
+        if (tray_vdd_action_running.load() || tray_vdd_action_cooldown.load() || tray_app_termination_running.load()) {
+          return { { "status", false }, { "error", "Another tray action is already in progress or VDD is cooling down" } };
         }
         if (tray_vdd_active()) {
           update_tray_vdd_state();
@@ -233,20 +407,22 @@ namespace tray_http {
         }
 
         tray_vdd_action_running = true;
+        const auto operation_id = tray_state::begin_operation(action);
         lock.unlock();
         update_tray_vdd_state();
-        if (!dispatch_tray_vdd_action(true)) {
+        if (!dispatch_tray_vdd_action(true, operation_id)) {
           tray_vdd_action_running = false;
+          tray_state::complete_operation(operation_id, false, {}, "Failed to start VDD create action");
           update_tray_vdd_state();
           return { { "status", false }, { "error", "Failed to start VDD create action" } };
         }
 
-        return { { "status", true }, { "message", "VDD create requested" } };
+        return { { "status", true }, { "message", "VDD create requested" }, { "operation_id", operation_id } };
       }
 
       if (action == "vdd_destroy") {
-        if (tray_vdd_action_running.load() || tray_vdd_action_cooldown.load()) {
-          return { { "status", false }, { "error", "VDD action is already in progress or cooling down" } };
+        if (tray_vdd_action_running.load() || tray_vdd_action_cooldown.load() || tray_app_termination_running.load()) {
+          return { { "status", false }, { "error", "Another tray action is already in progress or VDD is cooling down" } };
         }
         if (!tray_vdd_active()) {
           update_tray_vdd_state();
@@ -258,18 +434,23 @@ namespace tray_http {
         }
 
         tray_vdd_action_running = true;
+        const auto operation_id = tray_state::begin_operation(action);
         lock.unlock();
         update_tray_vdd_state();
-        if (!dispatch_tray_vdd_action(false)) {
+        if (!dispatch_tray_vdd_action(false, operation_id)) {
           tray_vdd_action_running = false;
+          tray_state::complete_operation(operation_id, false, {}, "Failed to start VDD close action");
           update_tray_vdd_state();
           return { { "status", false }, { "error", "Failed to start VDD close action" } };
         }
 
-        return { { "status", true }, { "message", "VDD close requested" } };
+        return { { "status", true }, { "message", "VDD close requested" }, { "operation_id", operation_id } };
       }
 
       if (action == "vdd_toggle_keep_enabled") {
+        if (tray_vdd_action_running.load() || tray_vdd_action_cooldown.load()) {
+          return { { "status", false }, { "error", "VDD settings cannot change while an action is in progress or cooling down" } };
+        }
         config::video.vdd_keep_enabled = enabled.value_or(!config::video.vdd_keep_enabled);
         config::update_config({ { "vdd_keep_enabled", config::video.vdd_keep_enabled ? "true" : "false" } });
         update_tray_vdd_state();
@@ -280,6 +461,9 @@ namespace tray_http {
       }
 
       if (action == "vdd_toggle_headless_create") {
+        if (tray_vdd_action_running.load() || tray_vdd_action_cooldown.load()) {
+          return { { "status", false }, { "error", "VDD settings cannot change while an action is in progress or cooling down" } };
+        }
         config::video.vdd_headless_create_enabled = enabled.value_or(!config::video.vdd_headless_create_enabled);
         config::update_config({ { "vdd_headless_create", config::video.vdd_headless_create_enabled ? "true" : "false" } });
         update_tray_vdd_state();
@@ -290,19 +474,27 @@ namespace tray_http {
       }
 
       if (action == "clear_app") {
+        if (tray_vdd_action_running.load()) {
+          return { { "status", false }, { "error", "Another asynchronous tray action is already in progress" } };
+        }
         if (tray_app_termination_running.exchange(true)) {
           return { { "status", false }, { "error", "Application termination is already in progress" } };
         }
 
+        const auto operation_id = tray_state::begin_operation(action);
         lock.unlock();
-        if (!dispatch_app_termination()) {
+        if (!dispatch_app_termination(operation_id)) {
           tray_app_termination_running = false;
+          tray_state::complete_operation(operation_id, false, {}, "Failed to start application termination");
           return { { "status", false }, { "error", "Failed to start application termination" } };
         }
-        return { { "status", true }, { "message", "Application termination requested" } };
+        return { { "status", true }, { "message", "Application termination requested" }, { "operation_id", operation_id } };
       }
 
       if (action == "reset_display_device_config") {
+        if (tray_vdd_action_running.load() || tray_vdd_action_cooldown.load()) {
+          return { { "status", false }, { "error", "Display device config cannot reset while a VDD action is in progress or cooling down" } };
+        }
         BOOST_LOG(info) << "Resetting display device config from GUI tray"sv;
         display_device::session_t::get().reset_persistence();
         update_tray_vdd_state();
@@ -332,6 +524,7 @@ namespace tray_http {
     get_tray_state(resp_https_t response, req_https_t request, const auth_fn &auth) {
       if (!auth(response, request)) return;
 
+      clear_provider_lease_if_expired();
       send_json(std::move(response), tray_state::to_json());
     }
 
@@ -414,6 +607,15 @@ namespace tray_http {
     };
     server.resource["^/api/tray/action$"]["POST"] = [action_auth](resp_https_t response, req_https_t request) {
       tray_action(std::move(response), std::move(request), action_auth);
+    };
+    server.resource["^/api/tray/provider/register$"]["POST"] = [action_auth](resp_https_t response, req_https_t request) {
+      register_provider(std::move(response), std::move(request), action_auth);
+    };
+    server.resource["^/api/tray/provider/heartbeat$"]["POST"] = [action_auth](resp_https_t response, req_https_t request) {
+      heartbeat_provider(std::move(response), std::move(request), action_auth);
+    };
+    server.resource["^/api/tray/provider/lease$"]["DELETE"] = [action_auth](resp_https_t response, req_https_t request) {
+      release_provider(std::move(response), std::move(request), action_auth);
     };
   }
 

--- a/src/tray/tray_http.cpp
+++ b/src/tray/tray_http.cpp
@@ -6,7 +6,6 @@
 #include <memory>
 #include <mutex>
 #include <optional>
-#include <random>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -49,24 +48,6 @@ namespace tray_http {
     std::mutex tray_subscribers_mutex;
     std::vector<std::shared_ptr<tray_subscriber_t>> tray_subscribers;
     std::atomic_bool tray_keepalive_started { false };
-
-    constexpr auto provider_lease_duration = 45s;
-    struct provider_lease_t {
-      std::string lease_id;
-      std::string provider_id;
-      std::string version;
-      std::chrono::steady_clock::time_point expires_at;
-    };
-    std::mutex provider_lease_mutex;
-    std::optional<provider_lease_t> provider_lease;
-
-    std::string
-    new_lease_id() {
-      std::random_device random;
-      std::ostringstream id;
-      id << std::hex << random() << random() << random() << random();
-      return id.str();
-    }
 
     std::string
     tray_state_event() {
@@ -137,15 +118,6 @@ namespace tray_http {
     }
 
     void
-    send_json(resp_https_t response, const SimpleWeb::StatusCode status, const nlohmann::json &body) {
-      SimpleWeb::CaseInsensitiveMultimap headers;
-      headers.emplace("Content-Type", "application/json");
-      headers.emplace("X-Frame-Options", "DENY");
-      headers.emplace("Content-Security-Policy", "frame-ancestors 'none';");
-      response->write(status, body.dump(), headers);
-    }
-
-    void
     send_bad_request(resp_https_t response, const std::string &error) {
       SimpleWeb::CaseInsensitiveMultimap headers;
       headers.emplace("Content-Type", "application/json");
@@ -171,137 +143,6 @@ namespace tray_http {
       }
 
       return true;
-    }
-
-    nlohmann::json
-    read_json_body(const req_https_t &request) {
-      std::stringstream content;
-      content << request->content.rdbuf();
-      return nlohmann::json::parse(content.str());
-    }
-
-    void
-    clear_provider_lease_if_expired(const std::optional<std::string_view> expected_lease = std::nullopt) {
-      std::lock_guard lock { provider_lease_mutex };
-      if (provider_lease &&
-          (!expected_lease || provider_lease->lease_id == *expected_lease) &&
-          provider_lease->expires_at <= std::chrono::steady_clock::now()) {
-        provider_lease.reset();
-        tray_state::clear_provider();
-      }
-    }
-
-    void
-    schedule_provider_lease_expiry(const std::string &lease_id) {
-      task_pool.pushDelayed([lease_id]() {
-        clear_provider_lease_if_expired(lease_id);
-      },
-        provider_lease_duration + 1s);
-    }
-
-    void
-    register_provider(resp_https_t response, req_https_t request, const auth_fn &auth) {
-      if (!check_json_content_type(response, request)) return;
-      if (!auth(response, request)) return;
-
-      try {
-        const auto body = read_json_body(request);
-        const auto provider_id = body.value("provider_id", ""s);
-        const auto version = body.value("version", ""s);
-        const auto requested_protocol = body.value("protocol_version", 0U);
-        if (provider_id.empty()) {
-          throw std::invalid_argument("provider_id is required");
-        }
-        if (requested_protocol != tray_state::protocol_version) {
-          throw std::invalid_argument("unsupported tray protocol version");
-        }
-
-        clear_provider_lease_if_expired();
-        provider_lease_t lease;
-        {
-          std::lock_guard lock { provider_lease_mutex };
-          if (provider_lease && provider_lease->provider_id != provider_id) {
-            send_json(std::move(response), SimpleWeb::StatusCode::client_error_conflict, {
-                                                                                           { "status", false },
-                                                                                           { "error", "Another tray provider owns the active lease" },
-                                                                                         });
-            return;
-          }
-          lease = { new_lease_id(), provider_id, version, std::chrono::steady_clock::now() + provider_lease_duration };
-          provider_lease = lease;
-          tray_state::set_provider(provider_id, version);
-        }
-
-        schedule_provider_lease_expiry(lease.lease_id);
-        send_json(std::move(response), {
-                                         { "status", true },
-                                         { "lease_id", lease.lease_id },
-                                         { "lease_duration_ms", std::chrono::duration_cast<std::chrono::milliseconds>(provider_lease_duration).count() },
-                                       });
-      }
-      catch (const std::exception &e) {
-        send_bad_request(std::move(response), e.what());
-      }
-    }
-
-    void
-    heartbeat_provider(resp_https_t response, req_https_t request, const auth_fn &auth) {
-      if (!check_json_content_type(response, request)) return;
-      if (!auth(response, request)) return;
-
-      try {
-        const auto lease_id = read_json_body(request).value("lease_id", ""s);
-        std::string provider_id;
-        std::string version;
-        {
-          std::lock_guard lock { provider_lease_mutex };
-          if (!provider_lease || provider_lease->lease_id != lease_id || provider_lease->expires_at <= std::chrono::steady_clock::now()) {
-            provider_lease.reset();
-            tray_state::clear_provider();
-          }
-          else {
-            provider_lease->expires_at = std::chrono::steady_clock::now() + provider_lease_duration;
-            provider_id = provider_lease->provider_id;
-            version = provider_lease->version;
-          }
-        }
-        if (provider_id.empty()) {
-          send_json(std::move(response), SimpleWeb::StatusCode::client_error_conflict, {
-                                                                                         { "status", false },
-                                                                                         { "error", "Provider lease is missing or expired" },
-                                                                                       });
-          return;
-        }
-
-        schedule_provider_lease_expiry(lease_id);
-        send_json(std::move(response), { { "status", true }, { "lease_duration_ms", std::chrono::duration_cast<std::chrono::milliseconds>(provider_lease_duration).count() } });
-      }
-      catch (const std::exception &e) {
-        send_bad_request(std::move(response), e.what());
-      }
-    }
-
-    void
-    release_provider(resp_https_t response, req_https_t request, const auth_fn &auth) {
-      if (!check_json_content_type(response, request)) return;
-      if (!auth(response, request)) return;
-
-      try {
-        const auto lease_id = read_json_body(request).value("lease_id", ""s);
-        bool released = false;
-        {
-          std::lock_guard lock { provider_lease_mutex };
-          if (provider_lease && provider_lease->lease_id == lease_id) {
-            provider_lease.reset();
-            tray_state::clear_provider();
-            released = true;
-          }
-        }
-        send_json(std::move(response), { { "status", released } });
-      }
-      catch (const std::exception &e) {
-        send_bad_request(std::move(response), e.what());
-      }
     }
 
     bool
@@ -524,7 +365,6 @@ namespace tray_http {
     get_tray_state(resp_https_t response, req_https_t request, const auth_fn &auth) {
       if (!auth(response, request)) return;
 
-      clear_provider_lease_if_expired();
       send_json(std::move(response), tray_state::to_json());
     }
 
@@ -607,15 +447,6 @@ namespace tray_http {
     };
     server.resource["^/api/tray/action$"]["POST"] = [action_auth](resp_https_t response, req_https_t request) {
       tray_action(std::move(response), std::move(request), action_auth);
-    };
-    server.resource["^/api/tray/provider/register$"]["POST"] = [action_auth](resp_https_t response, req_https_t request) {
-      register_provider(std::move(response), std::move(request), action_auth);
-    };
-    server.resource["^/api/tray/provider/heartbeat$"]["POST"] = [action_auth](resp_https_t response, req_https_t request) {
-      heartbeat_provider(std::move(response), std::move(request), action_auth);
-    };
-    server.resource["^/api/tray/provider/lease$"]["DELETE"] = [action_auth](resp_https_t response, req_https_t request) {
-      release_provider(std::move(response), std::move(request), action_auth);
     };
   }
 

--- a/src/tray/tray_http.cpp
+++ b/src/tray/tray_http.cpp
@@ -108,19 +108,24 @@ namespace tray_http {
         30s);
     }
 
-    void
-    send_json(resp_https_t response, const nlohmann::json &body) {
+    SimpleWeb::CaseInsensitiveMultimap
+    json_response_headers() {
       SimpleWeb::CaseInsensitiveMultimap headers;
       headers.emplace("Content-Type", "application/json");
       headers.emplace("X-Frame-Options", "DENY");
       headers.emplace("Content-Security-Policy", "frame-ancestors 'none';");
+      return headers;
+    }
+
+    void
+    send_json(resp_https_t response, const nlohmann::json &body) {
+      auto headers = json_response_headers();
       response->write(body.dump(), headers);
     }
 
     void
     send_bad_request(resp_https_t response, const std::string &error) {
-      SimpleWeb::CaseInsensitiveMultimap headers;
-      headers.emplace("Content-Type", "application/json");
+      auto headers = json_response_headers();
       response->write(SimpleWeb::StatusCode::client_error_bad_request, nlohmann::json {
                                                                          { "status", false },
                                                                          { "error", error },
@@ -143,6 +148,26 @@ namespace tray_http {
       }
 
       return true;
+    }
+
+    nlohmann::json
+    action_success(const std::string_view message, const std::optional<std::uint64_t> operation_id = std::nullopt) {
+      nlohmann::json result {
+        { "status", true },
+        { "message", message },
+      };
+      if (operation_id) {
+        result["operation_id"] = *operation_id;
+      }
+      return result;
+    }
+
+    nlohmann::json
+    action_error(const std::string_view error) {
+      return {
+        { "status", false },
+        { "error", error },
+      };
     }
 
     bool
@@ -238,88 +263,74 @@ namespace tray_http {
     run_tray_action(const std::string &action, const std::optional<bool> enabled, const std::optional<std::uint64_t> notification_id) {
       std::unique_lock lock { tray_action_mutex };
 
-      if (action == "vdd_create") {
-        if (tray_vdd_action_running.load() || tray_vdd_action_cooldown.load() || tray_app_termination_running.load()) {
-          return { { "status", false }, { "error", "Another tray action is already in progress or VDD is cooling down" } };
-        }
-        if (tray_vdd_active()) {
-          update_tray_vdd_state();
-          return { { "status", false }, { "error", "VDD is already active" } };
-        }
-
+      const auto start_vdd_action = [&](const bool create) {
+        const auto dispatch_error = create ? "Failed to start VDD create action"sv : "Failed to start VDD close action"sv;
+        const auto requested_message = create ? "VDD create requested"sv : "VDD close requested"sv;
         tray_vdd_action_running = true;
         const auto operation_id = tray_state::begin_operation(action);
         lock.unlock();
         update_tray_vdd_state();
-        if (!dispatch_tray_vdd_action(true, operation_id)) {
+        if (!dispatch_tray_vdd_action(create, operation_id)) {
           tray_vdd_action_running = false;
-          tray_state::complete_operation(operation_id, false, {}, "Failed to start VDD create action");
+          tray_state::complete_operation(operation_id, false, {}, std::string { dispatch_error });
           update_tray_vdd_state();
-          return { { "status", false }, { "error", "Failed to start VDD create action" } };
+          return action_error(dispatch_error);
         }
+        return action_success(requested_message, operation_id);
+      };
 
-        return { { "status", true }, { "message", "VDD create requested" }, { "operation_id", operation_id } };
+      if (action == "vdd_create") {
+        if (tray_vdd_action_running.load() || tray_vdd_action_cooldown.load() || tray_app_termination_running.load()) {
+          return action_error("Another tray action is already in progress or VDD is cooling down");
+        }
+        if (tray_vdd_active()) {
+          update_tray_vdd_state();
+          return action_error("VDD is already active");
+        }
+        return start_vdd_action(true);
       }
 
       if (action == "vdd_destroy") {
         if (tray_vdd_action_running.load() || tray_vdd_action_cooldown.load() || tray_app_termination_running.load()) {
-          return { { "status", false }, { "error", "Another tray action is already in progress or VDD is cooling down" } };
+          return action_error("Another tray action is already in progress or VDD is cooling down");
         }
         if (!tray_vdd_active()) {
           update_tray_vdd_state();
-          return { { "status", false }, { "error", "VDD is not active" } };
+          return action_error("VDD is not active");
         }
         if (config::video.vdd_keep_enabled) {
           update_tray_vdd_state();
-          return { { "status", false }, { "error", "VDD keep-enabled mode is active" } };
+          return action_error("VDD keep-enabled mode is active");
         }
-
-        tray_vdd_action_running = true;
-        const auto operation_id = tray_state::begin_operation(action);
-        lock.unlock();
-        update_tray_vdd_state();
-        if (!dispatch_tray_vdd_action(false, operation_id)) {
-          tray_vdd_action_running = false;
-          tray_state::complete_operation(operation_id, false, {}, "Failed to start VDD close action");
-          update_tray_vdd_state();
-          return { { "status", false }, { "error", "Failed to start VDD close action" } };
-        }
-
-        return { { "status", true }, { "message", "VDD close requested" }, { "operation_id", operation_id } };
+        return start_vdd_action(false);
       }
 
       if (action == "vdd_toggle_keep_enabled") {
         if (tray_vdd_action_running.load() || tray_vdd_action_cooldown.load()) {
-          return { { "status", false }, { "error", "VDD settings cannot change while an action is in progress or cooling down" } };
+          return action_error("VDD settings cannot change while an action is in progress or cooling down");
         }
         config::video.vdd_keep_enabled = enabled.value_or(!config::video.vdd_keep_enabled);
         config::update_config({ { "vdd_keep_enabled", config::video.vdd_keep_enabled ? "true" : "false" } });
         update_tray_vdd_state();
-        return {
-          { "status", true },
-          { "message", config::video.vdd_keep_enabled ? "VDD keep-enabled mode enabled" : "VDD keep-enabled mode disabled" },
-        };
+        return action_success(config::video.vdd_keep_enabled ? "VDD keep-enabled mode enabled" : "VDD keep-enabled mode disabled");
       }
 
       if (action == "vdd_toggle_headless_create") {
         if (tray_vdd_action_running.load() || tray_vdd_action_cooldown.load()) {
-          return { { "status", false }, { "error", "VDD settings cannot change while an action is in progress or cooling down" } };
+          return action_error("VDD settings cannot change while an action is in progress or cooling down");
         }
         config::video.vdd_headless_create_enabled = enabled.value_or(!config::video.vdd_headless_create_enabled);
         config::update_config({ { "vdd_headless_create", config::video.vdd_headless_create_enabled ? "true" : "false" } });
         update_tray_vdd_state();
-        return {
-          { "status", true },
-          { "message", config::video.vdd_headless_create_enabled ? "Headless VDD auto-create enabled" : "Headless VDD auto-create disabled" },
-        };
+        return action_success(config::video.vdd_headless_create_enabled ? "Headless VDD auto-create enabled" : "Headless VDD auto-create disabled");
       }
 
       if (action == "clear_app") {
         if (tray_vdd_action_running.load()) {
-          return { { "status", false }, { "error", "Another asynchronous tray action is already in progress" } };
+          return action_error("Another asynchronous tray action is already in progress");
         }
         if (tray_app_termination_running.exchange(true)) {
-          return { { "status", false }, { "error", "Application termination is already in progress" } };
+          return action_error("Application termination is already in progress");
         }
 
         const auto operation_id = tray_state::begin_operation(action);
@@ -327,38 +338,38 @@ namespace tray_http {
         if (!dispatch_app_termination(operation_id)) {
           tray_app_termination_running = false;
           tray_state::complete_operation(operation_id, false, {}, "Failed to start application termination");
-          return { { "status", false }, { "error", "Failed to start application termination" } };
+          return action_error("Failed to start application termination");
         }
-        return { { "status", true }, { "message", "Application termination requested" }, { "operation_id", operation_id } };
+        return action_success("Application termination requested", operation_id);
       }
 
       if (action == "reset_display_device_config") {
         if (tray_vdd_action_running.load() || tray_vdd_action_cooldown.load()) {
-          return { { "status", false }, { "error", "Display device config cannot reset while a VDD action is in progress or cooling down" } };
+          return action_error("Display device config cannot reset while a VDD action is in progress or cooling down");
         }
         BOOST_LOG(info) << "Resetting display device config from GUI tray"sv;
         display_device::session_t::get().reset_persistence();
         update_tray_vdd_state();
-        return { { "status", true }, { "message", "Display device config reset" } };
+        return action_success("Display device config reset");
       }
 
       if (action == "restart") {
         BOOST_LOG(info) << "Restarting from GUI tray"sv;
         platf::restart();
-        return { { "status", true }, { "message", "Restart requested" } };
+        return action_success("Restart requested");
       }
 
       if (action == "notification_ack") {
         if (!notification_id || *notification_id == 0) {
-          return { { "status", false }, { "error", "notification_id is required" } };
+          return action_error("notification_id is required");
         }
         if (!tray_state::acknowledge_notification(*notification_id)) {
-          return { { "status", false }, { "error", "Notification is stale or still actionable" } };
+          return action_error("Notification is stale or still actionable");
         }
-        return { { "status", true }, { "message", "Notification acknowledged" } };
+        return action_success("Notification acknowledged");
       }
 
-      return { { "status", false }, { "error", "Unknown tray action" } };
+      return action_error("Unknown tray action");
     }
 
     void

--- a/src/tray/tray_http.cpp
+++ b/src/tray/tray_http.cpp
@@ -30,6 +30,7 @@ namespace tray_http {
   namespace {
     std::atomic<bool> tray_vdd_action_cooldown { false };
     std::atomic<bool> tray_vdd_action_running { false };
+    std::atomic<std::uint64_t> tray_vdd_confirmation_operation_id { 0 };
     std::atomic<bool> tray_app_termination_running { false };
     std::mutex tray_action_mutex;
 
@@ -206,6 +207,9 @@ namespace tray_http {
         10s);
     }
 
+    void
+    schedule_vdd_confirmation_timeout(std::uint64_t operation_id);
+
     bool
     dispatch_tray_vdd_action(bool create, const std::uint64_t operation_id) {
       try {
@@ -217,7 +221,17 @@ namespace tray_http {
             const bool success = create ?
                                    display_device::session_t::get().create_vdd_monitor_noninteractive() :
                                    display_device::session_t::get().destroy_vdd_monitor();
-            finish_tray_vdd_action(operation_id, success, create ? "Failed to create virtual display"sv : "Failed to close virtual display"sv);
+            if (create && success) {
+              tray_vdd_action_running = false;
+              tray_vdd_confirmation_operation_id = operation_id;
+              tray_state::set_vdd_confirmation(true, operation_id);
+              update_tray_vdd_state();
+              tray_state::complete_operation(operation_id, true, "Virtual display created; awaiting confirmation");
+              schedule_vdd_confirmation_timeout(operation_id);
+            }
+            else {
+              finish_tray_vdd_action(operation_id, success, create ? "Failed to create virtual display"sv : "Failed to close virtual display"sv);
+            }
           }
           catch (const std::exception &e) {
             BOOST_LOG(error) << "VDD "sv << action_name << " action failed: "sv << e.what();
@@ -230,6 +244,28 @@ namespace tray_http {
         BOOST_LOG(error) << "Failed to dispatch VDD action: "sv << e.what();
         return false;
       }
+    }
+
+    void
+    schedule_vdd_confirmation_timeout(const std::uint64_t operation_id) {
+      task_pool.pushDelayed([operation_id]() {
+        std::unique_lock lock { tray_action_mutex };
+        auto expected_operation_id = operation_id;
+        if (!tray_vdd_confirmation_operation_id.compare_exchange_strong(expected_operation_id, 0)) {
+          return;
+        }
+
+        tray_state::set_vdd_confirmation(false);
+        tray_vdd_action_running = true;
+        lock.unlock();
+        update_tray_vdd_state();
+        tray_state::set_notification("Virtual display", "Virtual display was not confirmed and was closed", "default");
+        if (!dispatch_tray_vdd_action(false, operation_id)) {
+          tray_vdd_action_running = false;
+          update_tray_vdd_state();
+        }
+      },
+        20s);
     }
 
     bool
@@ -260,14 +296,18 @@ namespace tray_http {
     }
 
     nlohmann::json
-    run_tray_action(const std::string &action, const std::optional<bool> enabled, const std::optional<std::uint64_t> notification_id) {
+    run_tray_action(
+      const std::string &action,
+      const std::optional<bool> enabled,
+      const std::optional<std::uint64_t> notification_id,
+      const std::optional<std::uint64_t> operation_id) {
       std::unique_lock lock { tray_action_mutex };
 
-      const auto start_vdd_action = [&](const bool create) {
+      const auto start_vdd_action = [&](const bool create, const std::string_view operation_action) {
         const auto dispatch_error = create ? "Failed to start VDD create action"sv : "Failed to start VDD close action"sv;
         const auto requested_message = create ? "VDD create requested"sv : "VDD close requested"sv;
         tray_vdd_action_running = true;
-        const auto operation_id = tray_state::begin_operation(action);
+        const auto operation_id = tray_state::begin_operation(std::string { operation_action });
         lock.unlock();
         update_tray_vdd_state();
         if (!dispatch_tray_vdd_action(create, operation_id)) {
@@ -279,6 +319,34 @@ namespace tray_http {
         return action_success(requested_message, operation_id);
       };
 
+      if (action == "vdd_confirm_keep") {
+        if (!enabled || !operation_id || *operation_id == 0) {
+          return action_error("enabled and operation_id are required");
+        }
+        auto expected_operation_id = *operation_id;
+        if (!tray_vdd_confirmation_operation_id.compare_exchange_strong(expected_operation_id, 0)) {
+          return action_error("Virtual display confirmation is stale");
+        }
+
+        tray_state::set_vdd_confirmation(false);
+        if (*enabled) {
+          return action_success("Virtual display retained");
+        }
+        if (!tray_vdd_active()) {
+          update_tray_vdd_state();
+          return action_success("Virtual display is already closed");
+        }
+        tray_vdd_action_running = true;
+        lock.unlock();
+        update_tray_vdd_state();
+        if (!dispatch_tray_vdd_action(false, *operation_id)) {
+          tray_vdd_action_running = false;
+          update_tray_vdd_state();
+          return action_error("Failed to start virtual display rollback");
+        }
+        return action_success("Virtual display rollback requested");
+      }
+
       if (action == "vdd_create") {
         if (tray_vdd_action_running.load() || tray_vdd_action_cooldown.load() || tray_app_termination_running.load()) {
           return action_error("Another tray action is already in progress or VDD is cooling down");
@@ -287,7 +355,7 @@ namespace tray_http {
           update_tray_vdd_state();
           return action_error("VDD is already active");
         }
-        return start_vdd_action(true);
+        return start_vdd_action(true, action);
       }
 
       if (action == "vdd_destroy") {
@@ -302,7 +370,10 @@ namespace tray_http {
           update_tray_vdd_state();
           return action_error("VDD keep-enabled mode is active");
         }
-        return start_vdd_action(false);
+        if (tray_vdd_confirmation_operation_id.exchange(0) != 0) {
+          tray_state::set_vdd_confirmation(false);
+        }
+        return start_vdd_action(false, action);
       }
 
       if (action == "vdd_toggle_keep_enabled") {
@@ -427,7 +498,14 @@ namespace tray_http {
           }
           notification_id = body.at("notification_id").get<std::uint64_t>();
         }
-        auto result = run_tray_action(action, enabled, notification_id);
+        std::optional<std::uint64_t> operation_id;
+        if (body.contains("operation_id")) {
+          if (!body.at("operation_id").is_number_unsigned()) {
+            throw std::invalid_argument("operation_id must be an unsigned integer");
+          }
+          operation_id = body.at("operation_id").get<std::uint64_t>();
+        }
+        auto result = run_tray_action(action, enabled, notification_id, operation_id);
         result["action"] = action;
         result["tray_state"] = tray_state::to_json();
         send_json(std::move(response), result);

--- a/src/tray/tray_http.h
+++ b/src/tray/tray_http.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+
+#include <Simple-Web-Server/server_https.hpp>
+
+namespace tray_http {
+  using https_server_t = SimpleWeb::Server<SimpleWeb::HTTPS>;
+  using resp_https_t = std::shared_ptr<typename SimpleWeb::ServerBase<SimpleWeb::HTTPS>::Response>;
+  using req_https_t = std::shared_ptr<typename SimpleWeb::ServerBase<SimpleWeb::HTTPS>::Request>;
+  using auth_fn = std::function<bool(resp_https_t, req_https_t)>;
+
+  void
+  register_routes(https_server_t &server, auth_fn state_auth, auth_fn action_auth);
+}  // namespace tray_http

--- a/src/tray/tray_state.cpp
+++ b/src/tray/tray_state.cpp
@@ -268,6 +268,17 @@ namespace tray_state {
     notify_changed();
   }
 
+  void
+  set_vdd_confirmation(const bool awaiting_confirmation, const std::uint64_t operation_id) {
+    {
+      std::lock_guard lock { state_mutex };
+      current_state.vdd.awaiting_confirmation = awaiting_confirmation;
+      current_state.vdd.confirmation_operation_id = awaiting_confirmation ? operation_id : 0;
+      touch_locked();
+    }
+    notify_changed();
+  }
+
   std::uint64_t
   begin_operation(const std::string &action) {
     std::uint64_t operation_id;
@@ -330,6 +341,8 @@ namespace tray_state {
           { "keep_enabled", snapshot.vdd.keep_enabled },
           { "headless_create_enabled", snapshot.vdd.headless_create_enabled },
           { "cooldown", snapshot.vdd.cooldown },
+          { "awaiting_confirmation", snapshot.vdd.awaiting_confirmation },
+          { "confirmation_operation_id", snapshot.vdd.confirmation_operation_id },
         } },
       { "notification",
         {

--- a/src/tray/tray_state.cpp
+++ b/src/tray/tray_state.cpp
@@ -13,6 +13,7 @@ namespace tray_state {
     std::mutex state_mutex;
     state_t current_state;
     std::uint64_t next_notification_id = 0;
+    std::uint64_t next_operation_id = 0;
     std::mutex change_sink_mutex;
     change_sink_t change_sink;
     std::int64_t
@@ -267,6 +268,63 @@ namespace tray_state {
     notify_changed();
   }
 
+  std::uint64_t
+  begin_operation(const std::string &action) {
+    std::uint64_t operation_id;
+    {
+      std::lock_guard lock { state_mutex };
+      current_state.operation = {
+        ++next_operation_id,
+        action,
+        "running",
+        {},
+        {},
+      };
+      operation_id = current_state.operation.id;
+      touch_locked();
+    }
+    notify_changed();
+    return operation_id;
+  }
+
+  void
+  complete_operation(const std::uint64_t operation_id, const bool success, const std::string &message, const std::string &error) {
+    {
+      std::lock_guard lock { state_mutex };
+      if (current_state.operation.id != operation_id || current_state.operation.state != "running") {
+        return;
+      }
+      current_state.operation.state = success ? "succeeded" : "failed";
+      current_state.operation.message = message;
+      current_state.operation.error = error;
+      touch_locked();
+    }
+    notify_changed();
+  }
+
+  void
+  set_provider(const std::string &id, const std::string &version) {
+    {
+      std::lock_guard lock { state_mutex };
+      current_state.provider = { true, id, version };
+      touch_locked();
+    }
+    notify_changed();
+  }
+
+  void
+  clear_provider() {
+    {
+      std::lock_guard lock { state_mutex };
+      if (!current_state.provider.active) {
+        return;
+      }
+      current_state.provider = {};
+      touch_locked();
+    }
+    notify_changed();
+  }
+
   nlohmann::json
   to_json() {
     state_t snapshot;
@@ -281,7 +339,7 @@ namespace tray_state {
       { "protocol_version", protocol_version },
       { "instance_id", instance_id() },
       { "owner", tray_owner() },
-      { "capabilities", nlohmann::json::array({ "state-v1", "events-v1", "actions-v1", "notification-ack", "pairing", "vdd" }) },
+      { "capabilities", nlohmann::json::array({ "state-v1", "events-v1", "actions-v1", "operations-v1", "provider-lease-v1", "notification-ack", "pairing", "vdd" }) },
       { "status", current_presentation.status },
       { "icon", current_presentation.icon },
       { "tooltip", current_presentation.tooltip },
@@ -304,6 +362,20 @@ namespace tray_state {
           { "message", snapshot.notification.message },
           { "icon", snapshot.notification.icon },
           { "action", snapshot.notification.action },
+        } },
+      { "operation",
+        {
+          { "id", snapshot.operation.id },
+          { "action", snapshot.operation.action },
+          { "state", snapshot.operation.state },
+          { "message", snapshot.operation.message },
+          { "error", snapshot.operation.error },
+        } },
+      { "provider",
+        {
+          { "active", snapshot.provider.active },
+          { "id", snapshot.provider.id },
+          { "version", snapshot.provider.version },
         } },
     };
   }

--- a/src/tray/tray_state.cpp
+++ b/src/tray/tray_state.cpp
@@ -1,0 +1,309 @@
+#include "tray_state.h"
+
+#include <chrono>
+#include <mutex>
+#include <random>
+#include <sstream>
+#include <utility>
+
+namespace tray_state {
+
+  namespace {
+
+    std::mutex state_mutex;
+    state_t current_state;
+    std::uint64_t next_notification_id = 0;
+    std::mutex change_sink_mutex;
+    change_sink_t change_sink;
+    std::int64_t
+    now_ms() {
+      const auto now = std::chrono::system_clock::now().time_since_epoch();
+      return std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
+    }
+
+    const std::string &
+    instance_id() {
+      static const auto value = []() {
+        std::random_device random;
+        std::ostringstream id;
+        id << std::hex << now_ms() << '-' << random() << random();
+        return id.str();
+      }();
+      return value;
+    }
+
+    const char *
+    tray_owner() {
+#if defined SUNSHINE_TRAY && SUNSHINE_TRAY >= 1
+      return "core";
+#elif defined SUNSHINE_GUI_TRAY && SUNSHINE_GUI_TRAY >= 1
+      return "gui";
+#else
+      return "disabled";
+#endif
+    }
+
+    const char *
+    status_name(status_e status) {
+      switch (status) {
+        case status_e::idle:
+          return "idle";
+        case status_e::streaming:
+          return "streaming";
+        case status_e::paused:
+          return "paused";
+      }
+      return "idle";
+    }
+
+    struct presentation_t {
+      const char *status;
+      std::string icon;
+      std::string tooltip;
+    };
+
+    presentation_t
+    presentation_locked(const state_t &state) {
+      if (state.pairing_pending) {
+        return {
+          "pairing",
+          "locked",
+          state.pairing_client_name.empty() ? "Pairing request" : "Pairing request: " + state.pairing_client_name,
+        };
+      }
+
+      if (state.notification.active) {
+        auto tooltip = state.notification.title;
+        if (tooltip.empty()) {
+          tooltip = state.notification.message;
+        }
+        if (tooltip.empty()) {
+          tooltip = "Sunshine notification";
+        }
+        return {
+          "notification",
+          state.notification.icon.empty() ? "default" : state.notification.icon,
+          std::move(tooltip),
+        };
+      }
+
+      return { status_name(state.status), state.icon, state.tooltip };
+    }
+
+    void
+    touch_locked() {
+      ++current_state.revision;
+      current_state.updated_at_ms = now_ms();
+    }
+
+    void
+    notify_changed() {
+      change_sink_t sink;
+      {
+        std::lock_guard lock { change_sink_mutex };
+        sink = change_sink;
+      }
+      if (sink) {
+        sink();
+      }
+    }
+
+  }  // namespace
+
+  state_t
+  get() {
+    std::lock_guard lock { state_mutex };
+    return current_state;
+  }
+
+  void
+  set_change_sink(change_sink_t sink) {
+    std::lock_guard lock { change_sink_mutex };
+    change_sink = std::move(sink);
+  }
+
+  void
+  set_idle(const std::string &last_app_name) {
+    {
+      std::lock_guard lock { state_mutex };
+      current_state.status = status_e::idle;
+      current_state.icon = "default";
+      current_state.tooltip = "Sunshine";
+      current_state.app_name = last_app_name;
+      touch_locked();
+    }
+    notify_changed();
+  }
+
+  void
+  set_streaming(const std::string &app_name) {
+    {
+      std::lock_guard lock { state_mutex };
+      current_state.status = status_e::streaming;
+      current_state.icon = "playing";
+      current_state.tooltip = app_name.empty() ? "Streaming" : "Streaming " + app_name;
+      current_state.app_name = app_name;
+      touch_locked();
+    }
+    notify_changed();
+  }
+
+  void
+  set_paused(const std::string &app_name) {
+    {
+      std::lock_guard lock { state_mutex };
+      current_state.status = status_e::paused;
+      current_state.icon = "pausing";
+      current_state.tooltip = app_name.empty() ? "Stream paused" : "Stream paused: " + app_name;
+      current_state.app_name = app_name;
+      touch_locked();
+    }
+    notify_changed();
+  }
+
+  void
+  set_pairing_required(const std::string &client_name) {
+    {
+      std::lock_guard lock { state_mutex };
+      current_state.pairing_pending = true;
+      current_state.pairing_client_name = client_name;
+      current_state.notification.id = ++next_notification_id;
+      current_state.notification.active = true;
+      current_state.notification.icon = "locked";
+      current_state.notification.action = "open_pin";
+      touch_locked();
+    }
+    notify_changed();
+  }
+
+  void
+  clear_pairing_required() {
+    {
+      std::lock_guard lock { state_mutex };
+      current_state.pairing_pending = false;
+      current_state.pairing_client_name.clear();
+      if (current_state.notification.action == "open_pin") {
+        current_state.notification = {};
+      }
+      touch_locked();
+    }
+    notify_changed();
+  }
+
+  std::uint64_t
+  set_notification(const std::string &title, const std::string &message, const std::string &icon, const std::string &action) {
+    std::uint64_t notification_id;
+    {
+      std::lock_guard lock { state_mutex };
+      current_state.notification.id = ++next_notification_id;
+      current_state.notification.active = true;
+      current_state.notification.title = title;
+      current_state.notification.message = message;
+      current_state.notification.icon = icon;
+      current_state.notification.action = action;
+      touch_locked();
+      notification_id = current_state.notification.id;
+    }
+    notify_changed();
+    return notification_id;
+  }
+
+  void
+  clear_notification() {
+    {
+      std::lock_guard lock { state_mutex };
+      current_state.notification = {};
+      touch_locked();
+    }
+    notify_changed();
+  }
+
+  void
+  clear_notification_if(const std::uint64_t notification_id) {
+    {
+      std::lock_guard lock { state_mutex };
+      if (current_state.notification.id != notification_id) {
+        return;
+      }
+      current_state.notification = {};
+      touch_locked();
+    }
+    notify_changed();
+  }
+
+  bool
+  acknowledge_notification(const std::uint64_t notification_id) {
+    {
+      std::lock_guard lock { state_mutex };
+      if (!current_state.notification.active || current_state.notification.id != notification_id) {
+        return false;
+      }
+
+      // Pairing remains actionable until the pairing flow succeeds, expires, or
+      // is cancelled. Clicking the menu must not make the PIN entry point vanish.
+      if (current_state.pairing_pending || current_state.notification.action == "open_pin") {
+        return false;
+      }
+
+      current_state.notification = {};
+      touch_locked();
+    }
+    notify_changed();
+    return true;
+  }
+
+  void
+  set_vdd_state(bool active, bool keep_enabled, bool headless_create_enabled, bool cooldown) {
+    {
+      std::lock_guard lock { state_mutex };
+      current_state.vdd.active = active;
+      current_state.vdd.keep_enabled = keep_enabled;
+      current_state.vdd.headless_create_enabled = headless_create_enabled;
+      current_state.vdd.cooldown = cooldown;
+      touch_locked();
+    }
+    notify_changed();
+  }
+
+  nlohmann::json
+  to_json() {
+    state_t snapshot;
+    {
+      std::lock_guard lock { state_mutex };
+      snapshot = current_state;
+    }
+
+    const auto presentation = presentation_locked(snapshot);
+
+    return {
+      { "protocol_version", protocol_version },
+      { "instance_id", instance_id() },
+      { "owner", tray_owner() },
+      { "capabilities", nlohmann::json::array({ "state-v1", "events-v1", "actions-v1", "notification-ack", "pairing", "vdd" }) },
+      { "status", presentation.status },
+      { "icon", presentation.icon },
+      { "tooltip", presentation.tooltip },
+      { "app_name", snapshot.app_name },
+      { "pairing_client_name", snapshot.pairing_client_name },
+      { "revision", snapshot.revision },
+      { "updated_at_ms", snapshot.updated_at_ms },
+      { "vdd",
+        {
+          { "active", snapshot.vdd.active },
+          { "keep_enabled", snapshot.vdd.keep_enabled },
+          { "headless_create_enabled", snapshot.vdd.headless_create_enabled },
+          { "cooldown", snapshot.vdd.cooldown },
+        } },
+      { "notification",
+        {
+          { "id", snapshot.notification.id },
+          { "active", snapshot.notification.active },
+          { "title", snapshot.notification.title },
+          { "message", snapshot.notification.message },
+          { "icon", snapshot.notification.icon },
+          { "action", snapshot.notification.action },
+        } },
+    };
+  }
+
+}  // namespace tray_state

--- a/src/tray/tray_state.cpp
+++ b/src/tray/tray_state.cpp
@@ -302,29 +302,6 @@ namespace tray_state {
     notify_changed();
   }
 
-  void
-  set_provider(const std::string &id, const std::string &version) {
-    {
-      std::lock_guard lock { state_mutex };
-      current_state.provider = { true, id, version };
-      touch_locked();
-    }
-    notify_changed();
-  }
-
-  void
-  clear_provider() {
-    {
-      std::lock_guard lock { state_mutex };
-      if (!current_state.provider.active) {
-        return;
-      }
-      current_state.provider = {};
-      touch_locked();
-    }
-    notify_changed();
-  }
-
   nlohmann::json
   to_json() {
     state_t snapshot;
@@ -339,7 +316,7 @@ namespace tray_state {
       { "protocol_version", protocol_version },
       { "instance_id", instance_id() },
       { "owner", tray_owner() },
-      { "capabilities", nlohmann::json::array({ "state-v1", "events-v1", "actions-v1", "operations-v1", "provider-lease-v1", "notification-ack", "pairing", "vdd" }) },
+      { "capabilities", nlohmann::json::array({ "state-v1", "events-v1", "actions-v1", "operations-v1", "notification-ack", "pairing", "vdd" }) },
       { "status", current_presentation.status },
       { "icon", current_presentation.icon },
       { "tooltip", current_presentation.tooltip },
@@ -370,12 +347,6 @@ namespace tray_state {
           { "state", snapshot.operation.state },
           { "message", snapshot.operation.message },
           { "error", snapshot.operation.error },
-        } },
-      { "provider",
-        {
-          { "active", snapshot.provider.active },
-          { "id", snapshot.provider.id },
-          { "version", snapshot.provider.version },
         } },
     };
   }

--- a/src/tray/tray_state.cpp
+++ b/src/tray/tray_state.cpp
@@ -63,7 +63,7 @@ namespace tray_state {
     };
 
     presentation_t
-    presentation_locked(const state_t &state) {
+    presentation(const state_t &state) {
       if (state.pairing_pending) {
         return {
           "pairing",
@@ -169,6 +169,8 @@ namespace tray_state {
       current_state.pairing_client_name = client_name;
       current_state.notification.id = ++next_notification_id;
       current_state.notification.active = true;
+      current_state.notification.title.clear();
+      current_state.notification.message.clear();
       current_state.notification.icon = "locked";
       current_state.notification.action = "open_pin";
       touch_locked();
@@ -273,16 +275,16 @@ namespace tray_state {
       snapshot = current_state;
     }
 
-    const auto presentation = presentation_locked(snapshot);
+    const auto current_presentation = presentation(snapshot);
 
     return {
       { "protocol_version", protocol_version },
       { "instance_id", instance_id() },
       { "owner", tray_owner() },
       { "capabilities", nlohmann::json::array({ "state-v1", "events-v1", "actions-v1", "notification-ack", "pairing", "vdd" }) },
-      { "status", presentation.status },
-      { "icon", presentation.icon },
-      { "tooltip", presentation.tooltip },
+      { "status", current_presentation.status },
+      { "icon", current_presentation.icon },
+      { "tooltip", current_presentation.tooltip },
       { "app_name", snapshot.app_name },
       { "pairing_client_name", snapshot.pairing_client_name },
       { "revision", snapshot.revision },

--- a/src/tray/tray_state.h
+++ b/src/tray/tray_state.h
@@ -42,12 +42,6 @@ namespace tray_state {
     std::string error;
   };
 
-  struct provider_t {
-    bool active = false;
-    std::string id;
-    std::string version;
-  };
-
   struct state_t {
     status_e status = status_e::idle;
     std::string icon = "default";
@@ -58,7 +52,6 @@ namespace tray_state {
     vdd_state_t vdd;
     notification_t notification;
     operation_t operation;
-    provider_t provider;
     std::uint64_t revision = 0;
     std::int64_t updated_at_ms = 0;
   };
@@ -104,12 +97,6 @@ namespace tray_state {
 
   void
   complete_operation(std::uint64_t operation_id, bool success, const std::string &message = {}, const std::string &error = {});
-
-  void
-  set_provider(const std::string &id, const std::string &version);
-
-  void
-  clear_provider();
 
   nlohmann::json
   to_json();

--- a/src/tray/tray_state.h
+++ b/src/tray/tray_state.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+namespace tray_state {
+
+  using change_sink_t = std::function<void()>;
+
+  inline constexpr std::uint32_t protocol_version = 1;
+
+  enum class status_e {
+    idle,
+    streaming,
+    paused
+  };
+
+  struct vdd_state_t {
+    bool active = false;
+    bool keep_enabled = false;
+    bool headless_create_enabled = false;
+    bool cooldown = false;
+  };
+
+  struct notification_t {
+    std::uint64_t id = 0;
+    bool active = false;
+    std::string title;
+    std::string message;
+    std::string icon;
+    std::string action;
+  };
+
+  struct state_t {
+    status_e status = status_e::idle;
+    std::string icon = "default";
+    std::string tooltip = "Sunshine";
+    std::string app_name;
+    bool pairing_pending = false;
+    std::string pairing_client_name;
+    vdd_state_t vdd;
+    notification_t notification;
+    std::uint64_t revision = 0;
+    std::int64_t updated_at_ms = 0;
+  };
+
+  state_t
+  get();
+
+  void
+  set_change_sink(change_sink_t sink);
+
+  void
+  set_idle(const std::string &last_app_name = {});
+
+  void
+  set_streaming(const std::string &app_name);
+
+  void
+  set_paused(const std::string &app_name);
+
+  void
+  set_pairing_required(const std::string &client_name);
+
+  void
+  clear_pairing_required();
+
+  std::uint64_t
+  set_notification(const std::string &title, const std::string &message, const std::string &icon = "default", const std::string &action = {});
+
+  void
+  clear_notification();
+
+  void
+  clear_notification_if(std::uint64_t notification_id);
+
+  bool
+  acknowledge_notification(std::uint64_t notification_id);
+
+  void
+  set_vdd_state(bool active, bool keep_enabled, bool headless_create_enabled, bool cooldown);
+
+  nlohmann::json
+  to_json();
+
+}  // namespace tray_state

--- a/src/tray/tray_state.h
+++ b/src/tray/tray_state.h
@@ -23,6 +23,8 @@ namespace tray_state {
     bool keep_enabled = false;
     bool headless_create_enabled = false;
     bool cooldown = false;
+    bool awaiting_confirmation = false;
+    std::uint64_t confirmation_operation_id = 0;
   };
 
   struct notification_t {
@@ -91,6 +93,9 @@ namespace tray_state {
 
   void
   set_vdd_state(bool active, bool keep_enabled, bool headless_create_enabled, bool cooldown);
+
+  void
+  set_vdd_confirmation(bool awaiting_confirmation, std::uint64_t operation_id = 0);
 
   std::uint64_t
   begin_operation(const std::string &action);

--- a/src/tray/tray_state.h
+++ b/src/tray/tray_state.h
@@ -34,6 +34,20 @@ namespace tray_state {
     std::string action;
   };
 
+  struct operation_t {
+    std::uint64_t id = 0;
+    std::string action;
+    std::string state;
+    std::string message;
+    std::string error;
+  };
+
+  struct provider_t {
+    bool active = false;
+    std::string id;
+    std::string version;
+  };
+
   struct state_t {
     status_e status = status_e::idle;
     std::string icon = "default";
@@ -43,6 +57,8 @@ namespace tray_state {
     std::string pairing_client_name;
     vdd_state_t vdd;
     notification_t notification;
+    operation_t operation;
+    provider_t provider;
     std::uint64_t revision = 0;
     std::int64_t updated_at_ms = 0;
   };
@@ -82,6 +98,18 @@ namespace tray_state {
 
   void
   set_vdd_state(bool active, bool keep_enabled, bool headless_create_enabled, bool cooldown);
+
+  std::uint64_t
+  begin_operation(const std::string &action);
+
+  void
+  complete_operation(std::uint64_t operation_id, bool success, const std::string &message = {}, const std::string &error = {});
+
+  void
+  set_provider(const std::string &id, const std::string &version);
+
+  void
+  clear_provider();
 
   nlohmann::json
   to_json();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,24 @@ if (WIN32)
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)  # cmake-lint: disable=C0103
 endif ()
 
+add_executable(tray_state_unit_tests
+        ${CMAKE_SOURCE_DIR}/src/tray/tray_state.cpp
+        ${CMAKE_SOURCE_DIR}/tests/unit/test_tray_state.cpp)
+target_include_directories(tray_state_unit_tests PRIVATE "${CMAKE_SOURCE_DIR}")
+target_link_libraries(tray_state_unit_tests
+        nlohmann_json::nlohmann_json
+        gtest_main)
+target_compile_options(tray_state_unit_tests PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${SUNSHINE_COMPILE_OPTIONS}>)
+set_target_properties(tray_state_unit_tests PROPERTIES CXX_STANDARD 23)
+if (WIN32)
+    set_target_properties(tray_state_unit_tests PROPERTIES LINK_SEARCH_START_STATIC 1)
+endif ()
+add_test(NAME tray_state_unit_tests COMMAND tray_state_unit_tests)
+
+if (NOT BUILD_TESTS)
+    return()
+endif ()
+
 # modify SUNSHINE_DEFINITIONS
 if (WIN32)
     list(APPEND

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ endif ()
 
 add_executable(tray_state_unit_tests
         ${CMAKE_SOURCE_DIR}/src/tray/tray_state.cpp
+        ${CMAKE_SOURCE_DIR}/tests/unit/test_http_util.cpp
         ${CMAKE_SOURCE_DIR}/tests/unit/test_tray_state.cpp)
 target_include_directories(tray_state_unit_tests PRIVATE "${CMAKE_SOURCE_DIR}")
 target_link_libraries(tray_state_unit_tests

--- a/tests/unit/test_http_util.cpp
+++ b/tests/unit/test_http_util.cpp
@@ -1,0 +1,13 @@
+/**
+ * @file tests/unit/test_http_util.cpp
+ * @brief Tests for shared HTTP request validation helpers.
+ */
+#include <gtest/gtest.h>
+
+#include <src/http_util.h>
+
+TEST(HttpUtilTest, MatchesNormalizedMediaType) {
+  EXPECT_TRUE(http_util::content_type_matches(" Application/JSON; charset=utf-8", "application/json"));
+  EXPECT_TRUE(http_util::content_type_matches("text/plain", "TEXT/PLAIN"));
+  EXPECT_FALSE(http_util::content_type_matches("text/plain", "application/json"));
+}

--- a/tests/unit/test_tray_state.cpp
+++ b/tests/unit/test_tray_state.cpp
@@ -1,0 +1,157 @@
+/**
+ * @file tests/unit/test_tray_state.cpp
+ * @brief Tests for the tray state published to the GUI user-session agent.
+ */
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <atomic>
+
+#include <src/tray/tray_state.h>
+
+TEST(TrayStateTest, PublishesStreamingLifecycle) {
+	tray_state::set_idle();
+	const auto initial_revision = tray_state::get().revision;
+
+	tray_state::set_streaming("Desktop");
+	auto state = tray_state::get();
+	EXPECT_EQ(state.status, tray_state::status_e::streaming);
+	EXPECT_EQ(state.icon, "playing");
+	EXPECT_EQ(state.tooltip, "Streaming Desktop");
+	EXPECT_EQ(state.app_name, "Desktop");
+	EXPECT_GT(state.revision, initial_revision);
+	EXPECT_GT(state.updated_at_ms, 0);
+
+	tray_state::set_paused("Desktop");
+	state = tray_state::get();
+	EXPECT_EQ(state.status, tray_state::status_e::paused);
+	EXPECT_EQ(state.icon, "pausing");
+	EXPECT_EQ(state.tooltip, "Stream paused: Desktop");
+
+	tray_state::set_idle("Desktop");
+	state = tray_state::get();
+	EXPECT_EQ(state.status, tray_state::status_e::idle);
+	EXPECT_EQ(state.icon, "default");
+	EXPECT_EQ(state.tooltip, "Sunshine");
+	EXPECT_EQ(state.app_name, "Desktop");
+}
+
+TEST(TrayStateTest, SerializesPairingAndVddState) {
+	tray_state::set_idle();
+	tray_state::clear_notification();
+	tray_state::set_vdd_state(true, true, false, true);
+	tray_state::set_pairing_required("Moonlight Client");
+
+	const auto json = tray_state::to_json();
+	EXPECT_EQ(json.at("status"), "pairing");
+	EXPECT_EQ(json.at("icon"), "locked");
+	EXPECT_EQ(json.at("pairing_client_name"), "Moonlight Client");
+	EXPECT_TRUE(json.at("notification").at("active"));
+	EXPECT_GT(json.at("notification").at("id").get<std::uint64_t>(), 0);
+	EXPECT_EQ(json.at("notification").at("action"), "open_pin");
+	EXPECT_TRUE(json.at("vdd").at("active"));
+	EXPECT_TRUE(json.at("vdd").at("keep_enabled"));
+	EXPECT_FALSE(json.at("vdd").at("headless_create_enabled"));
+	EXPECT_TRUE(json.at("vdd").at("cooldown"));
+
+	tray_state::clear_pairing_required();
+	const auto restored = tray_state::to_json();
+	EXPECT_EQ(restored.at("status"), "idle");
+	EXPECT_EQ(restored.at("icon"), "default");
+	EXPECT_FALSE(restored.at("notification").at("active"));
+}
+
+TEST(TrayStateTest, PairingDoesNotDestroyStreamingState) {
+	tray_state::set_streaming("Desktop");
+	tray_state::set_pairing_required("Moonlight Client");
+
+	auto json = tray_state::to_json();
+	EXPECT_EQ(json.at("status"), "pairing");
+	EXPECT_EQ(json.at("icon"), "locked");
+
+	tray_state::set_paused("Desktop");
+	json = tray_state::to_json();
+	EXPECT_EQ(json.at("status"), "pairing");
+
+	tray_state::clear_pairing_required();
+	json = tray_state::to_json();
+	EXPECT_EQ(json.at("status"), "paused");
+	EXPECT_EQ(json.at("icon"), "pausing");
+	EXPECT_EQ(json.at("tooltip"), "Stream paused: Desktop");
+}
+
+TEST(TrayStateTest, NotificationDoesNotDestroyStreamingState) {
+	tray_state::set_streaming("Desktop");
+	tray_state::set_notification("Audio warning", "Audio device unavailable", "default");
+
+	auto json = tray_state::to_json();
+	EXPECT_EQ(json.at("status"), "notification");
+	EXPECT_EQ(json.at("tooltip"), "Audio warning");
+
+	tray_state::clear_notification();
+	json = tray_state::to_json();
+	EXPECT_EQ(json.at("status"), "streaming");
+	EXPECT_EQ(json.at("icon"), "playing");
+	EXPECT_EQ(json.at("tooltip"), "Streaming Desktop");
+}
+
+TEST(TrayStateTest, OldNotificationTimerCannotClearNewNotification) {
+	const auto old_id = tray_state::set_notification("Old", "Old notification");
+	const auto new_id = tray_state::set_notification("New", "New notification");
+
+	tray_state::clear_notification_if(old_id);
+	auto json = tray_state::to_json();
+	EXPECT_EQ(json.at("status"), "notification");
+	EXPECT_EQ(json.at("tooltip"), "New");
+
+	tray_state::clear_notification_if(new_id);
+	json = tray_state::to_json();
+	EXPECT_NE(json.at("status"), "notification");
+}
+
+TEST(TrayStateTest, PublishesStableProtocolIdentity) {
+	const auto first = tray_state::to_json();
+	const auto second = tray_state::to_json();
+
+	EXPECT_EQ(first.at("protocol_version"), tray_state::protocol_version);
+	EXPECT_FALSE(first.at("instance_id").get<std::string>().empty());
+	EXPECT_EQ(first.at("instance_id"), second.at("instance_id"));
+	EXPECT_TRUE(first.at("owner") == "gui" || first.at("owner") == "core" || first.at("owner") == "disabled");
+	EXPECT_TRUE(first.at("capabilities").is_array());
+	EXPECT_NE(
+		std::find(first.at("capabilities").begin(), first.at("capabilities").end(), "events-v1"),
+		first.at("capabilities").end());
+}
+
+TEST(TrayStateTest, PublishesChangesToTheEventSink) {
+	std::atomic<int> changes {0};
+	tray_state::set_change_sink([&changes]() {
+		++changes;
+	});
+
+	tray_state::set_idle();
+	const auto notification_id = tray_state::set_notification("Notice", "Changed");
+	tray_state::clear_notification_if(notification_id + 1);
+	EXPECT_EQ(changes.load(), 2);
+
+	tray_state::clear_notification_if(notification_id);
+	EXPECT_EQ(changes.load(), 3);
+	tray_state::set_change_sink({});
+}
+
+TEST(TrayStateTest, AcknowledgesOnlyCurrentNonPairingNotification) {
+	tray_state::clear_pairing_required();
+	const auto old_id = tray_state::set_notification("Old", "Old notification");
+	const auto current_id = tray_state::set_notification("Current", "Current notification");
+
+	EXPECT_FALSE(tray_state::acknowledge_notification(old_id));
+	EXPECT_TRUE(tray_state::to_json().at("notification").at("active"));
+	EXPECT_TRUE(tray_state::acknowledge_notification(current_id));
+	EXPECT_FALSE(tray_state::to_json().at("notification").at("active"));
+
+	tray_state::set_pairing_required("Moonlight Client");
+	const auto pairing_id = tray_state::to_json().at("notification").at("id").get<std::uint64_t>();
+	EXPECT_FALSE(tray_state::acknowledge_notification(pairing_id));
+	EXPECT_TRUE(tray_state::to_json().at("notification").at("active"));
+	tray_state::clear_pairing_required();
+}

--- a/tests/unit/test_tray_state.cpp
+++ b/tests/unit/test_tray_state.cpp
@@ -9,149 +9,171 @@
 
 #include <src/tray/tray_state.h>
 
-TEST(TrayStateTest, PublishesStreamingLifecycle) {
-	tray_state::set_idle();
-	const auto initial_revision = tray_state::get().revision;
+class TrayStateTest: public ::testing::Test {
+protected:
+  void
+  SetUp() override {
+    tray_state::set_change_sink({});
+    tray_state::clear_pairing_required();
+    tray_state::clear_notification();
+    tray_state::set_vdd_state(false, false, false, false);
+    tray_state::set_idle();
+  }
 
-	tray_state::set_streaming("Desktop");
-	auto state = tray_state::get();
-	EXPECT_EQ(state.status, tray_state::status_e::streaming);
-	EXPECT_EQ(state.icon, "playing");
-	EXPECT_EQ(state.tooltip, "Streaming Desktop");
-	EXPECT_EQ(state.app_name, "Desktop");
-	EXPECT_GT(state.revision, initial_revision);
-	EXPECT_GT(state.updated_at_ms, 0);
+  void
+  TearDown() override {
+    tray_state::set_change_sink({});
+  }
+};
 
-	tray_state::set_paused("Desktop");
-	state = tray_state::get();
-	EXPECT_EQ(state.status, tray_state::status_e::paused);
-	EXPECT_EQ(state.icon, "pausing");
-	EXPECT_EQ(state.tooltip, "Stream paused: Desktop");
+TEST_F(TrayStateTest, PublishesStreamingLifecycle) {
+  const auto initial_revision = tray_state::get().revision;
 
-	tray_state::set_idle("Desktop");
-	state = tray_state::get();
-	EXPECT_EQ(state.status, tray_state::status_e::idle);
-	EXPECT_EQ(state.icon, "default");
-	EXPECT_EQ(state.tooltip, "Sunshine");
-	EXPECT_EQ(state.app_name, "Desktop");
+  tray_state::set_streaming("Desktop");
+  auto state = tray_state::get();
+  EXPECT_EQ(state.status, tray_state::status_e::streaming);
+  EXPECT_EQ(state.icon, "playing");
+  EXPECT_EQ(state.tooltip, "Streaming Desktop");
+  EXPECT_EQ(state.app_name, "Desktop");
+  EXPECT_GT(state.revision, initial_revision);
+  EXPECT_GT(state.updated_at_ms, 0);
+
+  tray_state::set_paused("Desktop");
+  state = tray_state::get();
+  EXPECT_EQ(state.status, tray_state::status_e::paused);
+  EXPECT_EQ(state.icon, "pausing");
+  EXPECT_EQ(state.tooltip, "Stream paused: Desktop");
+
+  tray_state::set_idle("Desktop");
+  state = tray_state::get();
+  EXPECT_EQ(state.status, tray_state::status_e::idle);
+  EXPECT_EQ(state.icon, "default");
+  EXPECT_EQ(state.tooltip, "Sunshine");
+  EXPECT_EQ(state.app_name, "Desktop");
 }
 
-TEST(TrayStateTest, SerializesPairingAndVddState) {
-	tray_state::set_idle();
-	tray_state::clear_notification();
-	tray_state::set_vdd_state(true, true, false, true);
-	tray_state::set_pairing_required("Moonlight Client");
+TEST_F(TrayStateTest, SerializesPairingAndVddState) {
+  tray_state::set_vdd_state(true, true, false, true);
+  tray_state::set_pairing_required("Moonlight Client");
 
-	const auto json = tray_state::to_json();
-	EXPECT_EQ(json.at("status"), "pairing");
-	EXPECT_EQ(json.at("icon"), "locked");
-	EXPECT_EQ(json.at("pairing_client_name"), "Moonlight Client");
-	EXPECT_TRUE(json.at("notification").at("active"));
-	EXPECT_GT(json.at("notification").at("id").get<std::uint64_t>(), 0);
-	EXPECT_EQ(json.at("notification").at("action"), "open_pin");
-	EXPECT_TRUE(json.at("vdd").at("active"));
-	EXPECT_TRUE(json.at("vdd").at("keep_enabled"));
-	EXPECT_FALSE(json.at("vdd").at("headless_create_enabled"));
-	EXPECT_TRUE(json.at("vdd").at("cooldown"));
+  const auto json = tray_state::to_json();
+  EXPECT_EQ(json.at("status"), "pairing");
+  EXPECT_EQ(json.at("icon"), "locked");
+  EXPECT_EQ(json.at("pairing_client_name"), "Moonlight Client");
+  EXPECT_TRUE(json.at("notification").at("active"));
+  EXPECT_GT(json.at("notification").at("id").get<std::uint64_t>(), 0);
+  EXPECT_EQ(json.at("notification").at("action"), "open_pin");
+  EXPECT_TRUE(json.at("vdd").at("active"));
+  EXPECT_TRUE(json.at("vdd").at("keep_enabled"));
+  EXPECT_FALSE(json.at("vdd").at("headless_create_enabled"));
+  EXPECT_TRUE(json.at("vdd").at("cooldown"));
 
-	tray_state::clear_pairing_required();
-	const auto restored = tray_state::to_json();
-	EXPECT_EQ(restored.at("status"), "idle");
-	EXPECT_EQ(restored.at("icon"), "default");
-	EXPECT_FALSE(restored.at("notification").at("active"));
+  tray_state::clear_pairing_required();
+  const auto restored = tray_state::to_json();
+  EXPECT_EQ(restored.at("status"), "idle");
+  EXPECT_EQ(restored.at("icon"), "default");
+  EXPECT_FALSE(restored.at("notification").at("active"));
 }
 
-TEST(TrayStateTest, PairingDoesNotDestroyStreamingState) {
-	tray_state::set_streaming("Desktop");
-	tray_state::set_pairing_required("Moonlight Client");
+TEST_F(TrayStateTest, PairingClearsPreviousNotificationContent) {
+  tray_state::set_notification("Audio warning", "Audio device unavailable", "default");
+  tray_state::set_pairing_required("Moonlight Client");
 
-	auto json = tray_state::to_json();
-	EXPECT_EQ(json.at("status"), "pairing");
-	EXPECT_EQ(json.at("icon"), "locked");
-
-	tray_state::set_paused("Desktop");
-	json = tray_state::to_json();
-	EXPECT_EQ(json.at("status"), "pairing");
-
-	tray_state::clear_pairing_required();
-	json = tray_state::to_json();
-	EXPECT_EQ(json.at("status"), "paused");
-	EXPECT_EQ(json.at("icon"), "pausing");
-	EXPECT_EQ(json.at("tooltip"), "Stream paused: Desktop");
+  const auto notification = tray_state::to_json().at("notification");
+  EXPECT_TRUE(notification.at("title").get<std::string>().empty());
+  EXPECT_TRUE(notification.at("message").get<std::string>().empty());
+  EXPECT_EQ(notification.at("action"), "open_pin");
 }
 
-TEST(TrayStateTest, NotificationDoesNotDestroyStreamingState) {
-	tray_state::set_streaming("Desktop");
-	tray_state::set_notification("Audio warning", "Audio device unavailable", "default");
+TEST_F(TrayStateTest, PairingDoesNotDestroyStreamingState) {
+  tray_state::set_streaming("Desktop");
+  tray_state::set_pairing_required("Moonlight Client");
 
-	auto json = tray_state::to_json();
-	EXPECT_EQ(json.at("status"), "notification");
-	EXPECT_EQ(json.at("tooltip"), "Audio warning");
+  auto json = tray_state::to_json();
+  EXPECT_EQ(json.at("status"), "pairing");
+  EXPECT_EQ(json.at("icon"), "locked");
 
-	tray_state::clear_notification();
-	json = tray_state::to_json();
-	EXPECT_EQ(json.at("status"), "streaming");
-	EXPECT_EQ(json.at("icon"), "playing");
-	EXPECT_EQ(json.at("tooltip"), "Streaming Desktop");
+  tray_state::set_paused("Desktop");
+  json = tray_state::to_json();
+  EXPECT_EQ(json.at("status"), "pairing");
+
+  tray_state::clear_pairing_required();
+  json = tray_state::to_json();
+  EXPECT_EQ(json.at("status"), "paused");
+  EXPECT_EQ(json.at("icon"), "pausing");
+  EXPECT_EQ(json.at("tooltip"), "Stream paused: Desktop");
 }
 
-TEST(TrayStateTest, OldNotificationTimerCannotClearNewNotification) {
-	const auto old_id = tray_state::set_notification("Old", "Old notification");
-	const auto new_id = tray_state::set_notification("New", "New notification");
+TEST_F(TrayStateTest, NotificationDoesNotDestroyStreamingState) {
+  tray_state::set_streaming("Desktop");
+  tray_state::set_notification("Audio warning", "Audio device unavailable", "default");
 
-	tray_state::clear_notification_if(old_id);
-	auto json = tray_state::to_json();
-	EXPECT_EQ(json.at("status"), "notification");
-	EXPECT_EQ(json.at("tooltip"), "New");
+  auto json = tray_state::to_json();
+  EXPECT_EQ(json.at("status"), "notification");
+  EXPECT_EQ(json.at("tooltip"), "Audio warning");
 
-	tray_state::clear_notification_if(new_id);
-	json = tray_state::to_json();
-	EXPECT_NE(json.at("status"), "notification");
+  tray_state::clear_notification();
+  json = tray_state::to_json();
+  EXPECT_EQ(json.at("status"), "streaming");
+  EXPECT_EQ(json.at("icon"), "playing");
+  EXPECT_EQ(json.at("tooltip"), "Streaming Desktop");
 }
 
-TEST(TrayStateTest, PublishesStableProtocolIdentity) {
-	const auto first = tray_state::to_json();
-	const auto second = tray_state::to_json();
+TEST_F(TrayStateTest, OldNotificationTimerCannotClearNewNotification) {
+  const auto old_id = tray_state::set_notification("Old", "Old notification");
+  const auto new_id = tray_state::set_notification("New", "New notification");
 
-	EXPECT_EQ(first.at("protocol_version"), tray_state::protocol_version);
-	EXPECT_FALSE(first.at("instance_id").get<std::string>().empty());
-	EXPECT_EQ(first.at("instance_id"), second.at("instance_id"));
-	EXPECT_TRUE(first.at("owner") == "gui" || first.at("owner") == "core" || first.at("owner") == "disabled");
-	EXPECT_TRUE(first.at("capabilities").is_array());
-	EXPECT_NE(
-		std::find(first.at("capabilities").begin(), first.at("capabilities").end(), "events-v1"),
-		first.at("capabilities").end());
+  tray_state::clear_notification_if(old_id);
+  auto json = tray_state::to_json();
+  EXPECT_EQ(json.at("status"), "notification");
+  EXPECT_EQ(json.at("tooltip"), "New");
+
+  tray_state::clear_notification_if(new_id);
+  json = tray_state::to_json();
+  EXPECT_NE(json.at("status"), "notification");
 }
 
-TEST(TrayStateTest, PublishesChangesToTheEventSink) {
-	std::atomic<int> changes {0};
-	tray_state::set_change_sink([&changes]() {
-		++changes;
-	});
+TEST_F(TrayStateTest, PublishesStableProtocolIdentity) {
+  const auto first = tray_state::to_json();
+  const auto second = tray_state::to_json();
 
-	tray_state::set_idle();
-	const auto notification_id = tray_state::set_notification("Notice", "Changed");
-	tray_state::clear_notification_if(notification_id + 1);
-	EXPECT_EQ(changes.load(), 2);
-
-	tray_state::clear_notification_if(notification_id);
-	EXPECT_EQ(changes.load(), 3);
-	tray_state::set_change_sink({});
+  EXPECT_EQ(first.at("protocol_version"), tray_state::protocol_version);
+  EXPECT_FALSE(first.at("instance_id").get<std::string>().empty());
+  EXPECT_EQ(first.at("instance_id"), second.at("instance_id"));
+  EXPECT_TRUE(first.at("owner") == "gui" || first.at("owner") == "core" || first.at("owner") == "disabled");
+  EXPECT_TRUE(first.at("capabilities").is_array());
+  EXPECT_NE(
+    std::find(first.at("capabilities").begin(), first.at("capabilities").end(), "events-v1"),
+    first.at("capabilities").end());
 }
 
-TEST(TrayStateTest, AcknowledgesOnlyCurrentNonPairingNotification) {
-	tray_state::clear_pairing_required();
-	const auto old_id = tray_state::set_notification("Old", "Old notification");
-	const auto current_id = tray_state::set_notification("Current", "Current notification");
+TEST_F(TrayStateTest, PublishesChangesToTheEventSink) {
+  std::atomic<int> changes { 0 };
+  tray_state::set_change_sink([&changes]() {
+    ++changes;
+  });
 
-	EXPECT_FALSE(tray_state::acknowledge_notification(old_id));
-	EXPECT_TRUE(tray_state::to_json().at("notification").at("active"));
-	EXPECT_TRUE(tray_state::acknowledge_notification(current_id));
-	EXPECT_FALSE(tray_state::to_json().at("notification").at("active"));
+  tray_state::set_idle();
+  const auto notification_id = tray_state::set_notification("Notice", "Changed");
+  tray_state::clear_notification_if(notification_id + 1);
+  EXPECT_EQ(changes.load(), 2);
 
-	tray_state::set_pairing_required("Moonlight Client");
-	const auto pairing_id = tray_state::to_json().at("notification").at("id").get<std::uint64_t>();
-	EXPECT_FALSE(tray_state::acknowledge_notification(pairing_id));
-	EXPECT_TRUE(tray_state::to_json().at("notification").at("active"));
-	tray_state::clear_pairing_required();
+  tray_state::clear_notification_if(notification_id);
+  EXPECT_EQ(changes.load(), 3);
+}
+
+TEST_F(TrayStateTest, AcknowledgesOnlyCurrentNonPairingNotification) {
+  const auto old_id = tray_state::set_notification("Old", "Old notification");
+  const auto current_id = tray_state::set_notification("Current", "Current notification");
+
+  EXPECT_FALSE(tray_state::acknowledge_notification(old_id));
+  EXPECT_TRUE(tray_state::to_json().at("notification").at("active"));
+  EXPECT_TRUE(tray_state::acknowledge_notification(current_id));
+  EXPECT_FALSE(tray_state::to_json().at("notification").at("active"));
+
+  tray_state::set_pairing_required("Moonlight Client");
+  const auto pairing_id = tray_state::to_json().at("notification").at("id").get<std::uint64_t>();
+  EXPECT_FALSE(tray_state::acknowledge_notification(pairing_id));
+  EXPECT_TRUE(tray_state::to_json().at("notification").at("active"));
+  tray_state::clear_pairing_required();
 }

--- a/tests/unit/test_tray_state.cpp
+++ b/tests/unit/test_tray_state.cpp
@@ -17,6 +17,9 @@ protected:
     tray_state::clear_pairing_required();
     tray_state::clear_notification();
     tray_state::set_vdd_state(false, false, false, false);
+    const auto operation_id = tray_state::begin_operation("test_reset");
+    tray_state::complete_operation(operation_id, true);
+    tray_state::clear_provider();
     tray_state::set_idle();
   }
 
@@ -160,6 +163,33 @@ TEST_F(TrayStateTest, PublishesChangesToTheEventSink) {
 
   tray_state::clear_notification_if(notification_id);
   EXPECT_EQ(changes.load(), 3);
+}
+
+TEST_F(TrayStateTest, PublishesAsynchronousOperationLifecycle) {
+  const auto operation_id = tray_state::begin_operation("vdd_create");
+  auto operation = tray_state::to_json().at("operation");
+  EXPECT_EQ(operation.at("id"), operation_id);
+  EXPECT_EQ(operation.at("action"), "vdd_create");
+  EXPECT_EQ(operation.at("state"), "running");
+
+  tray_state::complete_operation(operation_id + 1, false, {}, "stale");
+  EXPECT_EQ(tray_state::to_json().at("operation").at("state"), "running");
+
+  tray_state::complete_operation(operation_id, false, {}, "create failed");
+  operation = tray_state::to_json().at("operation");
+  EXPECT_EQ(operation.at("state"), "failed");
+  EXPECT_EQ(operation.at("error"), "create failed");
+}
+
+TEST_F(TrayStateTest, PublishesProviderWithoutLeaseSecret) {
+  tray_state::set_provider("sunshine.gui.tauri", "0.3.41");
+  const auto json = tray_state::to_json();
+  EXPECT_TRUE(json.at("provider").at("active"));
+  EXPECT_EQ(json.at("provider").at("id"), "sunshine.gui.tauri");
+  EXPECT_FALSE(json.at("provider").contains("lease_id"));
+
+  tray_state::clear_provider();
+  EXPECT_FALSE(tray_state::to_json().at("provider").at("active"));
 }
 
 TEST_F(TrayStateTest, AcknowledgesOnlyCurrentNonPairingNotification) {

--- a/tests/unit/test_tray_state.cpp
+++ b/tests/unit/test_tray_state.cpp
@@ -17,6 +17,7 @@ protected:
     tray_state::clear_pairing_required();
     tray_state::clear_notification();
     tray_state::set_vdd_state(false, false, false, false);
+    tray_state::set_vdd_confirmation(false);
     const auto operation_id = tray_state::begin_operation("test_reset");
     tray_state::complete_operation(operation_id, true);
     tray_state::set_idle();
@@ -56,6 +57,7 @@ TEST_F(TrayStateTest, PublishesStreamingLifecycle) {
 
 TEST_F(TrayStateTest, SerializesPairingAndVddState) {
   tray_state::set_vdd_state(true, true, false, true);
+  tray_state::set_vdd_confirmation(true, 42);
   tray_state::set_pairing_required("Moonlight Client");
 
   const auto json = tray_state::to_json();
@@ -69,6 +71,13 @@ TEST_F(TrayStateTest, SerializesPairingAndVddState) {
   EXPECT_TRUE(json.at("vdd").at("keep_enabled"));
   EXPECT_FALSE(json.at("vdd").at("headless_create_enabled"));
   EXPECT_TRUE(json.at("vdd").at("cooldown"));
+  EXPECT_TRUE(json.at("vdd").at("awaiting_confirmation"));
+  EXPECT_EQ(json.at("vdd").at("confirmation_operation_id"), 42);
+
+  tray_state::set_vdd_confirmation(false);
+  const auto cleared_vdd = tray_state::to_json().at("vdd");
+  EXPECT_FALSE(cleared_vdd.at("awaiting_confirmation"));
+  EXPECT_EQ(cleared_vdd.at("confirmation_operation_id"), 0);
 
   tray_state::clear_pairing_required();
   const auto restored = tray_state::to_json();

--- a/tests/unit/test_tray_state.cpp
+++ b/tests/unit/test_tray_state.cpp
@@ -19,7 +19,6 @@ protected:
     tray_state::set_vdd_state(false, false, false, false);
     const auto operation_id = tray_state::begin_operation("test_reset");
     tray_state::complete_operation(operation_id, true);
-    tray_state::clear_provider();
     tray_state::set_idle();
   }
 
@@ -179,17 +178,6 @@ TEST_F(TrayStateTest, PublishesAsynchronousOperationLifecycle) {
   operation = tray_state::to_json().at("operation");
   EXPECT_EQ(operation.at("state"), "failed");
   EXPECT_EQ(operation.at("error"), "create failed");
-}
-
-TEST_F(TrayStateTest, PublishesProviderWithoutLeaseSecret) {
-  tray_state::set_provider("sunshine.gui.tauri", "0.3.41");
-  const auto json = tray_state::to_json();
-  EXPECT_TRUE(json.at("provider").at("active"));
-  EXPECT_EQ(json.at("provider").at("id"), "sunshine.gui.tauri");
-  EXPECT_FALSE(json.at("provider").contains("lease_id"));
-
-  tray_state::clear_provider();
-  EXPECT_FALSE(tray_state::to_json().at("provider").at("active"));
 }
 
 TEST_F(TrayStateTest, AcknowledgesOnlyCurrentNonPairingNotification) {


### PR DESCRIPTION
## 改了啥呀

- Core 新增版本化 tray state、SSE 事件流、通知确认和配对动作协议
- 把原 C++ tray 移到独立目录并降级为显式 legacy fallback
- 默认由 GUI 用户会话 Agent 独占托盘，消除双图标与退出语义冲突
- Windows 打包将 GUI/Tray Agent 设为必需组件，并固定 GUI 获取策略
- 增加聚焦的 tray 协议单元测试和 CI 执行入口
- 更新 GUI 子模块到 qiin2333/sunshine-control-panel#54

## 为啥要改

旧实现让 Core 和 GUI 都有机会抢托盘所有权，杂鱼状态一多就会出现两个图标、一个点不动、菜单功能分叉。现在 Core 负责状态和命令，GUI 负责用户会话交互，旧 C++ 托盘只作为明确选择的兼容路径。

## 验证

- `cmake --build build -j4`
- `ctest --test-dir build -R tray_state --output-on-failure`（1 passed）
- GUI 前端生产构建通过
- GUI Rust 测试 34 passed
- 本机安装验证：单托盘 Agent、Core 服务运行、协议事件连接稳定