### PR TITLE
perf(installer): speed up virtual display setup

### DIFF
--- a/cmake/packaging/windows.cmake
+++ b/cmake/packaging/windows.cmake
@@ -70,6 +70,7 @@ install(DIRECTORY "${SUNSHINE_SOURCE_ASSETS_DIR}/windows/misc/vsink/"
         COMPONENT vsink)
 # VDD: scripts & shared config from source tree, driver binaries from download cache
 install(FILES "${SUNSHINE_SOURCE_ASSETS_DIR}/windows/misc/vdd/install-vdd.bat"
+              "${SUNSHINE_SOURCE_ASSETS_DIR}/windows/misc/vdd/vdd-device-helper.ps1"
               "${SUNSHINE_SOURCE_ASSETS_DIR}/windows/misc/vdd/uninstall-vdd.bat"
         DESTINATION "scripts"
         COMPONENT vdd)

--- a/src_assets/windows/misc/vdd/install-vdd.bat
+++ b/src_assets/windows/misc/vdd/install-vdd.bat
@@ -1,28 +1,53 @@
 @echo off
-set "PATH=%SystemRoot%\System32;%SystemRoot%;%SystemRoot%\System32\Wbem;%SystemRoot%\System32\WindowsPowerShell\v1.0"
-chcp 65001 >nul
 setlocal enabledelayedexpansion
 
