### PR TITLE
refactor(rtsp): defer client session reaping

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -153,6 +153,8 @@ set(SUNSHINE_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/launch_session_manager.h"
         "${CMAKE_SOURCE_DIR}/src/session_coordinator.cpp"
         "${CMAKE_SOURCE_DIR}/src/session_coordinator.h"
+        "${CMAKE_SOURCE_DIR}/src/session_cleanup_gate.cpp"
+        "${CMAKE_SOURCE_DIR}/src/session_cleanup_gate.h"
         "${CMAKE_SOURCE_DIR}/src/perf_recorder.cpp"
         "${CMAKE_SOURCE_DIR}/src/perf_recorder.h"
         "${CMAKE_SOURCE_DIR}/src/confighttp.cpp"

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -560,6 +560,7 @@ namespace nvhttp {
     print_req<SunshineHTTPS>(request);
 
     print_request_ip<SunshineHTTPS>(request, "Launch request");
+    rtsp_stream::launch_operation_guard_t launch_operation;
 
     pt::ptree tree;
     bool need_to_restore_display_state { false };
@@ -700,6 +701,7 @@ namespace nvhttp {
     print_req<SunshineHTTPS>(request);
 
     print_request_ip<SunshineHTTPS>(request, "Resume request");
+    rtsp_stream::launch_operation_guard_t launch_operation;
 
     // If the system is in Away Mode, exit it now since we're resuming a session
     if (platf::is_away_mode_active()) {
@@ -850,14 +852,7 @@ namespace nvhttp {
     tree.put("root.cancel", 1);
     tree.put("root.<xmlattr>.status_code", 200);
 
-    if (result.remaining_sessions == 0) {
-      if (proc::proc.running() > 0) {
-        proc::proc.terminate();
-      }
-
-      // Preserve the legacy single-client behavior once no other session is using the host.
-      display_device::session_t::get().restore_state();
-    }
+    // The RTSP reaper performs final joins and legacy host cleanup in order.
   }
 
   void

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -27,11 +27,14 @@ extern "C" {
 // local includes
 #include "clipboard_bridge.h"
 #include "config.h"
+#include "display_device/session.h"
 #include "globals.h"
 #include "input.h"
 #include "logging.h"
 #include "network.h"
+#include "process.h"
 #include "rtsp.h"
+#include "session_cleanup_gate.h"
 #include "stream.h"
 #include "sync.h"
 #include "video.h"
@@ -756,9 +759,22 @@ namespace rtsp_stream {
       const auto result = _launch_sessions.register_session(
         std::move(launch_session), config::stream.ping_timeout);
       if (result == launch_ticket_register_e::accepted || result == launch_ticket_register_e::replaced) {
+        _cleanup_gate.cancel_cleanup();
         schedule_pending_prune();
       }
       return result;
+    }
+
+    void
+    begin_launch_operation() {
+      _cleanup_gate.begin_launch();
+    }
+
+    void
+    end_launch_operation() noexcept {
+      if (_cleanup_gate.end_launch()) {
+        wake_reaper();
+      }
     }
 
     /**
@@ -789,35 +805,29 @@ namespace rtsp_stream {
     cancel_client_sessions(std::string_view client_cert_uuid) {
       client_session_cancel_result_t result;
       result.cancelled_sessions = _launch_sessions.erase_client_sessions(client_cert_uuid);
-      std::vector<std::shared_ptr<stream::session_t>> sessions_to_join;
+      std::size_t active_sessions_cancelled {};
 
       {
         auto lg = _session_slots.lock();
-        for (auto i = _session_slots->begin(); i != _session_slots->end();) {
-          auto &slot = *(*i);
+        for (const auto &session : *_session_slots) {
+          auto &slot = *session;
           if (stream::session::stop_client_session(slot, client_cert_uuid)) {
             const auto reason = stream::session::stop_reason(slot);
             observe_session(slot, session_coord::state_e::draining, stream::session::stop_reason_name(reason));
-            sessions_to_join.push_back(*i);
-            i = _session_slots->erase(i);
             ++result.cancelled_sessions;
+            ++active_sessions_cancelled;
           }
-          else {
-            if (stream::session::state(slot) != stream::session::state_e::STOPPING) {
-              ++result.remaining_sessions;
-            }
-            ++i;
+          else if (stream::session::state(slot) != stream::session::state_e::STOPPING) {
+            ++result.remaining_sessions;
           }
         }
       }
 
-      for (const auto &session : sessions_to_join) {
-        stream::session::join(*session);
-        const auto reason = stream::session::stop_reason(*session);
-        observe_session(*session, session_coord::state_e::closed, stream::session::stop_reason_name(reason));
-      }
-
       result.remaining_sessions += _launch_sessions.size();
+      const bool cleanup_requested = result.remaining_sessions == 0 && _cleanup_gate.request_cleanup();
+      if (active_sessions_cancelled != 0 || cleanup_requested) {
+        wake_reaper();
+      }
       return result;
     }
 
@@ -845,6 +855,42 @@ namespace rtsp_stream {
     }
 
     launch_session_manager_t _launch_sessions;
+
+    void
+    wake_reaper() noexcept {
+      try {
+        boost::asio::post(io_context, []() {});
+      }
+      catch (...) {
+        // Shutdown can race with an HTTPS request. Cleanup will run during stop().
+      }
+    }
+
+    void
+    cleanup_host_if_idle() {
+      bool sessions_idle;
+      {
+        auto lg = _session_slots.lock();
+        sessions_idle = _session_slots->empty();
+      }
+      const bool host_idle = sessions_idle && _launch_sessions.size() == 0;
+      const auto claim = _cleanup_gate.claim_cleanup(host_idle);
+      if (claim == session_cleanup_gate_t::cleanup_claim_e::cancelled) {
+        BOOST_LOG(debug) << "Deferred client cleanup cancelled because a new session took ownership"sv;
+        return;
+      }
+      if (claim != session_cleanup_gate_t::cleanup_claim_e::acquired) {
+        return;
+      }
+
+      auto finish_cleanup = util::fail_guard([this]() {
+        _cleanup_gate.finish_cleanup();
+      });
+      if (proc::proc.running() > 0) {
+        proc::proc.terminate();
+      }
+      display_device::session_t::get().restore_state();
+    }
 
     void
     observe_session(stream::session_t &session,
@@ -880,23 +926,27 @@ namespace rtsp_stream {
         _launch_sessions.prune();
       }
 
-      auto lg = _session_slots.lock();
+      {
+        auto lg = _session_slots.lock();
 
-      for (auto i = _session_slots->begin(); i != _session_slots->end();) {
-        auto &slot = *(*i);
-        if (all || stream::session::state(slot) == stream::session::state_e::STOPPING) {
-          stream::session::stop(slot, stream::session::stop_reason_e::host_terminate);
-          const auto reason = stream::session::stop_reason(slot);
-          observe_session(slot, session_coord::state_e::draining, stream::session::stop_reason_name(reason));
-          stream::session::join(slot);
-          observe_session(slot, session_coord::state_e::closed, stream::session::stop_reason_name(reason));
+        for (auto i = _session_slots->begin(); i != _session_slots->end();) {
+          auto &slot = *(*i);
+          if (all || stream::session::state(slot) == stream::session::state_e::STOPPING) {
+            stream::session::stop(slot, stream::session::stop_reason_e::host_terminate);
+            const auto reason = stream::session::stop_reason(slot);
+            observe_session(slot, session_coord::state_e::draining, stream::session::stop_reason_name(reason));
+            stream::session::join(slot);
+            observe_session(slot, session_coord::state_e::closed, stream::session::stop_reason_name(reason));
 
-          i = _session_slots->erase(i);
-        }
-        else {
-          i++;
+            i = _session_slots->erase(i);
+          }
+          else {
+            i++;
+          }
         }
       }
+
+      cleanup_host_if_idle();
     }
 
     /**
@@ -921,6 +971,7 @@ namespace rtsp_stream {
      */
     void
     insert(const std::shared_ptr<stream::session_t> &session) {
+      _cleanup_gate.cancel_cleanup();
       {
         auto lg = _session_slots.lock();
         _session_slots->emplace(session);
@@ -971,6 +1022,7 @@ namespace rtsp_stream {
 
     boost::asio::io_context io_context;
     session_coord::coordinator_t _session_coordinator { io_context.get_executor() };
+    session_cleanup_gate_t _cleanup_gate;
     tcp::acceptor acceptor { io_context };
     boost::asio::steady_timer raised_timer { io_context };
 
@@ -978,6 +1030,14 @@ namespace rtsp_stream {
   };
 
   rtsp_server_t server {};
+
+  launch_operation_guard_t::launch_operation_guard_t() {
+    server.begin_launch_operation();
+  }
+
+  launch_operation_guard_t::~launch_operation_guard_t() {
+    server.end_launch_operation();
+  }
 
   launch_ticket_register_e
   launch_session_raise(std::shared_ptr<launch_session_t> launch_session) {

--- a/src/rtsp.h
+++ b/src/rtsp.h
@@ -18,6 +18,16 @@
 namespace rtsp_stream {
   constexpr auto RTSP_SETUP_PORT = 21;
 
+  class launch_operation_guard_t {
+  public:
+    launch_operation_guard_t();
+    ~launch_operation_guard_t();
+
+    launch_operation_guard_t(const launch_operation_guard_t &) = delete;
+    launch_operation_guard_t &
+    operator=(const launch_operation_guard_t &) = delete;
+  };
+
   struct client_session_cancel_result_t {
     std::size_t cancelled_sessions {};
     std::size_t remaining_sessions {};

--- a/src/session_cleanup_gate.cpp
+++ b/src/session_cleanup_gate.cpp
@@ -1,0 +1,80 @@
+/**
+ * @file src/session_cleanup_gate.cpp
+ * @brief Coordinates client cleanup with concurrent launch operations.
+ */
+
+#include "session_cleanup_gate.h"
+
+#include <cassert>
+
+namespace rtsp_stream {
+  void
+  session_cleanup_gate_t::begin_launch() {
+    std::unique_lock lock { _mutex };
+    _state_changed.wait(lock, [this]() {
+      return !_cleanup_requested && !_cleanup_running;
+    });
+    ++_launches_in_flight;
+  }
+
+  bool
+  session_cleanup_gate_t::end_launch() {
+    std::lock_guard lock { _mutex };
+    assert(_launches_in_flight != 0);
+    --_launches_in_flight;
+    return _cleanup_requested && _launches_in_flight == 0;
+  }
+
+  bool
+  session_cleanup_gate_t::request_cleanup() {
+    std::lock_guard lock { _mutex };
+    if (_cleanup_running) {
+      return false;
+    }
+
+    _cleanup_requested = true;
+    return _launches_in_flight == 0;
+  }
+
+  void
+  session_cleanup_gate_t::cancel_cleanup() {
+    {
+      std::lock_guard lock { _mutex };
+      if (!_cleanup_requested) {
+        return;
+      }
+      _cleanup_requested = false;
+    }
+    _state_changed.notify_all();
+  }
+
+  session_cleanup_gate_t::cleanup_claim_e
+  session_cleanup_gate_t::claim_cleanup(bool host_idle) {
+    std::lock_guard lock { _mutex };
+    if (!_cleanup_requested || _cleanup_running) {
+      return cleanup_claim_e::none;
+    }
+    if (!host_idle) {
+      _cleanup_requested = false;
+      _state_changed.notify_all();
+      return cleanup_claim_e::cancelled;
+    }
+    if (_launches_in_flight != 0) {
+      return cleanup_claim_e::none;
+    }
+
+    _cleanup_requested = false;
+    _cleanup_running = true;
+    return cleanup_claim_e::acquired;
+  }
+
+  void
+  session_cleanup_gate_t::finish_cleanup() {
+    {
+      std::lock_guard lock { _mutex };
+      assert(_cleanup_running);
+      _cleanup_running = false;
+    }
+    _state_changed.notify_all();
+  }
+}  // namespace rtsp_stream

--- a/src/session_cleanup_gate.h
+++ b/src/session_cleanup_gate.h
@@ -1,0 +1,45 @@
+/**
+ * @file src/session_cleanup_gate.h
+ * @brief Coordinates client cleanup with concurrent launch operations.
+ */
+#pragma once
+
+#include <condition_variable>
+#include <cstddef>
+#include <mutex>
+
+namespace rtsp_stream {
+  class session_cleanup_gate_t {
+  public:
+    enum class cleanup_claim_e {
+      none,
+      cancelled,
+      acquired,
+    };
+
+    void
+    begin_launch();
+
+    bool
+    end_launch();
+
+    bool
+    request_cleanup();
+
+    void
+    cancel_cleanup();
+
+    cleanup_claim_e
+    claim_cleanup(bool host_idle);
+
+    void
+    finish_cleanup();
+
+  private:
+    std::mutex _mutex;
+    std::condition_variable _state_changed;
+    std::size_t _launches_in_flight {};
+    bool _cleanup_requested { false };
+    bool _cleanup_running { false };
+  };
+}  // namespace rtsp_stream

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -124,11 +124,21 @@ foreach(dep ${SUNSHINE_TARGET_DEPENDENCIES})
     add_dependencies(launch_session_manager_unit_tests ${dep})
 endforeach()
 
+add_executable(session_cleanup_gate_unit_tests
+        ${CMAKE_SOURCE_DIR}/tests/unit/test_session_cleanup_gate.cpp
+        ${CMAKE_SOURCE_DIR}/src/session_cleanup_gate.cpp)
+target_include_directories(session_cleanup_gate_unit_tests PRIVATE "${CMAKE_SOURCE_DIR}")
+target_link_libraries(session_cleanup_gate_unit_tests gtest_main)
+target_compile_options(session_cleanup_gate_unit_tests PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${SUNSHINE_COMPILE_OPTIONS}>)
+set_target_properties(session_cleanup_gate_unit_tests PROPERTIES CXX_STANDARD 23)
+add_test(NAME session_cleanup_gate_unit_tests COMMAND session_cleanup_gate_unit_tests)
+
 if (WIN32)
     # prefer static libraries since we're linking statically
     # this fixes libcurl linking errors when using non MSYS2 version of CMake
     set_target_properties(${PROJECT_NAME} PROPERTIES LINK_SEARCH_START_STATIC 1)
     set_target_properties(abr_unit_tests PROPERTIES LINK_SEARCH_START_STATIC 1)
+    set_target_properties(session_cleanup_gate_unit_tests PROPERTIES LINK_SEARCH_START_STATIC 1)
 endif ()
 
 if (WIN32)

--- a/tests/unit/test_session_cleanup_gate.cpp
+++ b/tests/unit/test_session_cleanup_gate.cpp
@@ -1,0 +1,59 @@
+/**
+ * @file tests/unit/test_session_cleanup_gate.cpp
+ * @brief Tests for ordered session cleanup and launch handoff.
+ */
+
+#include <future>
+
+#include <gtest/gtest.h>
+
+#include "src/session_cleanup_gate.h"
+
+using namespace std::chrono_literals;
+
+TEST(SessionCleanupGate, DefersCleanupUntilLaunchOperationCompletes) {
+  rtsp_stream::session_cleanup_gate_t gate;
+
+  gate.begin_launch();
+  EXPECT_FALSE(gate.request_cleanup());
+  EXPECT_EQ(gate.claim_cleanup(true), rtsp_stream::session_cleanup_gate_t::cleanup_claim_e::none);
+
+  EXPECT_TRUE(gate.end_launch());
+  EXPECT_EQ(gate.claim_cleanup(true), rtsp_stream::session_cleanup_gate_t::cleanup_claim_e::acquired);
+  gate.finish_cleanup();
+}
+
+TEST(SessionCleanupGate, PublishedSessionCancelsDeferredCleanup) {
+  rtsp_stream::session_cleanup_gate_t gate;
+
+  gate.begin_launch();
+  EXPECT_FALSE(gate.request_cleanup());
+  gate.cancel_cleanup();
+  EXPECT_FALSE(gate.end_launch());
+  EXPECT_EQ(gate.claim_cleanup(true), rtsp_stream::session_cleanup_gate_t::cleanup_claim_e::none);
+}
+
+TEST(SessionCleanupGate, BlocksNewLaunchWhileCleanupRuns) {
+  rtsp_stream::session_cleanup_gate_t gate;
+  ASSERT_TRUE(gate.request_cleanup());
+  ASSERT_EQ(gate.claim_cleanup(true), rtsp_stream::session_cleanup_gate_t::cleanup_claim_e::acquired);
+
+  auto launch_started = std::async(std::launch::async, [&gate]() {
+    gate.begin_launch();
+    gate.end_launch();
+  });
+  EXPECT_EQ(launch_started.wait_for(50ms), std::future_status::timeout);
+
+  gate.finish_cleanup();
+  EXPECT_EQ(launch_started.wait_for(1s), std::future_status::ready);
+}
+
+TEST(SessionCleanupGate, AbandonsCleanupWhenHostIsNoLongerIdle) {
+  rtsp_stream::session_cleanup_gate_t gate;
+
+  ASSERT_TRUE(gate.request_cleanup());
+  EXPECT_EQ(gate.claim_cleanup(false), rtsp_stream::session_cleanup_gate_t::cleanup_claim_e::cancelled);
+
+  gate.begin_launch();
+  EXPECT_FALSE(gate.end_launch());
+}


### PR DESCRIPTION
## 依赖

- 当前堆叠为：`master`（已含 #801）← #802 ← #803 ← 本 PR
- 本分支已重放到更新后的 #803

## 杂鱼，这次改了什么呀

- 让认证客户端的 `/cancel` 只按证书 UUID 标记所属会话为 draining，并立即唤醒 RTSP reaper，不再在 HTTPS 请求线程里同步 `join()`
- 把会话 `join`、应用终止和显示恢复保留在同一个有序清理阶段，避免跨线程同时访问进程与显示生命周期
- 增加 launch/resume 清理闸门：清理运行时新请求等待；新 ticket 或 stream 成功接管时，旧的空闲清理意图会被取消
- 新增独立并发单测，覆盖 launch 在途、清理运行、新会话接管和 host 不再空闲四类竞态

## 为什么要这样改

之前客户端 cancel 会在 HTTPS 路径里持有 session registry 锁并等待视频、音频和控制线程结束，最坏会触及 10 秒 hang watchdog。多会话压力较高时，这会把协议响应和资源回收绑在一起，客户端就更容易感觉成“退了以后卡住啦”。

这一层仍保持现有所有权和最后会话语义，只拆开“发停止信号”和“完成资源回收”，不把编码、发包或阻塞 join 塞进 Asio strand。

## 风险和兼容性

- `/cancel` 的 200 响应会早于最终线程 join；如果客户端马上 launch/resume，闸门会等待清理完成，因此不会复用正在终止的应用
- 其他客户端仍活跃或有待认领 ticket 时，不会终止共享应用，也不会恢复显示
- 编码与网络数据面没有迁移，回滚边界保持很小

## 验证

- `git diff --check`
- range-diff 显示本提交重放前后完全等价
- 使用现有 Windows `-Werror` 编译参数检查 `nvhttp.cpp`、`rtsp.cpp`、`session_cleanup_gate.cpp` 和清理闸门测试
- 完整 Windows 构建与原生测试重新交给本分支 CI