### PR TITLE
perf(webui): streamline gui page loading

### DIFF
--- a/src_assets/common/assets/web/composables/useConfig.js
+++ b/src_assets/common/assets/web/composables/useConfig.js
@@ -1,6 +1,7 @@
 import { ref } from 'vue'
 import { trackEvents } from '../config/firebase.js'
-import { apiFetch, apiJson } from '../utils/apiFetch.js'
+import { getBootstrapConfig } from '../config/bootstrapData.js'
+import { apiFetch } from '../utils/apiFetch.js'
 import { deepClone, safeJsonParse } from '../utils/helpers.js'
 
 // 平台相关的标签页排除规则
@@ -421,7 +422,7 @@ export function useConfig() {
    */
   const loadConfig = async () => {
     try {
-      const data = await apiJson('/api/config')
+      const data = await getBootstrapConfig()
 
       platform.value = data.platform || ''
       filterTabsByPlatform(platform.value)

--- a/src_assets/common/assets/web/composables/usePin.js
+++ b/src_assets/common/assets/web/composables/usePin.js
@@ -1,4 +1,5 @@
 import { ref, reactive } from 'vue'
+import { getBootstrapConfig } from '../config/bootstrapData.js'
 import { apiFetch, apiJson, apiPostJson } from '../utils/apiFetch.js'
 
 const STATUS_RESET_DELAY = 5000
@@ -251,7 +252,7 @@ export function usePin() {
 
   const loadConfig = async () => {
     try {
-      const data = await apiJson('/api/config')
+      const data = await getBootstrapConfig()
       config.value = data
       pairingDeviceName.value = data.pair_name ?? ''
     } catch (error) {

--- a/src_assets/common/assets/web/composables/useTroubleshooting.js
+++ b/src_assets/common/assets/web/composables/useTroubleshooting.js
@@ -1,4 +1,5 @@
 import { ref, computed, onUnmounted } from 'vue'
+import { getBootstrapConfig } from '../config/bootstrapData.js'
 import { apiFetch, apiJson } from '../utils/apiFetch.js'
 
 const LOG_REFRESH_INTERVAL = 5000
@@ -199,7 +200,7 @@ export function useTroubleshooting() {
 
   const loadPlatform = async () => {
     try {
-      const data = await apiJson('/api/config')
+      const data = await getBootstrapConfig()
       platform.value = data.platform || ''
     } catch {}
   }

--- a/src_assets/common/assets/web/config/bootstrapData.js
+++ b/src_assets/common/assets/web/config/bootstrapData.js
@@ -1,0 +1,27 @@
+import { apiJson } from '../utils/apiFetch.js'
+
+let configRequest = null
+let localeRequest = null
+
+const cachedRequest = (path, getCurrent, setCurrent) => {
+  const current = getCurrent()
+  if (current) return current
+
+  const request = apiJson(path)
+  setCurrent(request)
+  request.catch(() => {
+    if (getCurrent() === request) setCurrent(null)
+  })
+  return request
+}
+
+export const getBootstrapConfig = () =>
+  cachedRequest('/api/config', () => configRequest, (request) => { configRequest = request })
+
+export const getBootstrapLocale = () =>
+  cachedRequest('/api/configLocale', () => localeRequest, (request) => { localeRequest = request })
+
+export const resetBootstrapDataCache = () => {
+  configRequest = null
+  localeRequest = null
+}

--- a/src_assets/common/assets/web/config/firebase.js
+++ b/src_assets/common/assets/web/config/firebase.js
@@ -18,12 +18,27 @@ let initializationScheduled = false
 let analyticsDisabled = false
 const pendingEvents = []
 
+const normalizeParamValue = (value) => {
+  let normalizedValue = value
+
+  if (Array.isArray(value)) {
+    normalizedValue = value.join(', ')
+  } else if (typeof value === 'object' && value) {
+    try {
+      normalizedValue = JSON.stringify(value)
+    } catch {
+      normalizedValue = '[unserializable]'
+    }
+  }
+
+  if (typeof normalizedValue === 'string' && normalizedValue.length > 100) {
+    return `${normalizedValue.substring(0, 97)}...`
+  }
+  return normalizedValue
+}
+
 const sanitizeParams = (params = {}) => Object.fromEntries(
-  Object.entries(params).map(([key, value]) => {
-    let nextValue = Array.isArray(value) ? value.join(', ') : typeof value === 'object' && value ? JSON.stringify(value) : value
-    if (typeof nextValue === 'string' && nextValue.length > 100) nextValue = `${nextValue.substring(0, 97)}...`
-    return [key, nextValue]
-  })
+  Object.entries(params ?? {}).map(([key, value]) => [key, normalizeParamValue(value)])
 )
 
 const sendEvent = ({ eventName, params }) => {

--- a/src_assets/common/assets/web/config/firebase.js
+++ b/src_assets/common/assets/web/config/firebase.js
@@ -1,7 +1,3 @@
-// Firebase配置和初始化
-import { initializeApp } from 'firebase/app'
-import { getAnalytics, logEvent } from 'firebase/analytics'
-
 const firebaseConfig = {
   apiKey: 'AIzaSyD7VDKZyA1PG6mCO2QdPAUXIziVfTahV0g',
   authDomain: 'sunshine-foundation-3c551.firebaseapp.com',
@@ -12,36 +8,94 @@ const firebaseConfig = {
   measurementId: 'G-F20721ZDL1',
 }
 
+const MAX_PENDING_EVENTS = 50
+const ANALYTICS_IDLE_TIMEOUT = 2000
+
 let analytics = null
+let analyticsModule = null
+let initialization = null
+let initializationScheduled = false
+let analyticsDisabled = false
+const pendingEvents = []
+
+const sanitizeParams = (params = {}) => Object.fromEntries(
+  Object.entries(params).map(([key, value]) => {
+    let nextValue = Array.isArray(value) ? value.join(', ') : typeof value === 'object' && value ? JSON.stringify(value) : value
+    if (typeof nextValue === 'string' && nextValue.length > 100) nextValue = `${nextValue.substring(0, 97)}...`
+    return [key, nextValue]
+  })
+)
+
+const sendEvent = ({ eventName, params }) => {
+  if (!analytics || !analyticsModule) return
+  try {
+    analyticsModule.logEvent(analytics, eventName, params)
+  } catch (error) {
+    console.warn('记录 Firebase 事件失败:', error)
+  }
+}
+
+const flushPendingEvents = () => {
+  pendingEvents.splice(0).forEach(sendEvent)
+}
 
 export function initFirebase() {
-  try {
-    const app = initializeApp(firebaseConfig)
-    analytics = getAnalytics(app)
-    return { app, analytics }
-  } catch (error) {
-    console.error('Firebase 初始化失败:', error)
-    return null
+  initializationScheduled = false
+  if (initialization) return initialization
+
+  initialization = (async () => {
+    try {
+      const [appModule, nextAnalyticsModule] = await Promise.all([
+        import('firebase/app'),
+        import('firebase/analytics'),
+      ])
+
+      if (nextAnalyticsModule.isSupported && !(await nextAnalyticsModule.isSupported())) {
+        analyticsDisabled = true
+        pendingEvents.length = 0
+        return null
+      }
+
+      const app = appModule.getApps().length ? appModule.getApp() : appModule.initializeApp(firebaseConfig)
+      analyticsModule = nextAnalyticsModule
+      analytics = nextAnalyticsModule.getAnalytics(app)
+      flushPendingEvents()
+      return { app, analytics }
+    } catch (error) {
+      analyticsDisabled = true
+      pendingEvents.length = 0
+      console.warn('Firebase 初始化失败:', error)
+      return null
+    }
+  })()
+
+  return initialization
+}
+
+const scheduleInitialization = () => {
+  if (analyticsDisabled || initialization || initializationScheduled) return
+  initializationScheduled = true
+
+  const initialize = () => { void initFirebase() }
+  if (typeof globalThis.requestIdleCallback === 'function') {
+    globalThis.requestIdleCallback(initialize, { timeout: ANALYTICS_IDLE_TIMEOUT })
+  } else {
+    globalThis.setTimeout(initialize, 0)
   }
 }
 
 export function trackEvent(eventName, params = {}) {
-  if (!analytics) return
+  if (analyticsDisabled) return
 
-  // 处理参数：数组转字符串，截断过长值
-  const sanitized = Object.fromEntries(
-    Object.entries(params).map(([k, v]) => {
-      let val = Array.isArray(v) ? v.join(', ') : typeof v === 'object' && v ? JSON.stringify(v) : v
-      if (typeof val === 'string' && val.length > 100) val = val.substring(0, 97) + '...'
-      return [k, val]
-    })
-  )
-
-  try {
-    logEvent(analytics, eventName, sanitized)
-  } catch (error) {
-    console.error('记录事件失败:', error)
+  const event = { eventName, params: sanitizeParams(params) }
+  if (analytics && analyticsModule) {
+    sendEvent(event)
+    return
   }
+
+  if (pendingEvents.length >= MAX_PENDING_EVENTS) pendingEvents.shift()
+  pendingEvents.push(event)
+  scheduleInitialization()
 }
 
 export const trackEvents = {

--- a/src_assets/common/assets/web/config/i18n.js
+++ b/src_assets/common/assets/web/config/i18n.js
@@ -1,4 +1,5 @@
 import {createI18n} from "vue-i18n";
+import { getBootstrapConfig, getBootstrapLocale } from './bootstrapData.js'
 
 // Import only the fallback language files
 import en from '../public/assets/locale/en.json'
@@ -40,15 +41,15 @@ export default async function() {
     // 全都拿不到才走系统语言探测，最后回退 en
     let locale = null;
     try {
-        let config = await (await fetch("/api/config")).json();
+        const config = await getBootstrapConfig();
         locale = config.locale || null;
     } catch (e) {
         console.warn("Failed to get /api/config", e);
     }
     if (!locale) {
         try {
-            let r = await (await fetch("/api/configLocale")).json();
-            locale = r.locale || null;
+            const configLocale = await getBootstrapLocale();
+            locale = configLocale.locale || null;
         } catch (e2) {
             console.error("Failed to get /api/configLocale", e2);
         }

--- a/src_assets/common/assets/web/index.html
+++ b/src_assets/common/assets/web/index.html
@@ -12,12 +12,8 @@
     import { createApp } from 'vue'
     import { initApp } from './init'
     import Home from './views/Home.vue'
-    import { initFirebase } from './config/firebase.js'
 
     console.log('Hello, Sunshine!')
-
-    // 初始化Firebase Analytics
-    initFirebase()
 
     // 创建应用实例
     const app = createApp(Home)

--- a/src_assets/common/assets/web/init.js
+++ b/src_assets/common/assets/web/init.js
@@ -1,5 +1,6 @@
 import i18n from './config/i18n.js'
 import { isTauriEnv } from './utils/helpers.js'
+import { markWebUiReady } from './utils/appReady.js'
 
 // must import even if not implicitly using here
 // https://github.com/aurelia/skeleton-navigation/issues/894
@@ -22,15 +23,19 @@ const enableStandaloneViewTransitions = () => {
     document.head.appendChild(style)
 }
 
-export function initApp(app, config) {
+export async function initApp(app, config) {
     enableStandaloneViewTransitions()
-    //Wait for locale initialization, then render
-    i18n().then(i18n => {
-        app.use(i18n);
-        app.provide('i18n', i18n.global)
-        app.mount('#app');
-        if (config) {
-            config(app)
-        }
-    });
+    const i18nInstance = await i18n()
+
+    app.use(i18nInstance)
+    app.provide('i18n', i18nInstance.global)
+    const root = app.mount('#app')
+    try {
+        config?.(app)
+        // Let Vue finish the mount microtask before the GUI reveals the iframe.
+        await Promise.resolve()
+    } finally {
+        markWebUiReady()
+    }
+    return root
 }

--- a/src_assets/common/assets/web/init.js
+++ b/src_assets/common/assets/web/init.js
@@ -1,4 +1,5 @@
 import i18n from './config/i18n.js'
+import { isTauriEnv } from './utils/helpers.js'
 
 // must import even if not implicitly using here
 // https://github.com/aurelia/skeleton-navigation/issues/894
@@ -11,15 +12,9 @@ if (typeof window !== 'undefined') {
   window.bootstrap = bootstrap
 }
 
-const enableTopLevelViewTransitions = () => {
-    let embedded = false
-    try {
-        embedded = window.self !== window.top
-    } catch {
-        embedded = true
-    }
-
-    if (embedded || document.querySelector('style[data-sunshine-view-transition]')) return
+const enableStandaloneViewTransitions = () => {
+    const isEmbeddedGui = isTauriEnv() && window.parent !== window
+    if (isEmbeddedGui || document.querySelector('style[data-sunshine-view-transition]')) return
 
     const style = document.createElement('style')
     style.dataset.sunshineViewTransition = 'true'
@@ -28,7 +23,7 @@ const enableTopLevelViewTransitions = () => {
 }
 
 export function initApp(app, config) {
-    enableTopLevelViewTransitions()
+    enableStandaloneViewTransitions()
     //Wait for locale initialization, then render
     i18n().then(i18n => {
         app.use(i18n);

--- a/src_assets/common/assets/web/init.js
+++ b/src_assets/common/assets/web/init.js
@@ -11,7 +11,24 @@ if (typeof window !== 'undefined') {
   window.bootstrap = bootstrap
 }
 
+const enableTopLevelViewTransitions = () => {
+    let embedded = false
+    try {
+        embedded = window.self !== window.top
+    } catch {
+        embedded = true
+    }
+
+    if (embedded || document.querySelector('style[data-sunshine-view-transition]')) return
+
+    const style = document.createElement('style')
+    style.dataset.sunshineViewTransition = 'true'
+    style.textContent = '@view-transition { navigation: auto; }'
+    document.head.appendChild(style)
+}
+
 export function initApp(app, config) {
+    enableTopLevelViewTransitions()
     //Wait for locale initialization, then render
     i18n().then(i18n => {
         app.use(i18n);

--- a/src_assets/common/assets/web/styles/global.less
+++ b/src_assets/common/assets/web/styles/global.less
@@ -1,11 +1,8 @@
 @import './var.css';
 
-// Cross-document navigation motion. The WebUI uses separate HTML entry points,
-// so this progressive enhancement keeps the shared shell calm while the page
-// content changes. Browsers without View Transitions simply use normal links.
-@view-transition {
-  navigation: auto;
-}
+// Cross-document navigation motion. The animation rules are shared by every
+// page, while the opt-in is added by init.js only for top-level WebUI pages.
+// The GUI embeds WebUI in an iframe and already owns its loading transition.
 
 ::view-transition-group(root) {
   animation-duration: 180ms;

--- a/src_assets/common/assets/web/styles/global.less
+++ b/src_assets/common/assets/web/styles/global.less
@@ -1,8 +1,8 @@
 @import './var.css';
 
 // Cross-document navigation motion. The animation rules are shared by every
-// page, while the opt-in is added by init.js only for top-level WebUI pages.
-// The GUI embeds WebUI in an iframe and already owns its loading transition.
+// page, while init.js opts out only for the Tauri GUI iframe, which already
+// owns its loading transition.
 
 ::view-transition-group(root) {
   animation-duration: 180ms;

--- a/src_assets/common/assets/web/tests/appReady.test.js
+++ b/src_assets/common/assets/web/tests/appReady.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { markWebUiReady, WEBUI_READY_MESSAGE } from '../utils/appReady.js'
+
+const createDocument = () => ({ documentElement: { dataset: {} } })
+
+test('marks a standalone WebUI as ready without messaging a parent', () => {
+  const documentObject = createDocument()
+  const windowObject = {}
+  windowObject.parent = windowObject
+
+  markWebUiReady(windowObject, documentObject)
+
+  assert.equal(documentObject.documentElement.dataset.sunshineReady, 'true')
+})
+
+test('notifies the parent when the WebUI is embedded by Tauri', () => {
+  const documentObject = createDocument()
+  const messages = []
+  const windowObject = {
+    isTauri: true,
+    parent: {
+      postMessage: (...args) => messages.push(args),
+    },
+  }
+
+  markWebUiReady(windowObject, documentObject)
+
+  assert.deepEqual(messages, [[{ type: WEBUI_READY_MESSAGE }, '*']])
+})

--- a/src_assets/common/assets/web/tests/bootstrapData.test.js
+++ b/src_assets/common/assets/web/tests/bootstrapData.test.js
@@ -1,0 +1,73 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  getBootstrapConfig,
+  getBootstrapLocale,
+  resetBootstrapDataCache,
+} from '../config/bootstrapData.js'
+
+const jsonResponse = (data, { ok = true, status = 200 } = {}) => ({
+  ok,
+  status,
+  json: async () => data,
+})
+
+test('deduplicates concurrent bootstrap config requests', async () => {
+  resetBootstrapDataCache()
+  const originalFetch = globalThis.fetch
+  let calls = 0
+  globalThis.fetch = async () => {
+    calls += 1
+    return jsonResponse({ locale: 'zh', platform: 'windows' })
+  }
+
+  try {
+    const [first, second] = await Promise.all([getBootstrapConfig(), getBootstrapConfig()])
+    assert.equal(calls, 1)
+    assert.strictEqual(first, second)
+  } finally {
+    globalThis.fetch = originalFetch
+    resetBootstrapDataCache()
+  }
+})
+
+test('keeps config and locale bootstrap requests independent', async () => {
+  resetBootstrapDataCache()
+  const originalFetch = globalThis.fetch
+  const calls = []
+  globalThis.fetch = async (url) => {
+    calls.push(url)
+    return jsonResponse({ locale: url.endsWith('configLocale') ? 'zh_TW' : 'zh' })
+  }
+
+  try {
+    const [config, locale] = await Promise.all([getBootstrapConfig(), getBootstrapLocale()])
+    assert.equal(config.locale, 'zh')
+    assert.equal(locale.locale, 'zh_TW')
+    assert.deepEqual(calls, ['/api/config', '/api/configLocale'])
+  } finally {
+    globalThis.fetch = originalFetch
+    resetBootstrapDataCache()
+  }
+})
+
+test('retries bootstrap data after a failed request', async () => {
+  resetBootstrapDataCache()
+  const originalFetch = globalThis.fetch
+  let calls = 0
+  globalThis.fetch = async () => {
+    calls += 1
+    return calls === 1
+      ? jsonResponse({ error: 'temporary failure' }, { ok: false, status: 503 })
+      : jsonResponse({ locale: 'en' })
+  }
+
+  try {
+    await assert.rejects(getBootstrapConfig(), /temporary failure/)
+    assert.equal((await getBootstrapConfig()).locale, 'en')
+    assert.equal(calls, 2)
+  } finally {
+    globalThis.fetch = originalFetch
+    resetBootstrapDataCache()
+  }
+})

--- a/src_assets/common/assets/web/tests/firebase.test.js
+++ b/src_assets/common/assets/web/tests/firebase.test.js
@@ -1,0 +1,26 @@
+import test, { after } from 'node:test'
+import assert from 'node:assert/strict'
+
+const originalRequestIdleCallback = globalThis.requestIdleCallback
+globalThis.requestIdleCallback = () => 1
+
+const { trackEvent } = await import('../config/firebase.js')
+
+after(() => {
+  if (originalRequestIdleCallback) {
+    globalThis.requestIdleCallback = originalRequestIdleCallback
+  } else {
+    delete globalThis.requestIdleCallback
+  }
+})
+
+test('accepts explicitly null analytics parameters', () => {
+  assert.doesNotThrow(() => trackEvent('null_params', null))
+})
+
+test('does not throw when an analytics parameter contains a cycle', () => {
+  const circularValue = {}
+  circularValue.self = circularValue
+
+  assert.doesNotThrow(() => trackEvent('circular_params', { value: circularValue }))
+})

--- a/src_assets/common/assets/web/utils/appReady.js
+++ b/src_assets/common/assets/web/utils/appReady.js
@@ -1,0 +1,15 @@
+export const WEBUI_READY_MESSAGE = 'webui-ready'
+
+export const markWebUiReady = (windowObject = window, documentObject = document) => {
+  if (documentObject.documentElement) {
+    documentObject.documentElement.dataset.sunshineReady = 'true'
+  }
+
+  const isEmbeddedTauri = Boolean(windowObject.isTauri || windowObject.__TAURI__)
+    && windowObject.parent
+    && windowObject.parent !== windowObject
+
+  if (isEmbeddedTauri) {
+    windowObject.parent.postMessage({ type: WEBUI_READY_MESSAGE }, '*')
+  }
+}

--- a/src_assets/common/assets/web/views/Apps.vue
+++ b/src_assets/common/assets/web/views/Apps.vue
@@ -611,7 +611,7 @@ import AppCard from '../components/AppCard.vue'
 import AppListItem from '../components/AppListItem.vue'
 import ScanResultModal from '../components/ScanResultModal.vue'
 import { useApps } from '../composables/useApps.js'
-import { initFirebase, trackEvents } from '../config/firebase.js'
+import { trackEvents } from '../config/firebase.js'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
@@ -703,7 +703,6 @@ const initEnvVarsModal = () => {
 }
 
 onMounted(async () => {
-  initFirebase()
   trackEvents.pageView('applications')
   init(t)
   initEnvVarsModal()

--- a/src_assets/common/assets/web/views/Config.vue
+++ b/src_assets/common/assets/web/views/Config.vue
@@ -234,9 +234,7 @@ import Navbar from '../components/layout/Navbar.vue'
 import ConfirmDialog from '../components/common/ConfirmDialog.vue'
 import { getPreferredEncoderTab } from '../config/encoderTabs.js'
 import { useConfig } from '../composables/useConfig.js'
-import { initFirebase, trackEvents } from '../config/firebase.js'
-
-initFirebase()
+import { trackEvents } from '../config/firebase.js'
 
 const General = defineAsyncComponent(() => import('../configs/tabs/General.vue'))
 const Inputs = defineAsyncComponent(() => import('../configs/tabs/Inputs.vue'))

--- a/src_assets/common/assets/web/views/Home.vue
+++ b/src_assets/common/assets/web/views/Home.vue
@@ -129,6 +129,7 @@ import { VERSION_CHECK_STATUS, useVersion } from '../composables/useVersion.js'
 import { useLogs } from '../composables/useLogs.js'
 import { useSetupWizard } from '../composables/useSetupWizard.js'
 import { trackEvents } from '../config/firebase.js'
+import { getBootstrapConfig } from '../config/bootstrapData.js'
 import { apiJson } from '../utils/apiFetch.js'
 
 const { t } = useI18n()
@@ -264,7 +265,7 @@ onMounted(async () => {
   trackEvents.pageView('home')
 
   try {
-    const config = await apiJson('/api/config')
+    const config = await getBootstrapConfig()
     hostConfig.value = config
     hostStatus.value = 'ready'
 

--- a/src_assets/common/assets/web/views/Welcome.vue
+++ b/src_assets/common/assets/web/views/Welcome.vue
@@ -162,7 +162,7 @@
 import { ref, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useWelcome } from '../composables/useWelcome.js'
-import { apiJson } from '../utils/apiFetch.js'
+import { getBootstrapLocale } from '../config/bootstrapData.js'
 import { loadAutoTheme } from '../utils/theme.js'
 
 const { locale, setLocaleMessage } = useI18n()
@@ -194,7 +194,7 @@ const loadLanguage = (lang) => {
 onMounted(async () => {
   try {
     // 使用 /api/configLocale，这个 API 不需要认证（在 welcome 页面时可能还没有账号）
-    const config = await apiJson('/api/configLocale')
+    const config = await getBootstrapLocale()
     if (config.locale) {
       selectedLocale.value = config.locale
       loadLanguage(config.locale)


### PR DESCRIPTION
## 改了啥呀

- Tauri GUI 内嵌 WebUI 时跳过跨文档 View Transition，普通浏览器继续保留轻量转场
- 启动阶段复用同一份 `/api/config` 请求，失败后自动清缓存重试，切换到新文档仍会重新获取
- Firebase Analytics 改为浏览器空闲时动态加载，不再抢首屏关键路径
- WebUI 在语言初始化与 Vue 挂载完成后发送 `webui-ready`，GUI 收到后再揭开 iframe，并保留 5 秒兼容兜底
- 补充启动请求复用与 ready 握手测试

## 为啥要改

iframe 的 `load` 会早于 WebUI 真正可交互的时刻；再叠上重复配置请求、Firebase 静态依赖和双重转场，GUI 看起来就像慢吞吞地多加载了一轮。现在首屏关键工作只做一次，遮罩也以真实应用就绪为准，杂鱼切页时终于不会看到初始化过程抢镜啦。

## GUI 依赖

- qiin2333/sunshine-control-panel#59

## 验证

- `npm run test:webui`（81/81）
- `npm run build`
- GUI `npm run build:renderer`
- 普通页面启动仅请求一次 `/api/config`
- 人为延迟 `/api/config` 1.5 秒时，iframe 保持遮罩直到 `webui-ready`
- Tauri iframe 模拟验证：收到一次 ready 消息后正常揭开页面
- 1920×1080 首页视觉检查通过