### PR TITLE
docs: fix clone URL in building.md to point to this fork

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -105,8 +105,8 @@ pacman -S ${dependencies[@]}
 Ensure [git](https://git-scm.com) is installed on your system, then clone the repository using the following command:
 
 ```bash
-git clone https://github.com/lizardbyte/sunshine.git --recurse-submodules
-cd sunshine
+git clone https://github.com/AlkaidLab/foundation-sunshine.git --recurse-submodules
+cd foundation-sunshine
 mkdir build
 ```
 


### PR DESCRIPTION
## Summary
`docs/building.md` still tells contributors to clone `lizardbyte/sunshine` and `cd sunshine`, which points new contributors at the upstream repo instead of this fork and at the wrong local directory name.

## Change
- Updated the `git clone` command and `cd` target in the Windows/general build instructions to `AlkaidLab/foundation-sunshine`.

No functional/code change — docs only.

## Test plan
- [x] Verified the corrected clone URL resolves to this repository
- [x] Diff limited to the two affected lines in `docs/building.md`