### PR TITLE
fix(rtsp): retain tickets across request sockets

### DIFF
--- a/docs/rtsp_launch_ticket_manager.md
+++ b/docs/rtsp_launch_ticket_manager.md
@@ -10,18 +10,18 @@ protocol phases.
 /launch or /resume
         |
         v
-     pending  -- first RTSP request authenticated --> claimed
-        ^                                         |
-        |---- request socket closes before ANNOUNCE|
-                                                  v
-                           successful ANNOUNCE --> active stream
-                                                  (ticket removed)
+     pending  -- RTSP request authenticated --> claimed (lease count + 1)
+        ^                                      |
+        |---- request socket closes -----------|  (lease count - 1)
+        |
+        +---- stream startup confirmed --> active stream (ticket removed)
 ```
 
-Both `pending` and `claimed` tickets expire. A claimed ticket is released back
-to `pending` when an RTSP request socket closes before the stream is activated.
-This is required because GameStream uses a separate TCP connection for each
-RTSP request.
+Only unclaimed `pending` tickets expire. Authenticated RTSP sockets hold counted
+leases, so overlapping requests cannot prematurely release the ticket. The
+ticket returns to `pending` when its last socket closes and remains available
+until stream startup is confirmed. This is required because GameStream uses a
+separate TCP connection for each RTSP request.
 
 ## Identity and compatibility
 

--- a/src/launch_session_manager.cpp
+++ b/src/launch_session_manager.cpp
@@ -16,6 +16,7 @@ namespace rtsp_stream {
     struct launch_ticket_t {
       std::shared_ptr<launch_session_t> session;
       launch_ticket_state_e state { launch_ticket_state_e::pending };
+      std::size_t claim_count { 0 };
       launch_session_manager_t::clock_t::time_point expires_at;
     };
 
@@ -87,6 +88,7 @@ namespace rtsp_stream {
 
         same_client->session = std::move(session);
         same_client->state = launch_ticket_state_e::pending;
+        same_client->claim_count = 0;
         same_client->expires_at = now + timeout;
         return launch_ticket_register_e::replaced;
       }
@@ -109,6 +111,7 @@ namespace rtsp_stream {
     _impl->tickets.push_back({
       .session = std::move(session),
       .state = launch_ticket_state_e::pending,
+      .claim_count = 0,
       .expires_at = now + timeout,
     });
     return launch_ticket_register_e::accepted;
@@ -122,8 +125,7 @@ namespace rtsp_stream {
     launch_ticket_t *match = nullptr;
     if (!remote_address.empty()) {
       for (auto &ticket : _impl->tickets) {
-        if (ticket.state != launch_ticket_state_e::pending ||
-            !ticket.session ||
+        if (!ticket.session ||
             ticket.session->rtsp_cipher ||
             ticket.session->rtsp_peer_address != remote_address) {
           continue;
@@ -138,7 +140,7 @@ namespace rtsp_stream {
     if (!match) {
       auto only_pending = static_cast<launch_ticket_t *>(nullptr);
       for (auto &ticket : _impl->tickets) {
-        if (ticket.state != launch_ticket_state_e::pending || !ticket.session || ticket.session->rtsp_cipher) {
+        if (!ticket.session || ticket.session->rtsp_cipher) {
           continue;
         }
         if (only_pending) {
@@ -154,6 +156,7 @@ namespace rtsp_stream {
     }
 
     match->state = launch_ticket_state_e::claimed;
+    ++match->claim_count;
     return match->session;
   }
 
@@ -172,8 +175,7 @@ namespace rtsp_stream {
     // GCM authentication tag remains the sole identity decision.
     for (int route_pass = 0; route_pass < 2; ++route_pass) {
       for (auto &ticket : _impl->tickets) {
-        if (ticket.state != launch_ticket_state_e::pending ||
-            !ticket.session ||
+        if (!ticket.session ||
             !ticket.session->rtsp_cipher) {
           continue;
         }
@@ -203,6 +205,7 @@ namespace rtsp_stream {
     }
 
     match->state = launch_ticket_state_e::claimed;
+    ++match->claim_count;
     return {
       .session = match->session,
       .plaintext = std::move(matched_plaintext),
@@ -226,8 +229,10 @@ namespace rtsp_stream {
       return false;
     }
 
-    ticket->state = launch_ticket_state_e::pending;
-    ticket->expires_at = now + timeout;
+    if (--ticket->claim_count == 0) {
+      ticket->state = launch_ticket_state_e::pending;
+      ticket->expires_at = now + timeout;
+    }
     return true;
   }
 

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -1559,10 +1559,6 @@ namespace rtsp_stream {
       return;
     }
 
-    // The RTSP handshake has created the active stream. The launch ticket is
-    // no longer needed for connection routing and must not block a reconnect.
-    server->activate_launch_session(session.id);
-
     respond(sock, session, &option, 200, "OK", req->sequenceNumber, {});
   }
 

--- a/tests/unit/test_rtsp.cpp
+++ b/tests/unit/test_rtsp.cpp
@@ -155,6 +155,39 @@ TEST(LaunchSessionManager, SupportsOverlappingRtspConnectionsForOneLaunch) {
   EXPECT_TRUE(manager.release(33, 10s, now));
   EXPECT_EQ(manager.register_session(make_session(34, "multi-rtsp-cert", "192.0.2.34"), 10s, now),
             rtsp_stream::launch_ticket_register_e::replaced);
+
+  rtsp_stream::launch_session_manager_t encrypted_manager;
+  const crypto::aes_t key(16, 0x33);
+  ASSERT_EQ(encrypted_manager.register_session(make_session(35, "encrypted-cert", "192.0.2.35", &key), 10s, now),
+            rtsp_stream::launch_ticket_register_e::accepted);
+
+  constexpr std::string_view plaintext { "OPTIONS rtsp://host RTSP/1.0\r\nCSeq: 1\r\n\r\n" };
+  crypto::aes_t iv(12, 0);
+  iv[10] = 'C';
+  iv[11] = 'R';
+  crypto::cipher::gcm_t client_cipher { key, false };
+  std::vector<std::uint8_t> tagged_cipher(
+    crypto::cipher::round_to_pkcs7_padded(plaintext.size()) + crypto::cipher::tag_size);
+  const auto encrypted_size = client_cipher.encrypt(plaintext, tagged_cipher.data(), &iv);
+  ASSERT_GT(encrypted_size, 0);
+  const auto encrypted_message = std::string_view {
+    reinterpret_cast<const char *>(tagged_cipher.data()),
+    static_cast<std::size_t>(encrypted_size) + crypto::cipher::tag_size
+  };
+
+  auto encrypted_describe = encrypted_manager.claim_encrypted("192.0.2.35", encrypted_message, iv, now);
+  auto encrypted_announce = encrypted_manager.claim_encrypted("192.0.2.35", encrypted_message, iv, now);
+  ASSERT_TRUE(encrypted_describe);
+  ASSERT_TRUE(encrypted_announce);
+  EXPECT_EQ(encrypted_describe.session->id, 35U);
+  EXPECT_EQ(encrypted_announce.session->id, 35U);
+
+  EXPECT_TRUE(encrypted_manager.release(35, 10s, now));
+  EXPECT_EQ(encrypted_manager.register_session(make_session(36, "encrypted-cert", "192.0.2.36", &key), 10s, now),
+            rtsp_stream::launch_ticket_register_e::client_busy);
+  EXPECT_TRUE(encrypted_manager.release(35, 10s, now));
+  EXPECT_EQ(encrypted_manager.register_session(make_session(36, "encrypted-cert", "192.0.2.36", &key), 10s, now),
+            rtsp_stream::launch_ticket_register_e::replaced);
 }
 
 TEST(LaunchSessionManager, AuthenticatesEncryptedClaimByGcmTagAcrossRouteChanges) {

--- a/tests/unit/test_rtsp.cpp
+++ b/tests/unit/test_rtsp.cpp
@@ -135,6 +135,28 @@ TEST(LaunchSessionManager, PreservesClaimedTicketsPastPendingExpiry) {
   EXPECT_EQ(manager.size(now + 4s), 0U);
 }
 
+TEST(LaunchSessionManager, SupportsOverlappingRtspConnectionsForOneLaunch) {
+  rtsp_stream::launch_session_manager_t manager;
+  const auto now = rtsp_stream::launch_session_manager_t::clock_t::now();
+
+  ASSERT_EQ(manager.register_session(make_session(33, "multi-rtsp-cert", "192.0.2.33"), 10s, now),
+            rtsp_stream::launch_ticket_register_e::accepted);
+
+  auto describe = manager.claim_plaintext("192.0.2.33", now);
+  auto announce = manager.claim_plaintext("192.0.2.33", now);
+  ASSERT_TRUE(describe);
+  ASSERT_TRUE(announce);
+  EXPECT_EQ(describe->id, 33U);
+  EXPECT_EQ(announce->id, 33U);
+
+  EXPECT_TRUE(manager.release(33, 10s, now));
+  EXPECT_EQ(manager.register_session(make_session(34, "multi-rtsp-cert", "192.0.2.34"), 10s, now),
+            rtsp_stream::launch_ticket_register_e::client_busy);
+  EXPECT_TRUE(manager.release(33, 10s, now));
+  EXPECT_EQ(manager.register_session(make_session(34, "multi-rtsp-cert", "192.0.2.34"), 10s, now),
+            rtsp_stream::launch_ticket_register_e::replaced);
+}
+
 TEST(LaunchSessionManager, AuthenticatesEncryptedClaimByGcmTagAcrossRouteChanges) {
   rtsp_stream::launch_session_manager_t manager;
   const auto now = rtsp_stream::launch_session_manager_t::clock_t::now();


### PR DESCRIPTION
## 改了啥呀

- Launch ticket 的 `claimed` 状态改为引用计数 lease，允许同一次启动的多个 RTSP 请求 socket 重叠认领
- 每个 socket 关闭时只释放自己的 lease，最后一个 lease 释放后 ticket 才回到 pending
- 不再在 ANNOUNCE 时过早删除 ticket；恢复到流启动真正确认后再清理
- 新增多 RTSP 连接重叠的回归测试，并更新生命周期文档

## 为啥要改

GameStream 的 RTSP 请求不是一直复用一条 TCP 连接：Sunshine 处理完一条请求后会关闭 socket，客户端再为后续 DESCRIBE、ANNOUNCE、SETUP 等请求建立新连接。

#793 的实现把第一次请求独占标成 `claimed`，还在 ANNOUNCE 就删掉 ticket，导致后续合法连接无法通过 AES-GCM ticket 认证，客户端只看到连接终结 `-1`。这个杂鱼竞态在日志里表现为 `Unable to authenticate encrypted RTSP launch ticket`。

## 验证

- 根据用户复现日志确认失败发生在第二个加密 RTSP socket 的 ticket 认领阶段
- 新增 `SupportsOverlappingRtspConnectionsForOneLaunch`，覆盖双 lease、部分释放仍 busy、全部释放后可替换
- `git diff --check` — passed
- 完整 Windows 构建与测试交由 CI