### PR TITLE
fix(tray): align service and agent lifecycle

### DIFF
--- a/docs/tray-protocol.md
+++ b/docs/tray-protocol.md
@@ -35,10 +35,16 @@ endpoint is the compatibility fallback.
 - `notification-ack`: non-pairing notification acknowledgement
 - `pairing`: pairing notification with the `open_pin` action
 - `vdd`: virtual-display state and actions
+- `shutdown`: graceful Core and service-wrapper shutdown
 
 The `owner` field describes the packaged tray strategy (`gui`, `core`, or
 `disabled`). The packaged GUI uses its existing single-instance guard. Version
 1 deliberately does not add a second ownership heartbeat.
+
+On Windows, the service wrapper starts the packaged GUI agent in the active
+signed-in user's session after Core starts. Failed launches are retried while
+Core remains alive, and the GUI's single-instance guard absorbs duplicate
+logon and service-start attempts.
 
 ## Actions and operations
 
@@ -51,7 +57,8 @@ The `owner` field describes the packaged tray strategy (`gui`, `core`, or
 Only fields relevant to the selected action are required. Supported actions
 are `vdd_create`, `vdd_destroy`, `vdd_toggle_keep_enabled`,
 `vdd_toggle_headless_create`, `clear_app`, `reset_display_device_config`,
-`restart`, and `notification_ack`. While `vdd.awaiting_confirmation` is true,
+`restart`, `shutdown`, and `notification_ack`. While
+`vdd.awaiting_confirmation` is true,
 the GUI answers with `vdd_confirm_keep`, an `enabled` decision, and the matching
 `operation_id`.
 

--- a/src/tray/tray_http.cpp
+++ b/src/tray/tray_http.cpp
@@ -9,6 +9,7 @@
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include <nlohmann/json.hpp>
@@ -33,9 +34,12 @@ namespace tray_http {
     std::atomic<bool> tray_vdd_action_running { false };
     std::atomic<std::uint64_t> tray_vdd_confirmation_operation_id { 0 };
     std::atomic<bool> tray_app_termination_running { false };
-    std::atomic<bool> tray_restart_running { false };
-    std::atomic<bool> tray_shutdown_running { false };
-    constexpr auto tray_lifecycle_response_grace = 250ms;
+    enum class tray_lifecycle_action_e : std::uint8_t {
+      none,
+      restart,
+      shutdown,
+    };
+    std::atomic<tray_lifecycle_action_e> tray_lifecycle_action { tray_lifecycle_action_e::none };
     std::mutex tray_action_mutex;
 
     thread_pool_util::ThreadPool &
@@ -126,6 +130,14 @@ namespace tray_http {
     send_json(resp_https_t response, const nlohmann::json &body) {
       auto headers = json_response_headers();
       response->write(body.dump(), headers);
+    }
+
+    template <typename Callback>
+    void
+    send_json(resp_https_t response, const nlohmann::json &body, Callback &&callback) {
+      auto headers = json_response_headers();
+      response->write(body.dump(), headers);
+      response->send(std::forward<Callback>(callback));
     }
 
     void
@@ -429,49 +441,22 @@ namespace tray_http {
       }
 
       if (action == "restart") {
-        if (tray_restart_running.exchange(true)) {
-          return action_error("Sunshine restart is already in progress");
+        auto expected = tray_lifecycle_action_e::none;
+        if (!tray_lifecycle_action.compare_exchange_strong(expected, tray_lifecycle_action_e::restart)) {
+          return action_error("A Sunshine restart or shutdown is already in progress");
         }
 
         BOOST_LOG(info) << "Restart requested from GUI tray"sv;
-        lock.unlock();
-        try {
-          task_pool.pushDelayed([]() {
-            platf::restart();
-          },
-            tray_lifecycle_response_grace);
-        }
-        catch (const std::exception &e) {
-          tray_restart_running = false;
-          BOOST_LOG(error) << "Failed to schedule Sunshine restart: "sv << e.what();
-          return action_error("Failed to schedule Sunshine restart");
-        }
         return action_success("Restart requested");
       }
 
       if (action == "shutdown") {
-        if (tray_shutdown_running.exchange(true)) {
-          return action_error("Sunshine shutdown is already in progress");
+        auto expected = tray_lifecycle_action_e::none;
+        if (!tray_lifecycle_action.compare_exchange_strong(expected, tray_lifecycle_action_e::shutdown)) {
+          return action_error("A Sunshine restart or shutdown is already in progress");
         }
 
         BOOST_LOG(info) << "Shutting down Sunshine from GUI tray"sv;
-        lock.unlock();
-        try {
-          task_pool.pushDelayed([]() {
-#ifdef _WIN32
-            const auto exit_code = GetConsoleWindow() == NULL ? ERROR_SHUTDOWN_IN_PROGRESS : 0;
-#else
-            constexpr auto exit_code = 0;
-#endif
-            lifetime::exit_sunshine(exit_code, true);
-          },
-            tray_lifecycle_response_grace);
-        }
-        catch (const std::exception &e) {
-          tray_shutdown_running = false;
-          BOOST_LOG(error) << "Failed to schedule Sunshine shutdown: "sv << e.what();
-          return action_error("Failed to schedule Sunshine shutdown");
-        }
         return action_success("Sunshine shutdown requested");
       }
 
@@ -553,6 +538,28 @@ namespace tray_http {
         auto result = run_tray_action(action, enabled, notification_id, operation_id);
         result["action"] = action;
         result["tray_state"] = tray_state::to_json();
+
+        if (result.value("status", false) && (action == "restart" || action == "shutdown")) {
+          send_json(std::move(response), result, [action](const auto &error) {
+            if (error) {
+              BOOST_LOG(debug) << "Tray "sv << action << " response did not reach the client: "sv << error.message();
+            }
+
+            if (action == "restart") {
+              platf::restart();
+              return;
+            }
+
+#ifdef _WIN32
+            const auto exit_code = GetConsoleWindow() == NULL ? ERROR_SHUTDOWN_IN_PROGRESS : 0;
+#else
+            constexpr auto exit_code = 0;
+#endif
+            lifetime::exit_sunshine(exit_code, true);
+          });
+          return;
+        }
+
         send_json(std::move(response), result);
       }
       catch (const std::exception &e) {

--- a/src/tray/tray_http.cpp
+++ b/src/tray/tray_http.cpp
@@ -16,6 +16,7 @@
 #include "src/config.h"
 #include "src/display_device/display_device.h"
 #include "src/display_device/session.h"
+#include "src/entry_handler.h"
 #include "src/globals.h"
 #include "src/http_util.h"
 #include "src/logging.h"
@@ -32,6 +33,7 @@ namespace tray_http {
     std::atomic<bool> tray_vdd_action_running { false };
     std::atomic<std::uint64_t> tray_vdd_confirmation_operation_id { 0 };
     std::atomic<bool> tray_app_termination_running { false };
+    std::atomic<bool> tray_shutdown_running { false };
     std::mutex tray_action_mutex;
 
     thread_pool_util::ThreadPool &
@@ -428,6 +430,32 @@ namespace tray_http {
         BOOST_LOG(info) << "Restarting from GUI tray"sv;
         platf::restart();
         return action_success("Restart requested");
+      }
+
+      if (action == "shutdown") {
+        if (tray_shutdown_running.exchange(true)) {
+          return action_error("Sunshine shutdown is already in progress");
+        }
+
+        BOOST_LOG(info) << "Shutting down Sunshine from GUI tray"sv;
+        lock.unlock();
+        try {
+          task_pool.pushDelayed([]() {
+#ifdef _WIN32
+            const auto exit_code = GetConsoleWindow() == NULL ? ERROR_SHUTDOWN_IN_PROGRESS : 0;
+#else
+            constexpr auto exit_code = 0;
+#endif
+            lifetime::exit_sunshine(exit_code, true);
+          },
+            250ms);
+        }
+        catch (const std::exception &e) {
+          tray_shutdown_running = false;
+          BOOST_LOG(error) << "Failed to schedule Sunshine shutdown: "sv << e.what();
+          return action_error("Failed to schedule Sunshine shutdown");
+        }
+        return action_success("Sunshine shutdown requested");
       }
 
       if (action == "notification_ack") {

--- a/src/tray/tray_http.cpp
+++ b/src/tray/tray_http.cpp
@@ -34,6 +34,7 @@ namespace tray_http {
     std::atomic<std::uint64_t> tray_vdd_confirmation_operation_id { 0 };
     std::atomic<bool> tray_app_termination_running { false };
     std::atomic<bool> tray_shutdown_running { false };
+    constexpr auto tray_shutdown_response_grace = 250ms;
     std::mutex tray_action_mutex;
 
     thread_pool_util::ThreadPool &
@@ -448,7 +449,7 @@ namespace tray_http {
 #endif
             lifetime::exit_sunshine(exit_code, true);
           },
-            250ms);
+            tray_shutdown_response_grace);
         }
         catch (const std::exception &e) {
           tray_shutdown_running = false;

--- a/src/tray/tray_http.cpp
+++ b/src/tray/tray_http.cpp
@@ -33,8 +33,9 @@ namespace tray_http {
     std::atomic<bool> tray_vdd_action_running { false };
     std::atomic<std::uint64_t> tray_vdd_confirmation_operation_id { 0 };
     std::atomic<bool> tray_app_termination_running { false };
+    std::atomic<bool> tray_restart_running { false };
     std::atomic<bool> tray_shutdown_running { false };
-    constexpr auto tray_shutdown_response_grace = 250ms;
+    constexpr auto tray_lifecycle_response_grace = 250ms;
     std::mutex tray_action_mutex;
 
     thread_pool_util::ThreadPool &
@@ -428,8 +429,23 @@ namespace tray_http {
       }
 
       if (action == "restart") {
-        BOOST_LOG(info) << "Restarting from GUI tray"sv;
-        platf::restart();
+        if (tray_restart_running.exchange(true)) {
+          return action_error("Sunshine restart is already in progress");
+        }
+
+        BOOST_LOG(info) << "Restart requested from GUI tray"sv;
+        lock.unlock();
+        try {
+          task_pool.pushDelayed([]() {
+            platf::restart();
+          },
+            tray_lifecycle_response_grace);
+        }
+        catch (const std::exception &e) {
+          tray_restart_running = false;
+          BOOST_LOG(error) << "Failed to schedule Sunshine restart: "sv << e.what();
+          return action_error("Failed to schedule Sunshine restart");
+        }
         return action_success("Restart requested");
       }
 
@@ -449,7 +465,7 @@ namespace tray_http {
 #endif
             lifetime::exit_sunshine(exit_code, true);
           },
-            tray_shutdown_response_grace);
+            tray_lifecycle_response_grace);
         }
         catch (const std::exception &e) {
           tray_shutdown_running = false;

--- a/src/tray/tray_state.cpp
+++ b/src/tray/tray_state.cpp
@@ -327,7 +327,7 @@ namespace tray_state {
       { "protocol_version", protocol_version },
       { "instance_id", instance_id() },
       { "owner", tray_owner() },
-      { "capabilities", nlohmann::json::array({ "state-v1", "events-v1", "actions-v1", "operations-v1", "notification-ack", "pairing", "vdd" }) },
+      { "capabilities", nlohmann::json::array({ "state-v1", "events-v1", "actions-v1", "operations-v1", "notification-ack", "pairing", "vdd", "shutdown" }) },
       { "status", current_presentation.status },
       { "icon", current_presentation.icon },
       { "tooltip", current_presentation.tooltip },

--- a/tests/unit/test_tray_state.cpp
+++ b/tests/unit/test_tray_state.cpp
@@ -156,6 +156,9 @@ TEST_F(TrayStateTest, PublishesStableProtocolIdentity) {
   EXPECT_NE(
     std::find(first.at("capabilities").begin(), first.at("capabilities").end(), "events-v1"),
     first.at("capabilities").end());
+  EXPECT_NE(
+    std::find(first.at("capabilities").begin(), first.at("capabilities").end(), "shutdown"),
+    first.at("capabilities").end());
 }
 
 TEST_F(TrayStateTest, PublishesChangesToTheEventSink) {

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(sunshinesvc sunshinesvc.cpp)
 set_target_properties(sunshinesvc PROPERTIES CXX_STANDARD 23)
 target_link_libraries(sunshinesvc
         ${CMAKE_THREAD_LIBS_INIT}
+        userenv
         wtsapi32
         ${PLATFORM_LIBRARIES})
 target_compile_options(sunshinesvc PRIVATE ${SUNSHINE_COMPILE_OPTIONS})

--- a/tools/sunshinesvc.cpp
+++ b/tools/sunshinesvc.cpp
@@ -122,42 +122,50 @@ DuplicateTokenForSession(DWORD console_session_id) {
   return new_token;
 }
 
-bool
+DWORD
 LaunchGuiAgent(DWORD console_session_id) {
   std::wstring service_path(32768, L'\0');
   const auto service_path_length =
     GetModuleFileNameW(NULL, service_path.data(), static_cast<DWORD>(service_path.size()));
-  if (service_path_length == 0 || service_path_length >= service_path.size()) {
-    return false;
+  if (service_path_length == 0) {
+    const auto error = GetLastError();
+    return error == ERROR_SUCCESS ? ERROR_BAD_PATHNAME : error;
+  }
+  if (service_path_length >= service_path.size()) {
+    return ERROR_INSUFFICIENT_BUFFER;
   }
   service_path.resize(service_path_length);
 
   const auto tools_separator = service_path.find_last_of(L"\\/");
   if (tools_separator == std::wstring::npos || tools_separator == 0) {
-    return false;
+    return ERROR_BAD_PATHNAME;
   }
   const auto install_separator = service_path.find_last_of(L"\\/", tools_separator - 1);
   if (install_separator == std::wstring::npos) {
-    return false;
+    return ERROR_BAD_PATHNAME;
   }
 
   const auto install_directory = service_path.substr(0, install_separator);
   const auto gui_directory = install_directory + L"\\assets\\gui";
   const auto gui_path = gui_directory + L"\\sunshine-gui.exe";
   const auto gui_attributes = GetFileAttributesW(gui_path.c_str());
-  if (gui_attributes == INVALID_FILE_ATTRIBUTES || (gui_attributes & FILE_ATTRIBUTE_DIRECTORY)) {
-    return false;
+  if (gui_attributes == INVALID_FILE_ATTRIBUTES) {
+    return GetLastError();
+  }
+  if (gui_attributes & FILE_ATTRIBUTE_DIRECTORY) {
+    return ERROR_FILE_NOT_FOUND;
   }
 
   HANDLE user_token = NULL;
   if (!WTSQueryUserToken(console_session_id, &user_token)) {
-    return false;
+    return GetLastError();
   }
 
   LPVOID environment = NULL;
   if (!CreateEnvironmentBlock(&environment, user_token, FALSE)) {
+    const auto error = GetLastError();
     CloseHandle(user_token);
-    return false;
+    return error;
   }
 
   auto command = L"\"" + gui_path + L"\" --hidden";
@@ -180,6 +188,7 @@ LaunchGuiAgent(DWORD console_session_id) {
     gui_directory.c_str(),
     &startup_info,
     &process_info);
+  const auto launch_error = launched ? ERROR_SUCCESS : GetLastError();
 
   if (launched) {
     CloseHandle(process_info.hThread);
@@ -187,7 +196,31 @@ LaunchGuiAgent(DWORD console_session_id) {
   }
   DestroyEnvironmentBlock(environment);
   CloseHandle(user_token);
-  return launched;
+  return launch_error;
+}
+
+void
+WriteServiceLog(HANDLE log_file, const std::string &message) {
+  DWORD bytes_written;
+  const auto line = "[sunshinesvc] " + message + "\r\n";
+  WriteFile(log_file, line.data(), static_cast<DWORD>(line.size()), &bytes_written, NULL);
+}
+
+bool
+ReconcileGuiAgent(HANDLE log_file, DWORD console_session_id, DWORD &last_error) {
+  const auto error = LaunchGuiAgent(console_session_id);
+  if (error == ERROR_SUCCESS) {
+    if (last_error != ERROR_SUCCESS) {
+      WriteServiceLog(log_file, "GUI agent launch recovered for session " + std::to_string(console_session_id));
+    }
+  }
+  else if (error != last_error) {
+    WriteServiceLog(log_file,
+      "GUI agent launch failed for session " + std::to_string(console_session_id) +
+        " (Win32 error " + std::to_string(error) + "); retrying");
+  }
+  last_error = error;
+  return error == ERROR_SUCCESS;
 }
 
 HANDLE
@@ -387,7 +420,8 @@ ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
 
     // Launch the tray in the signed-in user's session so HKCU settings and
     // single-instance ownership remain scoped to that user.
-    bool gui_agent_started = LaunchGuiAgent(console_session_id);
+    DWORD gui_agent_error = ERROR_SUCCESS;
+    bool gui_agent_started = ReconcileGuiAgent(log_file_handle, console_session_id, gui_agent_error);
 
     bool still_running;
     do {
@@ -397,7 +431,7 @@ ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
         WaitForMultipleObjects(_countof(wait_objects), wait_objects, FALSE, gui_agent_started ? INFINITE : 3000);
       switch (wait_result) {
         case WAIT_TIMEOUT:
-          gui_agent_started = LaunchGuiAgent(console_session_id);
+          gui_agent_started = ReconcileGuiAgent(log_file_handle, console_session_id, gui_agent_error);
           still_running = true;
           break;
 

--- a/tools/sunshinesvc.cpp
+++ b/tools/sunshinesvc.cpp
@@ -4,9 +4,11 @@
  */
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
+#include <userenv.h>
 #include <wtsapi32.h>
 
 #include <string>
+#include <vector>
 
 // PROC_THREAD_ATTRIBUTE_JOB_LIST is currently missing from MinGW headers
 #ifndef PROC_THREAD_ATTRIBUTE_JOB_LIST
@@ -118,6 +120,74 @@ DuplicateTokenForSession(DWORD console_session_id) {
   }
 
   return new_token;
+}
+
+bool
+LaunchGuiAgent(DWORD console_session_id) {
+  std::wstring service_path(32768, L'\0');
+  const auto service_path_length =
+    GetModuleFileNameW(NULL, service_path.data(), static_cast<DWORD>(service_path.size()));
+  if (service_path_length == 0 || service_path_length >= service_path.size()) {
+    return false;
+  }
+  service_path.resize(service_path_length);
+
+  const auto tools_separator = service_path.find_last_of(L"\\/");
+  if (tools_separator == std::wstring::npos || tools_separator == 0) {
+    return false;
+  }
+  const auto install_separator = service_path.find_last_of(L"\\/", tools_separator - 1);
+  if (install_separator == std::wstring::npos) {
+    return false;
+  }
+
+  const auto install_directory = service_path.substr(0, install_separator);
+  const auto gui_directory = install_directory + L"\\assets\\gui";
+  const auto gui_path = gui_directory + L"\\sunshine-gui.exe";
+  const auto gui_attributes = GetFileAttributesW(gui_path.c_str());
+  if (gui_attributes == INVALID_FILE_ATTRIBUTES || (gui_attributes & FILE_ATTRIBUTE_DIRECTORY)) {
+    return false;
+  }
+
+  HANDLE user_token = NULL;
+  if (!WTSQueryUserToken(console_session_id, &user_token)) {
+    return false;
+  }
+
+  LPVOID environment = NULL;
+  if (!CreateEnvironmentBlock(&environment, user_token, FALSE)) {
+    CloseHandle(user_token);
+    return false;
+  }
+
+  auto command = L"\"" + gui_path + L"\" --hidden";
+  std::vector<wchar_t> command_line(command.begin(), command.end());
+  command_line.push_back(L'\0');
+
+  STARTUPINFOW startup_info = {};
+  startup_info.cb = sizeof(startup_info);
+  startup_info.lpDesktop = (LPWSTR) L"winsta0\\default";
+
+  PROCESS_INFORMATION process_info = {};
+  const auto launched = CreateProcessAsUserW(user_token,
+    gui_path.c_str(),
+    command_line.data(),
+    NULL,
+    NULL,
+    FALSE,
+    CREATE_UNICODE_ENVIRONMENT,
+    environment,
+    gui_directory.c_str(),
+    &startup_info,
+    &process_info);
+
+  if (launched) {
+    CloseHandle(process_info.hThread);
+    CloseHandle(process_info.hProcess);
+  }
+  DestroyEnvironmentBlock(environment);
+  CloseHandle(user_token);
+  return launched;
 }
 
 HANDLE
@@ -315,11 +385,22 @@ ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
       continue;
     }
 
+    // Launch the tray in the signed-in user's session so HKCU settings and
+    // single-instance ownership remain scoped to that user.
+    bool gui_agent_started = LaunchGuiAgent(console_session_id);
+
     bool still_running;
     do {
       // Wait for the stop event to be set, Sunshine.exe to terminate, or the console session to change
       const HANDLE wait_objects[] = { stop_event, process_info.hProcess, session_change_event };
-      switch (WaitForMultipleObjects(_countof(wait_objects), wait_objects, FALSE, INFINITE)) {
+      const auto wait_result =
+        WaitForMultipleObjects(_countof(wait_objects), wait_objects, FALSE, gui_agent_started ? INFINITE : 3000);
+      switch (wait_result) {
+        case WAIT_TIMEOUT:
+          gui_agent_started = LaunchGuiAgent(console_session_id);
+          still_running = true;
+          break;
+
         case WAIT_OBJECT_0 + 2:
           if (WTSGetActiveConsoleSessionId() == console_session_id) {
             // The active console session didn't actually change. Let Sunshine keep running.
@@ -349,6 +430,11 @@ ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
           still_running = false;
           break;
         }
+
+        default:
+          SetEvent(stop_event);
+          still_running = false;
+          break;
       }
     } while (still_running);
 


### PR DESCRIPTION
## 改了啥呀

- Windows 服务成功启动 Core 后，使用当前登录用户的真实令牌启动 `sunshine-gui.exe --hidden`
- GUI Agent 初次启动失败时每 3 秒重试，成功后回到事件等待；登录启动和服务启动的重复请求交给 GUI 单实例去重
- Agent 启动失败会把 Win32 错误码写入现有 `sunshine.log`；相同错误不重复刷屏，错误变化或恢复时再记录
- Tray 协议新增 `shutdown` 能力和动作，Core 返回请求结果后优雅停止自身与服务包装器
- 配套 GUI 修复确认弹窗翻译、取消后的勾选回滚，并恢复“显示桌宠”命名
- 更新 Tray 协议文档、能力测试，并指向配套 GUI PR #55

## 为啥要改

之前生命周期有两个没闭环的小杂鱼状态：手动启动 Sunshine 服务不会恢复 GUI/托盘；“退出托盘”又只关用户态界面，不会停止 Core。现在由服务包装器负责启动边界、Core 负责特权停机，GUI 只负责确认和展示，职责终于对齐啦。

## 验证

- `cmake --build build --target sunshinesvc sunshine tray_state_unit_tests -j2`
- `ctest --test-dir build -R tray_state --output-on-failure`，1/1 通过
- 配套 GUI：`cargo test --manifest-path src-tauri/Cargo.toml`，36/36 通过
- `git diff --check`

全量 `cmake --build build -j2` 已编译本次修改文件，但被基线已有的 webhook 测试源码问题阻断：`test_webhook.cpp` 找不到 `webhook.h`，`test_webhook_config.cpp` 调用了不存在的 `config::apply_config`。本次涉及的三个 Windows 目标均已单独编译并链接成功。

## 配套 PR

- qiin2333/sunshine-control-panel#55
