### PR TITLE
fix(webui): align home page scale

### DIFF
--- a/src_assets/common/assets/web/components/common/ResourceCard.vue
+++ b/src_assets/common/assets/web/components/common/ResourceCard.vue
@@ -168,7 +168,7 @@ const confirmHarmonyLink = async () => {
   gap: 0.35rem;
   margin: 0 0.1rem 0.45rem;
   color: var(--ui-text-primary);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   font-weight: 650;
   letter-spacing: 0.03em;
 }

--- a/src_assets/common/assets/web/components/common/ResourceCard.vue
+++ b/src_assets/common/assets/web/components/common/ResourceCard.vue
@@ -191,7 +191,7 @@ const confirmHarmonyLink = async () => {
   align-items: center;
   gap: 0.2rem;
   margin-top: auto;
-  padding: 0.85rem 0.2rem 0.18rem;
+  padding: 0.85rem 0.2rem 0.55rem;
   flex-direction: column;
   color: var(--ui-text-primary);
   font-size: 0.7rem;

--- a/src_assets/common/assets/web/components/common/ResourceCard.vue
+++ b/src_assets/common/assets/web/components/common/ResourceCard.vue
@@ -127,6 +127,7 @@ const confirmHarmonyLink = async () => {
 
 .resource-groups {
   display: grid;
+  align-items: start;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.6rem;
 }

--- a/src_assets/common/assets/web/components/common/ResourceCard.vue
+++ b/src_assets/common/assets/web/components/common/ResourceCard.vue
@@ -128,13 +128,13 @@ const confirmHarmonyLink = async () => {
 .resource-groups {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.42rem;
+  gap: 0.6rem;
 }
 
 .resource-group {
   min-width: 0;
   margin: 0;
-  padding: 0.38rem 0.42rem 0.42rem;
+  padding: 0.55rem 0.6rem 0.6rem;
   border: 1px solid var(--ui-border);
   border-radius: var(--ui-radius-md);
   background: linear-gradient(
@@ -146,9 +146,9 @@ const confirmHarmonyLink = async () => {
 
 .resource-items {
   display: grid;
-  grid-auto-rows: 2.75rem;
+  grid-auto-rows: 3.4rem;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.42rem;
+  gap: 0.6rem;
 }
 
 .resource-item {
@@ -165,9 +165,9 @@ const confirmHarmonyLink = async () => {
   display: flex;
   align-items: center;
   gap: 0.35rem;
-  margin: 0 0.1rem 0.32rem;
+  margin: 0 0.1rem 0.45rem;
   color: var(--ui-text-primary);
-  font-size: 0.7rem;
+  font-size: 0.875rem;
   font-weight: 650;
   letter-spacing: 0.03em;
 }
@@ -278,7 +278,7 @@ const confirmHarmonyLink = async () => {
   }
 
   .resource-items {
-    grid-auto-rows: minmax(2.75rem, auto);
+    grid-auto-rows: minmax(3.25rem, auto);
     grid-template-columns: 1fr;
   }
 

--- a/src_assets/common/assets/web/components/common/ResourceLink.vue
+++ b/src_assets/common/assets/web/components/common/ResourceLink.vue
@@ -102,8 +102,8 @@ const rel = computed(() => (props.target === '_blank' ? 'noopener noreferrer' : 
 }
 
 .resource-link--compact {
-  min-height: 2.6rem;
-  padding: 0.3rem 0.4rem;
+  min-height: 3.3rem;
+  padding: 0.45rem 0.6rem;
 }
 
 .resource-icon {
@@ -122,8 +122,8 @@ const rel = computed(() => (props.target === '_blank' ? 'noopener noreferrer' : 
 }
 
 .resource-link--compact .resource-icon {
-  width: 27px;
-  height: 27px;
+  width: 32px;
+  height: 32px;
   margin-right: 0.45rem;
   border-radius: 0.56rem;
   font-size: 0.76rem;
@@ -170,12 +170,12 @@ const rel = computed(() => (props.target === '_blank' ? 'noopener noreferrer' : 
 
 .resource-link--compact .resource-title {
   margin-bottom: 1px;
-  font-size: 0.72rem;
+  font-size: 0.875rem;
 }
 
 .resource-link--compact .resource-desc {
   overflow: hidden;
-  font-size: 0.61rem;
+  font-size: 0.75rem;
   line-height: 1.25;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src_assets/common/assets/web/components/common/ResourceLink.vue
+++ b/src_assets/common/assets/web/components/common/ResourceLink.vue
@@ -170,12 +170,12 @@ const rel = computed(() => (props.target === '_blank' ? 'noopener noreferrer' : 
 
 .resource-link--compact .resource-title {
   margin-bottom: 1px;
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
 }
 
 .resource-link--compact .resource-desc {
   overflow: hidden;
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   line-height: 1.25;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src_assets/common/assets/web/components/layout/Navbar.vue
+++ b/src_assets/common/assets/web/components/layout/Navbar.vue
@@ -159,6 +159,10 @@ html[data-sunshine-gui='true'] body {
   transition: color 0.2s ease, background-color 0.2s ease;
 }
 
+.header {
+  view-transition-name: sunshine-navbar;
+}
+
 .header .navbar-utilities .nav-link:hover,
 .header .navbar-utilities .nav-link:focus,
 .header .navbar-utilities .nav-utility-button:hover,

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -772,7 +772,7 @@
     "window_title_placeholder": "e.g., Application Name"
   },
   "index": {
-    "description": "Foundation Sunshine - The elegant game streaming solution for the community",
+    "description": "Alkaid. Be There, From Anywhere.",
     "download": "Download",
     "installed_version_not_stable": "You are running a pre-release version of Sunshine. You may experience bugs or other issues. Please report any issues you encounter. Thank you for helping to make Sunshine a better software!",
     "loading_latest": "Loading latest release...",

--- a/src_assets/common/assets/web/public/assets/locale/zh.json
+++ b/src_assets/common/assets/web/public/assets/locale/zh.json
@@ -772,7 +772,7 @@
     "window_title_placeholder": "例如：yuanshen"
   },
   "index": {
-    "description": "桑帅 - 杂鱼们一起搞的串流服务",
+    "description": "摇光所至，皆为现场。",
     "download": "下崽",
     "installed_version_not_stable": "你正在用 Sunshine 的测试版呢！可能会遇到各种小问题，记得报告给咱哦～感谢帮忙让 Sunshine 变得更好！",
     "loading_latest": "正在检查最新版本...",

--- a/src_assets/common/assets/web/styles/global.less
+++ b/src_assets/common/assets/web/styles/global.less
@@ -1,5 +1,71 @@
 @import './var.css';
 
+// Cross-document navigation motion. The WebUI uses separate HTML entry points,
+// so this progressive enhancement keeps the shared shell calm while the page
+// content changes. Browsers without View Transitions simply use normal links.
+@view-transition {
+  navigation: auto;
+}
+
+::view-transition-group(root) {
+  animation-duration: 180ms;
+  animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: 180ms;
+  animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+::view-transition-old(root) {
+  animation-name: sunshine-page-out;
+}
+
+::view-transition-new(root) {
+  animation-name: sunshine-page-in;
+}
+
+::view-transition-group(sunshine-navbar) {
+  animation-duration: 1ms;
+}
+
+::view-transition-old(sunshine-navbar),
+::view-transition-new(sunshine-navbar) {
+  animation: none;
+}
+
+@keyframes sunshine-page-out {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0.98;
+  }
+}
+
+@keyframes sunshine-page-in {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-group(root),
+  ::view-transition-old(root),
+  ::view-transition-new(root),
+  ::view-transition-group(sunshine-navbar),
+  ::view-transition-old(sunshine-navbar),
+  ::view-transition-new(sunshine-navbar) {
+    animation-duration: 1ms !important;
+  }
+}
+
 // Scrollbar stability
 // html {
 //   scrollbar-gutter: stable;

--- a/src_assets/common/assets/web/styles/var.css
+++ b/src_assets/common/assets/web/styles/var.css
@@ -21,7 +21,15 @@
   --border-radius-xl: var(--ui-radius-lg);
   --border-radius-pill: 50rem;
   --border-radius-circle: 50%;
-  --font-family-base: 'Microsoft YaHei', 'Segoe UI', sans-serif;
+  /* Match the desktop GUI while keeping native CJK rendering on every platform. */
+  --font-family-sans: Inter, 'Segoe UI Variable Text', 'Segoe UI Variable', -apple-system,
+    BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Hiragino Sans GB', 'Noto Sans CJK SC',
+    'Noto Sans SC', 'Noto Sans', 'Microsoft YaHei UI', 'Microsoft YaHei', sans-serif;
+  --font-family-base: var(--font-family-sans);
+  --font-family-mono: ui-monospace, 'Cascadia Code', 'SFMono-Regular', Menlo, Monaco, Consolas,
+    'Liberation Mono', monospace;
+  --font-mono: var(--font-family-mono);
+  --bs-body-font-family: var(--font-family-base);
   --font-size-xs: 0.75rem;
   --font-size-sm: 0.875rem;
   --font-size-md: 1rem;

--- a/src_assets/common/assets/web/styles/welcome.less
+++ b/src_assets/common/assets/web/styles/welcome.less
@@ -10,7 +10,7 @@ body {
   margin: 0;
   background: var(--ui-page-bg, #e6f2ff);
   color: var(--ui-text-primary, #1e293b);
-  font-family: var(--font-family-base, 'Microsoft YaHei', 'Segoe UI', sans-serif);
+  font-family: var(--font-family-base);
   position: relative;
   min-height: 100vh;
 

--- a/src_assets/common/assets/web/views/Apps.vue
+++ b/src_assets/common/assets/web/views/Apps.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="apps-page">
     <Navbar />
-    <div class="container-fluid px-4">
+    <div class="container-fluid px-3">
       <div class="my-4">
         <h1 class="page-title">{{ $t('apps.applications_title') }}</h1>
         <p class="page-subtitle">{{ $t('apps.applications_desc') }}</p>

--- a/src_assets/common/assets/web/views/Config.vue
+++ b/src_assets/common/assets/web/views/Config.vue
@@ -127,7 +127,7 @@
     </ConfirmDialog>
 
     <div class="container">
-      <h1 class="my-4 page-title">{{ $t('config.configuration') }}</h1>
+      <h1 class="mt-2 mb-4 page-title">{{ $t('config.configuration') }}</h1>
 
       <div v-if="!config" class="form card config-skeleton">
         <div class="card-header skeleton-header">

--- a/src_assets/common/assets/web/views/Home.vue
+++ b/src_assets/common/assets/web/views/Home.vue
@@ -378,7 +378,6 @@ onMounted(async () => {
 
 .home-intro .page-subtitle {
   max-width: 48rem;
-  font-size: 1rem;
 }
 
 .home-status {
@@ -392,7 +391,7 @@ onMounted(async () => {
   background: color-mix(in srgb, var(--ui-surface) 88%, transparent);
   color: var(--ui-text-primary, #1e293b);
   backdrop-filter: blur(10px);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   font-weight: 600;
   font-family: inherit;
   text-align: left;
@@ -499,7 +498,7 @@ onMounted(async () => {
 .host-meta {
   margin: 0.22rem 0 0;
   color: var(--ui-text-secondary, #64748b);
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
 }
 
 .host-metrics {
@@ -543,7 +542,7 @@ onMounted(async () => {
 
 .metric-label {
   color: var(--ui-text-secondary, #64748b);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
   line-height: 1.1;
 }
 
@@ -608,13 +607,13 @@ onMounted(async () => {
 }
 
 .quick-action-copy > span {
-  font-size: 0.875rem;
+  font-size: var(--font-size-sm);
   font-weight: 650;
 }
 
 .quick-action-copy > small {
   color: var(--ui-text-secondary, #64748b);
-  font-size: 0.75rem;
+  font-size: var(--font-size-xs);
 }
 
 .quick-action-arrow {
@@ -660,17 +659,8 @@ onMounted(async () => {
     padding: 1rem 1.25rem 0.9rem 1.35rem;
   }
 
-  .home-intro .page-title {
-    font-size: 1.9rem;
-  }
-
-  .home-intro .page-subtitle {
-    font-size: 1rem;
-  }
-
   .home-status {
     padding: 0.55rem 0.9rem;
-    font-size: 0.875rem;
   }
 
   .host-overview {
@@ -687,10 +677,6 @@ onMounted(async () => {
 
   .host-name {
     font-size: 1.7rem;
-  }
-
-  .host-meta {
-    font-size: 0.875rem;
   }
 
   .host-metrics,
@@ -715,10 +701,6 @@ onMounted(async () => {
     font-size: 1.2rem;
   }
 
-  .metric-label {
-    font-size: 0.75rem;
-  }
-
   .quick-action {
     grid-template-columns: 2.1rem minmax(0, 1fr) auto;
     column-gap: 0.58rem;
@@ -729,14 +711,6 @@ onMounted(async () => {
     width: 2.1rem;
     height: 2.1rem;
     font-size: 0.82rem;
-  }
-
-  .quick-action-copy > span {
-    font-size: 0.875rem;
-  }
-
-  .quick-action-copy > small {
-    font-size: 0.75rem;
   }
 
 }

--- a/src_assets/common/assets/web/views/Home.vue
+++ b/src_assets/common/assets/web/views/Home.vue
@@ -370,7 +370,7 @@ onMounted(async () => {
 
 .home-intro .page-title {
   margin-bottom: 0.18rem;
-  font-size: 1.55rem;
+  font-size: 1.9rem;
   line-height: 1.15;
   font-weight: 650;
   letter-spacing: -0.03em;
@@ -378,7 +378,7 @@ onMounted(async () => {
 
 .home-intro .page-subtitle {
   max-width: 48rem;
-  font-size: 0.86rem;
+  font-size: 1rem;
 }
 
 .home-status {
@@ -392,7 +392,7 @@ onMounted(async () => {
   background: color-mix(in srgb, var(--ui-surface) 88%, transparent);
   color: var(--ui-text-primary, #1e293b);
   backdrop-filter: blur(10px);
-  font-size: 0.76rem;
+  font-size: 0.875rem;
   font-weight: 600;
   font-family: inherit;
   text-align: left;
@@ -499,7 +499,7 @@ onMounted(async () => {
 .host-meta {
   margin: 0.22rem 0 0;
   color: var(--ui-text-secondary, #64748b);
-  font-size: 0.76rem;
+  font-size: 0.875rem;
 }
 
 .host-metrics {
@@ -543,7 +543,7 @@ onMounted(async () => {
 
 .metric-label {
   color: var(--ui-text-secondary, #64748b);
-  font-size: 0.64rem;
+  font-size: 0.75rem;
   line-height: 1.1;
 }
 
@@ -608,13 +608,13 @@ onMounted(async () => {
 }
 
 .quick-action-copy > span {
-  font-size: 0.76rem;
+  font-size: 0.875rem;
   font-weight: 650;
 }
 
 .quick-action-copy > small {
   color: var(--ui-text-secondary, #64748b);
-  font-size: 0.62rem;
+  font-size: 0.75rem;
 }
 
 .quick-action-arrow {
@@ -661,16 +661,16 @@ onMounted(async () => {
   }
 
   .home-intro .page-title {
-    font-size: 1.85rem;
+    font-size: 1.9rem;
   }
 
   .home-intro .page-subtitle {
-    font-size: 0.95rem;
+    font-size: 1rem;
   }
 
   .home-status {
     padding: 0.55rem 0.9rem;
-    font-size: 0.82rem;
+    font-size: 0.875rem;
   }
 
   .host-overview {
@@ -690,7 +690,7 @@ onMounted(async () => {
   }
 
   .host-meta {
-    font-size: 0.82rem;
+    font-size: 0.875rem;
   }
 
   .host-metrics,
@@ -716,7 +716,7 @@ onMounted(async () => {
   }
 
   .metric-label {
-    font-size: 0.7rem;
+    font-size: 0.75rem;
   }
 
   .quick-action {
@@ -732,46 +732,11 @@ onMounted(async () => {
   }
 
   .quick-action-copy > span {
-    font-size: 0.84rem;
+    font-size: 0.875rem;
   }
 
   .quick-action-copy > small {
-    font-size: 0.68rem;
-  }
-
-  .home-resources .resource-groups {
-    gap: 0.58rem;
-  }
-
-  .home-resources .resource-group {
-    padding: 0.5rem 0.55rem 0.55rem;
-  }
-
-  .home-resources .resource-items {
-    grid-auto-rows: 3.1rem;
-    gap: 0.55rem;
-  }
-
-  .home-resources .resource-group-title {
-    margin-bottom: 0.42rem;
-    font-size: 0.78rem;
-  }
-
-  .home-resources .resource-link--compact {
-    padding: 0.42rem 0.55rem;
-  }
-
-  .home-resources .resource-link--compact .resource-icon {
-    width: 30px;
-    height: 30px;
-  }
-
-  .home-resources .resource-link--compact .resource-title {
-    font-size: 0.8rem;
-  }
-
-  .home-resources .resource-link--compact .resource-desc {
-    font-size: 0.68rem;
+    font-size: 0.75rem;
   }
 
 }
@@ -825,7 +790,7 @@ onMounted(async () => {
   }
 
   .home-intro .page-title {
-    font-size: 1.55rem;
+    font-size: 1.7rem;
   }
 
   .home-status {

--- a/src_assets/common/assets/web/views/Pin.vue
+++ b/src_assets/common/assets/web/views/Pin.vue
@@ -2,7 +2,7 @@
   <div class="pin-page">
     <Navbar />
     <div id="content" class="container">
-      <h1 class="my-4 text-center page-title">{{ $t('pin.pin_pairing') }}</h1>
+      <h1 class="mt-2 mb-4 text-center page-title">{{ $t('pin.pin_pairing') }}</h1>
 
       <!-- QR Code Pairing -->
       <div class="card mb-4 qr-pair-card">


### PR DESCRIPTION
## 改了啥呀

- 统一首页标题、副标题、状态信息、主机摘要和快捷入口的字号层级
- 恢复首页资源卡片的可读尺寸，放大卡片高度、图标、标题和描述文字
- 将资源卡片尺寸收拢到 ResourceCard / ResourceLink，移除首页重复的大屏覆盖样式
- 保持 1280px、1600px 和窄屏布局的响应式表现

## 为啥要改

首页的文字和资源卡片被压得太紧，和 Apps、配置等页面的视觉节奏不一致。现在首页终于不用像被缩小一圈的杂鱼了。

## 验证

- `npm run test:webui`（74 passed）
- `npm run build`
- 浏览器视觉验证：1280×720、1600×900、900×800
- 1280×720 和 1600×900 首页无默认滚动条
- 首页与 Apps 页标题/副标题实测字号分别为 30.4px / 16px
- 窄屏无横向溢出