-if /i "%~1"=="--resolve-only" (
-    set "RESOLVE_ONLY=1"
+set "PATH=%SystemRoot%\System32;%SystemRoot%;%SystemRoot%\System32\Wbem;%SystemRoot%\System32\WindowsPowerShell\v1.0"
+chcp 65001 >nul
+
+set "VDD_HARDWARE_ID=Root\ZakoVDD"
+set "VDD_CLASS_GUID=4D36E968-E325-11CE-BFC1-08002BE10318"
+set "VDD_SERVICE_NAME=ZAKO_HDR_FOR_SUNSHINE"
+
+for %%A in (%*) do (
+    if /i "%%~A"=="--resolve-only" set "RESOLVE_ONLY=1"
+    if /i "%%~A"=="--probe-only" set "PROBE_ONLY=1"
 )
-if /i "%~1"=="--probe-only" (
-    set "PROBE_ONLY=1"
+call :select_payload || exit /b 1
+call :print_payload
+
+if defined RESOLVE_ONLY (
+    call :print_resolution
+    exit /b 0
 )
 
-rem install
-set "DRIVER_ROOT=%~dp0\driver"
-set "DRIVER_DIR=%DRIVER_ROOT%\win10"
-if not exist "%DRIVER_DIR%\ZakoVDD.inf" (
-    set "DRIVER_DIR=%DRIVER_ROOT%\latest"
+call :init_paths
+call :probe_vdd || exit /b 1
+call :choose_action
+if defined PROBE_ONLY exit /b 0
+
+call :stage_payload || exit /b 1
+if "!VDD_CLEANUP_REQUIRED!"=="1" (
+    call :remove_vdd || exit /b 1
 )
+call :configure_vdd || exit /b 1
+if "!VDD_INSTALL_REQUIRED!"=="1" (
+    call :install_vdd || exit /b 1
+)
+
+echo [%TIME%] VDD adapter is ready.
+echo VDD installation completed!
+exit /b 0
+
+:select_payload
+set "DRIVER_ROOT=%~dp0driver"
+set "DRIVER_DIR=%DRIVER_ROOT%\win10"
 set "CONFIG_SOURCE=%DRIVER_ROOT%\vdd_settings.xml"
 set "WIN_BUILD="
 set "WIN_BUILD_NUM="
 set "WIN_BUILD_SOURCE=registry"
 
 if defined VDD_TEST_WIN_BUILD (
-    set "WIN_BUILD=%VDD_TEST_WIN_BUILD%"
+    set "WIN_BUILD=!VDD_TEST_WIN_BUILD!"
     set "WIN_BUILD_SOURCE=override"
 ) else (
     for /f "tokens=3" %%A in ('reg query "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion" /v CurrentBuildNumber 2^>nul ^| find /i "CurrentBuildNumber"') do set "WIN_BUILD=%%A"
@@ -33,188 +58,173 @@ if defined VDD_TEST_WIN_BUILD (
 
 if defined WIN_BUILD (
     echo(!WIN_BUILD!| findstr /r "^[0-9][0-9]*$" >nul
-    if not errorlevel 1 (
-        set "WIN_BUILD_NUM=!WIN_BUILD!"
-    )
+    if not errorlevel 1 set "WIN_BUILD_NUM=!WIN_BUILD!"
 )
 
-if not defined WIN_BUILD (
-    echo WARNING: Could not detect Windows build; defaulting to Win10 payload.
-)
+if not defined WIN_BUILD echo WARNING: Could not detect Windows build; defaulting to Win10 payload.
+if defined WIN_BUILD if not defined WIN_BUILD_NUM echo WARNING: Ignoring non-numeric Windows build "!WIN_BUILD!" from !WIN_BUILD_SOURCE!; defaulting to Win10 payload.
 
-if defined WIN_BUILD if not defined WIN_BUILD_NUM (
-    echo WARNING: Ignoring non-numeric Windows build "!WIN_BUILD!" from !WIN_BUILD_SOURCE!; defaulting to Win10 payload.
-)
+if not exist "!DRIVER_DIR!\ZakoVDD.inf" set "DRIVER_DIR=!DRIVER_ROOT!\latest"
+if defined WIN_BUILD_NUM if !WIN_BUILD_NUM! GEQ 22000 if exist "!DRIVER_ROOT!\latest\ZakoVDD.inf" set "DRIVER_DIR=!DRIVER_ROOT!\latest"
+if not exist "!DRIVER_DIR!\ZakoVDD.inf" set "DRIVER_DIR=!DRIVER_ROOT!"
+if exist "!DRIVER_DIR!\vdd_settings.xml" set "CONFIG_SOURCE=!DRIVER_DIR!\vdd_settings.xml"
 
-if defined WIN_BUILD_NUM if !WIN_BUILD_NUM! GEQ 22000 if exist "%DRIVER_ROOT%\latest\ZakoVDD.inf" (
-    set "DRIVER_DIR=%DRIVER_ROOT%\latest"
-)
-
-if not exist "%DRIVER_DIR%\ZakoVDD.inf" (
-    set "DRIVER_DIR=%DRIVER_ROOT%"
-)
-
-if exist "%DRIVER_DIR%\vdd_settings.xml" (
-    set "CONFIG_SOURCE=%DRIVER_DIR%\vdd_settings.xml"
-)
-
-if not exist "%DRIVER_DIR%\ZakoVDD.inf" (
-    echo ERROR: VDD driver payload not found in "%DRIVER_DIR%"
+if not exist "!DRIVER_DIR!\ZakoVDD.inf" (
+    echo ERROR: VDD driver payload not found in "!DRIVER_DIR!"
     exit /b 1
 )
-
-if defined WIN_BUILD_NUM (
-    echo Detected Windows build: !WIN_BUILD_NUM!
+if not exist "!CONFIG_SOURCE!" (
+    echo ERROR: VDD configuration template not found at "!CONFIG_SOURCE!"
+    exit /b 1
 )
-if not defined WIN_BUILD_NUM if defined WIN_BUILD echo Detected Windows build (raw): !WIN_BUILD!
+exit /b 0
+
+:print_payload
+if defined WIN_BUILD_NUM echo Detected Windows build: !WIN_BUILD_NUM!
+if not defined WIN_BUILD_NUM if defined WIN_BUILD echo Detected Windows build ^(raw^): !WIN_BUILD!
 echo Using VDD payload: !DRIVER_DIR!
+exit /b 0
 
-if defined RESOLVE_ONLY goto :resolve_only
-
-rem Get sunshine root directory
-for %%I in ("%~dp0\..") do set "ROOT_DIR=%%~fI"
-
-set "DIST_DIR=%ROOT_DIR%\tools\vdd"
-set "CONFIG_DIR=%ROOT_DIR%\config"
-set "NEFCON=%ROOT_DIR%\tools\nefconw.exe"
-if not exist "%NEFCON%" set "NEFCON=%DIST_DIR%\nefconw.exe"
-set "VDD_CONFIG=%CONFIG_DIR%\vdd_settings.xml"
-
-rem Probe the existing device and both driver versions once. Starting a new
-rem PowerShell process for every 250 ms poll was itself taking 1-3 seconds.
-set "EXISTING_VDD_DEVICES=0"
-set "CURRENT_VDD_VERSION="
-set "CURRENT_VDD_STATUS="
-set "BUNDLED_VDD_VERSION="
-for /f "tokens=1,* delims==" %%A in ('powershell -NoProfile -Command ^
-    "$device = $null; foreach ($candidate in @(Get-PnpDevice -Class Display -ErrorAction SilentlyContinue)) { if (@($candidate.HardwareID) -contains 'Root\ZakoVDD') { $device = $candidate; break } };" ^
-    "$driverVerLine = (Select-String -LiteralPath (Join-Path $env:DRIVER_DIR 'ZakoVDD.inf') -Pattern '^\s*DriverVer\s*=' -ErrorAction SilentlyContinue).Line;" ^
-    "$bundled = if ($driverVerLine) { ($driverVerLine -split ',')[-1].Trim() } else { '' };" ^
-    "$current = if ($device) { (Get-PnpDeviceProperty -InstanceId $device.InstanceId -KeyName DEVPKEY_Device_DriverVersion -ErrorAction SilentlyContinue).Data } else { '' };" ^
-    "$status = if ($device) { $device.Status } else { '' };" ^
-    "Write-Output ('EXISTING_VDD_DEVICES=' + @($device).Count); Write-Output ('CURRENT_VDD_VERSION=' + $current); Write-Output ('CURRENT_VDD_STATUS=' + $status); Write-Output ('BUNDLED_VDD_VERSION=' + $bundled)"') do set "%%A=%%B"
-
-echo Existing VDD devices: !EXISTING_VDD_DEVICES!
-if defined CURRENT_VDD_VERSION echo Installed VDD version: !CURRENT_VDD_VERSION!
-if defined CURRENT_VDD_STATUS echo Installed VDD status: !CURRENT_VDD_STATUS!
-if defined BUNDLED_VDD_VERSION echo Bundled VDD version: !BUNDLED_VDD_VERSION!
-if defined PROBE_ONLY exit /b 0
-
-set "VDD_CLEANUP_REQUIRED=0"
-if !EXISTING_VDD_DEVICES! GTR 0 set "VDD_CLEANUP_REQUIRED=1"
-set "VDD_INSTALL_REQUIRED=1"
-if /i "!CURRENT_VDD_STATUS!"=="OK" if defined CURRENT_VDD_VERSION if defined BUNDLED_VDD_VERSION if /i "!CURRENT_VDD_VERSION!"=="!BUNDLED_VDD_VERSION!" (
-    set "VDD_CLEANUP_REQUIRED=0"
-    set "VDD_INSTALL_REQUIRED=0"
-    echo Matching VDD driver is already active; skipping driver reinstall.
-)
-
-rem First, copy files to target directory so nefconw.exe can be used
-if exist "%DIST_DIR%" (
-    rmdir /s /q "%DIST_DIR%"
-)
-mkdir "%DIST_DIR%"
-copy /y "%DRIVER_DIR%\*.*" "%DIST_DIR%" >nul
-
-if "!VDD_CLEANUP_REQUIRED!"=="1" goto :cleanup_existing_vdd
-echo No existing VDD device requires cleanup.
-goto :after_existing_vdd_cleanup
-
-:cleanup_existing_vdd
-echo Existing VDD installation detected; cleaning it up...
-
-rem Remove all device nodes with the same hardware ID (multiple instances)
-echo Removing all existing device nodes...
-"%NEFCON%" --remove-device-node --hardware-id Root\ZakoVDD --class-guid 4d36e968-e325-11ce-bfc1-08002be10318
-if %ERRORLEVEL% EQU 0 (
-    echo Successfully removed device node
-) else (
-    echo Device node removal failed or not found
-)
-
-rem One PowerShell process performs the whole bounded wait.
-call :wait_for_vdd_removal 10
-set "VDD_REMOVE_WAIT_RESULT=!ERRORLEVEL!"
-
-rem Clean up registry entries
-echo Cleaning registry...
-reg delete "HKLM\SOFTWARE\ZakoTech\ZakoDisplayAdapter" /f 2>nul
-if %ERRORLEVEL% EQU 0 (
-    echo Successfully cleaned registry
-) else (
-    echo Registry cleanup failed or not found
-)
-
-if not "!VDD_REMOVE_WAIT_RESULT!"=="0" (
-    echo Device still present; performing one fallback removal...
-    "%NEFCON%" --remove-device-node --hardware-id Root\ZakoVDD --class-guid 4d36e968-e325-11ce-bfc1-08002be10318 2>nul
-    call :wait_for_vdd_removal 10
-)
-
-:after_existing_vdd_cleanup
-
-if not exist "%CONFIG_DIR%" mkdir "%CONFIG_DIR%"
-if not exist "%VDD_CONFIG%" (
-    copy /y "%CONFIG_SOURCE%" "%VDD_CONFIG%" >nul
-)
-
-@REM write registry
-reg add "HKLM\SOFTWARE\ZakoTech\ZakoDisplayAdapter" /v VDDPATH /t REG_SZ /d "%CONFIG_DIR%" /f
-
-if "!VDD_INSTALL_REQUIRED!"=="0" goto :vdd_install_complete
-
-@REM rem install cet
-set "CERTIFICATE=%DIST_DIR%\ZakoVDD.cer"
-certutil -addstore -f root "%CERTIFICATE%"
-@REM certutil -addstore -f TrustedPublisher %CERTIFICATE%
-
-rem Stage the package before creating the root device. The old order created an
-rem unbound ROOT\DISPLAY node and then updated it, which made SetupAPI remove and
-rem restart that brand-new device tree and could block for about 60 seconds.
-echo [%TIME%] Staging VDD driver package...
-pnputil /add-driver "%DIST_DIR%\ZakoVDD.inf"
-if errorlevel 1 (
-    echo ERROR: Failed to stage the VDD driver package.
-    exit /b 1
-)
-
-echo [%TIME%] Creating VDD adapter...
-"%NEFCON%" --create-device-node --hardware-id Root\ZakoVDD --service-name ZAKO_HDR_FOR_SUNSHINE --class-name Display --class-guid 4D36E968-E325-11CE-BFC1-08002BE10318
-if errorlevel 1 (
-    echo ERROR: Failed to create the VDD device node.
-    exit /b 1
-)
-
-rem Creating the root node does not reliably trigger automatic binding. The
-rem package is already staged, so the explicit install completes without the
-rem expensive remove-and-restart cycle seen in the old order.
-"%NEFCON%" --install-driver --inf-path "%DIST_DIR%\ZakoVDD.inf"
-if errorlevel 1 (
-    echo ERROR: Explicit VDD driver installation failed.
-    exit /b 1
-)
-call :wait_for_vdd_ready 10
-if errorlevel 1 (
-    echo ERROR: VDD device did not become ready with version !BUNDLED_VDD_VERSION!.
-    exit /b 1
-)
-
-:vdd_install_complete
-echo [%TIME%] VDD adapter is ready.
-echo VDD installation completed!
-goto :eof
-
-:resolve_only
+:print_resolution
 echo RESOLVED_WIN_BUILD=!WIN_BUILD!
 echo RESOLVED_WIN_BUILD_NUM=!WIN_BUILD_NUM!
 echo RESOLVED_DRIVER_DIR=!DRIVER_DIR!
 echo RESOLVED_CONFIG_SOURCE=!CONFIG_SOURCE!
 exit /b 0
 
-:wait_for_vdd_removal
-powershell -NoProfile -Command "$deadline = [DateTime]::UtcNow.AddSeconds(%~1); do { $device = $null; foreach ($candidate in @(Get-PnpDevice -Class Display -ErrorAction SilentlyContinue)) { if (@($candidate.HardwareID) -contains 'Root\ZakoVDD') { $device = $candidate; break } }; if (-not $device) { exit 0 }; Start-Sleep -Milliseconds 250 } while ([DateTime]::UtcNow -lt $deadline); exit 1"
-exit /b %ERRORLEVEL%
+:init_paths
+for %%I in ("%~dp0..") do set "ROOT_DIR=%%~fI"
+set "DIST_DIR=!ROOT_DIR!\tools\vdd"
+set "CONFIG_DIR=!ROOT_DIR!\config"
+set "VDD_CONFIG=!CONFIG_DIR!\vdd_settings.xml"
+set "VDD_HELPER=%~dp0vdd-device-helper.ps1"
+set "NEFCON=!ROOT_DIR!\tools\nefconw.exe"
+if not exist "!NEFCON!" set "NEFCON=!DIST_DIR!\nefconw.exe"
+exit /b 0
 
-:wait_for_vdd_ready
-powershell -NoProfile -Command "$deadline = [DateTime]::UtcNow.AddSeconds(%~1); do { $device = $null; foreach ($candidate in @(Get-PnpDevice -Class Display -ErrorAction SilentlyContinue)) { if (@($candidate.HardwareID) -contains 'Root\ZakoVDD') { $device = $candidate; break } }; if ($device -and ($device.Status -eq 'OK')) { $version = (Get-PnpDeviceProperty -InstanceId $device.InstanceId -KeyName DEVPKEY_Device_DriverVersion -ErrorAction SilentlyContinue).Data; if (-not $env:BUNDLED_VDD_VERSION -or ($version -eq $env:BUNDLED_VDD_VERSION)) { exit 0 } }; Start-Sleep -Milliseconds 250 } while ([DateTime]::UtcNow -lt $deadline); exit 1"
-exit /b %ERRORLEVEL%
+:probe_vdd
+if not exist "!VDD_HELPER!" (
+    echo ERROR: VDD device helper not found at "!VDD_HELPER!"
+    exit /b 1
+)
+
+set "VDD_DEVICE_PRESENT=0"
+set "CURRENT_VDD_VERSION="
+set "CURRENT_VDD_STATUS="
+set "BUNDLED_VDD_VERSION="
+for /f "tokens=1,* delims==" %%A in ('powershell -NoProfile -ExecutionPolicy Bypass -File "!VDD_HELPER!" -Action Probe -InfPath "!DRIVER_DIR!\ZakoVDD.inf"') do set "%%A=%%B"
+if not defined VDD_PROBE_OK (
+    echo ERROR: Failed to inspect the VDD device and driver versions.
+    exit /b 1
+)
+
+echo Existing VDD device: !VDD_DEVICE_PRESENT!
+if defined CURRENT_VDD_VERSION echo Installed VDD version: !CURRENT_VDD_VERSION!
+if defined CURRENT_VDD_STATUS echo Installed VDD status: !CURRENT_VDD_STATUS!
+echo Bundled VDD version: !BUNDLED_VDD_VERSION!
+exit /b 0
+
+:choose_action
+set "VDD_CLEANUP_REQUIRED=!VDD_DEVICE_PRESENT!"
+set "VDD_INSTALL_REQUIRED=1"
+
+if not "!CURRENT_VDD_STATUS!"=="OK" exit /b 0
+if not defined CURRENT_VDD_VERSION exit /b 0
+if not defined BUNDLED_VDD_VERSION exit /b 0
+if /i not "!CURRENT_VDD_VERSION!"=="!BUNDLED_VDD_VERSION!" exit /b 0
+
+set "VDD_CLEANUP_REQUIRED=0"
+set "VDD_INSTALL_REQUIRED=0"
+echo Matching VDD driver is already active; skipping driver reinstall.
+exit /b 0
+
+:stage_payload
+if exist "!DIST_DIR!" rmdir /s /q "!DIST_DIR!"
+mkdir "!DIST_DIR!" 2>nul
+if errorlevel 1 (
+    echo ERROR: Failed to create VDD payload directory "!DIST_DIR!".
+    exit /b 1
+)
+copy /y "!DRIVER_DIR!\*.*" "!DIST_DIR!" >nul
+if errorlevel 1 (
+    echo ERROR: Failed to stage the VDD payload.
+    exit /b 1
+)
+exit /b 0
+
+:remove_vdd
+echo Existing VDD installation detected; removing its device node...
+"!NEFCON!" --remove-device-node --hardware-id !VDD_HARDWARE_ID! --class-guid !VDD_CLASS_GUID!
+call :wait_vdd Removed 10
+if not errorlevel 1 goto :vdd_removed
+
+echo Device still present; retrying removal once...
+"!NEFCON!" --remove-device-node --hardware-id !VDD_HARDWARE_ID! --class-guid !VDD_CLASS_GUID! 2>nul
+call :wait_vdd Removed 10
+if errorlevel 1 (
+    echo ERROR: VDD device remained present after removal.
+    exit /b 1
+)
+
+:vdd_removed
+reg delete "HKLM\SOFTWARE\ZakoTech\ZakoDisplayAdapter" /f >nul 2>&1
+exit /b 0
+
+:configure_vdd
+if not exist "!CONFIG_DIR!" mkdir "!CONFIG_DIR!" 2>nul
+if not exist "!CONFIG_DIR!" (
+    echo ERROR: Failed to create VDD configuration directory "!CONFIG_DIR!".
+    exit /b 1
+)
+
+if not exist "!VDD_CONFIG!" copy /y "!CONFIG_SOURCE!" "!VDD_CONFIG!" >nul
+if not exist "!VDD_CONFIG!" (
+    echo ERROR: Failed to create VDD configuration file "!VDD_CONFIG!".
+    exit /b 1
+)
+
+reg add "HKLM\SOFTWARE\ZakoTech\ZakoDisplayAdapter" /v VDDPATH /t REG_SZ /d "!CONFIG_DIR!" /f >nul
+if errorlevel 1 (
+    echo ERROR: Failed to register the VDD configuration path.
+    exit /b 1
+)
+exit /b 0
+
+:install_vdd
+set "CERTIFICATE=!DIST_DIR!\ZakoVDD.cer"
+certutil -addstore -f root "!CERTIFICATE!" >nul
+if errorlevel 1 (
+    echo ERROR: Failed to import the VDD certificate.
+    exit /b 1
+)
+
+echo [%TIME%] Staging VDD driver package...
+pnputil /add-driver "!DIST_DIR!\ZakoVDD.inf"
+if errorlevel 1 (
+    echo ERROR: Failed to stage the VDD driver package.
+    exit /b 1
+)
+
+echo [%TIME%] Creating VDD adapter...
+"!NEFCON!" --create-device-node --hardware-id !VDD_HARDWARE_ID! --service-name !VDD_SERVICE_NAME! --class-name Display --class-guid !VDD_CLASS_GUID!
+if errorlevel 1 (
+    echo ERROR: Failed to create the VDD device node.
+    exit /b 1
+)
+
+"!NEFCON!" --install-driver --inf-path "!DIST_DIR!\ZakoVDD.inf"
+if errorlevel 1 (
+    echo ERROR: Failed to bind the VDD driver.
+    exit /b 1
+)
+
+call :wait_vdd Ready 10
+if errorlevel 1 (
+    echo ERROR: VDD device did not become ready with version !BUNDLED_VDD_VERSION!.
+    exit /b 1
+)
+exit /b 0
+
+:wait_vdd
+powershell -NoProfile -ExecutionPolicy Bypass -File "!VDD_HELPER!" -Action %~1 -ExpectedVersion "!BUNDLED_VDD_VERSION!" -TimeoutSeconds %~2
+exit /b !ERRORLEVEL!

--- a/src_assets/windows/misc/vdd/install-vdd.bat
+++ b/src_assets/windows/misc/vdd/install-vdd.bat
@@ -200,10 +200,12 @@ if errorlevel 1 (
 
 echo [%TIME%] Staging VDD driver package...
 pnputil /add-driver "!DIST_DIR!\ZakoVDD.inf"
-if errorlevel 1 (
-    echo ERROR: Failed to stage the VDD driver package.
+set "PNPUTIL_EXIT_CODE=!ERRORLEVEL!"
+if not "!PNPUTIL_EXIT_CODE!"=="0" if not "!PNPUTIL_EXIT_CODE!"=="3010" (
+    echo ERROR: Failed to stage the VDD driver package ^(exit code !PNPUTIL_EXIT_CODE!^).
     exit /b 1
 )
+if "!PNPUTIL_EXIT_CODE!"=="3010" echo VDD driver package staged; Windows reports that a reboot is required.
 
 echo [%TIME%] Creating VDD adapter...
 "!NEFCON!" --create-device-node --hardware-id !VDD_HARDWARE_ID! --service-name !VDD_SERVICE_NAME! --class-name Display --class-guid !VDD_CLASS_GUID!

--- a/src_assets/windows/misc/vdd/install-vdd.bat
+++ b/src_assets/windows/misc/vdd/install-vdd.bat
@@ -6,6 +6,9 @@ setlocal enabledelayedexpansion
 if /i "%~1"=="--resolve-only" (
     set "RESOLVE_ONLY=1"
 )
+if /i "%~1"=="--probe-only" (
+    set "PROBE_ONLY=1"
+)
 
 rem install
 set "DRIVER_ROOT=%~dp0\driver"
@@ -77,13 +80,34 @@ set "NEFCON=%ROOT_DIR%\tools\nefconw.exe"
 if not exist "%NEFCON%" set "NEFCON=%DIST_DIR%\nefconw.exe"
 set "VDD_CONFIG=%CONFIG_DIR%\vdd_settings.xml"
 
-rem A clean install has nothing to remove. The old implementation always ran
-rem the full device/driver cleanup and slept for 13 seconds even on a machine
-rem that had never installed VDD.
+rem Probe the existing device and both driver versions once. Starting a new
+rem PowerShell process for every 250 ms poll was itself taking 1-3 seconds.
+set "EXISTING_VDD_DEVICES=0"
+set "CURRENT_VDD_VERSION="
+set "CURRENT_VDD_STATUS="
+set "BUNDLED_VDD_VERSION="
+for /f "tokens=1,* delims==" %%A in ('powershell -NoProfile -Command ^
+    "$device = $null; foreach ($candidate in @(Get-PnpDevice -Class Display -ErrorAction SilentlyContinue)) { if (@($candidate.HardwareID) -contains 'Root\ZakoVDD') { $device = $candidate; break } };" ^
+    "$driverVerLine = (Select-String -LiteralPath (Join-Path $env:DRIVER_DIR 'ZakoVDD.inf') -Pattern '^\s*DriverVer\s*=' -ErrorAction SilentlyContinue).Line;" ^
+    "$bundled = if ($driverVerLine) { ($driverVerLine -split ',')[-1].Trim() } else { '' };" ^
+    "$current = if ($device) { (Get-PnpDeviceProperty -InstanceId $device.InstanceId -KeyName DEVPKEY_Device_DriverVersion -ErrorAction SilentlyContinue).Data } else { '' };" ^
+    "$status = if ($device) { $device.Status } else { '' };" ^
+    "Write-Output ('EXISTING_VDD_DEVICES=' + @($device).Count); Write-Output ('CURRENT_VDD_VERSION=' + $current); Write-Output ('CURRENT_VDD_STATUS=' + $status); Write-Output ('BUNDLED_VDD_VERSION=' + $bundled)"') do set "%%A=%%B"
+
+echo Existing VDD devices: !EXISTING_VDD_DEVICES!
+if defined CURRENT_VDD_VERSION echo Installed VDD version: !CURRENT_VDD_VERSION!
+if defined CURRENT_VDD_STATUS echo Installed VDD status: !CURRENT_VDD_STATUS!
+if defined BUNDLED_VDD_VERSION echo Bundled VDD version: !BUNDLED_VDD_VERSION!
+if defined PROBE_ONLY exit /b 0
+
 set "VDD_CLEANUP_REQUIRED=0"
-if exist "%DIST_DIR%\ZakoVDD.inf" set "VDD_CLEANUP_REQUIRED=1"
-call :count_vdd_devices EXISTING_VDD_DEVICES
 if !EXISTING_VDD_DEVICES! GTR 0 set "VDD_CLEANUP_REQUIRED=1"
+set "VDD_INSTALL_REQUIRED=1"
+if /i "!CURRENT_VDD_STATUS!"=="OK" if defined CURRENT_VDD_VERSION if defined BUNDLED_VDD_VERSION if /i "!CURRENT_VDD_VERSION!"=="!BUNDLED_VDD_VERSION!" (
+    set "VDD_CLEANUP_REQUIRED=0"
+    set "VDD_INSTALL_REQUIRED=0"
+    echo Matching VDD driver is already active; skipping driver reinstall.
+)
 
 rem First, copy files to target directory so nefconw.exe can be used
 if exist "%DIST_DIR%" (
@@ -93,7 +117,7 @@ mkdir "%DIST_DIR%"
 copy /y "%DRIVER_DIR%\*.*" "%DIST_DIR%" >nul
 
 if "!VDD_CLEANUP_REQUIRED!"=="1" goto :cleanup_existing_vdd
-echo No existing VDD device or payload found; skipping legacy cleanup.
+echo No existing VDD device requires cleanup.
 goto :after_existing_vdd_cleanup
 
 :cleanup_existing_vdd
@@ -108,18 +132,9 @@ if %ERRORLEVEL% EQU 0 (
     echo Device node removal failed or not found
 )
 
-rem Wait only while Windows still reports the old device instead of sleeping
-rem unconditionally on every installation.
-call :wait_for_vdd_removal 20
-
-rem Try to uninstall driver completely
-echo Uninstalling VDD driver...
-"%NEFCON%" --uninstall-driver --inf-path "%DIST_DIR%\ZakoVDD.inf"
-if %ERRORLEVEL% EQU 0 (
-    echo Successfully uninstalled driver
-) else (
-    echo Driver uninstall failed or not found
-)
+rem One PowerShell process performs the whole bounded wait.
+call :wait_for_vdd_removal 10
+set "VDD_REMOVE_WAIT_RESULT=!ERRORLEVEL!"
 
 rem Clean up registry entries
 echo Cleaning registry...
@@ -130,13 +145,15 @@ if %ERRORLEVEL% EQU 0 (
     echo Registry cleanup failed or not found
 )
 
-rem Additional cleanup - remove any remaining device instances
-echo Performing additional cleanup...
-"%NEFCON%" --remove-device-node --hardware-id Root\ZakoVDD --class-guid 4d36e968-e325-11ce-bfc1-08002be10318 2>nul
-call :wait_for_vdd_removal 20
+if not "!VDD_REMOVE_WAIT_RESULT!"=="0" (
+    echo Device still present; performing one fallback removal...
+    "%NEFCON%" --remove-device-node --hardware-id Root\ZakoVDD --class-guid 4d36e968-e325-11ce-bfc1-08002be10318 2>nul
+    call :wait_for_vdd_removal 10
+)
 
 :after_existing_vdd_cleanup
 
+if not exist "%CONFIG_DIR%" mkdir "%CONFIG_DIR%"
 if not exist "%VDD_CONFIG%" (
     copy /y "%CONFIG_SOURCE%" "%VDD_CONFIG%" >nul
 )
@@ -144,16 +161,46 @@ if not exist "%VDD_CONFIG%" (
 @REM write registry
 reg add "HKLM\SOFTWARE\ZakoTech\ZakoDisplayAdapter" /v VDDPATH /t REG_SZ /d "%CONFIG_DIR%" /f
 
+if "!VDD_INSTALL_REQUIRED!"=="0" goto :vdd_install_complete
+
 @REM rem install cet
 set "CERTIFICATE=%DIST_DIR%\ZakoVDD.cer"
 certutil -addstore -f root "%CERTIFICATE%"
 @REM certutil -addstore -f TrustedPublisher %CERTIFICATE%
 
-@REM install inf
-echo Installing VDD adapter...
-"%NEFCON%" --create-device-node --hardware-id Root\ZakoVDD --service-name ZAKO_HDR_FOR_SUNSHINE --class-name Display --class-guid 4D36E968-E325-11CE-BFC1-08002BE10318
-"%NEFCON%" --install-driver --inf-path "%DIST_DIR%\ZakoVDD.inf"
+rem Stage the package before creating the root device. The old order created an
+rem unbound ROOT\DISPLAY node and then updated it, which made SetupAPI remove and
+rem restart that brand-new device tree and could block for about 60 seconds.
+echo [%TIME%] Staging VDD driver package...
+pnputil /add-driver "%DIST_DIR%\ZakoVDD.inf"
+if errorlevel 1 (
+    echo ERROR: Failed to stage the VDD driver package.
+    exit /b 1
+)
 
+echo [%TIME%] Creating VDD adapter...
+"%NEFCON%" --create-device-node --hardware-id Root\ZakoVDD --service-name ZAKO_HDR_FOR_SUNSHINE --class-name Display --class-guid 4D36E968-E325-11CE-BFC1-08002BE10318
+if errorlevel 1 (
+    echo ERROR: Failed to create the VDD device node.
+    exit /b 1
+)
+
+rem Creating the root node does not reliably trigger automatic binding. The
+rem package is already staged, so the explicit install completes without the
+rem expensive remove-and-restart cycle seen in the old order.
+"%NEFCON%" --install-driver --inf-path "%DIST_DIR%\ZakoVDD.inf"
+if errorlevel 1 (
+    echo ERROR: Explicit VDD driver installation failed.
+    exit /b 1
+)
+call :wait_for_vdd_ready 10
+if errorlevel 1 (
+    echo ERROR: VDD device did not become ready with version !BUNDLED_VDD_VERSION!.
+    exit /b 1
+)
+
+:vdd_install_complete
+echo [%TIME%] VDD adapter is ready.
 echo VDD installation completed!
 goto :eof
 
@@ -164,22 +211,10 @@ echo RESOLVED_DRIVER_DIR=!DRIVER_DIR!
 echo RESOLVED_CONFIG_SOURCE=!CONFIG_SOURCE!
 exit /b 0
 
-:count_vdd_devices
-setlocal
-set "VDD_DEVICE_COUNT=0"
-for /f %%C in ('powershell -NoProfile -Command "$devices = Get-PnpDevice -Class Display -ErrorAction SilentlyContinue | Where-Object { @($_.HardwareID) -contains 'Root\ZakoVDD' }; @($devices).Count"') do set "VDD_DEVICE_COUNT=%%C"
-endlocal & set "%~1=%VDD_DEVICE_COUNT%"
-exit /b 0
-
 :wait_for_vdd_removal
-setlocal enabledelayedexpansion
-set "MAX_POLLS=%~1"
-for /l %%P in (1,1,!MAX_POLLS!) do (
-    call :count_vdd_devices REMAINING_VDD_DEVICES
-    if !REMAINING_VDD_DEVICES! LEQ 0 goto :vdd_removed
-    powershell -NoProfile -Command "Start-Sleep -Milliseconds 250"
-)
-endlocal & exit /b 1
+powershell -NoProfile -Command "$deadline = [DateTime]::UtcNow.AddSeconds(%~1); do { $device = $null; foreach ($candidate in @(Get-PnpDevice -Class Display -ErrorAction SilentlyContinue)) { if (@($candidate.HardwareID) -contains 'Root\ZakoVDD') { $device = $candidate; break } }; if (-not $device) { exit 0 }; Start-Sleep -Milliseconds 250 } while ([DateTime]::UtcNow -lt $deadline); exit 1"
+exit /b %ERRORLEVEL%
 
-:vdd_removed
-endlocal & exit /b 0
+:wait_for_vdd_ready
+powershell -NoProfile -Command "$deadline = [DateTime]::UtcNow.AddSeconds(%~1); do { $device = $null; foreach ($candidate in @(Get-PnpDevice -Class Display -ErrorAction SilentlyContinue)) { if (@($candidate.HardwareID) -contains 'Root\ZakoVDD') { $device = $candidate; break } }; if ($device -and ($device.Status -eq 'OK')) { $version = (Get-PnpDeviceProperty -InstanceId $device.InstanceId -KeyName DEVPKEY_Device_DriverVersion -ErrorAction SilentlyContinue).Data; if (-not $env:BUNDLED_VDD_VERSION -or ($version -eq $env:BUNDLED_VDD_VERSION)) { exit 0 } }; Start-Sleep -Milliseconds 250 } while ([DateTime]::UtcNow -lt $deadline); exit 1"
+exit /b %ERRORLEVEL%

--- a/src_assets/windows/misc/vdd/vdd-device-helper.ps1
+++ b/src_assets/windows/misc/vdd/vdd-device-helper.ps1
@@ -1,0 +1,91 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateSet('Probe', 'Ready', 'Removed')]
+    [string] $Action,
+
+    [string] $InfPath,
+    [string] $ExpectedVersion,
+
+    [ValidateRange(1, 60)]
+    [int] $TimeoutSeconds = 10
+)
+
+$ErrorActionPreference = 'Stop'
+$hardwareId = 'Root\ZakoVDD'
+
+function Get-VddDevice {
+    foreach ($candidate in @(Get-PnpDevice -Class Display -ErrorAction SilentlyContinue)) {
+        if (@($candidate.HardwareID) -contains $hardwareId) {
+            return $candidate
+        }
+    }
+    return $null
+}
+
+function Get-InstalledVersion([Microsoft.Management.Infrastructure.CimInstance] $Device) {
+    if (-not $Device) {
+        return ''
+    }
+    return (Get-PnpDeviceProperty `
+        -InstanceId $Device.InstanceId `
+        -KeyName DEVPKEY_Device_DriverVersion `
+        -ErrorAction SilentlyContinue).Data
+}
+
+function Get-BundledVersion([string] $Path) {
+    $driverVer = (Select-String `
+        -LiteralPath $Path `
+        -Pattern '^\s*DriverVer\s*=' `
+        -ErrorAction Stop).Line
+    if (-not $driverVer) {
+        throw "DriverVer was not found in $Path"
+    }
+    return ($driverVer -split ',')[-1].Trim()
+}
+
+function Wait-Until([scriptblock] $Condition) {
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    do {
+        if (& $Condition) {
+            return $true
+        }
+        Start-Sleep -Milliseconds 250
+    } while ([DateTime]::UtcNow -lt $deadline)
+    return $false
+}
+
+try {
+    switch ($Action) {
+        'Probe' {
+            $device = Get-VddDevice
+            $bundledVersion = Get-BundledVersion $InfPath
+            Write-Output 'VDD_PROBE_OK=1'
+            Write-Output ('VDD_DEVICE_PRESENT=' + [int]($null -ne $device))
+            Write-Output ('CURRENT_VDD_VERSION=' + (Get-InstalledVersion $device))
+            Write-Output ('CURRENT_VDD_STATUS=' + $(if ($device) { $device.Status } else { '' }))
+            Write-Output ('BUNDLED_VDD_VERSION=' + $bundledVersion)
+            exit 0
+        }
+        'Removed' {
+            if (Wait-Until { $null -eq (Get-VddDevice) }) {
+                exit 0
+            }
+            exit 1
+        }
+        'Ready' {
+            if (Wait-Until {
+                $device = Get-VddDevice
+                $device -and
+                    $device.Status -eq 'OK' -and
+                    (Get-InstalledVersion $device) -eq $ExpectedVersion
+            }) {
+                exit 0
+            }
+            exit 1
+        }
+    }
+} catch {
+    Write-Error $_
+    exit 1
+}


### PR DESCRIPTION
## 改了啥呀

- 同版本且设备状态正常时，直接跳过 VDD 卸载和重装
- 先用 `pnputil` 预暂存驱动，再创建设备并显式绑定，避免安装阶段重复移除设备树
- 把多次 PowerShell 启动改成单进程短间隔轮询
- 去掉设备节点删除后重复的驱动卸载和无条件二次清理
- 补齐配置目录创建、安装错误检查和版本/状态诊断输出

## 为啥要改

杂鱼旧流程每次安装都会重置虚拟显示器，还会在驱动未预暂存时创建节点。Windows PnP 因此可能花约一分钟停止/移除设备树；脚本本身又叠加固定等待、重复卸载和重复轮询进程。

跨版本升级仍受 Windows 驱动停止耗时限制，但脚本侧不再额外浪费时间；同版本重装则完全不触碰设备树。

## 本机验证

- Windows build `26200`
- 发布包 VDD `100.0.16.4`
- 跨版本升级：`84.0s → 71.0s`
- 同版本重装：`3.93s`，`setupapi.dev.log` 零增长
- 单独测量 Windows `pnputil /disable-device`：禁用 `60.87s`，启用 `0.12s`，确认剩余瓶颈在驱动停止
- 完整往返验证：`100.0.16.4 → 101.0.0.5 → 100.0.16.4`
- 最终设备：`ROOT\DISPLAY\0000`，状态 `OK`，版本 `100.0.16.4`
- `cmake --install build --prefix build/inno_staging`
- Win10 / Win11 payload `--resolve-only` 冒烟测试
- `git diff --check`