### PR TITLE
fix(nvhttp): scope cancel to authenticated client

### DIFF
--- a/src/launch_session_manager.cpp
+++ b/src/launch_session_manager.cpp
@@ -247,6 +247,20 @@ namespace rtsp_stream {
   }
 
   std::size_t
+  launch_session_manager_t::erase_client_sessions(std::string_view client_cert_uuid) {
+    if (client_cert_uuid.empty()) {
+      return 0;
+    }
+
+    std::lock_guard lock { _impl->mutex };
+    const auto old_size = _impl->tickets.size();
+    std::erase_if(_impl->tickets, [client_cert_uuid](const auto &ticket) {
+      return ticket.session && ticket.session->client_cert_uuid == client_cert_uuid;
+    });
+    return old_size - _impl->tickets.size();
+  }
+
+  std::size_t
   launch_session_manager_t::prune(clock_t::time_point now) {
     std::lock_guard lock { _impl->mutex };
     const auto old_size = _impl->tickets.size();

--- a/src/launch_session_manager.h
+++ b/src/launch_session_manager.h
@@ -82,6 +82,9 @@ namespace rtsp_stream {
     erase(std::uint32_t launch_session_id);
 
     std::size_t
+    erase_client_sessions(std::string_view client_cert_uuid);
+
+    std::size_t
     prune(clock_t::time_point now = clock_t::now());
 
     void

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -834,17 +834,30 @@ namespace nvhttp {
       response->close_connection_after_response = true;
     });
 
+    const auto client_cert_uuid = get_client_cert_uuid_from_request(request);
+    if (client_cert_uuid.empty()) {
+      tree.put("root.cancel", 0);
+      tree.put("root.<xmlattr>.status_code", 401);
+      tree.put("root.<xmlattr>.status_message", "Unable to identify the authenticated client");
+      return;
+    }
+
+    const auto result = rtsp_stream::cancel_client_sessions(client_cert_uuid);
+    BOOST_LOG(info) << "Client-scoped cancel [client_uuid="sv << client_cert_uuid
+                    << ", cancelled="sv << result.cancelled_sessions
+                    << ", remaining="sv << result.remaining_sessions << ']';
+
     tree.put("root.cancel", 1);
     tree.put("root.<xmlattr>.status_code", 200);
 
-    rtsp_stream::terminate_sessions();
+    if (result.remaining_sessions == 0) {
+      if (proc::proc.running() > 0) {
+        proc::proc.terminate();
+      }
 
-    if (proc::proc.running() > 0) {
-      proc::proc.terminate();
+      // Preserve the legacy single-client behavior once no other session is using the host.
+      display_device::session_t::get().restore_state();
     }
-
-    // The state needs to be restored regardless of whether "proc::proc.terminate()" was called or not.
-    display_device::session_t::get().restore_state();
   }
 
   void

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -789,13 +789,14 @@ namespace rtsp_stream {
     cancel_client_sessions(std::string_view client_cert_uuid) {
       client_session_cancel_result_t result;
       result.cancelled_sessions = _launch_sessions.erase_client_sessions(client_cert_uuid);
+      std::vector<std::shared_ptr<stream::session_t>> sessions_to_join;
 
       {
         auto lg = _session_slots.lock();
         for (auto i = _session_slots->begin(); i != _session_slots->end();) {
           auto &slot = *(*i);
           if (stream::session::stop_client_session(slot, client_cert_uuid)) {
-            stream::session::join(slot);
+            sessions_to_join.push_back(*i);
             i = _session_slots->erase(i);
             ++result.cancelled_sessions;
           }
@@ -806,6 +807,10 @@ namespace rtsp_stream {
             ++i;
           }
         }
+      }
+
+      for (const auto &session : sessions_to_join) {
+        stream::session::join(*session);
       }
 
       result.remaining_sessions += _launch_sessions.size();

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -785,6 +785,33 @@ namespace rtsp_stream {
       return static_cast<int>(_launch_sessions.size());
     }
 
+    client_session_cancel_result_t
+    cancel_client_sessions(std::string_view client_cert_uuid) {
+      client_session_cancel_result_t result;
+      result.cancelled_sessions = _launch_sessions.erase_client_sessions(client_cert_uuid);
+
+      {
+        auto lg = _session_slots.lock();
+        for (auto i = _session_slots->begin(); i != _session_slots->end();) {
+          auto &slot = *(*i);
+          if (stream::session::stop_client_session(slot, client_cert_uuid)) {
+            stream::session::join(slot);
+            i = _session_slots->erase(i);
+            ++result.cancelled_sessions;
+          }
+          else {
+            if (stream::session::state(slot) != stream::session::state_e::STOPPING) {
+              ++result.remaining_sessions;
+            }
+            ++i;
+          }
+        }
+      }
+
+      result.remaining_sessions += _launch_sessions.size();
+      return result;
+    }
+
     bool
     activate_launch_session(std::uint32_t launch_session_id) {
       return _launch_sessions.activate(launch_session_id);
@@ -928,6 +955,11 @@ namespace rtsp_stream {
   void
   terminate_sessions() {
     server.clear(true);
+  }
+
+  client_session_cancel_result_t
+  cancel_client_sessions(std::string_view client_cert_uuid) {
+    return server.cancel_client_sessions(client_cert_uuid);
   }
 
   int

--- a/src/rtsp.h
+++ b/src/rtsp.h
@@ -5,6 +5,8 @@
 #pragma once
 
 #include <atomic>
+#include <cstddef>
+#include <string_view>
 
 #include <boost/process/v1.hpp>
 
@@ -14,6 +16,11 @@
 
 namespace rtsp_stream {
   constexpr auto RTSP_SETUP_PORT = 21;
+
+  struct client_session_cancel_result_t {
+    std::size_t cancelled_sessions {};
+    std::size_t remaining_sessions {};
+  };
 
   struct launch_session_t {
     uint32_t id;
@@ -88,6 +95,12 @@ namespace rtsp_stream {
    */
   void
   terminate_sessions();
+
+  /**
+   * @brief Terminates sessions owned by one authenticated client.
+   */
+  client_session_cancel_result_t
+  cancel_client_sessions(std::string_view client_cert_uuid);
 
   /**
    * @brief Runs the RTSP server loop.

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -3033,6 +3033,8 @@ namespace stream {
           return "video_ended";
         case stop_reason_e::audio_ended:
           return "audio_ended";
+        case stop_reason_e::client_cancel:
+          return "client_cancel";
         case stop_reason_e::host_terminate:
           return "host_terminate";
       }
@@ -3061,6 +3063,16 @@ namespace stream {
 
       perf::end_session(session.launch_session_id);
       session.shutdown_event->raise(true);
+    }
+
+    bool
+    stop_client_session(session_t &session, std::string_view client_cert_uuid) {
+      if (client_cert_uuid.empty() || session.client_cert_uuid != client_cert_uuid) {
+        return false;
+      }
+
+      stop(session, stop_reason_e::client_cancel);
+      return session.lifecycle.state() == state_e::STOPPING;
     }
 
     void

--- a/src/stream.h
+++ b/src/stream.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <mutex>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -51,6 +52,7 @@ namespace stream {
       protocol_error,
       video_ended,
       audio_ended,
+      client_cancel,
       host_terminate,
     };
 
@@ -144,6 +146,8 @@ namespace stream {
     start(session_t &session, const std::string &addr_string);
     void
     stop(session_t &session, stop_reason_e reason = stop_reason_e::none);
+    bool
+    stop_client_session(session_t &session, std::string_view client_cert_uuid);
     void
     join(session_t &session);
     state_e

--- a/tests/unit/test_rtsp.cpp
+++ b/tests/unit/test_rtsp.cpp
@@ -135,6 +135,27 @@ TEST(LaunchSessionManager, PreservesClaimedTicketsPastPendingExpiry) {
   EXPECT_EQ(manager.size(now + 4s), 0U);
 }
 
+TEST(LaunchSessionManager, ErasesOnlyTicketsOwnedByAuthenticatedClient) {
+  rtsp_stream::launch_session_manager_t manager;
+  const auto now = rtsp_stream::launch_session_manager_t::clock_t::now();
+
+  ASSERT_EQ(manager.register_session(make_session(40, "cert-a", "192.0.2.40"), 10s, now),
+            rtsp_stream::launch_ticket_register_e::accepted);
+  ASSERT_EQ(manager.register_session(make_session(41, "cert-b", "192.0.2.41"), 10s, now),
+            rtsp_stream::launch_ticket_register_e::accepted);
+  ASSERT_EQ(manager.register_session(make_session(42, {}, "192.0.2.42"), 10s, now),
+            rtsp_stream::launch_ticket_register_e::accepted);
+
+  EXPECT_EQ(manager.erase_client_sessions({}), 0U);
+  EXPECT_EQ(manager.erase_client_sessions("cert-a"), 1U);
+  EXPECT_EQ(manager.size(now), 2U);
+
+  EXPECT_FALSE(manager.claim_plaintext("192.0.2.40", now));
+  auto other_client = manager.claim_plaintext("192.0.2.41", now);
+  ASSERT_TRUE(other_client);
+  EXPECT_EQ(other_client->id, 41U);
+}
+
 TEST(LaunchSessionManager, SupportsOverlappingRtspConnectionsForOneLaunch) {
   rtsp_stream::launch_session_manager_t manager;
   const auto now = rtsp_stream::launch_session_manager_t::clock_t::now();

--- a/tests/unit/test_stream_session_observability.cpp
+++ b/tests/unit/test_stream_session_observability.cpp
@@ -23,6 +23,7 @@ TEST(StreamSessionObservability, NamesEveryStopReason) {
   EXPECT_STREQ(stop_reason_name(stop_reason_e::protocol_error), "protocol_error");
   EXPECT_STREQ(stop_reason_name(stop_reason_e::video_ended), "video_ended");
   EXPECT_STREQ(stop_reason_name(stop_reason_e::audio_ended), "audio_ended");
+  EXPECT_STREQ(stop_reason_name(stop_reason_e::client_cancel), "client_cancel");
   EXPECT_STREQ(stop_reason_name(stop_reason_e::host_terminate), "host_terminate");
 }
 


### PR DESCRIPTION
## 改了啥呀

- `/cancel` 从当前 HTTPS 请求提取已配对证书的稳定 UUID，身份缺失时直接失败关闭
- 只删除该证书 UUID 拥有的待认领 RTSP 票据，只停止并同步回收该客户端的活动会话
- 其他客户端仍有活动会话或待认领票据时，保留宿主应用和显示状态
- 没有其他会话后，继续沿用原来的单客户端行为：终止应用并恢复显示
- 增加 `client_cancel` 终止原因和跨客户端隔离测试

## 当前基线

#801 已经 squash 合入 `master`，本 PR 已重新重放到最新 `master`，分支里只保留客户端级取消这一层自己的提交。重放时同步修正了 #801 生命周期重构后的状态读取，统一使用 `session.lifecycle.state()`，不会再访问已经移除的旧 `session.state`，哼，旧字段别想偷偷混回来啦。

## 兼容性与安全边界

客户端不需要配套修改：现有 Moonlight `/cancel` 请求已经走双向 TLS，Sunshine 直接使用配对证书身份；不依赖 IP、客户端名称或客户端自报 ID。

这层没有加入新的超时或自动回收策略，也保留内部全局 `terminate_sessions()` 给主机关闭流程使用。它只把客户端发起的 `/cancel` 从全局清理改成所有者范围清理。

## 验证

- `git diff --check`
- 使用现有 Windows `-Werror` 编译参数检查 `stream.cpp`、`nvhttp.cpp`、`rtsp.cpp`、`launch_session_manager.cpp` 及相关测试单元
- range-diff 确认除 lifecycle 状态读取修复外，原功能 patch 保持不变
- 完整 Windows 构建与原生测试重新交给本分支 CI