### PR TITLE
fix(rtsp): authenticate concurrent launch tickets

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -149,6 +149,8 @@ set(SUNSHINE_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/abr.h"
         "${CMAKE_SOURCE_DIR}/src/httpcommon.cpp"
         "${CMAKE_SOURCE_DIR}/src/httpcommon.h"
+        "${CMAKE_SOURCE_DIR}/src/launch_session_manager.cpp"
+        "${CMAKE_SOURCE_DIR}/src/launch_session_manager.h"
         "${CMAKE_SOURCE_DIR}/src/perf_recorder.cpp"
         "${CMAKE_SOURCE_DIR}/src/perf_recorder.h"
         "${CMAKE_SOURCE_DIR}/src/confighttp.cpp"

--- a/docs/rtsp_launch_ticket_manager.md
+++ b/docs/rtsp_launch_ticket_manager.md
@@ -1,0 +1,55 @@
+# RTSP launch ticket manager
+
+Sunshine separates the HTTPS launch transaction from the later RTSP setup.
+The launch ticket manager is the single owner of state between those two
+protocol phases.
+
+## Lifecycle
+
+```text
+/launch or /resume
+        |
+        v
+     pending  -- first RTSP request authenticated --> claimed
+        ^                                         |
+        |---- request socket closes before ANNOUNCE|
+                                                  v
+                           successful ANNOUNCE --> active stream
+                                                  (ticket removed)
+```
+
+Both `pending` and `claimed` tickets expire. A claimed ticket is released back
+to `pending` when an RTSP request socket closes before the stream is activated.
+This is required because GameStream uses a separate TCP connection for each
+RTSP request.
+
+## Identity and compatibility
+
+- Encrypted RTSP is claimed by successfully verifying the first request's
+  AES-GCM authentication tag. The HTTPS and RTSP source addresses are only a
+  candidate-order hint and are not identity.
+- Plaintext legacy RTSP is matched by a unique observed source address.
+- The historical single-pending-ticket fallback remains for legacy clients
+  whose HTTPS and RTSP routes differ.
+- Multiple plaintext candidates behind the same visible address fail closed;
+  Sunshine never guesses and risks attaching one client's keys to another.
+
+## Transaction invariant
+
+`/launch` and `/resume` return success only after a ticket has been accepted by
+the bounded registry. If registration fails, the endpoint returns an explicit
+busy/capacity response. An application started solely for a failed `/launch`
+transaction is rolled back.
+
+## Resource bounds
+
+The registry has a fixed global pending-ticket limit and a per-client/legacy
+peer limit. Ticket expiration bounds registry lifetime, while each accepted
+RTSP socket has an initial-handshake deadline to prevent idle connections from
+holding resources indefinitely.
+
+## Operational signal
+
+The local sessions API reports `pending_sessions` separately from active stream
+sessions. A healthy launch normally moves from one pending ticket to an active
+session within one RTSP handshake interval.

--- a/src/launch_session_manager.cpp
+++ b/src/launch_session_manager.cpp
@@ -47,7 +47,8 @@ namespace rtsp_stream {
     void
     prune_locked(clock_t::time_point now) {
       tickets.erase(std::remove_if(tickets.begin(), tickets.end(), [now](const auto &ticket) {
-                      return !ticket.session || now >= ticket.expires_at;
+                      return !ticket.session ||
+                             (ticket.state == launch_ticket_state_e::pending && now >= ticket.expires_at);
                     }),
                     tickets.end());
     }

--- a/src/launch_session_manager.cpp
+++ b/src/launch_session_manager.cpp
@@ -1,0 +1,264 @@
+/**
+ * @file src/launch_session_manager.cpp
+ * @brief Bounded lifecycle manager for pending GameStream launch tickets.
+ */
+
+#include "launch_session_manager.h"
+
+#include <algorithm>
+#include <mutex>
+#include <utility>
+
+#include "rtsp.h"
+
+namespace rtsp_stream {
+  namespace {
+    struct launch_ticket_t {
+      std::shared_ptr<launch_session_t> session;
+      launch_ticket_state_e state { launch_ticket_state_e::pending };
+      launch_session_manager_t::clock_t::time_point expires_at;
+    };
+
+    bool
+    same_authenticated_client(const launch_ticket_t &ticket, const launch_session_t &session) {
+      return ticket.session &&
+             !session.client_cert_uuid.empty() &&
+             ticket.session->client_cert_uuid == session.client_cert_uuid;
+    }
+
+    bool
+    same_legacy_client(const launch_ticket_t &ticket, const launch_session_t &session) {
+      return ticket.session &&
+             ticket.session->client_cert_uuid.empty() &&
+             session.client_cert_uuid.empty() &&
+             !session.unique_id.empty() &&
+             session.unique_id != "unknown" &&
+             ticket.session->unique_id == session.unique_id &&
+             ticket.session->rtsp_peer_address == session.rtsp_peer_address;
+    }
+  }  // namespace
+
+  struct launch_session_manager_t::impl_t {
+    explicit impl_t(std::size_t global_limit, std::size_t per_client_limit):
+        global_limit { std::max<std::size_t>(1, global_limit) },
+        per_client_limit { std::max<std::size_t>(1, per_client_limit) } {
+    }
+
+    void
+    prune_locked(clock_t::time_point now) {
+      tickets.erase(std::remove_if(tickets.begin(), tickets.end(), [now](const auto &ticket) {
+                      return !ticket.session || now >= ticket.expires_at;
+                    }),
+                    tickets.end());
+    }
+
+    std::mutex mutex;
+    std::vector<launch_ticket_t> tickets;
+    std::size_t global_limit;
+    std::size_t per_client_limit;
+  };
+
+  launch_session_manager_t::launch_session_manager_t(std::size_t global_limit, std::size_t per_client_limit):
+      _impl { std::make_unique<impl_t>(global_limit, per_client_limit) } {
+  }
+
+  launch_session_manager_t::~launch_session_manager_t() = default;
+
+  launch_ticket_register_e
+  launch_session_manager_t::register_session(std::shared_ptr<launch_session_t> session,
+                                             std::chrono::milliseconds timeout,
+                                             clock_t::time_point now) {
+    if (!session) {
+      return launch_ticket_register_e::global_limit;
+    }
+
+    std::lock_guard lock { _impl->mutex };
+    _impl->prune_locked(now);
+
+    if (!session->client_cert_uuid.empty() || (!session->unique_id.empty() && session->unique_id != "unknown")) {
+      auto same_client = std::find_if(_impl->tickets.begin(), _impl->tickets.end(), [&session](const auto &ticket) {
+        return same_authenticated_client(ticket, *session) || same_legacy_client(ticket, *session);
+      });
+      if (same_client != _impl->tickets.end()) {
+        if (same_client->state == launch_ticket_state_e::claimed) {
+          return launch_ticket_register_e::client_busy;
+        }
+
+        same_client->session = std::move(session);
+        same_client->state = launch_ticket_state_e::pending;
+        same_client->expires_at = now + timeout;
+        return launch_ticket_register_e::replaced;
+      }
+
+    }
+    if (session->client_cert_uuid.empty() && !session->rtsp_peer_address.empty()) {
+      const auto peer_count = std::count_if(_impl->tickets.begin(), _impl->tickets.end(), [&session](const auto &ticket) {
+        return ticket.session && ticket.session->client_cert_uuid.empty() &&
+               ticket.session->rtsp_peer_address == session->rtsp_peer_address;
+      });
+      if (static_cast<std::size_t>(peer_count) >= _impl->per_client_limit) {
+        return launch_ticket_register_e::client_limit;
+      }
+    }
+
+    if (_impl->tickets.size() >= _impl->global_limit) {
+      return launch_ticket_register_e::global_limit;
+    }
+
+    _impl->tickets.push_back({
+      .session = std::move(session),
+      .state = launch_ticket_state_e::pending,
+      .expires_at = now + timeout,
+    });
+    return launch_ticket_register_e::accepted;
+  }
+
+  std::shared_ptr<launch_session_t>
+  launch_session_manager_t::claim_plaintext(std::string_view remote_address, clock_t::time_point now) {
+    std::lock_guard lock { _impl->mutex };
+    _impl->prune_locked(now);
+
+    launch_ticket_t *match = nullptr;
+    if (!remote_address.empty()) {
+      for (auto &ticket : _impl->tickets) {
+        if (ticket.state != launch_ticket_state_e::pending ||
+            !ticket.session ||
+            ticket.session->rtsp_cipher ||
+            ticket.session->rtsp_peer_address != remote_address) {
+          continue;
+        }
+        if (match) {
+          return nullptr;
+        }
+        match = &ticket;
+      }
+    }
+
+    if (!match) {
+      auto only_pending = static_cast<launch_ticket_t *>(nullptr);
+      for (auto &ticket : _impl->tickets) {
+        if (ticket.state != launch_ticket_state_e::pending || !ticket.session || ticket.session->rtsp_cipher) {
+          continue;
+        }
+        if (only_pending) {
+          return nullptr;
+        }
+        only_pending = &ticket;
+      }
+      match = only_pending;
+    }
+
+    if (!match) {
+      return nullptr;
+    }
+
+    match->state = launch_ticket_state_e::claimed;
+    return match->session;
+  }
+
+  encrypted_launch_claim_t
+  launch_session_manager_t::claim_encrypted(std::string_view remote_address,
+                                            std::string_view tagged_cipher,
+                                            crypto::aes_t iv,
+                                            clock_t::time_point now) {
+    std::lock_guard lock { _impl->mutex };
+    _impl->prune_locked(now);
+
+    launch_ticket_t *match = nullptr;
+    std::vector<std::uint8_t> matched_plaintext;
+
+    // Route-matching candidates are attempted first for efficiency, but the
+    // GCM authentication tag remains the sole identity decision.
+    for (int route_pass = 0; route_pass < 2; ++route_pass) {
+      for (auto &ticket : _impl->tickets) {
+        if (ticket.state != launch_ticket_state_e::pending ||
+            !ticket.session ||
+            !ticket.session->rtsp_cipher) {
+          continue;
+        }
+
+        const bool route_matches = !remote_address.empty() && ticket.session->rtsp_peer_address == remote_address;
+        if ((route_pass == 0) != route_matches) {
+          continue;
+        }
+
+        std::vector<std::uint8_t> plaintext;
+        auto candidate_iv = iv;
+        if (ticket.session->rtsp_cipher->decrypt(tagged_cipher, plaintext, &candidate_iv) != 0) {
+          continue;
+        }
+
+        if (match) {
+          // Reused keys would make the claim ambiguous. Fail closed.
+          return {};
+        }
+        match = &ticket;
+        matched_plaintext = std::move(plaintext);
+      }
+    }
+
+    if (!match) {
+      return {};
+    }
+
+    match->state = launch_ticket_state_e::claimed;
+    return {
+      .session = match->session,
+      .plaintext = std::move(matched_plaintext),
+    };
+  }
+
+  bool
+  launch_session_manager_t::activate(std::uint32_t launch_session_id) {
+    return erase(launch_session_id);
+  }
+
+  bool
+  launch_session_manager_t::release(std::uint32_t launch_session_id,
+                                    std::chrono::milliseconds timeout,
+                                    clock_t::time_point now) {
+    std::lock_guard lock { _impl->mutex };
+    auto ticket = std::find_if(_impl->tickets.begin(), _impl->tickets.end(), [launch_session_id](const auto &entry) {
+      return entry.session && entry.session->id == launch_session_id;
+    });
+    if (ticket == _impl->tickets.end() || ticket->state != launch_ticket_state_e::claimed) {
+      return false;
+    }
+
+    ticket->state = launch_ticket_state_e::pending;
+    ticket->expires_at = now + timeout;
+    return true;
+  }
+
+  bool
+  launch_session_manager_t::erase(std::uint32_t launch_session_id) {
+    std::lock_guard lock { _impl->mutex };
+    const auto old_size = _impl->tickets.size();
+    std::erase_if(_impl->tickets, [launch_session_id](const auto &ticket) {
+      return ticket.session && ticket.session->id == launch_session_id;
+    });
+    return _impl->tickets.size() != old_size;
+  }
+
+  std::size_t
+  launch_session_manager_t::prune(clock_t::time_point now) {
+    std::lock_guard lock { _impl->mutex };
+    const auto old_size = _impl->tickets.size();
+    _impl->prune_locked(now);
+    return old_size - _impl->tickets.size();
+  }
+
+  void
+  launch_session_manager_t::clear() {
+    std::lock_guard lock { _impl->mutex };
+    _impl->tickets.clear();
+  }
+
+  std::size_t
+  launch_session_manager_t::size(clock_t::time_point now) {
+    std::lock_guard lock { _impl->mutex };
+    _impl->prune_locked(now);
+    return _impl->tickets.size();
+  }
+
+}  // namespace rtsp_stream

--- a/src/launch_session_manager.h
+++ b/src/launch_session_manager.h
@@ -1,0 +1,97 @@
+/**
+ * @file src/launch_session_manager.h
+ * @brief Bounded lifecycle manager for pending GameStream launch tickets.
+ */
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "crypto.h"
+
+namespace rtsp_stream {
+  struct launch_session_t;
+
+  constexpr std::size_t DEFAULT_PENDING_LAUNCH_LIMIT = 16;
+  constexpr std::size_t DEFAULT_PENDING_LAUNCH_LIMIT_PER_CLIENT = 2;
+
+  enum class launch_ticket_state_e {
+    pending,
+    claimed,
+  };
+
+  enum class launch_ticket_register_e {
+    accepted,
+    replaced,
+    global_limit,
+    client_limit,
+    client_busy,
+  };
+
+  struct encrypted_launch_claim_t {
+    std::shared_ptr<launch_session_t> session;
+    std::vector<std::uint8_t> plaintext;
+
+    explicit operator bool() const noexcept {
+      return session != nullptr;
+    }
+  };
+
+  class launch_session_manager_t {
+  public:
+    using clock_t = std::chrono::steady_clock;
+
+    explicit launch_session_manager_t(
+      std::size_t global_limit = DEFAULT_PENDING_LAUNCH_LIMIT,
+      std::size_t per_client_limit = DEFAULT_PENDING_LAUNCH_LIMIT_PER_CLIENT);
+    ~launch_session_manager_t();
+
+    launch_session_manager_t(const launch_session_manager_t &) = delete;
+    launch_session_manager_t &
+    operator=(const launch_session_manager_t &) = delete;
+
+    launch_ticket_register_e
+    register_session(std::shared_ptr<launch_session_t> session,
+                     std::chrono::milliseconds timeout,
+                     clock_t::time_point now = clock_t::now());
+
+    std::shared_ptr<launch_session_t>
+    claim_plaintext(std::string_view remote_address,
+                    clock_t::time_point now = clock_t::now());
+
+    encrypted_launch_claim_t
+    claim_encrypted(std::string_view remote_address,
+                    std::string_view tagged_cipher,
+                    crypto::aes_t iv,
+                    clock_t::time_point now = clock_t::now());
+
+    bool
+    activate(std::uint32_t launch_session_id);
+
+    bool
+    release(std::uint32_t launch_session_id,
+            std::chrono::milliseconds timeout,
+            clock_t::time_point now = clock_t::now());
+
+    bool
+    erase(std::uint32_t launch_session_id);
+
+    std::size_t
+    prune(clock_t::time_point now = clock_t::now());
+
+    void
+    clear();
+
+    std::size_t
+    size(clock_t::time_point now = clock_t::now());
+
+  private:
+    struct impl_t;
+    std::unique_ptr<impl_t> _impl;
+  };
+}  // namespace rtsp_stream

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -345,6 +345,27 @@ namespace nvhttp {
     return launch_session;
   }
 
+  bool
+  register_launch_ticket(pt::ptree &tree,
+                         const std::shared_ptr<rtsp_stream::launch_session_t> &launch_session,
+                         std::string_view result_node) {
+    const auto result = rtsp_stream::launch_session_raise(launch_session);
+    if (result == rtsp_stream::launch_ticket_register_e::accepted ||
+        result == rtsp_stream::launch_ticket_register_e::replaced) {
+      return true;
+    }
+
+    const auto busy = result == rtsp_stream::launch_ticket_register_e::client_busy;
+    tree.put("root.<xmlattr>.status_code", busy ? 409 : 503);
+    tree.put("root.<xmlattr>.status_message",
+             busy ? "A streaming handshake is already in progress for this client" :
+                    "The host has no capacity for another pending streaming handshake");
+    tree.put(std::string { "root." } + std::string { result_node }, 0);
+    BOOST_LOG(warning) << "Unable to register RTSP launch ticket for client "sv
+                       << launch_session->client_name << ": result="sv << static_cast<int>(result);
+    return false;
+  }
+
   template <class T>
   struct tunnel;
 
@@ -594,10 +615,12 @@ namespace nvhttp {
 
     host_audio = util::from_view(get_arg(args, "localAudioPlayMode"));
     const auto launch_session = make_launch_session(host_audio, args);
+    launch_session->rtsp_peer_address = net::addr_to_normalized_string(request->remote_endpoint().address());
 
     // Store the stable client certificate UUID in the launch environment.
     std::string client_cert_uuid = get_client_cert_uuid_from_request(request);
     if (!client_cert_uuid.empty()) {
+      launch_session->client_cert_uuid = client_cert_uuid;
       launch_session->env["SUNSHINE_CLIENT_CERT_UUID"] = client_cert_uuid;
     }
 
@@ -637,13 +660,20 @@ namespace nvhttp {
       }
     }
 
+    if (!register_launch_ticket(tree, launch_session, "gamesession")) {
+      // The application was started solely for this launch request. Roll it
+      // back if the bounded ticket registry cannot publish the handshake.
+      if (appid > 0 && proc::proc.running() == appid) {
+        proc::proc.terminate();
+      }
+      return;
+    }
+
     tree.put("root.<xmlattr>.status_code", 200);
     tree.put("root.sessionUrl0", launch_session->rtsp_url_scheme +
                                    net::addr_to_url_escaped_string(request->local_endpoint().address()) + ':' +
                                    std::to_string(net::map_port(rtsp_stream::RTSP_SETUP_PORT)));
     tree.put("root.gamesession", 1);
-
-    rtsp_stream::launch_session_raise(launch_session);
 
     // Send webhook notification for successful launch
     webhook::send_event_async(webhook::event_t {
@@ -678,6 +708,7 @@ namespace nvhttp {
     }
 
     pt::ptree tree;
+    bool need_to_restore_display_state { false };
     auto g = util::fail_guard([&]() {
       std::ostringstream data;
 
@@ -688,6 +719,10 @@ namespace nvhttp {
       pt::write_xml(data, tree);
       response->write(data.str());
       response->close_connection_after_response = true;
+
+      if (need_to_restore_display_state) {
+        display_device::session_t::get().restore_state();
+      }
     });
 
     auto current_appid = proc::proc.running();
@@ -726,31 +761,37 @@ namespace nvhttp {
       host_audio = util::from_view(get_arg(args, "localAudioPlayMode"));
     }
     const auto launch_session = make_launch_session(host_audio, args);
+    launch_session->rtsp_peer_address = net::addr_to_normalized_string(request->remote_endpoint().address());
 
     // Get client certificate UUID (stable client identifier) and store it in env
     std::string client_cert_uuid = get_client_cert_uuid_from_request(request);
     if (!client_cert_uuid.empty()) {
+      launch_session->client_cert_uuid = client_cert_uuid;
       launch_session->env["SUNSHINE_CLIENT_CERT_UUID"] = client_cert_uuid;
     }
 
     if (no_active_sessions) {
-      // We want to prepare display only if there are no active sessions at
-      // the moment. This should be done before probing encoders as it could
-      // change the active displays.
+      // Prepare before publishing the ticket so the handshake expiration
+      // window starts only when the host is ready to accept RTSP.
       if (!stream_start::prepare_display_and_probe_encoders(tree, *launch_session, false)) {
         tree.put("root.resume", 0);
-
         return;
       }
+      need_to_restore_display_state = true;
     }
+
     auto encryption_mode = net::encryption_mode_for_address(request->remote_endpoint().address());
     if (!launch_session->rtsp_cipher && encryption_mode == config::ENCRYPTION_MODE_MANDATORY) {
       BOOST_LOG(error) << "Rejecting client that cannot comply with mandatory encryption requirement"sv;
 
       tree.put("root.<xmlattr>.status_code", 403);
       tree.put("root.<xmlattr>.status_message", "Encryption is mandatory for this host but unsupported by the client");
-      tree.put("root.gamesession", 0);
+      tree.put("root.resume", 0);
 
+      return;
+    }
+
+    if (!register_launch_ticket(tree, launch_session, "resume")) {
       return;
     }
 
@@ -759,8 +800,7 @@ namespace nvhttp {
                                    net::addr_to_url_escaped_string(request->local_endpoint().address()) + ':' +
                                    std::to_string(net::map_port(rtsp_stream::RTSP_SETUP_PORT)));
     tree.put("root.resume", 1);
-
-    rtsp_stream::launch_session_raise(launch_session);
+    need_to_restore_display_state = false;
 
     // Send webhook notification for successful resume
     webhook::send_event_async(webhook::event_t {

--- a/src/nvhttp/sessions.cpp
+++ b/src/nvhttp/sessions.cpp
@@ -59,6 +59,7 @@ namespace nvhttp::sessions {
       response_json["status_code"] = 200;
       response_json["status_message"] = "Success";
       response_json["total_sessions"] = sessions_info.size();
+      response_json["pending_sessions"] = rtsp_stream::pending_session_count();
 
       json sessions_array = json::array();
 

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -14,6 +14,7 @@ extern "C" {
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <cstring>
 #include <set>
 #include <unordered_map>
 #include <utility>
@@ -193,9 +194,101 @@ namespace rtsp_stream {
 
   class socket_t: public std::enable_shared_from_this<socket_t> {
   public:
-    socket_t(boost::asio::io_context &io_context, std::function<void(tcp::socket &sock, launch_session_t &, msg_t &&)> &&handle_data_fn):
+    using claim_plaintext_fn_t = std::function<std::shared_ptr<launch_session_t>(std::string_view)>;
+    using claim_encrypted_fn_t = std::function<encrypted_launch_claim_t(std::string_view, std::string_view, crypto::aes_t)>;
+    using release_claim_fn_t = std::function<void(std::uint32_t)>;
+
+    socket_t(boost::asio::io_context &io_context,
+             std::function<void(tcp::socket &sock, launch_session_t &, msg_t &&)> &&handle_data_fn,
+             claim_plaintext_fn_t &&claim_plaintext_fn,
+             claim_encrypted_fn_t &&claim_encrypted_fn,
+             release_claim_fn_t &&release_claim_fn):
         handle_data_fn { std::move(handle_data_fn) },
-        sock { io_context } {
+        claim_plaintext_fn { std::move(claim_plaintext_fn) },
+        claim_encrypted_fn { std::move(claim_encrypted_fn) },
+        release_claim_fn { std::move(release_claim_fn) },
+        sock { io_context },
+        handshake_timer { io_context } {
+    }
+
+    ~socket_t() {
+      if (session && release_claim_fn) {
+        release_claim_fn(session->id);
+      }
+    }
+
+    void
+    start(std::string remote, std::chrono::milliseconds timeout) {
+      remote_address = std::move(remote);
+      handshake_timer.expires_after(timeout);
+      handshake_timer.async_wait([socket = shared_from_this()](const boost::system::error_code &ec) {
+        if (ec == boost::asio::error::operation_aborted) {
+          return;
+        }
+        BOOST_LOG(debug) << "RTSP initial handshake timeout for peer "sv << socket->remote_address;
+        boost::system::error_code close_ec;
+        socket->sock.close(close_ec);
+      });
+      boost::asio::async_read(
+        sock,
+        boost::asio::buffer(&initial_type_and_length, sizeof(initial_type_and_length)),
+        boost::bind(&socket_t::handle_initial_read,
+                    shared_from_this(),
+                    boost::asio::placeholders::error,
+                    boost::asio::placeholders::bytes_transferred));
+    }
+
+    static void
+    handle_initial_read(std::shared_ptr<socket_t> &socket, const boost::system::error_code &ec, std::size_t bytes) {
+      if (ec || bytes < sizeof(socket->initial_type_and_length)) {
+        BOOST_LOG(debug) << "RTSP: unable to inspect initial message: "sv << ec.message();
+        boost::system::error_code close_ec;
+        socket->sock.close(close_ec);
+        return;
+      }
+
+      const auto initial = util::endian::big<std::uint32_t>(socket->initial_type_and_length);
+      if ((initial & encrypted_rtsp_header_t::ENCRYPTED_MESSAGE_TYPE_BIT) != 0) {
+        std::memcpy(socket->begin, &socket->initial_type_and_length, sizeof(socket->initial_type_and_length));
+        boost::asio::async_read(
+          socket->sock,
+          boost::asio::buffer(socket->begin + sizeof(socket->initial_type_and_length),
+                              sizeof(encrypted_rtsp_header_t) - sizeof(socket->initial_type_and_length)),
+          boost::bind(&socket_t::handle_initial_encrypted_header_rest,
+                      socket->shared_from_this(),
+                      boost::asio::placeholders::error,
+                      boost::asio::placeholders::bytes_transferred));
+        return;
+      }
+
+      socket->session = socket->claim_plaintext_fn(socket->remote_address);
+      if (!socket->session) {
+        BOOST_LOG(debug) << "No unambiguous plaintext RTSP launch ticket for peer "sv << socket->remote_address;
+        boost::system::error_code close_ec;
+        socket->sock.close(close_ec);
+        return;
+      }
+      std::memcpy(socket->msg_buf.data(), &socket->initial_type_and_length, sizeof(socket->initial_type_and_length));
+      socket->begin = socket->msg_buf.data() + sizeof(socket->initial_type_and_length);
+      socket->sock.async_read_some(
+        boost::asio::buffer(socket->begin, static_cast<std::size_t>(std::end(socket->msg_buf) - socket->begin)),
+        boost::bind(&socket_t::handle_read_plaintext,
+                    socket->shared_from_this(),
+                    boost::asio::placeholders::error,
+                    boost::asio::placeholders::bytes_transferred));
+    }
+
+    static void
+    handle_initial_encrypted_header_rest(std::shared_ptr<socket_t> &socket,
+                                         const boost::system::error_code &ec,
+                                         std::size_t bytes) {
+      if (ec || bytes < sizeof(encrypted_rtsp_header_t) - sizeof(socket->initial_type_and_length)) {
+        BOOST_LOG(debug) << "RTSP: unable to read initial encrypted header: "sv << ec.message();
+        boost::system::error_code close_ec;
+        socket->sock.close(close_ec);
+        return;
+      }
+      handle_read_encrypted_header(socket, {}, sizeof(encrypted_rtsp_header_t));
     }
 
     /**
@@ -254,7 +347,9 @@ namespace rtsp_stream {
       if (ec || bytes < sizeof(encrypted_rtsp_header_t)) {
         BOOST_LOG(error) << "RTSP: handle_read_encrypted_header(): Couldn't read from tcp socket: "sv << ec.message();
 
-        respond(socket->sock, *socket->session, nullptr, 400, "BAD REQUEST", 0, {});
+        if (socket->session) {
+          respond(socket->sock, *socket->session, nullptr, 400, "BAD REQUEST", 0, {});
+        }
         return;
       }
 
@@ -262,7 +357,9 @@ namespace rtsp_stream {
       if (!header->is_encrypted()) {
         BOOST_LOG(error) << "RTSP: handle_read_encrypted_header(): Rejecting unencrypted RTSP message"sv;
 
-        respond(socket->sock, *socket->session, nullptr, 400, "BAD REQUEST", 0, {});
+        if (socket->session) {
+          respond(socket->sock, *socket->session, nullptr, 400, "BAD REQUEST", 0, {});
+        }
         return;
       }
 
@@ -272,7 +369,9 @@ namespace rtsp_stream {
       if (socket->begin + sizeof(*header) + payload_length >= std::end(socket->msg_buf)) {
         BOOST_LOG(error) << "RTSP: handle_read_encrypted_header(): Exceeded maximum rtsp packet size: "sv << socket->msg_buf.size();
 
-        respond(socket->sock, *socket->session, nullptr, 400, "BAD REQUEST", 0, {});
+        if (socket->session) {
+          respond(socket->sock, *socket->session, nullptr, 400, "BAD REQUEST", 0, {});
+        }
         return;
       }
 
@@ -308,7 +407,9 @@ namespace rtsp_stream {
       if (ec || bytes < payload_length) {
         BOOST_LOG(error) << "RTSP: handle_read_encrypted(): Couldn't read from tcp socket: "sv << ec.message();
 
-        respond(socket->sock, *socket->session, nullptr, 400, "BAD REQUEST", 0, {});
+        if (socket->session) {
+          respond(socket->sock, *socket->session, nullptr, 400, "BAD REQUEST", 0, {});
+        }
         return;
       }
 
@@ -326,10 +427,21 @@ namespace rtsp_stream {
       iv[11] = 'R';  // RTSP
 
       std::vector<uint8_t> plaintext;
-      if (socket->session->rtsp_cipher->decrypt(std::string_view { (const char *) header->tag, sizeof(header->tag) + bytes }, plaintext, &iv)) {
+      const auto tagged_cipher = std::string_view { (const char *) header->tag, sizeof(header->tag) + bytes };
+      if (!socket->session) {
+        auto claim = socket->claim_encrypted_fn(socket->remote_address, tagged_cipher, iv);
+        socket->session = std::move(claim.session);
+        plaintext = std::move(claim.plaintext);
+      }
+      else if (socket->session->rtsp_cipher->decrypt(tagged_cipher, plaintext, &iv)) {
         BOOST_LOG(error) << "Failed to verify RTSP message tag"sv;
 
         respond(socket->sock, *socket->session, nullptr, 400, "BAD REQUEST", 0, {});
+        return;
+      }
+
+      if (!socket->session) {
+        BOOST_LOG(warning) << "Unable to authenticate encrypted RTSP launch ticket from peer "sv << socket->remote_address;
         return;
       }
 
@@ -474,13 +586,13 @@ namespace rtsp_stream {
         socket->read();
       });
 
-      auto begin = std::max(socket->begin - 4, socket->begin);
-      auto buf_size = bytes + (begin - socket->begin);
-      auto end = begin + buf_size;
+      auto begin = socket->msg_buf.data();
+      auto end = socket->begin + bytes;
+      auto buf_size = static_cast<std::size_t>(end - begin);
 
       constexpr auto needle = "\r\n\r\n"sv;
 
-      auto it = std::search(begin, begin + buf_size, std::begin(needle), std::end(needle));
+      auto it = std::search(begin, end, std::begin(needle), std::end(needle));
       if (it == end) {
         socket->begin = end;
 
@@ -498,17 +610,24 @@ namespace rtsp_stream {
 
     void
     handle_data(msg_t &&req) {
+      handshake_timer.cancel();
       handle_data_fn(sock, *session, std::move(req));
     }
 
     std::function<void(tcp::socket &sock, launch_session_t &, msg_t &&)> handle_data_fn;
+    claim_plaintext_fn_t claim_plaintext_fn;
+    claim_encrypted_fn_t claim_encrypted_fn;
+    release_claim_fn_t release_claim_fn;
 
     tcp::socket sock;
+    boost::asio::steady_timer handshake_timer;
 
     std::array<char, 2048> msg_buf;
 
     char *crlf;
     char *begin = msg_buf.data();
+    std::uint32_t initial_type_and_length { 0 };
+    std::string remote_address;
 
     std::shared_ptr<launch_session_t> session;
   };
@@ -517,6 +636,24 @@ namespace rtsp_stream {
   public:
     ~rtsp_server_t() {
       clear();
+    }
+
+    std::shared_ptr<socket_t>
+    make_socket() {
+      return std::make_shared<socket_t>(
+        io_context,
+        [this](tcp::socket &sock, launch_session_t &session, msg_t &&msg) {
+          handle_msg(sock, session, std::move(msg));
+        },
+        [this](std::string_view remote_address) {
+          return _launch_sessions.claim_plaintext(remote_address);
+        },
+        [this](std::string_view remote_address, std::string_view tagged_cipher, crypto::aes_t iv) {
+          return _launch_sessions.claim_encrypted(remote_address, tagged_cipher, std::move(iv));
+        },
+        [this](std::uint32_t launch_session_id) {
+          _launch_sessions.release(launch_session_id, config::stream.ping_timeout);
+        });
     }
 
     int
@@ -545,9 +682,7 @@ namespace rtsp_stream {
         return -1;
       }
 
-      next_socket = std::make_shared<socket_t>(io_context, [this](tcp::socket &sock, launch_session_t &session, msg_t &&msg) {
-        handle_msg(sock, session, std::move(msg));
-      });
+      next_socket = make_socket();
 
       acceptor.async_accept(next_socket->sock, [this](const auto &ec) {
         handle_accept(ec);
@@ -585,28 +720,17 @@ namespace rtsp_stream {
 
       auto socket = std::move(next_socket);
 
-      auto launch_session { launch_event.view(0s) };
-      if (launch_session) {
-        // Associate the current RTSP session with this socket and start reading
-        socket->session = launch_session;
-        socket->read();
+      boost::system::error_code remote_ec;
+      const auto remote_endpoint = socket->sock.remote_endpoint(remote_ec);
+      const auto remote_address = remote_ec ? std::string {} : net::addr_to_normalized_string(remote_endpoint.address());
+      if (remote_ec) {
+        BOOST_LOG(debug) << "Unable to resolve RTSP peer address: "sv << remote_ec.message();
       }
-      else {
-        // This can happen due to normal things like port scanning, so let's not make these visible by default
-        BOOST_LOG(debug) << "No pending session for incoming RTSP connection"sv;
 
-        // If there is no session pending, close the connection immediately
-        boost::system::error_code ec;
-        socket->sock.close(ec);
-        if (ec) {
-          BOOST_LOG(debug) << "Error closing socket: "sv << ec.message();
-        }
-      }
+      socket->start(remote_address, config::stream.ping_timeout);
 
       // Queue another asynchronous accept for the next incoming connection
-      next_socket = std::make_shared<socket_t>(io_context, [this](tcp::socket &sock, launch_session_t &session, msg_t &&msg) {
-        handle_msg(sock, session, std::move(msg));
-      });
+      next_socket = make_socket();
       acceptor.async_accept(next_socket->sock, [this](const auto &ec) {
         handle_accept(ec);
       });
@@ -623,28 +747,18 @@ namespace rtsp_stream {
      *       the session will be discarded.
      * @param launch_session Streaming session information.
      */
-    void
+    launch_ticket_register_e
     session_raise(std::shared_ptr<launch_session_t> launch_session) {
-      // If a launch event is still pending, don't overwrite it.
-      if (launch_event.view(0s)) {
-        return;
+      if (!launch_session) {
+        return launch_ticket_register_e::global_limit;
       }
 
-      // Raise the new launch session to prepare for the RTSP handshake
-      launch_event.raise(std::move(launch_session));
-
-      // Arm the timer to expire this launch session if the client times out
-      raised_timer.expires_after(config::stream.ping_timeout);
-      raised_timer.async_wait([this](const boost::system::error_code &ec) {
-        if (!ec) {
-          auto discarded = launch_event.pop(0s);
-          if (discarded) {
-            BOOST_LOG(debug) << "Event timeout: "sv << discarded->unique_id;
-          }
-        } else {
-          BOOST_LOG(debug) << "Timer error: "sv << ec.message();
-        }
-      });
+      const auto result = _launch_sessions.register_session(
+        std::move(launch_session), config::stream.ping_timeout);
+      if (result == launch_ticket_register_e::accepted || result == launch_ticket_register_e::replaced) {
+        schedule_pending_prune();
+      }
+      return result;
     }
 
     /**
@@ -653,18 +767,7 @@ namespace rtsp_stream {
      */
     void
     session_clear(uint32_t launch_session_id) {
-      // We currently only support a single pending RTSP session,
-      // so the ID should always match the one for that session.
-      auto launch_session = launch_event.view(0s);
-      if (launch_session) {
-        if (launch_session->id != launch_session_id) {
-          BOOST_LOG(error) << "Attempted to clear unexpected session: "sv << launch_session_id << " vs "sv << launch_session->id;
-        }
-        else {
-          raised_timer.cancel();
-          launch_event.pop();
-        }
-      }
+      _launch_sessions.erase(launch_session_id);
     }
 
     /**
@@ -677,7 +780,35 @@ namespace rtsp_stream {
       return _session_slots->size();
     }
 
-    safe::event_t<std::shared_ptr<launch_session_t>> launch_event;
+    int
+    pending_session_count() {
+      return static_cast<int>(_launch_sessions.size());
+    }
+
+    bool
+    activate_launch_session(std::uint32_t launch_session_id) {
+      return _launch_sessions.activate(launch_session_id);
+    }
+
+    void
+    schedule_pending_prune() {
+      boost::asio::post(io_context, [this]() {
+        raised_timer.expires_after(config::stream.ping_timeout);
+        raised_timer.async_wait([this](const boost::system::error_code &ec) {
+          if (!ec) {
+            const auto pruned = _launch_sessions.prune();
+            if (pruned != 0) {
+              BOOST_LOG(debug) << "Expired "sv << pruned << " pending RTSP launch ticket(s)"sv;
+            }
+          }
+          else if (ec != boost::asio::error::operation_aborted) {
+            BOOST_LOG(debug) << "Timer error: "sv << ec.message();
+          }
+        });
+      });
+    }
+
+    launch_session_manager_t _launch_sessions;
 
     /**
      * @brief Clear launch sessions.
@@ -688,6 +819,13 @@ namespace rtsp_stream {
      */
     void
     clear(bool all = true) {
+      if (all) {
+        _launch_sessions.clear();
+      }
+      else {
+        _launch_sessions.prune();
+      }
+
       auto lg = _session_slots.lock();
 
       for (auto i = _session_slots->begin(); i != _session_slots->end();) {
@@ -764,9 +902,9 @@ namespace rtsp_stream {
 
   rtsp_server_t server {};
 
-  void
+  launch_ticket_register_e
   launch_session_raise(std::shared_ptr<launch_session_t> launch_session) {
-    server.session_raise(std::move(launch_session));
+    return server.session_raise(std::move(launch_session));
   }
 
   void
@@ -780,6 +918,11 @@ namespace rtsp_stream {
     server.clear(false);
 
     return server.session_count();
+  }
+
+  int
+  pending_session_count() {
+    return server.pending_session_count();
   }
 
   void
@@ -1415,6 +1558,10 @@ namespace rtsp_stream {
       respond(sock, session, &option, 500, "Internal Server Error", req->sequenceNumber, {});
       return;
     }
+
+    // The RTSP handshake has created the active stream. The launch ticket is
+    // no longer needed for connection routing and must not block a reconnect.
+    server->activate_launch_session(session.id);
 
     respond(sock, session, &option, 200, "OK", req->sequenceNumber, {});
   }

--- a/src/rtsp.h
+++ b/src/rtsp.h
@@ -9,6 +9,7 @@
 #include <boost/process/v1.hpp>
 
 #include "crypto.h"
+#include "launch_session_manager.h"
 #include "thread_safe.h"
 
 namespace rtsp_stream {
@@ -22,6 +23,8 @@ namespace rtsp_stream {
 
     std::string av_ping_payload;
     uint32_t control_connect_data;
+    std::string client_cert_uuid;
+    std::string rtsp_peer_address;
 
     boost::process::v1::environment env;
 
@@ -57,7 +60,7 @@ namespace rtsp_stream {
     bool control_only { false };
   };
 
-  void
+  launch_ticket_register_e
   launch_session_raise(std::shared_ptr<launch_session_t> launch_session);
 
   /**
@@ -73,6 +76,12 @@ namespace rtsp_stream {
    */
   int
   session_count();
+
+  /**
+   * @brief Get the number of bounded launch tickets awaiting RTSP activation.
+   */
+  int
+  pending_session_count();
 
   /**
    * @brief Terminates all running streaming sessions.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -88,6 +88,23 @@ foreach(dep ${SUNSHINE_TARGET_DEPENDENCIES})
 endforeach()
 add_test(NAME abr_unit_tests COMMAND abr_unit_tests)
 
+add_executable(launch_session_manager_unit_tests
+        ${CMAKE_SOURCE_DIR}/tests/unit/test_rtsp.cpp
+        ${CMAKE_SOURCE_DIR}/src/launch_session_manager.cpp
+        ${CMAKE_SOURCE_DIR}/src/crypto.cpp)
+target_include_directories(launch_session_manager_unit_tests PRIVATE "${CMAKE_SOURCE_DIR}")
+target_link_libraries(launch_session_manager_unit_tests
+        ${SUNSHINE_EXTERNAL_LIBRARIES}
+        gtest_main
+        ${PLATFORM_LIBRARIES})
+target_compile_definitions(launch_session_manager_unit_tests PUBLIC ${SUNSHINE_DEFINITIONS} ${TEST_DEFINITIONS})
+target_compile_options(launch_session_manager_unit_tests PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${SUNSHINE_COMPILE_OPTIONS}>)
+set_target_properties(launch_session_manager_unit_tests PROPERTIES CXX_STANDARD 23)
+add_test(NAME launch_session_manager_unit_tests COMMAND launch_session_manager_unit_tests)
+foreach(dep ${SUNSHINE_TARGET_DEPENDENCIES})
+    add_dependencies(launch_session_manager_unit_tests ${dep})
+endforeach()
+
 if (WIN32)
     # prefer static libraries since we're linking statically
     # this fixes libcurl linking errors when using non MSYS2 version of CMake

--- a/tests/unit/test_rtsp.cpp
+++ b/tests/unit/test_rtsp.cpp
@@ -1,0 +1,165 @@
+/**
+ * @file tests/unit/test_rtsp.cpp
+ * @brief Tests for launch-ticket lifecycle and RTSP claim routing.
+ */
+
+#include <array>
+
+#include "src/launch_session_manager.h"
+#include "src/rtsp.h"
+
+#include "../tests_common.h"
+
+using namespace std::chrono_literals;
+
+namespace {
+  std::shared_ptr<rtsp_stream::launch_session_t>
+  make_session(std::uint32_t id,
+               std::string cert,
+               std::string peer,
+               const crypto::aes_t *key = nullptr) {
+    auto session = std::make_shared<rtsp_stream::launch_session_t>();
+    session->id = id;
+    session->unique_id = "client-" + std::to_string(id);
+    session->client_cert_uuid = std::move(cert);
+    session->rtsp_peer_address = std::move(peer);
+    if (key) {
+      session->gcm_key = *key;
+      session->rtsp_cipher.emplace(*key, false);
+    }
+    return session;
+  }
+}  // namespace
+
+TEST(LaunchSessionManager, RoutesConcurrentPlaintextClientsAndPreservesSingletonFallback) {
+  rtsp_stream::launch_session_manager_t manager;
+  const auto now = rtsp_stream::launch_session_manager_t::clock_t::now();
+
+  EXPECT_EQ(manager.register_session(make_session(1, "cert-a", "192.0.2.10"), 10s, now),
+            rtsp_stream::launch_ticket_register_e::accepted);
+  EXPECT_EQ(manager.register_session(make_session(2, "cert-b", "192.0.2.20"), 10s, now),
+            rtsp_stream::launch_ticket_register_e::accepted);
+
+  auto first = manager.claim_plaintext("192.0.2.10", now);
+  auto second = manager.claim_plaintext("192.0.2.20", now);
+  ASSERT_TRUE(first);
+  ASSERT_TRUE(second);
+  EXPECT_EQ(first->id, 1U);
+  EXPECT_EQ(second->id, 2U);
+
+  rtsp_stream::launch_session_manager_t singleton_manager;
+  ASSERT_EQ(singleton_manager.register_session(make_session(3, "cert-c", "198.51.100.10"), 10s, now),
+            rtsp_stream::launch_ticket_register_e::accepted);
+  auto fallback = singleton_manager.claim_plaintext("198.51.100.20", now);
+  ASSERT_TRUE(fallback);
+  EXPECT_EQ(fallback->id, 3U);
+}
+
+TEST(LaunchSessionManager, ReplacesPendingRetryButDoesNotReplaceClaimedHandshake) {
+  rtsp_stream::launch_session_manager_t manager;
+  const auto now = rtsp_stream::launch_session_manager_t::clock_t::now();
+
+  ASSERT_EQ(manager.register_session(make_session(10, "same-cert", "203.0.113.10"), 10s, now),
+            rtsp_stream::launch_ticket_register_e::accepted);
+  EXPECT_EQ(manager.register_session(make_session(11, "same-cert", "203.0.113.20"), 10s, now),
+            rtsp_stream::launch_ticket_register_e::replaced);
+  EXPECT_EQ(manager.size(now), 1U);
+
+  auto claimed = manager.claim_plaintext("203.0.113.20", now);
+  ASSERT_TRUE(claimed);
+  EXPECT_EQ(claimed->id, 11U);
+  EXPECT_EQ(manager.register_session(make_session(12, "same-cert", "203.0.113.30"), 10s, now),
+            rtsp_stream::launch_ticket_register_e::client_busy);
+
+  EXPECT_TRUE(manager.release(11, 10s, now));
+  auto reclaimed = manager.claim_plaintext("203.0.113.20", now);
+  ASSERT_TRUE(reclaimed);
+  EXPECT_EQ(reclaimed->id, 11U);
+  EXPECT_TRUE(manager.activate(11));
+  EXPECT_EQ(manager.size(now), 0U);
+}
+
+TEST(LaunchSessionManager, EnforcesCapacityAndExpiresTickets) {
+  rtsp_stream::launch_session_manager_t manager { 2, 1 };
+  const auto now = rtsp_stream::launch_session_manager_t::clock_t::now();
+
+  ASSERT_EQ(manager.register_session(make_session(20, "cert-20", "192.0.2.20"), 1s, now),
+            rtsp_stream::launch_ticket_register_e::accepted);
+  ASSERT_EQ(manager.register_session(make_session(21, "cert-21", "192.0.2.21"), 1s, now),
+            rtsp_stream::launch_ticket_register_e::accepted);
+  EXPECT_EQ(manager.register_session(make_session(22, "cert-22", "192.0.2.22"), 1s, now),
+            rtsp_stream::launch_ticket_register_e::global_limit);
+
+  EXPECT_EQ(manager.prune(now + 2s), 2U);
+  EXPECT_EQ(manager.size(now + 2s), 0U);
+
+  rtsp_stream::launch_session_manager_t legacy_manager { 4, 2 };
+  auto legacy = make_session(23, {}, "192.0.2.23");
+  legacy->unique_id = "legacy-retry";
+  ASSERT_EQ(legacy_manager.register_session(legacy, 10s, now),
+            rtsp_stream::launch_ticket_register_e::accepted);
+  auto legacy_retry = make_session(24, {}, "192.0.2.23");
+  legacy_retry->unique_id = "legacy-retry";
+  EXPECT_EQ(legacy_manager.register_session(legacy_retry, 10s, now),
+            rtsp_stream::launch_ticket_register_e::replaced);
+  auto legacy_claim = legacy_manager.claim_plaintext("192.0.2.23", now);
+  ASSERT_TRUE(legacy_claim);
+  EXPECT_EQ(legacy_claim->id, 24U);
+
+  rtsp_stream::launch_session_manager_t peer_limited_manager { 4, 2 };
+  ASSERT_EQ(peer_limited_manager.register_session(make_session(25, {}, "192.0.2.25"), 10s, now),
+            rtsp_stream::launch_ticket_register_e::accepted);
+  ASSERT_EQ(peer_limited_manager.register_session(make_session(26, {}, "192.0.2.25"), 10s, now),
+            rtsp_stream::launch_ticket_register_e::accepted);
+  EXPECT_EQ(peer_limited_manager.register_session(make_session(27, {}, "192.0.2.25"), 10s, now),
+            rtsp_stream::launch_ticket_register_e::client_limit);
+}
+
+TEST(LaunchSessionManager, AuthenticatesEncryptedClaimByGcmTagAcrossRouteChanges) {
+  rtsp_stream::launch_session_manager_t manager;
+  const auto now = rtsp_stream::launch_session_manager_t::clock_t::now();
+  const crypto::aes_t key_a(16, 0x11);
+  const crypto::aes_t key_b(16, 0x22);
+
+  ASSERT_EQ(manager.register_session(make_session(30, "cert-a", "192.0.2.30", &key_a), 10s, now),
+            rtsp_stream::launch_ticket_register_e::accepted);
+  ASSERT_EQ(manager.register_session(make_session(31, "cert-b", "192.0.2.30", &key_b), 10s, now),
+            rtsp_stream::launch_ticket_register_e::accepted);
+
+  // Two plaintext clients behind the same visible address are intentionally
+  // ambiguous. Encrypted RTSP can still distinguish them cryptographically.
+  EXPECT_FALSE(manager.claim_plaintext("192.0.2.30", now));
+
+  rtsp_stream::launch_session_manager_t encrypted_only_manager;
+  ASSERT_EQ(encrypted_only_manager.register_session(make_session(32, "cert-c", "192.0.2.32", &key_a), 10s, now),
+            rtsp_stream::launch_ticket_register_e::accepted);
+  EXPECT_FALSE(encrypted_only_manager.claim_plaintext("192.0.2.32", now));
+
+  constexpr std::string_view plaintext { "OPTIONS rtsp://host RTSP/1.0\r\nCSeq: 1\r\n\r\n" };
+  crypto::aes_t iv(12, 0);
+  iv[10] = 'C';
+  iv[11] = 'R';
+  crypto::cipher::gcm_t client_cipher { key_b, false };
+  std::vector<std::uint8_t> tagged_cipher(
+    crypto::cipher::round_to_pkcs7_padded(plaintext.size()) + crypto::cipher::tag_size);
+  const auto encrypted_size = client_cipher.encrypt(
+    plaintext, tagged_cipher.data(), &iv);
+  ASSERT_GT(encrypted_size, 0);
+
+  const std::array<char, 32> invalid_tagged_cipher {};
+  EXPECT_FALSE(manager.claim_encrypted(
+    "198.51.100.99",
+    std::string_view { invalid_tagged_cipher.data(), invalid_tagged_cipher.size() },
+    iv,
+    now));
+
+  auto claim = manager.claim_encrypted(
+    "198.51.100.99",
+    std::string_view { reinterpret_cast<const char *>(tagged_cipher.data()),
+                       static_cast<std::size_t>(encrypted_size) + crypto::cipher::tag_size },
+    iv,
+    now);
+  ASSERT_TRUE(claim);
+  EXPECT_EQ(claim.session->id, 31U);
+  EXPECT_EQ(std::string_view(reinterpret_cast<const char *>(claim.plaintext.data()), claim.plaintext.size()), plaintext);
+}

--- a/tests/unit/test_rtsp.cpp
+++ b/tests/unit/test_rtsp.cpp
@@ -115,6 +115,26 @@ TEST(LaunchSessionManager, EnforcesCapacityAndExpiresTickets) {
             rtsp_stream::launch_ticket_register_e::client_limit);
 }
 
+TEST(LaunchSessionManager, PreservesClaimedTicketsPastPendingExpiry) {
+  rtsp_stream::launch_session_manager_t manager;
+  const auto now = rtsp_stream::launch_session_manager_t::clock_t::now();
+
+  ASSERT_EQ(manager.register_session(make_session(30, "claimed-cert", "192.0.2.30"), 1s, now),
+            rtsp_stream::launch_ticket_register_e::accepted);
+  ASSERT_EQ(manager.register_session(make_session(31, "pending-cert", "192.0.2.31"), 1s, now),
+            rtsp_stream::launch_ticket_register_e::accepted);
+  ASSERT_TRUE(manager.claim_plaintext("192.0.2.30", now));
+
+  EXPECT_EQ(manager.prune(now + 2s), 1U);
+  EXPECT_EQ(manager.size(now + 2s), 1U);
+  EXPECT_EQ(manager.register_session(make_session(32, "claimed-cert", "192.0.2.32"), 1s, now + 2s),
+            rtsp_stream::launch_ticket_register_e::client_busy);
+
+  EXPECT_TRUE(manager.release(30, 1s, now + 2s));
+  EXPECT_EQ(manager.prune(now + 4s), 1U);
+  EXPECT_EQ(manager.size(now + 4s), 0U);
+}
+
 TEST(LaunchSessionManager, AuthenticatesEncryptedClaimByGcmTagAcrossRouteChanges) {
   rtsp_stream::launch_session_manager_t manager;
   const auto now = rtsp_stream::launch_session_manager_t::clock_t::now();


### PR DESCRIPTION
## 改了啥呀

- 新增有界 Launch Ticket Session Manager，显式管理 pending/claimed 到 active 的交接
- `/launch`、`/resume` 只有 ticket 注册成功后才返回成功，忙碌或容量不足返回明确状态
- 加密 RTSP 通过首包 AES-GCM 标签认领 session，不再把 IP 当身份
- 明文旧客户端保留唯一地址匹配和 singleton fallback；歧义时安全拒绝
- 增加握手超时、容量限制、失败释放、`pending_sessions` 观测与设计文档
- 增加独立专项测试目标，免得杂鱼旧测试把核心验证一起拖下水

## 为啥要改

旧实现只有一个全局 pending launch。多客户端或重连重叠时，新 `/resume` 可能已经返回成功，实际 RTSP session 却被静默丢弃，客户端最后只看到连接终结 `-1`。同 NAT、换路由时按 IP 认领也不够可靠。

现在身份由加密握手本身证明，HTTPS/RTSP 地址只作为候选排序提示；旧客户端继续走兼容路径，不让杂鱼状态偷偷串到别人的 session。

## 验证

- `build\tests\launch_session_manager_unit_tests.exe --gtest_color=no` — 4/4 passed
- `git diff --check` — passed
- GCC Release 核心对象编译通过：Session Manager、RTSP、NVHTTP、sessions API
- 完整 Release 构建交由 CI（本地 Ninja 增量日志在多次超时后损坏，避免继续用不可靠缓存冒充验证）