### PR TITLE
perf(installer): reduce setup latency and isolate release flow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: Build and Release
 
+# Published releases are owned by sign-and-repackage.yml. Keeping that event
+# out of this workflow prevents a release created below from starting another
+# build-and-release cycle.
 on:
   pull_request:
     branches:
@@ -11,8 +14,6 @@ on:
   push:
     branches:
       - master
-  release:
-    types: [published]
   workflow_dispatch:
 
 concurrency:
@@ -30,12 +31,12 @@ jobs:
   setup_release:
     name: Setup Release
     outputs:
-      publish_release: ${{ steps.setup_release_auto.outputs.publish_release || steps.setup_release_release.outputs.publish_release || steps.setup_release_manual.outputs.publish_release }}
-      release_body: ${{ steps.setup_release_auto.outputs.release_body || steps.setup_release_release.outputs.release_body || steps.setup_release_manual.outputs.release_body }}
-      release_commit: ${{ steps.setup_release_auto.outputs.release_commit || steps.setup_release_release.outputs.release_commit || steps.setup_release_manual.outputs.release_commit }}
-      release_generate_release_notes: ${{ steps.setup_release_auto.outputs.release_generate_release_notes || steps.setup_release_release.outputs.release_generate_release_notes || steps.setup_release_manual.outputs.release_generate_release_notes }}
-      release_tag: ${{ steps.setup_release_auto.outputs.release_tag || steps.setup_release_release.outputs.release_tag || steps.setup_release_manual.outputs.release_tag }}
-      release_version: ${{ steps.setup_release_auto.outputs.release_version || steps.setup_release_release.outputs.release_version || steps.setup_release_manual.outputs.release_version }}
+      publish_release: ${{ steps.setup_release_auto.outputs.publish_release || steps.setup_release_manual.outputs.publish_release }}
+      release_body: ${{ steps.setup_release_auto.outputs.release_body || steps.setup_release_manual.outputs.release_body }}
+      release_commit: ${{ steps.setup_release_auto.outputs.release_commit || steps.setup_release_manual.outputs.release_commit }}
+      release_generate_release_notes: ${{ steps.setup_release_auto.outputs.release_generate_release_notes || steps.setup_release_manual.outputs.release_generate_release_notes }}
+      release_tag: ${{ steps.setup_release_auto.outputs.release_tag || steps.setup_release_manual.outputs.release_tag }}
+      release_version: ${{ steps.setup_release_auto.outputs.release_version || steps.setup_release_manual.outputs.release_version }}
     permissions:
       contents: write  # read does not work to check squash and merge details
     runs-on: ubuntu-latest
@@ -45,29 +46,10 @@ jobs:
 
       - name: Setup Release (Auto)
         id: setup_release_auto
-        if: github.event_name != 'workflow_dispatch' && github.event_name != 'release'
+        if: github.event_name != 'workflow_dispatch'
         uses: LizardByte/setup-release-action@v2025.426.225
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Setup Release (Release event)
-        id: setup_release_release
-        if: github.event_name == 'release'
-        env:
-          RELEASE_BODY: ${{ github.event.release.body }}
-        run: |
-          TAG="${{ github.event.release.tag_name }}"
-          SUFFIX=$([ "${{ github.event.release.target_commitish }}" = "master" ] && echo "" || echo "-dev")
-          echo "publish_release=true" >> $GITHUB_OUTPUT
-          {
-            echo "release_body<<RELEASE_BODY_EOF"
-            echo "$RELEASE_BODY"
-            echo "RELEASE_BODY_EOF"
-          } >> $GITHUB_OUTPUT
-          echo "release_commit=${{ github.event.release.target_commitish }}" >> $GITHUB_OUTPUT
-          echo "release_generate_release_notes=false" >> $GITHUB_OUTPUT
-          echo "release_tag=${TAG}${SUFFIX}" >> $GITHUB_OUTPUT
-          echo "release_version=${TAG}${SUFFIX}" >> $GITHUB_OUTPUT
 
       - name: Setup Release (Manual)
         id: setup_release_manual
@@ -89,7 +71,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
+          ref: ${{ github.sha }}
           submodules: recursive
 
       - name: Setup Dependencies Windows

--- a/cmake/packaging/FetchDriverDeps.cmake
+++ b/cmake/packaging/FetchDriverDeps.cmake
@@ -17,6 +17,9 @@
 #   VDD_DRIVER_VERSION      — ZakoVDD release tag (e.g. v0.1.4)
 #   VDD_WIN10_DRIVER_VERSION — Win10-pinned ZakoVDD release tag
 #   NEFCON_VERSION          — nefcon release tag (e.g. v1.10.0)
