### PR TITLE
feat(stream): expose active session telemetry

### DIFF
--- a/src/nvhttp/sessions.cpp
+++ b/src/nvhttp/sessions.cpp
@@ -28,6 +28,31 @@ namespace nvhttp::sessions {
 
   }  // namespace
 
+  json
+  make_session_json(const stream::session_info_t &session_info) {
+    json session_obj;
+    session_obj["client_name"] = session_info.client_name;
+    session_obj["client_uuid"] = session_info.client_uuid;
+    session_obj["client_address"] = session_info.client_address;
+    session_obj["state"] = session_info.state;
+    session_obj["stop_reason"] = session_info.stop_reason;
+    session_obj["session_id"] = session_info.session_id;
+    session_obj["uptime_ms"] = session_info.uptime_ms;
+    session_obj["control_connected"] = session_info.control_connected;
+    session_obj["control_idle_ms"] = session_info.control_idle_ms < 0 ? json(nullptr) : json(session_info.control_idle_ms);
+    session_obj["video_idle_ms"] = session_info.video_idle_ms < 0 ? json(nullptr) : json(session_info.video_idle_ms);
+    session_obj["audio_idle_ms"] = session_info.audio_idle_ms < 0 ? json(nullptr) : json(session_info.audio_idle_ms);
+    session_obj["width"] = session_info.width;
+    session_obj["height"] = session_info.height;
+    session_obj["fps"] = session_info.fps;
+    session_obj["host_audio"] = session_info.host_audio;
+    session_obj["enable_hdr"] = session_info.enable_hdr;
+    session_obj["enable_mic"] = session_info.enable_mic;
+    session_obj["app_name"] = session_info.app_name;
+    session_obj["app_id"] = session_info.app_id;
+    return session_obj;
+  }
+
   void
   get(resp_https_t response, req_https_t request) {
     log_request(request);
@@ -64,28 +89,7 @@ namespace nvhttp::sessions {
       json sessions_array = json::array();
 
       for (const auto &session_info : sessions_info) {
-        json session_obj;
-        session_obj["client_name"] = session_info.client_name;
-        session_obj["client_uuid"] = session_info.client_uuid;
-        session_obj["client_address"] = session_info.client_address;
-        session_obj["state"] = session_info.state;
-        session_obj["stop_reason"] = session_info.stop_reason;
-        session_obj["session_id"] = session_info.session_id;
-        session_obj["uptime_ms"] = session_info.uptime_ms;
-        session_obj["control_connected"] = session_info.control_connected;
-        session_obj["control_idle_ms"] = session_info.control_idle_ms < 0 ? json(nullptr) : json(session_info.control_idle_ms);
-        session_obj["video_idle_ms"] = session_info.video_idle_ms < 0 ? json(nullptr) : json(session_info.video_idle_ms);
-        session_obj["audio_idle_ms"] = session_info.audio_idle_ms < 0 ? json(nullptr) : json(session_info.audio_idle_ms);
-        session_obj["width"] = session_info.width;
-        session_obj["height"] = session_info.height;
-        session_obj["fps"] = session_info.fps;
-        session_obj["host_audio"] = session_info.host_audio;
-        session_obj["enable_hdr"] = session_info.enable_hdr;
-        session_obj["enable_mic"] = session_info.enable_mic;
-        session_obj["app_name"] = session_info.app_name;
-        session_obj["app_id"] = session_info.app_id;
-
-        sessions_array.push_back(session_obj);
+        sessions_array.push_back(make_session_json(session_info));
       }
 
       response_json["sessions"] = sessions_array;

--- a/src/nvhttp/sessions.cpp
+++ b/src/nvhttp/sessions.cpp
@@ -66,9 +66,16 @@ namespace nvhttp::sessions {
       for (const auto &session_info : sessions_info) {
         json session_obj;
         session_obj["client_name"] = session_info.client_name;
+        session_obj["client_uuid"] = session_info.client_uuid;
         session_obj["client_address"] = session_info.client_address;
         session_obj["state"] = session_info.state;
+        session_obj["stop_reason"] = session_info.stop_reason;
         session_obj["session_id"] = session_info.session_id;
+        session_obj["uptime_ms"] = session_info.uptime_ms;
+        session_obj["control_connected"] = session_info.control_connected;
+        session_obj["control_idle_ms"] = session_info.control_idle_ms < 0 ? json(nullptr) : json(session_info.control_idle_ms);
+        session_obj["video_idle_ms"] = session_info.video_idle_ms < 0 ? json(nullptr) : json(session_info.video_idle_ms);
+        session_obj["audio_idle_ms"] = session_info.audio_idle_ms < 0 ? json(nullptr) : json(session_info.audio_idle_ms);
         session_obj["width"] = session_info.width;
         session_obj["height"] = session_info.height;
         session_obj["fps"] = session_info.fps;

--- a/src/nvhttp/sessions.h
+++ b/src/nvhttp/sessions.h
@@ -2,12 +2,21 @@
 
 #include <memory>
 
+#include <nlohmann/json_fwd.hpp>
+
 #include "src/nvhttp.h"
+
+namespace stream {
+  struct session_info_t;
+}
 
 namespace nvhttp::sessions {
 
   using resp_https_t = std::shared_ptr<typename SimpleWeb::ServerBase<SunshineHTTPS>::Response>;
   using req_https_t = std::shared_ptr<typename SimpleWeb::ServerBase<SunshineHTTPS>::Request>;
+
+  nlohmann::json
+  make_session_json(const stream::session_info_t &session_info);
 
   void
   get(resp_https_t response, req_https_t request);

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -831,7 +831,7 @@ namespace rtsp_stream {
       for (auto i = _session_slots->begin(); i != _session_slots->end();) {
         auto &slot = *(*i);
         if (all || stream::session::state(slot) == stream::session::state_e::STOPPING) {
-          stream::session::stop(slot);
+          stream::session::stop(slot, stream::session::stop_reason_e::host_terminate);
           stream::session::join(slot);
 
           i = _session_slots->erase(i);

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -357,8 +357,8 @@ namespace stream {
   }
 
   static inline void
-  while_starting_do_nothing(std::atomic<session::state_e> &state) {
-    while (state.load(std::memory_order_acquire) == session::state_e::STARTING) {
+  while_starting_do_nothing(const session::lifecycle_t &lifecycle) {
+    while (lifecycle.state() == session::state_e::STARTING) {
       std::this_thread::sleep_for(1ms);
     }
   }
@@ -509,7 +509,7 @@ namespace stream {
     std::atomic<std::int64_t> last_control_activity_ms { 0 };
     std::atomic<std::int64_t> last_video_activity_ms { 0 };
     std::atomic<std::int64_t> last_audio_activity_ms { 0 };
-    std::atomic<session::stop_reason_e> stop_reason { session::stop_reason_e::none };
+    session::lifecycle_t lifecycle;
 
     struct {
       std::string ping_payload;
@@ -574,8 +574,6 @@ namespace stream {
 
     safe::mail_raw_t::event_t<bool> shutdown_event;
     safe::signal_t controlEnd;
-
-    std::atomic<session::state_e> state;
 
     // Current total bitrate for this session (including FEC overhead) in Kbps
     // This is the user-configured bitrate, not the encoding bitrate
@@ -890,9 +888,7 @@ namespace stream {
         case ENET_EVENT_TYPE_DISCONNECT:
           BOOST_LOG(info) << "CLIENT DISCONNECTED"sv;
           // No more clients to send video data to ^_^
-          if (session->state == session::state_e::RUNNING) {
-            session::stop(*session, session::stop_reason_e::control_disconnect);
-          }
+          session::stop(*session, session::stop_reason_e::control_disconnect);
           break;
         case ENET_EVENT_TYPE_NONE:
           break;
@@ -1774,7 +1770,7 @@ namespace stream {
             session::stop(*session, session::stop_reason_e::control_timeout);
           }
 
-          if (session->state.load(std::memory_order_acquire) == session::state_e::STOPPING) {
+          if (session->lifecycle.state() == session::state_e::STOPPING) {
             clipboard_bridge::bridge_t::instance().session_stopped(session->launch_session_id);
             pos = server->_sessions->erase(pos);
 
@@ -2968,11 +2964,13 @@ namespace stream {
 
   void
   videoThread(session_t *session) {
+    auto global_shutdown_event = mail::man->event<bool>(mail::shutdown);
     auto fg = util::fail_guard([&]() {
-      session::stop(*session, session::stop_reason_e::video_ended);
+      const auto reason = global_shutdown_event->peek() ? session::stop_reason_e::host_terminate : session::stop_reason_e::video_ended;
+      session::stop(*session, reason);
     });
 
-    while_starting_do_nothing(session->state);
+    while_starting_do_nothing(session->lifecycle);
 
     auto ref = broadcast_shared.ref();
     auto error = recv_ping(session, ref, socket_e::video, session->video.ping_payload, session->video.peer, config::stream.ping_timeout);
@@ -2993,11 +2991,13 @@ namespace stream {
 
   void
   audioThread(session_t *session) {
+    auto global_shutdown_event = mail::man->event<bool>(mail::shutdown);
     auto fg = util::fail_guard([&]() {
-      session::stop(*session, session::stop_reason_e::audio_ended);
+      const auto reason = global_shutdown_event->peek() ? session::stop_reason_e::host_terminate : session::stop_reason_e::audio_ended;
+      session::stop(*session, reason);
     });
 
-    while_starting_do_nothing(session->state);
+    while_starting_do_nothing(session->lifecycle);
 
     auto ref = broadcast_shared.ref();
     auto error = recv_ping(session, ref, socket_e::audio, session->audio.ping_payload, session->audio.peer, config::stream.ping_timeout);
@@ -3040,7 +3040,7 @@ namespace stream {
     }
     state_e
     state(session_t &session) {
-      return session.state.load(std::memory_order_relaxed);
+      return session.lifecycle.state();
     }
 
     bool
@@ -3050,14 +3050,11 @@ namespace stream {
 
     void
     stop(session_t &session, stop_reason_e reason) {
-      while_starting_do_nothing(session.state);
-      auto expected = state_e::RUNNING;
-      auto already_stopping = !session.state.compare_exchange_strong(expected, state_e::STOPPING);
-      if (already_stopping) {
+      while_starting_do_nothing(session.lifecycle);
+      if (!session.lifecycle.request_stop(reason)) {
         return;
       }
 
-      session.stop_reason.store(reason, std::memory_order_relaxed);
       BOOST_LOG(info) << "Stopping streaming session "sv << session.launch_session_id
                       << " [client_uuid="sv << session.client_cert_uuid
                       << ", reason="sv << stop_reason_name(reason) << ']';
@@ -3169,7 +3166,7 @@ namespace stream {
 
       BOOST_LOG(debug) << "Session ended [session_id="sv << session.launch_session_id
                        << ", client_uuid="sv << session.client_cert_uuid
-                       << ", reason="sv << stop_reason_name(session.stop_reason.load(std::memory_order_relaxed)) << ']';
+                       << ", reason="sv << stop_reason_name(session.lifecycle.snapshot().stop_reason) << ']';
     }
 
     int
@@ -3204,6 +3201,10 @@ namespace stream {
       session.audio.peer.port(0);
 
       session.pingTimeout = std::chrono::steady_clock::now() + config::stream.ping_timeout;
+      session.lifecycle.set_state(state_e::STARTING);
+      auto starting_guard = util::fail_guard([&]() {
+        session.lifecycle.set_state(state_e::RUNNING);
+      });
 
       // 仅控制流会话不启动视频/音频线程
       if (!session.control_only) {
@@ -3214,7 +3215,8 @@ namespace stream {
         BOOST_LOG(debug) << "Control-only session: skipping video and audio thread creation"sv;
       }
 
-      session.state.store(state_e::RUNNING, std::memory_order_relaxed);
+      session.lifecycle.set_state(state_e::RUNNING);
+      starting_guard.disable();
       perf::begin_session({
         session.launch_session_id,
         session.client_name,
@@ -3367,7 +3369,6 @@ namespace stream {
       session->control_only = launch_session.control_only;
 
       session->control.peer = nullptr;
-      session->state.store(state_e::STOPPED, std::memory_order_relaxed);
 
       session->mail = std::move(mail);
 
@@ -3394,7 +3395,7 @@ namespace stream {
       auto lg = broadcast_ref->control_server._sessions.lock();
       for (auto session_p : *broadcast_ref->control_server._sessions) {
         if (session_p->client_name == client_name &&
-            session_p->state.load(std::memory_order_relaxed) == state_e::RUNNING) {
+            session_p->lifecycle.state() == state_e::RUNNING) {
           // Update session's current total bitrate if this is a bitrate change
           if (effective_param.type == video::dynamic_param_type_e::BITRATE && effective_param.valid) {
             effective_param.value.int_value = clamp_total_bitrate_to_host_cap(effective_param.value.int_value, client_name);
@@ -3447,14 +3448,16 @@ namespace stream {
           info.client_name = session_p->client_name;
           info.client_uuid = session_p->client_cert_uuid;
           info.session_id = session_p->launch_session_id;
-          info.stop_reason = stop_reason_name(session_p->stop_reason.load(std::memory_order_relaxed));
+
+          const auto lifecycle = session_p->lifecycle.snapshot();
+          info.stop_reason = stop_reason_name(lifecycle.stop_reason);
 
           const auto now_ms = steady_now_ms();
           info.uptime_ms = std::max<std::int64_t>(0, now_ms - session_p->created_at_ms);
           info.control_idle_ms = idle_ms(now_ms, session_p->last_control_activity_ms.load(std::memory_order_relaxed));
           info.video_idle_ms = idle_ms(now_ms, session_p->last_video_activity_ms.load(std::memory_order_relaxed));
           info.audio_idle_ms = idle_ms(now_ms, session_p->last_audio_activity_ms.load(std::memory_order_relaxed));
-          info.control_connected = session_p->control.peer != nullptr;
+          info.control_connected = lifecycle.state == state_e::RUNNING && session_p->control.peer != nullptr;
 
           // Get client address
           if (session_p->control.peer) {
@@ -3470,8 +3473,7 @@ namespace stream {
           }
 
           // Get session state
-          auto state = session_p->state.load(std::memory_order_relaxed);
-          switch (state) {
+          switch (lifecycle.state) {
             case state_e::STOPPED:
               info.state = "STOPPED";
               break;

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -108,6 +108,20 @@ using namespace std::literals;
 
 namespace stream {
 
+  namespace {
+    std::int64_t
+    steady_now_ms() {
+      return std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::steady_clock::now().time_since_epoch())
+        .count();
+    }
+
+    std::int64_t
+    idle_ms(std::int64_t now, std::int64_t last_activity) {
+      return last_activity == 0 ? -1 : std::max<std::int64_t>(0, now - last_activity);
+    }
+  }  // namespace
+
   enum class socket_e : int {
     video,  ///< Video
     audio,  ///< Audio
@@ -489,6 +503,13 @@ namespace stream {
 
     // 添加客户端名称字段
     std::string client_name;
+    std::string client_cert_uuid;
+
+    std::int64_t created_at_ms { 0 };
+    std::atomic<std::int64_t> last_control_activity_ms { 0 };
+    std::atomic<std::int64_t> last_video_activity_ms { 0 };
+    std::atomic<std::int64_t> last_audio_activity_ms { 0 };
+    std::atomic<session::stop_reason_e> stop_reason { session::stop_reason_e::none };
 
     struct {
       std::string ping_payload;
@@ -852,6 +873,7 @@ namespace stream {
       }
 
       session->pingTimeout = std::chrono::steady_clock::now() + config::stream.ping_timeout;
+      session->last_control_activity_ms.store(steady_now_ms(), std::memory_order_relaxed);
 
       switch (event.type) {
         case ENET_EVENT_TYPE_RECEIVE: {
@@ -869,7 +891,7 @@ namespace stream {
           BOOST_LOG(info) << "CLIENT DISCONNECTED"sv;
           // No more clients to send video data to ^_^
           if (session->state == session::state_e::RUNNING) {
-            session::stop(*session);
+            session::stop(*session, session::stop_reason_e::control_disconnect);
           }
           break;
         case ENET_EVENT_TYPE_NONE:
@@ -1643,7 +1665,7 @@ namespace stream {
 
         BOOST_LOG(error) << "Failed to verify tag"sv;
 
-        session::stop(*session);
+        session::stop(*session, session::stop_reason_e::protocol_error);
         return;
       }
 
@@ -1699,7 +1721,7 @@ namespace stream {
 
         BOOST_LOG(error) << "Failed to verify tag"sv;
 
-        session::stop(*session);
+        session::stop(*session, session::stop_reason_e::protocol_error);
         return;
       }
 
@@ -1708,7 +1730,7 @@ namespace stream {
 
       if (type == packetTypes[IDX_ENCRYPTED]) {
         BOOST_LOG(error) << "Bad packet type [IDX_ENCRYPTED] found"sv;
-        session::stop(*session);
+        session::stop(*session, session::stop_reason_e::protocol_error);
         return;
       }
 
@@ -1749,7 +1771,7 @@ namespace stream {
           if (now > session->pingTimeout) {
             auto address = session->control.peer ? platf::from_sockaddr((sockaddr *) &session->control.peer->address.address) : session->control.expected_peer_address;
             BOOST_LOG(info) << address << ": Ping Timeout"sv;
-            session::stop(*session);
+            session::stop(*session, session::stop_reason_e::control_timeout);
           }
 
           if (session->state.load(std::memory_order_acquire) == session::state_e::STOPPING) {
@@ -2288,6 +2310,7 @@ namespace stream {
       frame_network_latency_logger.first_point_now();
 
       auto session = (session_t *) packet->channel_data;
+      session->last_video_activity_ms.store(steady_now_ms(), std::memory_order_relaxed);
       auto lowseq = session->video.lowseq;
 
       std::string_view payload { (char *) packet->data(), packet->data_size() };
@@ -2639,6 +2662,7 @@ namespace stream {
 
       TUPLE_2D_REF(channel_data, packet_data, *packet);
       auto session = (session_t *) channel_data;
+      session->last_audio_activity_ms.store(steady_now_ms(), std::memory_order_relaxed);
 
       auto sequenceNumber = session->audio.sequenceNumber;
       auto timestamp = session->audio.timestamp;
@@ -2945,7 +2969,7 @@ namespace stream {
   void
   videoThread(session_t *session) {
     auto fg = util::fail_guard([&]() {
-      session::stop(*session);
+      session::stop(*session, session::stop_reason_e::video_ended);
     });
 
     while_starting_do_nothing(session->state);
@@ -2970,7 +2994,7 @@ namespace stream {
   void
   audioThread(session_t *session) {
     auto fg = util::fail_guard([&]() {
-      session::stop(*session);
+      session::stop(*session, session::stop_reason_e::audio_ended);
     });
 
     while_starting_do_nothing(session->state);
@@ -2994,6 +3018,26 @@ namespace stream {
     std::atomic_uint running_sessions;
     std::atomic_uint running_non_control_only_sessions;  // 跟踪非仅控制流会话的数量
 
+    const char *
+    stop_reason_name(stop_reason_e reason) {
+      switch (reason) {
+        case stop_reason_e::none:
+          return "none";
+        case stop_reason_e::control_disconnect:
+          return "control_disconnect";
+        case stop_reason_e::control_timeout:
+          return "control_timeout";
+        case stop_reason_e::protocol_error:
+          return "protocol_error";
+        case stop_reason_e::video_ended:
+          return "video_ended";
+        case stop_reason_e::audio_ended:
+          return "audio_ended";
+        case stop_reason_e::host_terminate:
+          return "host_terminate";
+      }
+      return "unknown";
+    }
     state_e
     state(session_t &session) {
       return session.state.load(std::memory_order_relaxed);
@@ -3005,13 +3049,18 @@ namespace stream {
     }
 
     void
-    stop(session_t &session) {
+    stop(session_t &session, stop_reason_e reason) {
       while_starting_do_nothing(session.state);
       auto expected = state_e::RUNNING;
       auto already_stopping = !session.state.compare_exchange_strong(expected, state_e::STOPPING);
       if (already_stopping) {
         return;
       }
+
+      session.stop_reason.store(reason, std::memory_order_relaxed);
+      BOOST_LOG(info) << "Stopping streaming session "sv << session.launch_session_id
+                      << " [client_uuid="sv << session.client_cert_uuid
+                      << ", reason="sv << stop_reason_name(reason) << ']';
 
       perf::end_session(session.launch_session_id);
       session.shutdown_event->raise(true);
@@ -3118,7 +3167,9 @@ namespace stream {
       // Clean up ABR state for this client
       abr::cleanup(session.client_name);
 
-      BOOST_LOG(debug) << "Session ended"sv;
+      BOOST_LOG(debug) << "Session ended [session_id="sv << session.launch_session_id
+                       << ", client_uuid="sv << session.client_cert_uuid
+                       << ", reason="sv << stop_reason_name(session.stop_reason.load(std::memory_order_relaxed)) << ']';
     }
 
     int
@@ -3224,9 +3275,11 @@ namespace stream {
 
       session->shutdown_event = mail->event<bool>(mail::shutdown);
       session->launch_session_id = launch_session.id;
+      session->created_at_ms = steady_now_ms();
 
       // 设置客户端名称
       session->client_name = launch_session.client_name;
+      session->client_cert_uuid = launch_session.client_cert_uuid;
 
       // 保存 launch_session 的关键字段，用于后续动态参数更新
       session->enable_sops = launch_session.enable_sops;
@@ -3392,7 +3445,16 @@ namespace stream {
           session_info_t info;
 
           info.client_name = session_p->client_name;
+          info.client_uuid = session_p->client_cert_uuid;
           info.session_id = session_p->launch_session_id;
+          info.stop_reason = stop_reason_name(session_p->stop_reason.load(std::memory_order_relaxed));
+
+          const auto now_ms = steady_now_ms();
+          info.uptime_ms = std::max<std::int64_t>(0, now_ms - session_p->created_at_ms);
+          info.control_idle_ms = idle_ms(now_ms, session_p->last_control_activity_ms.load(std::memory_order_relaxed));
+          info.video_idle_ms = idle_ms(now_ms, session_p->last_video_activity_ms.load(std::memory_order_relaxed));
+          info.audio_idle_ms = idle_ms(now_ms, session_p->last_audio_activity_ms.load(std::memory_order_relaxed));
+          info.control_connected = session_p->control.peer != nullptr;
 
           // Get client address
           if (session_p->control.peer) {

--- a/src/stream.h
+++ b/src/stream.h
@@ -3,16 +3,22 @@
  * @brief Declarations for the streaming protocols.
  */
 #pragma once
+#include <atomic>
 #include <cstdint>
+#include <mutex>
+#include <string>
 #include <utility>
 #include <vector>
-#include <string>
 
 #include <boost/asio.hpp>
 
 #include "audio.h"
 #include "crypto.h"
 #include "video.h"
+
+namespace rtsp_stream {
+  struct launch_session_t;
+}
 
 namespace stream {
   constexpr auto VIDEO_STREAM_PORT = 9;
@@ -50,6 +56,61 @@ namespace stream {
 
     const char *
     stop_reason_name(stop_reason_e reason);
+
+    enum class state_e : int {
+      STOPPED,  ///< The session is stopped
+      STOPPING,  ///< The session is stopping
+      STARTING,  ///< The session is starting
+      RUNNING,  ///< The session is running
+    };
+
+    struct lifecycle_snapshot_t {
+      state_e state;
+      stop_reason_e stop_reason;
+    };
+
+    class lifecycle_t {
+    public:
+      explicit lifecycle_t(state_e initial_state = state_e::STOPPED) noexcept:
+          _state(initial_state) {}
+
+      state_e
+      state() const noexcept {
+        return _state.load(std::memory_order_acquire);
+      }
+
+      void
+      set_state(state_e state) {
+        std::lock_guard lock(_mutex);
+        _state.store(state, std::memory_order_release);
+      }
+
+      bool
+      request_stop(stop_reason_e reason) {
+        std::lock_guard lock(_mutex);
+        if (_state.load(std::memory_order_relaxed) != state_e::RUNNING) {
+          return false;
+        }
+
+        _stop_reason = reason;
+        _state.store(state_e::STOPPING, std::memory_order_release);
+        return true;
+      }
+
+      lifecycle_snapshot_t
+      snapshot() const {
+        std::lock_guard lock(_mutex);
+        return {
+          _state.load(std::memory_order_relaxed),
+          _stop_reason,
+        };
+      }
+
+    private:
+      mutable std::mutex _mutex;
+      std::atomic<state_e> _state;
+      stop_reason_e _stop_reason { stop_reason_e::none };
+    };
   }  // namespace session
 
   // Session information structure for API responses
@@ -77,13 +138,6 @@ namespace stream {
   };
 
   namespace session {
-    enum class state_e : int {
-      STOPPED,  ///< The session is stopped
-      STOPPING,  ///< The session is stopping
-      STARTING,  ///< The session is starting
-      RUNNING,  ///< The session is running
-    };
-
     std::shared_ptr<session_t>
     alloc(config_t &config, rtsp_stream::launch_session_t &launch_session);
     int

--- a/src/stream.h
+++ b/src/stream.h
@@ -3,6 +3,7 @@
  * @brief Declarations for the streaming protocols.
  */
 #pragma once
+#include <cstdint>
 #include <utility>
 #include <vector>
 #include <string>
@@ -36,12 +37,34 @@ namespace stream {
     std::optional<int> gcmap;
   };
 
+  namespace session {
+    enum class stop_reason_e : int {
+      none,
+      control_disconnect,
+      control_timeout,
+      protocol_error,
+      video_ended,
+      audio_ended,
+      host_terminate,
+    };
+
+    const char *
+    stop_reason_name(stop_reason_e reason);
+  }  // namespace session
+
   // Session information structure for API responses
   struct session_info_t {
     std::string client_name;
+    std::string client_uuid;
     std::string client_address;
     std::string state;
+    std::string stop_reason;
     uint32_t session_id;
+    std::int64_t uptime_ms;
+    std::int64_t control_idle_ms;
+    std::int64_t video_idle_ms;
+    std::int64_t audio_idle_ms;
+    bool control_connected;
     int width;
     int height;
     int fps;
@@ -66,7 +89,7 @@ namespace stream {
     int
     start(session_t &session, const std::string &addr_string);
     void
-    stop(session_t &session);
+    stop(session_t &session, stop_reason_e reason = stop_reason_e::none);
     void
     join(session_t &session);
     state_e

--- a/tests/unit/test_stream_session_observability.cpp
+++ b/tests/unit/test_stream_session_observability.cpp
@@ -1,0 +1,21 @@
+/**
+ * @file tests/unit/test_stream_session_observability.cpp
+ * @brief Tests for active streaming-session telemetry values.
+ */
+
+#include "src/stream.h"
+
+#include "../tests_common.h"
+
+TEST(StreamSessionObservability, NamesEveryStopReason) {
+  using stream::session::stop_reason_e;
+  using stream::session::stop_reason_name;
+
+  EXPECT_STREQ(stop_reason_name(stop_reason_e::none), "none");
+  EXPECT_STREQ(stop_reason_name(stop_reason_e::control_disconnect), "control_disconnect");
+  EXPECT_STREQ(stop_reason_name(stop_reason_e::control_timeout), "control_timeout");
+  EXPECT_STREQ(stop_reason_name(stop_reason_e::protocol_error), "protocol_error");
+  EXPECT_STREQ(stop_reason_name(stop_reason_e::video_ended), "video_ended");
+  EXPECT_STREQ(stop_reason_name(stop_reason_e::audio_ended), "audio_ended");
+  EXPECT_STREQ(stop_reason_name(stop_reason_e::host_terminate), "host_terminate");
+}

--- a/tests/unit/test_stream_session_observability.cpp
+++ b/tests/unit/test_stream_session_observability.cpp
@@ -3,7 +3,13 @@
  * @brief Tests for active streaming-session telemetry values.
  */
 
+#include <atomic>
+#include <thread>
+
+#include <nlohmann/json.hpp>
+
 #include "src/stream.h"
+#include "src/nvhttp/sessions.h"
 
 #include "../tests_common.h"
 
@@ -18,4 +24,61 @@ TEST(StreamSessionObservability, NamesEveryStopReason) {
   EXPECT_STREQ(stop_reason_name(stop_reason_e::video_ended), "video_ended");
   EXPECT_STREQ(stop_reason_name(stop_reason_e::audio_ended), "audio_ended");
   EXPECT_STREQ(stop_reason_name(stop_reason_e::host_terminate), "host_terminate");
+}
+
+TEST(StreamSessionObservability, PreservesFirstStopReason) {
+  using stream::session::lifecycle_t;
+  using stream::session::state_e;
+  using stream::session::stop_reason_e;
+
+  lifecycle_t lifecycle { state_e::RUNNING };
+
+  EXPECT_TRUE(lifecycle.request_stop(stop_reason_e::control_disconnect));
+  EXPECT_FALSE(lifecycle.request_stop(stop_reason_e::video_ended));
+
+  const auto snapshot = lifecycle.snapshot();
+  EXPECT_EQ(snapshot.state, state_e::STOPPING);
+  EXPECT_EQ(snapshot.stop_reason, stop_reason_e::control_disconnect);
+}
+
+TEST(StreamSessionObservability, PublishesOneConcurrentStopReason) {
+  using stream::session::lifecycle_t;
+  using stream::session::state_e;
+  using stream::session::stop_reason_e;
+
+  lifecycle_t lifecycle { state_e::RUNNING };
+  std::atomic<int> winners { 0 };
+  std::thread control_stop([&]() {
+    winners += lifecycle.request_stop(stop_reason_e::control_disconnect);
+  });
+  std::thread video_stop([&]() {
+    winners += lifecycle.request_stop(stop_reason_e::video_ended);
+  });
+
+  control_stop.join();
+  video_stop.join();
+
+  const auto snapshot = lifecycle.snapshot();
+  EXPECT_EQ(winners.load(), 1);
+  EXPECT_EQ(snapshot.state, state_e::STOPPING);
+  EXPECT_NE(snapshot.stop_reason, stop_reason_e::none);
+}
+
+TEST(StreamSessionObservability, SerializesSessionBoundaries) {
+  stream::session_info_t info {};
+  info.stop_reason = "control_disconnect";
+  info.uptime_ms = 123;
+  info.control_connected = false;
+  info.control_idle_ms = -1;
+  info.video_idle_ms = -1;
+  info.audio_idle_ms = -1;
+
+  const auto json = nvhttp::sessions::make_session_json(info);
+
+  EXPECT_EQ(json["stop_reason"], "control_disconnect");
+  EXPECT_EQ(json["uptime_ms"], 123);
+  EXPECT_EQ(json["control_connected"], false);
+  EXPECT_TRUE(json["control_idle_ms"].is_null());
+  EXPECT_TRUE(json["video_idle_ms"].is_null());
+  EXPECT_TRUE(json["audio_idle_ms"].is_null());
 }


### PR DESCRIPTION
## 改了啥呀

- 把已认证的客户端证书 UUID 带进活动串流会话，并在本地会话 API 中返回
- 为控制通道、视频发送和音频发送记录最近活动时间，同时暴露会话运行时长与控制连接状态
- 记录首个终止原因，并在停止/回收日志里带上会话 ID、客户端 UUID 和原因
- 补齐终止原因名称的单元测试

## 为啥要改

多客户端断开异常现在只能看到一个笼统的 `-1`，很难判断是控制通道断开、超时、协议错误，还是音视频线程结束。先把会话身份和生命周期信号补齐，后续才能安全地做按客户端取消和陈旧会话回收，哼，这次不靠猜啦。

这层只增加观测信息，不新增超时、不主动回收会话，也不改变现有串流与全局终止逻辑。`*_idle_ms` 表示主机侧最近一次控制事件/媒体发送活动；活动尚未出现时返回 `null`。客户端 UUID 仅通过现有本地管理接口暴露。

## 验证

- `git diff --check`
- 核对所有现有 `session::stop()` 调用均标注具体终止原因
- 单元测试覆盖全部终止原因字符串
- 完整 Windows 构建交给 CI：隔离 worktree 的子模块拉取发生网络超时，未继续阻塞本地发布