### PR TITLE
fix(vdd): handle transient sealed producer readiness

### DIFF
--- a/src/display_device/vdd_ioctl.cpp
+++ b/src/display_device/vdd_ioctl.cpp
@@ -392,7 +392,9 @@ namespace display_device::vdd_ioctl {
       const DWORD err = GetLastError();
       if (err == ERROR_NOT_READY) {
         if (log_failures) {
-          BOOST_LOG(debug) << "vdd_ioctl: frame-channel producer is not ready yet";
+          BOOST_LOG(debug) << "vdd_ioctl: frame-channel producer is not ready yet"
+                           << " (status=" << frame_channel_open_status_name(frame_channel_open_status::not_ready)
+                           << ", win32=" << err << ")";
         }
         return frame_channel_open_status::not_ready;
       }
@@ -403,7 +405,9 @@ namespace display_device::vdd_ioctl {
         return frame_channel_open_status::unsupported;
       }
       if (log_failures) {
-        BOOST_LOG(warning) << "vdd_ioctl: DeviceIoControl(IOCTL_VDD_OPEN_FRAME_CHANNEL) failed (err=" << err << ")";
+        BOOST_LOG(warning) << "vdd_ioctl: DeviceIoControl(IOCTL_VDD_OPEN_FRAME_CHANNEL) failed"
+                           << " (status=" << frame_channel_open_status_name(frame_channel_open_status::failed)
+                           << ", win32=" << err << ")";
       }
       return frame_channel_open_status::failed;
     }