+#   VIGEMBUS_VERSION        — pinned ViGEmBus release tag
+#   VIGEMBUS_ASSET_NAME     — pinned multi-architecture installer asset
+#   VIGEMBUS_SHA256         — expected installer digest
 #   GITHUB_TOKEN            — Token for private repos (or set env GITHUB_TOKEN)
 #
 # Output variables (CACHE FORCE, available to parent):
@@ -24,6 +27,7 @@
 #   VDD_DRIVER_DIR          — Directory containing latest VDD driver files
 #   VDD_WIN10_DRIVER_DIR    — Directory containing Win10-pinned VDD driver files
 #   NEFCON_DRIVER_DIR       — Directory containing nefconw.exe
+#   VIGEMBUS_INSTALLER      — Hash-verified installer bundled into packages
 
 include_guard(GLOBAL)
 
@@ -41,6 +45,11 @@ set(VDD_WIN10_DRIVER_VERSION "v0.14.3-rc1-edid13-test" CACHE STRING "Win10-pinne
 set(VDD_DRIVER_ASSET_NAME "zakovdd.zip" CACHE STRING "Latest ZakoVDD release asset name")
 set(VDD_WIN10_DRIVER_ASSET_NAME "ZakoVDD-edid13-issue612.zip" CACHE STRING "Win10-pinned ZakoVDD release asset name")
 set(NEFCON_VERSION "v1.17.40" CACHE STRING "nefcon version tag")
+set(VIGEMBUS_VERSION "v1.22.0" CACHE STRING "ViGEmBus release tag")
+set(VIGEMBUS_ASSET_NAME "ViGEmBus_1.22.0_x64_x86_arm64.exe"
+    CACHE STRING "ViGEmBus release asset name")
+set(VIGEMBUS_SHA256 "89220a7865076b342892f98865f3499fb7c4cfd673159e89d352c360fd014c6a"
+    CACHE STRING "SHA256 of the pinned ViGEmBus installer")
 
 # Repositories
 set(_VMOUSE_REPO "AlkaidLab/ZakoVirtualMouse")
@@ -55,6 +64,9 @@ set(VMOUSE_DRIVER_DIR "${DRIVER_DEPS_CACHE}/vmouse" CACHE PATH "" FORCE)
 set(VDD_DRIVER_DIR "${DRIVER_DEPS_CACHE}/vdd" CACHE PATH "" FORCE)
 set(VDD_WIN10_DRIVER_DIR "${DRIVER_DEPS_CACHE}/vdd-win10" CACHE PATH "" FORCE)
 set(NEFCON_DRIVER_DIR "${DRIVER_DEPS_CACHE}/nefcon" CACHE PATH "" FORCE)
+set(VIGEMBUS_DIR "${DRIVER_DEPS_CACHE}/vigembus" CACHE PATH "" FORCE)
+set(VIGEMBUS_INSTALLER "${VIGEMBUS_DIR}/${VIGEMBUS_ASSET_NAME}"
+    CACHE FILEPATH "Pinned ViGEmBus installer" FORCE)
 
 if(NOT FETCH_DRIVER_DEPS)
   message(STATUS "Driver dependency downloads disabled (FETCH_DRIVER_DEPS=OFF)")
@@ -72,8 +84,22 @@ endif()
 # properly (CMake file(DOWNLOAD) doesn't forward auth headers on redirect).
 # ---------------------------------------------------------------------------
 function(_driver_download url output_path)
+  set(_expected_sha256 "")
+  if(ARGC GREATER 2)
+    set(_expected_sha256 "${ARGV2}")
+  endif()
+
   if(EXISTS "${output_path}")
-    return()
+    if(_expected_sha256)
+      file(SHA256 "${output_path}" _cached_sha256)
+      if(_cached_sha256 STREQUAL _expected_sha256)
+        return()
+      endif()
+      message(WARNING "  Cached file hash mismatch; downloading again: ${output_path}")
+      file(REMOVE "${output_path}")
+    else()
+      return()
+    endif()
   endif()
 
   get_filename_component(_dir "${output_path}" DIRECTORY)
@@ -115,6 +141,17 @@ function(_driver_download url output_path)
     file(SIZE "${output_path}" _size)
     if(_size EQUAL 0)
       message(WARNING "  Downloaded file is empty: ${output_path}")
+      file(REMOVE "${output_path}")
+    endif()
+  endif()
+
+  if(EXISTS "${output_path}" AND _expected_sha256)
+    file(SHA256 "${output_path}" _actual_sha256)
+    if(NOT _actual_sha256 STREQUAL _expected_sha256)
+      message(WARNING
+        "  SHA256 mismatch for ${output_path}\n"
+        "  expected: ${_expected_sha256}\n"
+        "  actual:   ${_actual_sha256}")
       file(REMOVE "${output_path}")
     endif()
   endif()
@@ -306,12 +343,20 @@ function(_fetch_nefcon)
   endif()
 endfunction()
 
+# Pinned installer bundled into the package so installation never downloads it.
+function(_fetch_vigembus)
+  set(_url
+    "https://github.com/nefarius/ViGEmBus/releases/download/${VIGEMBUS_VERSION}/${VIGEMBUS_ASSET_NAME}")
+  _driver_download("${_url}" "${VIGEMBUS_INSTALLER}" "${VIGEMBUS_SHA256}")
+endfunction()
+
 # ---------------------------------------------------------------------------
 # Execute all fetches
 # ---------------------------------------------------------------------------
 _fetch_vmouse()
 _fetch_vdd()
 _fetch_nefcon()
+_fetch_vigembus()
 
 # ---------------------------------------------------------------------------
 # Verify critical files (per-driver, so optional drivers can be skipped
@@ -359,3 +404,5 @@ _check_driver("vdd (win10)" VDD_WIN10_DRIVER_AVAILABLE
     "${VDD_WIN10_DRIVER_DIR}/ZakoVDD.cer")
 _check_driver("nefcon" NEFCON_DRIVER_AVAILABLE
     "${NEFCON_DRIVER_DIR}/nefconw.exe")
+_check_driver("ViGEmBus" VIGEMBUS_AVAILABLE
+    "${VIGEMBUS_INSTALLER}")

--- a/cmake/packaging/sunshine.iss.in
+++ b/cmake/packaging/sunshine.iss.in
@@ -238,6 +238,7 @@ Source: "{#MySourceDir}\scripts\driver\*"; DestDir: "{app}\scripts\driver"; Flag
 ; Gamepad scripts
 Source: "{#MySourceDir}\scripts\install-gamepad.bat"; DestDir: "{app}\scripts"; Flags: ignoreversion
 Source: "{#MySourceDir}\scripts\uninstall-gamepad.bat"; DestDir: "{app}\scripts"; Flags: ignoreversion
+Source: "{#MySourceDir}\scripts\gamepad\*"; DestDir: "{app}\scripts\gamepad"; Flags: ignoreversion recursesubdirs skipifsourcedoesntexist; Components: gamepad
 
 ; Virtual Mouse Driver scripts & files
 Source: "{#MySourceDir}\scripts\vmouse\install-vmouse.bat"; DestDir: "{app}\scripts\vmouse"; Flags: ignoreversion
@@ -275,7 +276,7 @@ Root: HKLM64; Subkey: "SOFTWARE\AlkaidLab\Sunshine"; ValueType: string; ValueNam
 [Run]
 ; Post-install: drop explicit ACEs (inherit from parent) + clear READONLY
 ; attribute on files & dirs. The latter is what fixes the rare "Sunshine
-Filename: "{cmd}"; Parameters: "/c icacls ""{app}"" /reset /T /C > ""{tmp}\sunshine-icacls-reset.log"" 2>&1 & attrib -R ""{app}\*.*"" /S /D > ""{tmp}\sunshine-attrib-clear.log"" 2>&1"; StatusMsg: "{cm:StatusResetPermissions}"; Flags: runhidden waituntilterminated
+Filename: "{cmd}"; Parameters: "/c icacls ""{app}"" /reset /T /C > ""{tmp}\sunshine-icacls-reset.log"" 2>&1 & attrib -R ""{app}\*.*"" /S /D > ""{tmp}\sunshine-attrib-clear.log"" 2>&1"; StatusMsg: "{cm:StatusResetPermissions}"; Flags: runhidden waituntilterminated; Check: ShouldRepairInstallPermissions
 Filename: "{app}\scripts\update-path.bat"; Parameters: "add"; StatusMsg: "{cm:StatusUpdatePath}"; Flags: runhidden waituntilterminated
 Filename: "{app}\scripts\migrate-config.bat"; StatusMsg: "{cm:StatusMigrateConfig}"; Flags: runhidden waituntilterminated
 Filename: "{app}\scripts\add-firewall-rule.bat"; StatusMsg: "{cm:StatusFirewall}"; Flags: runhidden waituntilterminated; Components: firewall
@@ -340,6 +341,7 @@ var
   BrandTitle: TNewStaticText;
   BrandSubtitle: TNewStaticText;
   AccentBar: TBevel;
+  ExistingInnoInstall: Boolean;
 
 procedure InitializeWizard();
 var
@@ -599,6 +601,42 @@ begin
   RegDeleteKeyIfEmpty(HKLM32, 'SOFTWARE\AlkaidLab');
 end;
 
+function DetectExistingInnoInstall(): Boolean;
+var
+  InstallDir: String;
+begin
+  Result := RegQueryStringValue(HKLM64, 'SOFTWARE\AlkaidLab\Sunshine', 'InstallDir', InstallDir);
+  if not Result then
+    Result := RegQueryStringValue(HKLM32, 'SOFTWARE\AlkaidLab\Sunshine', 'InstallDir', InstallDir);
+  Result := Result and (InstallDir <> '') and DirExists(InstallDir);
+end;
+
+function ShouldRepairInstallPermissions(): Boolean;
+var
+  ResultCode: Integer;
+  VerifyLog, Params: String;
+begin
+  Result := False;
+  if not ExistingInnoInstall then
+    Exit;
+
+  // Verification is read-only and substantially cheaper than rewriting every
+  // ACL. Only legacy installs with malformed/non-canonical ACLs take the slow
+  // recursive reset path.
+  VerifyLog := ExpandConstant('{tmp}\sunshine-icacls-verify.log');
+  Params := '/c icacls "' + ExpandConstant('{app}') +
+            '" /verify /T /C > "' + VerifyLog + '" 2>&1';
+  ResultCode := -1;
+  if not Exec(ExpandConstant('{cmd}'), Params, '', SW_HIDE,
+              ewWaitUntilTerminated, ResultCode) then
+    Result := True
+  else
+    Result := ResultCode <> 0;
+
+  if not Result then
+    DeleteFile(VerifyLog);
+end;
+
 procedure VerifyServiceInstalled();
 var
   ExpectedPath, ImagePath, Lower, Detail, TmpFile, Line: String;
@@ -687,6 +725,7 @@ var
   ResultCode: Integer;
   Waited: Integer;
 begin
+  ExistingInnoInstall := DetectExistingInnoInstall();
   Result := True;
 
   if not DetectOldNSISInstall() then

--- a/cmake/packaging/windows.cmake
+++ b/cmake/packaging/windows.cmake
@@ -54,6 +54,11 @@ install(DIRECTORY "${SUNSHINE_SOURCE_ASSETS_DIR}/windows/misc/firewall/"
 install(DIRECTORY "${SUNSHINE_SOURCE_ASSETS_DIR}/windows/misc/gamepad/"
         DESTINATION "scripts"
         COMPONENT gamepad)
+if(VIGEMBUS_AVAILABLE)
+  install(FILES "${VIGEMBUS_INSTALLER}"
+          DESTINATION "scripts/gamepad"
+          COMPONENT gamepad)
+endif()
 install(DIRECTORY "${SUNSHINE_SOURCE_ASSETS_DIR}/windows/misc/vsink/"
         DESTINATION "scripts"
         COMPONENT vsink)

--- a/cmake/packaging/windows.cmake
+++ b/cmake/packaging/windows.cmake
@@ -51,7 +51,13 @@ install(DIRECTORY "${SUNSHINE_SOURCE_ASSETS_DIR}/windows/misc/autostart/"
 install(DIRECTORY "${SUNSHINE_SOURCE_ASSETS_DIR}/windows/misc/firewall/"
         DESTINATION "scripts"
         COMPONENT firewall)
-install(DIRECTORY "${SUNSHINE_SOURCE_ASSETS_DIR}/windows/misc/gamepad/"
+set(GENERATED_GAMEPAD_INSTALL_SCRIPT "${CMAKE_BINARY_DIR}/generated/install-gamepad.bat")
+configure_file(
+        "${SUNSHINE_SOURCE_ASSETS_DIR}/windows/misc/gamepad/install-gamepad.bat.in"
+        "${GENERATED_GAMEPAD_INSTALL_SCRIPT}"
+        @ONLY)
+install(FILES "${GENERATED_GAMEPAD_INSTALL_SCRIPT}"
+              "${SUNSHINE_SOURCE_ASSETS_DIR}/windows/misc/gamepad/uninstall-gamepad.bat"
         DESTINATION "scripts"
         COMPONENT gamepad)
 if(VIGEMBUS_AVAILABLE)

--- a/src_assets/windows/misc/gamepad/install-gamepad.bat
+++ b/src_assets/windows/misc/gamepad/install-gamepad.bat
@@ -2,6 +2,11 @@
 set "PATH=%SystemRoot%\System32;%SystemRoot%;%SystemRoot%\System32\Wbem;%SystemRoot%\System32\WindowsPowerShell\v1.0"
 setlocal enabledelayedexpansion
 
+if /I "%~1"=="--verify-only" (
+  set "VERIFY_ONLY=1"
+  goto continue
+)
+
 rem Optional first argument: "force" to skip the version check and always
 rem download + reinstall the latest ViGEmBus release. Without it the script
 rem keeps the original behaviour (bail out early if a compatible version
@@ -23,75 +28,31 @@ echo "The installed version is 1.17 or later, no update needed. Exiting."
 exit /b 0
 
 :continue
-rem Get temp directory
-set "temp_dir=%temp%\Sunshine"
-
-rem Create temp directory if it doesn't exist
-if not exist "%temp_dir%" mkdir "%temp_dir%"
-
-rem Get system proxy setting
-set proxy= 
-for /f "tokens=3" %%a in ('reg query "HKCU\Software\Microsoft\Windows\CurrentVersion\Internet Settings" ^| find /i "ProxyEnable"') do (
-  set ProxyEnable=%%a
-    
-  if !ProxyEnable! equ 0x1 (
-  for /f "tokens=3" %%a in ('reg query "HKCU\Software\Microsoft\Windows\CurrentVersion\Internet Settings" ^| find /i "ProxyServer"') do (
-      set proxy=%%a
-      echo Using system proxy !proxy! to download Virtual Gamepad
-      set proxy=-x !proxy!
-    )
-  ) else (
-    rem Proxy is not enabled.
-  )
-)
-
-rem get browser_download_url from asset 0 of https://api.github.com/repos/nefarius/vigembus/releases/latest
-set latest_release_url=https://api.github.com/repos/nefarius/vigembus/releases/latest
-
-rem Use curl to get the api response, and find the browser_download_url.
-rem `--connect-timeout 10 --max-time 20` ensures we don't hang for minutes if
-rem GitHub or the local network is unreachable during install.
-for /F "tokens=* USEBACKQ" %%F in (`curl -s --connect-timeout 10 --max-time 20 !proxy! -L %latest_release_url% ^| findstr browser_download_url`) do (
-  set browser_download_url=%%F
-)
-
-rem Strip quotes
-set browser_download_url=%browser_download_url:"=%
-
-rem Remove the browser_download_url key
-set browser_download_url=%browser_download_url:browser_download_url: =%
-
-if "%browser_download_url%"=="" (
-  echo ERROR: Could not resolve ViGEmBus download URL.
-  exit /b 1
-)
-
-echo %browser_download_url%
-
-rem Download the exe (with connect/transfer timeout to avoid install hang)
-set "installer=%temp_dir%\virtual_gamepad.exe"
-curl -f -s -L --connect-timeout 10 --max-time 120 !proxy! -o "%installer%" "%browser_download_url%"
-if errorlevel 1 (
-  echo Direct download failed, trying mirror...
-  curl -f -s -L --connect-timeout 10 --max-time 120 !proxy! -o "%installer%" "https://mirror.ghproxy.com/%browser_download_url%"
-)
+rem ViGEmBus is pinned, hash-verified at package build time, and bundled next
+rem to this script. Installation must not depend on GitHub or a proxy.
+set "installer=%~dp0gamepad\ViGEmBus_1.22.0_x64_x86_arm64.exe"
+set "expected_sha256=89220A7865076B342892F98865F3499FB7C4CFD673159E89D352C360FD014C6A"
 
 if not exist "%installer%" (
-  echo ERROR: Failed to download ViGEmBus installer.
+  echo ERROR: Bundled ViGEmBus installer not found: "%installer%"
   exit /b 1
 )
 
-for %%I in ("%installer%") do if %%~zI LEQ 0 (
-  echo ERROR: Downloaded ViGEmBus installer is empty.
-  del /f /q "%installer%" >nul 2>&1
+for /f "usebackq tokens=*" %%H in (`powershell -NoProfile -Command "(Get-FileHash -Algorithm SHA256 -LiteralPath $env:installer).Hash"`) do set "actual_sha256=%%H"
+if /I not "!actual_sha256!"=="!expected_sha256!" (
+  echo ERROR: Bundled ViGEmBus installer failed SHA256 verification.
+  echo Expected: !expected_sha256!
+  echo Actual:   !actual_sha256!
   exit /b 1
+)
+
+if defined VERIFY_ONLY (
+  echo Bundled ViGEmBus installer verified successfully.
+  exit /b 0
 )
 
 rem Install Virtual Gamepad
 "%installer%" /passive /norestart
 set "INSTALL_RESULT=%ERRORLEVEL%"
-
-rem Delete temp directory
-rmdir /S /Q "%temp_dir%"
 
 exit /b %INSTALL_RESULT%

--- a/src_assets/windows/misc/gamepad/install-gamepad.bat.in
+++ b/src_assets/windows/misc/gamepad/install-gamepad.bat.in
@@ -8,11 +8,11 @@ if /I "%~1"=="--verify-only" (
 )
 
 rem Optional first argument: "force" to skip the version check and always
-rem download + reinstall the latest ViGEmBus release. Without it the script
+rem reinstall the bundled ViGEmBus release. Without it the script
 rem keeps the original behaviour (bail out early if a compatible version
 rem is already installed).
 if /I "%~1"=="force" (
-    echo Force mode: skipping version check, will download and reinstall latest.
+    echo Force mode: skipping version check, will reinstall bundled ViGEmBus.
     goto continue
 )
 
@@ -30,8 +30,8 @@ exit /b 0
 :continue
 rem ViGEmBus is pinned, hash-verified at package build time, and bundled next
 rem to this script. Installation must not depend on GitHub or a proxy.
-set "installer=%~dp0gamepad\ViGEmBus_1.22.0_x64_x86_arm64.exe"
-set "expected_sha256=89220A7865076B342892F98865F3499FB7C4CFD673159E89D352C360FD014C6A"
+set "installer=%~dp0gamepad\@VIGEMBUS_ASSET_NAME@"
+set "expected_sha256=@VIGEMBUS_SHA256@"
 
 if not exist "%installer%" (
   echo ERROR: Bundled ViGEmBus installer not found: "%installer%"

--- a/src_assets/windows/misc/vdd/install-vdd.bat
+++ b/src_assets/windows/misc/vdd/install-vdd.bat
@@ -77,6 +77,14 @@ set "NEFCON=%ROOT_DIR%\tools\nefconw.exe"
 if not exist "%NEFCON%" set "NEFCON=%DIST_DIR%\nefconw.exe"
 set "VDD_CONFIG=%CONFIG_DIR%\vdd_settings.xml"
 
+rem A clean install has nothing to remove. The old implementation always ran
+rem the full device/driver cleanup and slept for 13 seconds even on a machine
+rem that had never installed VDD.
+set "VDD_CLEANUP_REQUIRED=0"
+if exist "%DIST_DIR%\ZakoVDD.inf" set "VDD_CLEANUP_REQUIRED=1"
+call :count_vdd_devices EXISTING_VDD_DEVICES
+if !EXISTING_VDD_DEVICES! GTR 0 set "VDD_CLEANUP_REQUIRED=1"
+
 rem First, copy files to target directory so nefconw.exe can be used
 if exist "%DIST_DIR%" (
     rmdir /s /q "%DIST_DIR%"
@@ -84,8 +92,12 @@ if exist "%DIST_DIR%" (
 mkdir "%DIST_DIR%"
 copy /y "%DRIVER_DIR%\*.*" "%DIST_DIR%" >nul
 
-rem Now we can use nefconw.exe to thoroughly clean up existing VDD adapters
-echo Thoroughly cleaning up existing VDD adapters...
+if "!VDD_CLEANUP_REQUIRED!"=="1" goto :cleanup_existing_vdd
+echo No existing VDD device or payload found; skipping legacy cleanup.
+goto :after_existing_vdd_cleanup
+
+:cleanup_existing_vdd
+echo Existing VDD installation detected; cleaning it up...
 
 rem Remove all device nodes with the same hardware ID (multiple instances)
 echo Removing all existing device nodes...
@@ -96,8 +108,9 @@ if %ERRORLEVEL% EQU 0 (
     echo Device node removal failed or not found
 )
 
-rem Wait to ensure device is completely removed
-timeout /t 3 /nobreak 1>nul
+rem Wait only while Windows still reports the old device instead of sleeping
+rem unconditionally on every installation.
+call :wait_for_vdd_removal 20
 
 rem Try to uninstall driver completely
 echo Uninstalling VDD driver...
@@ -107,9 +120,6 @@ if %ERRORLEVEL% EQU 0 (
 ) else (
     echo Driver uninstall failed or not found
 )
-
-rem Wait to ensure driver is completely uninstalled
-timeout /t 3 /nobreak 1>nul
 
 rem Clean up registry entries
 echo Cleaning registry...
@@ -123,10 +133,9 @@ if %ERRORLEVEL% EQU 0 (
 rem Additional cleanup - remove any remaining device instances
 echo Performing additional cleanup...
 "%NEFCON%" --remove-device-node --hardware-id Root\ZakoVDD --class-guid 4d36e968-e325-11ce-bfc1-08002be10318 2>nul
-timeout /t 2 /nobreak 1>nul
+call :wait_for_vdd_removal 20
 
-rem Wait a bit more to ensure everything is cleaned up
-timeout /t 5 /nobreak 1>nul
+:after_existing_vdd_cleanup
 
 if not exist "%VDD_CONFIG%" (
     copy /y "%CONFIG_SOURCE%" "%VDD_CONFIG%" >nul
@@ -154,3 +163,23 @@ echo RESOLVED_WIN_BUILD_NUM=!WIN_BUILD_NUM!
 echo RESOLVED_DRIVER_DIR=!DRIVER_DIR!
 echo RESOLVED_CONFIG_SOURCE=!CONFIG_SOURCE!
 exit /b 0
+
+:count_vdd_devices
+setlocal
+set "VDD_DEVICE_COUNT=0"
+for /f %%C in ('powershell -NoProfile -Command "$devices = Get-PnpDevice -Class Display -ErrorAction SilentlyContinue | Where-Object { @($_.HardwareID) -contains 'Root\ZakoVDD' }; @($devices).Count"') do set "VDD_DEVICE_COUNT=%%C"
+endlocal & set "%~1=%VDD_DEVICE_COUNT%"
+exit /b 0
+
+:wait_for_vdd_removal
+setlocal enabledelayedexpansion
+set "MAX_POLLS=%~1"
+for /l %%P in (1,1,!MAX_POLLS!) do (
+    call :count_vdd_devices REMAINING_VDD_DEVICES
+    if !REMAINING_VDD_DEVICES! LEQ 0 goto :vdd_removed
+    powershell -NoProfile -Command "Start-Sleep -Milliseconds 250"
+)
+endlocal & exit /b 1
+
+:vdd_removed
+endlocal & exit /b 0

--- a/src_assets/windows/misc/vmouse/install-vmouse.bat
+++ b/src_assets/windows/misc/vmouse/install-vmouse.bat
@@ -46,6 +46,12 @@ if not errorlevel 1 (
     exit /b 87
 )
 
+rem Skip expensive PnP and DriverStore cleanup on a clean installation.
+set "VMOUSE_CLEANUP_REQUIRED=0"
+if exist "%DIST_DIR%\ZakoVirtualMouse.inf" set "VMOUSE_CLEANUP_REQUIRED=1"
+call :count_vmouse_devices EXISTING_VIRTUAL_MOUSE_DEVICES
+if !EXISTING_VIRTUAL_MOUSE_DEVICES! GTR 0 set "VMOUSE_CLEANUP_REQUIRED=1"
+
 rem Copy driver files to target directory
 if exist "%DIST_DIR%" (
     rmdir /s /q "%DIST_DIR%"
@@ -53,14 +59,19 @@ if exist "%DIST_DIR%" (
 mkdir "%DIST_DIR%"
 copy "%DRIVER_DIR%\*.*" "%DIST_DIR%"
 
+set "SERVICE_WAS_RUNNING=0"
+if "!VMOUSE_CLEANUP_REQUIRED!"=="1" goto :cleanup_existing_vmouse
+echo No existing Virtual Mouse device or payload found; skipping legacy cleanup.
+goto :after_existing_vmouse_cleanup
+
 rem ============================================================================
 rem  Stop Sunshine service to release HID device handle
 rem ============================================================================
 
+:cleanup_existing_vmouse
 rem Use sc + taskkill (non-blocking) instead of `net stop`, which can block
 rem for up to 30 seconds on a stuck stop handler.
 echo Stopping Sunshine service...
-set "SERVICE_WAS_RUNNING=0"
 sc query SunshineService >nul 2>&1
 if not errorlevel 1 (
     sc query SunshineService | find /I "RUNNING" >nul 2>&1
@@ -69,7 +80,6 @@ if not errorlevel 1 (
         sc stop SunshineService >nul 2>&1
     )
     taskkill /f /im sunshinesvc.exe >nul 2>&1
-    timeout /t 1 /nobreak >nul 2>&1
     echo Sunshine service stopped.
 ) else (
     echo Sunshine service not installed, OK.
@@ -106,7 +116,6 @@ if !REMAINING_AFTER! LSS !REMAINING_BEFORE! (
     set /a CLEANUP_COUNT+=REMOVED_NOW
     echo Removed !REMOVED_NOW! device node^(s^), !REMAINING_AFTER! remaining...
     set "REMAINING_BEFORE=!REMAINING_AFTER!"
-    timeout /t 1 /nobreak >nul
     goto remove_loop
 )
 if !NEFCON_REMOVE_RC! GEQ 1 (
@@ -125,14 +134,13 @@ for /f "tokens=*" %%d in ('powershell -NoProfile -Command ^
     echo Removing remaining device: %%d
     pnputil /remove-device "%%d" >nul 2>&1
 )
+call :wait_for_vmouse_removal 20
 call :count_vmouse_devices REMAINING_AFTER_PNPUTIL
 if !REMAINING_AFTER_PNPUTIL! GTR 0 (
     echo WARN: !REMAINING_AFTER_PNPUTIL! device node^(s^) still remain after pnputil cleanup.
 ) else (
     echo All existing device nodes removed.
 )
-
-timeout /t 2 /nobreak 1>nul
 
 rem Uninstall previous driver
 "%NEFCON%" --uninstall-driver --inf-path "%DIST_DIR%\ZakoVirtualMouse.inf"
@@ -142,17 +150,14 @@ if not errorlevel 1 (
     echo No previous driver found, OK.
 )
 
-timeout /t 3 /nobreak 1>nul
-
 rem Clean up stale driver packages from DriverStore (locale-independent)
 powershell -NoProfile -Command "Get-ChildItem ($env:SystemRoot + '\INF\oem*.inf') -ErrorAction SilentlyContinue | Where-Object { Select-String -Path $_.FullName -Pattern 'ZakoVirtualMouse' -Quiet } | ForEach-Object { Write-Host ('Removing stale driver package: ' + $_.Name); pnputil /delete-driver $_.Name /force | Out-Null }"
-
-timeout /t 1 /nobreak 1>nul
 
 rem ============================================================================
 rem  Install Certificate and Driver
 rem ============================================================================
 
+:after_existing_vmouse_cleanup
 rem Install certificate to Trusted Root and Trusted Publisher stores
 set "CERTIFICATE=%DIST_DIR%\ZakoVirtualMouse.cer"
 if exist "%CERTIFICATE%" (
@@ -209,3 +214,16 @@ for /f %%C in ('powershell -NoProfile -Command ^
     "$devices = Get-PnpDevice -InstanceId 'ROOT\HIDCLASS\*' -ErrorAction SilentlyContinue | Where-Object { $_.HardwareID -contains 'Root\ZakoVirtualMouse' }; @($devices).Count"') do set "COUNT=%%C"
 endlocal & set "%~1=%COUNT%"
 exit /b 0
+
+:wait_for_vmouse_removal
+setlocal enabledelayedexpansion
+set "MAX_POLLS=%~1"
+for /l %%P in (1,1,!MAX_POLLS!) do (
+    call :count_vmouse_devices REMAINING_VIRTUAL_MOUSE_DEVICES
+    if !REMAINING_VIRTUAL_MOUSE_DEVICES! LEQ 0 goto :vmouse_removed
+    powershell -NoProfile -Command "Start-Sleep -Milliseconds 250"
+)
+endlocal & exit /b 1
+
+:vmouse_removed
+endlocal & exit /b 0


### PR DESCRIPTION
## 改了啥呀

- 把正式 Release 的处理权留给签名发布工作流，主构建流程不再响应 `release.published`，免得发布自己追着自己跑，杂鱼递归退散。
- VDD 和虚拟鼠标在全新安装时跳过旧设备、旧驱动清理；升级时用设备状态轮询替代固定睡眠。
- 固定并随包携带官方 ViGEmBus `v1.22.0` 安装器，构建时校验 SHA-256，用户安装阶段不再临时访问 GitHub。
- ACL 递归修复只在检测到既有安装且校验异常时执行，正常安装不再无条件重写全部文件权限。
- 保持 `recommended` 默认安装必要驱动的产品行为不变。

## 为啥要改

安装慢主要不是解压，而是多个驱动清理、固定等待、安装时联网和递归权限重置串行叠加。顺手也隔离了普通构建和正式发布的职责，避免 Release 事件产生重复发布风险。

## 验证

- Windows 10/11 VDD payload 选择 smoke test 通过。
- ViGEmBus `v1.22.0` SHA-256 与离线脚本校验通过。
- CMake configure 与 staging install 通过。
- Inno Setup 6.7.1 完整编译成功，并确认 ViGEmBus 被压入最终安装器。
- `git diff --check` 通过。

没有在开发机上实际安装驱动，避免测试过程修改系统驱动和证书状态，哼哼。