--- a/src/display_device/vdd_ioctl.cpp
+++ b/src/display_device/vdd_ioctl.cpp
@@ -390,6 +390,12 @@ namespace display_device::vdd_ioctl {
 
     if (!ok) {
       const DWORD err = GetLastError();
+      if (err == ERROR_NOT_READY) {
+        if (log_failures) {
+          BOOST_LOG(debug) << "vdd_ioctl: frame-channel producer is not ready yet";
+        }
+        return frame_channel_open_status::not_ready;
+      }
       if (err == ERROR_INVALID_FUNCTION ||
           err == ERROR_NOT_SUPPORTED ||
           err == ERROR_INVALID_PARAMETER) {

--- a/src/display_device/vdd_ioctl.h
+++ b/src/display_device/vdd_ioctl.h
@@ -63,6 +63,7 @@ namespace display_device::vdd_ioctl {
 
   enum class frame_channel_open_status {
     opened,
+    not_ready,       ///< Producer is transitioning modes; retry within the caller's deadline.
     unsupported,
     interface_missing,
     failed,

--- a/src/display_device/vdd_ioctl.h
+++ b/src/display_device/vdd_ioctl.h
@@ -69,6 +69,23 @@ namespace display_device::vdd_ioctl {
     failed,
   };
 
+  inline const char *
+  frame_channel_open_status_name(frame_channel_open_status status) {
+    switch (status) {
+      case frame_channel_open_status::opened:
+        return "opened";
+      case frame_channel_open_status::not_ready:
+        return "not_ready";
+      case frame_channel_open_status::unsupported:
+        return "unsupported";
+      case frame_channel_open_status::interface_missing:
+        return "interface_missing";
+      case frame_channel_open_status::failed:
+        return "failed";
+    }
+    return "unknown";
+  }
+
   struct frame_channel_open_request {
     std::uint32_t monitor_index = 0;
     std::uint32_t required_flags = 0;

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -636,6 +636,7 @@ namespace platf::dxgi {
     enum class sealed_channel_attempt {
       skipped,
       opened,
+      not_ready,
       fallback_allowed,
       required_failed,
     };

--- a/src/platform/windows/display_vdd.cpp
+++ b/src/platform/windows/display_vdd.cpp
@@ -511,7 +511,7 @@ namespace platf::dxgi {
       m_frameChannelSelection = vdd_frame_channel::channel_selection::sealed_required_failed;
       BOOST_LOG(error) << "[vdd_capture] SUNSHINE_VDD_FRAME_CHANNEL=sealed requested, "
                        << "but sealed frame channel open failed with status "sv
-                       << static_cast<int>(open_status);
+                       << display_device::vdd_ioctl::frame_channel_open_status_name(open_status);
       return sealed_channel_attempt::required_failed;
     }
 
@@ -520,7 +520,7 @@ namespace platf::dxgi {
         vdd_frame_channel::channel_selection::open_unsupported :
         vdd_frame_channel::channel_selection::open_failed;
     BOOST_LOG(warning) << "[vdd_capture] sealed frame channel open failed with status "sv
-                       << static_cast<int>(open_status)
+                       << display_device::vdd_ioctl::frame_channel_open_status_name(open_status)
                        << "; falling back to hardened legacy named channel"sv;
     return sealed_channel_attempt::fallback_allowed;
   }
@@ -1070,7 +1070,8 @@ namespace platf::dxgi {
 
       if (std::chrono::steady_clock::now() >= producer_discovery_deadline) {
         BOOST_LOG(error) << "[vdd] vdd_capture_t::init failed for monitor "sv << monitor_idx
-                         << " before the producer discovery deadline"sv;
+                         << " before the producer discovery deadline; last_channel_selection="sv
+                         << vdd_frame_channel::channel_selection_name(dup.frame_channel_selection());
         return -1;
       }
 

--- a/src/platform/windows/display_vdd.cpp
+++ b/src/platform/windows/display_vdd.cpp
@@ -501,6 +501,12 @@ namespace platf::dxgi {
       return sealed_channel_attempt::fallback_allowed;
     }
 
+    if (open_status == display_device::vdd_ioctl::frame_channel_open_status::not_ready) {
+      m_frameChannelSelection = vdd_frame_channel::channel_selection::open_not_ready;
+      BOOST_LOG(debug) << "[vdd_capture] sealed frame channel is not ready; retrying producer transition"sv;
+      return sealed_channel_attempt::not_ready;
+    }
+
     if (m_frameChannelMode == vdd_frame_channel::channel_mode::sealed_required) {
       m_frameChannelSelection = vdd_frame_channel::channel_selection::sealed_required_failed;
       BOOST_LOG(error) << "[vdd_capture] SUNSHINE_VDD_FRAME_CHANNEL=sealed requested, "
@@ -632,6 +638,8 @@ namespace platf::dxgi {
       case sealed_channel_attempt::opened:
         return 0;
       case sealed_channel_attempt::required_failed:
+        return -1;
+      case sealed_channel_attempt::not_ready:
         return -1;
       case sealed_channel_attempt::skipped:
       case sealed_channel_attempt::fallback_allowed:
@@ -798,6 +806,14 @@ namespace platf::dxgi {
     unsigned int only_valid_height = 0;
   };
 
+  // A display-mode commit and the first frame from the replacement VDD swap
+  // chain are separate asynchronous events. Windows can therefore expose the
+  // old producer for a few seconds after SetDisplayConfig() reports success.
+  // Keep the exact-dimension safety check, but give the replacement producer
+  // a bounded window to become visible before failing video initialization.
+  static constexpr auto vdd_producer_discovery_window = 8s;
+  static constexpr auto vdd_producer_discovery_retry_delay = 100ms;
+
   static vdd_probe_result_t
   probe_vdd_monitor_index(unsigned int target_w, unsigned int target_h, unsigned int max_probe) {
     vdd_probe_result_t result;
@@ -913,11 +929,8 @@ namespace platf::dxgi {
                             unsigned int target_h,
                             unsigned int max_probe = 16,
                             std::optional<std::chrono::steady_clock::time_point> deadline_override = std::nullopt) {
-    constexpr auto retry_window = 2500ms;
-    constexpr auto retry_delay = 100ms;
-
     vdd_probe_result_t last_result;
-    const auto deadline = deadline_override.value_or(std::chrono::steady_clock::now() + retry_window);
+    const auto deadline = deadline_override.value_or(std::chrono::steady_clock::now() + vdd_producer_discovery_window);
 
     for (;;) {
       last_result = probe_vdd_monitor_index(target_w, target_h, max_probe);
@@ -931,7 +944,7 @@ namespace platf::dxgi {
         break;
       }
 
-      std::this_thread::sleep_for(retry_delay);
+      std::this_thread::sleep_for(vdd_producer_discovery_retry_delay);
     }
 
     if (last_result.valid_count == 0) {
@@ -960,9 +973,6 @@ namespace platf::dxgi {
                                    unsigned int target_h,
                                    unsigned int max_probe = 16,
                                    std::optional<std::chrono::steady_clock::time_point> deadline_override = std::nullopt) {
-    constexpr auto retry_window = 2500ms;
-    constexpr auto retry_delay = 100ms;
-
     const auto device_luid = vdd_device_adapter_luid(d3d_device);
     if (!device_luid) {
       return -1;
@@ -974,7 +984,7 @@ namespace platf::dxgi {
     }
 
     vdd_probe_result_t last_result;
-    const auto deadline = deadline_override.value_or(std::chrono::steady_clock::now() + retry_window);
+    const auto deadline = deadline_override.value_or(std::chrono::steady_clock::now() + vdd_producer_discovery_window);
 
     for (;;) {
       last_result = probe_sealed_vdd_monitor_index(*device_luid, sealed_caps, target_w, target_h, max_probe);
@@ -988,7 +998,7 @@ namespace platf::dxgi {
         break;
       }
 
-      std::this_thread::sleep_for(retry_delay);
+      std::this_thread::sleep_for(vdd_producer_discovery_retry_delay);
     }
 
     if (last_result.valid_count == 0) {
@@ -1021,15 +1031,14 @@ namespace platf::dxgi {
     // Try to identify which VDD monitor backs this DXGI output by matching
     // dimensions. width/height come from DXGI DesktopCoordinates / orientation.
     // NOTE: We intentionally do NOT trigger CREATEMONITOR here. Sunshine's
-    // display-device layer (prepare_vdd) already manages monitor lifecycle, and
-    // adding a 3s NamedPipe round-trip per encoder probe wastes ~20s on every
-    // startup with no real benefit. If no producer is reachable, we just fail
-    // and let the upper layer try a different backend.
+    // display-device layer (prepare_vdd) already manages monitor lifecycle.
+    // Producer discovery is limited to a bounded wait because the mode commit,
+    // swap-chain replacement, and first shared frame are asynchronous.
     const auto target_w = static_cast<unsigned>(width_before_rotation);
     const auto target_h = static_cast<unsigned>(height_before_rotation);
     const auto frame_channel_mode =
       vdd_frame_channel_mode_env_override().value_or(vdd_frame_channel::channel_mode::auto_probe);
-    const auto producer_discovery_deadline = std::chrono::steady_clock::now() + 2500ms;
+    const auto producer_discovery_deadline = std::chrono::steady_clock::now() + vdd_producer_discovery_window;
 
     int idx = -1;
     if (frame_channel_mode != vdd_frame_channel::channel_mode::legacy_named) {
@@ -1054,9 +1063,20 @@ namespace platf::dxgi {
     }
     monitor_idx = static_cast<unsigned int>(idx);
 
-    if (dup.init(device.get(), monitor_idx) != 0) {
-      BOOST_LOG(error) << "[vdd] vdd_capture_t::init failed for monitor "sv << monitor_idx;
-      return -1;
+    for (;;) {
+      if (dup.init(device.get(), monitor_idx) == 0) {
+        break;
+      }
+
+      if (std::chrono::steady_clock::now() >= producer_discovery_deadline) {
+        BOOST_LOG(error) << "[vdd] vdd_capture_t::init failed for monitor "sv << monitor_idx
+                         << " before the producer discovery deadline"sv;
+        return -1;
+      }
+
+      BOOST_LOG(debug) << "[vdd] VDD capture attach is not stable yet; retrying monitor "sv
+                       << monitor_idx;
+      std::this_thread::sleep_for(vdd_producer_discovery_retry_delay);
     }
 
     // Use producer-reported format as our capture format. complete_img() / image

--- a/src/platform/windows/vdd_frame_channel.h
+++ b/src/platform/windows/vdd_frame_channel.h
@@ -95,6 +95,7 @@ namespace platf::dxgi::vdd_frame_channel {
     caps_unsupported,
     caps_failed,
     open_unsupported,
+    open_not_ready,
     open_failed,
     attach_failed,
     sealed_required_failed,
@@ -175,6 +176,8 @@ namespace platf::dxgi::vdd_frame_channel {
         return "caps_failed";
       case channel_selection::open_unsupported:
         return "open_unsupported";
+      case channel_selection::open_not_ready:
+        return "open_not_ready";
       case channel_selection::open_failed:
         return "open_failed";
       case channel_selection::attach_failed:

--- a/tests/unit/test_vdd_safety.cpp
+++ b/tests/unit/test_vdd_safety.cpp
@@ -3,6 +3,7 @@
 #ifdef _WIN32
 
 #include "src/display_device/vdd_control_ioctl.h"
+#include "src/display_device/vdd_ioctl.h"
 #include "src/platform/windows/display_device/settings_topology.h"
 #include "src/platform/windows/vdd_frame_channel.h"
 
@@ -204,6 +205,16 @@ TEST(VddFrameChannelSafety, ParsesFrameChannelModes) {
 
   EXPECT_FALSE(parse_channel_mode("host_owned"));
   EXPECT_FALSE(parse_channel_mode(""));
+}
+
+TEST(VddFrameChannelSafety, NamesFrameChannelOpenStatuses) {
+  using namespace display_device::vdd_ioctl;
+
+  EXPECT_STREQ(frame_channel_open_status_name(frame_channel_open_status::opened), "opened");
+  EXPECT_STREQ(frame_channel_open_status_name(frame_channel_open_status::not_ready), "not_ready");
+  EXPECT_STREQ(frame_channel_open_status_name(frame_channel_open_status::unsupported), "unsupported");
+  EXPECT_STREQ(frame_channel_open_status_name(frame_channel_open_status::interface_missing), "interface_missing");
+  EXPECT_STREQ(frame_channel_open_status_name(frame_channel_open_status::failed), "failed");
 }
 
 TEST(VddFrameChannelSafety, DefinesSealedChannelCapsAbi) {


### PR DESCRIPTION
## What changed

- Keep exact-resolution producer validation and wait within one bounded 8-second discovery deadline.
- Treat `ERROR_NOT_READY` (`21`) as a transient `not_ready` state instead of a generic open failure.
- Retry the real sealed-channel attach within the remaining discovery deadline without falling back to stale or mismatched textures.
- Log stable symbolic open states such as `not_ready`, `unsupported`, `interface_missing`, and `failed` instead of integer enum values.
- Include `last_channel_selection` in the terminal initialization error, so a final `-1` is traceable to `open_not_ready`, `open_failed`, or another concrete state.
- Add unit coverage for every symbolic frame-channel open status.

## Why

A VDD mode commit and the first frame from its replacement swap chain are asynchronous. During that legitimate transition the driver can return `STATUS_DEVICE_NOT_READY`, surfaced by `DeviceIoControl` as `ERROR_NOT_READY`. Sunshine should retry that transient state within a bounded deadline, but it must keep rejecting stale producers; relaxing dimensions, HDR, or texture validation would merely turn this little gremlin of a `-1` into a black screen or a reinitialization loop.

The indefinite readiness failure reproduced on the affected machine was ultimately driver-side: the default HDR metadata callback was incorrectly treated as active HDR state. That root cause is fixed by qiin2333/zako-vdd#19. This PR remains the consumer-side resilience and diagnostics layer; it does not attempt to compensate for an invalid producer by accepting unsafe metadata.

## Validation

- `cmake --build build --target sunshine vdd-frame-channel-probe -j 4`
- Changed `vdd_ioctl.cpp`, `display_vdd.cpp`, and `test_vdd_safety.cpp` objects compiled with the project's `-Werror` flags.
- `build/sunshine.exe --version`
- `build/tools/vdd-frame-channel-probe.exe --open --monitor 0` reproduced `ERROR_NOT_READY (21)` while the producer was inactive, covering the newly named transient path.
- With the matching driver fix installed, a real remote `3840x2160` SDR resume opened sealed monitor 0 (`fmt=87 hdr=false`) and reached `[vdd] backend ready` without legacy `Meta_*` fallback.
- GitHub Windows CI passed in 21m 7s, including native tests and Windows packaging; CodeRabbit also passed.

## Related

- Driver-side root cause and authoritative HDR readiness fix: qiin2333/zako-vdd#19
