### PR TITLE
fix(installer): wait for asynchronous VDD removal

### DIFF
--- a/src_assets/windows/misc/vdd/install-vdd.bat
+++ b/src_assets/windows/misc/vdd/install-vdd.bat
@@ -29,6 +29,7 @@ call :stage_payload || exit /b 1
 if "!VDD_CLEANUP_REQUIRED!"=="1" (
     call :remove_vdd || exit /b 1
 )
+call :cleanup_vdd_packages || exit /b 1
 call :configure_vdd || exit /b 1
 if "!VDD_INSTALL_REQUIRED!"=="1" (
     call :install_vdd || exit /b 1
@@ -108,34 +109,44 @@ if not exist "!VDD_HELPER!" (
     exit /b 1
 )
 
-set "VDD_DEVICE_PRESENT=0"
+set "VDD_DEVICE_COUNT="
+set "VDD_CLEANUP_REQUIRED="
+set "VDD_INSTALL_REQUIRED="
 set "CURRENT_VDD_VERSION="
 set "CURRENT_VDD_STATUS="
+set "CURRENT_VDD_INF="
 set "BUNDLED_VDD_VERSION="
 for /f "tokens=1,* delims==" %%A in ('powershell -NoProfile -ExecutionPolicy Bypass -File "!VDD_HELPER!" -Action Probe -InfPath "!DRIVER_DIR!\ZakoVDD.inf"') do set "%%A=%%B"
 if not defined VDD_PROBE_OK (
     echo ERROR: Failed to inspect the VDD device and driver versions.
     exit /b 1
 )
+if not defined VDD_DEVICE_COUNT (
+    echo ERROR: VDD probe did not return a device count.
+    exit /b 1
+)
+if not defined VDD_CLEANUP_REQUIRED (
+    echo ERROR: VDD probe did not return a cleanup decision.
+    exit /b 1
+)
+if not defined VDD_INSTALL_REQUIRED (
+    echo ERROR: VDD probe did not return an install decision.
+    exit /b 1
+)
 
-echo Existing VDD device: !VDD_DEVICE_PRESENT!
+echo Existing VDD devices: !VDD_DEVICE_COUNT!
 if defined CURRENT_VDD_VERSION echo Installed VDD version: !CURRENT_VDD_VERSION!
 if defined CURRENT_VDD_STATUS echo Installed VDD status: !CURRENT_VDD_STATUS!
+if defined CURRENT_VDD_INF echo Active VDD package: !CURRENT_VDD_INF!
 echo Bundled VDD version: !BUNDLED_VDD_VERSION!
 exit /b 0
 
 :choose_action
-set "VDD_CLEANUP_REQUIRED=!VDD_DEVICE_PRESENT!"
-set "VDD_INSTALL_REQUIRED=1"
-
-if not "!CURRENT_VDD_STATUS!"=="OK" exit /b 0
-if not defined CURRENT_VDD_VERSION exit /b 0
-if not defined BUNDLED_VDD_VERSION exit /b 0
-if /i not "!CURRENT_VDD_VERSION!"=="!BUNDLED_VDD_VERSION!" exit /b 0
-
-set "VDD_CLEANUP_REQUIRED=0"
-set "VDD_INSTALL_REQUIRED=0"
-echo Matching VDD driver is already active; skipping driver reinstall.
+if "!VDD_INSTALL_REQUIRED!"=="0" (
+    echo Exactly one matching VDD device is active; skipping driver reinstall.
+) else (
+    echo VDD state requires reconciliation before installation.
+)
 exit /b 0
 
 :stage_payload
@@ -153,21 +164,28 @@ if errorlevel 1 (
 exit /b 0
 
 :remove_vdd
-echo Existing VDD installation detected; removing its device node...
-"!NEFCON!" --remove-device-node --hardware-id !VDD_HARDWARE_ID! --class-guid !VDD_CLASS_GUID!
-call :wait_vdd Removed 10
-if not errorlevel 1 goto :vdd_removed
-
-echo Device still present; retrying removal once...
-"!NEFCON!" --remove-device-node --hardware-id !VDD_HARDWARE_ID! --class-guid !VDD_CLASS_GUID! 2>nul
-call :wait_vdd Removed 10
+echo Existing VDD installation detected; removing all of its device nodes...
+powershell -NoProfile -ExecutionPolicy Bypass -File "!VDD_HELPER!" -Action Remove -NefconPath "!NEFCON!" -TimeoutSeconds 30
 if errorlevel 1 (
-    echo ERROR: VDD device remained present after removal.
+    echo ERROR: Failed to remove every VDD device node.
     exit /b 1
 )
 
-:vdd_removed
 reg delete "HKLM\SOFTWARE\ZakoTech\ZakoDisplayAdapter" /f >nul 2>&1
+exit /b 0
+
+:cleanup_vdd_packages
+if "!VDD_INSTALL_REQUIRED!"=="1" (
+    echo Removing superseded VDD driver packages before installation...
+    powershell -NoProfile -ExecutionPolicy Bypass -File "!VDD_HELPER!" -Action CleanupPackages
+) else (
+    echo Pruning stale VDD driver packages...
+    powershell -NoProfile -ExecutionPolicy Bypass -File "!VDD_HELPER!" -Action CleanupPackages -KeepActivePackage -ExpectedVersion "!BUNDLED_VDD_VERSION!"
+)
+if errorlevel 1 (
+    echo ERROR: Failed to clean up VDD driver packages.
+    exit /b 1
+)
 exit /b 0
 
 :configure_vdd

--- a/src_assets/windows/misc/vdd/install-vdd.bat
+++ b/src_assets/windows/misc/vdd/install-vdd.bat
@@ -165,7 +165,7 @@ exit /b 0
 
 :remove_vdd
 echo Existing VDD installation detected; removing all of its device nodes...
-powershell -NoProfile -ExecutionPolicy Bypass -File "!VDD_HELPER!" -Action Remove -NefconPath "!NEFCON!" -TimeoutSeconds 30
+powershell -NoProfile -ExecutionPolicy Bypass -File "!VDD_HELPER!" -Action Remove -NefconPath "!NEFCON!" -TimeoutSeconds 120
 if errorlevel 1 (
     echo ERROR: Failed to remove every VDD device node.
     exit /b 1

--- a/src_assets/windows/misc/vdd/smoke-test-vdd-device-helper.ps1
+++ b/src_assets/windows/misc/vdd/smoke-test-vdd-device-helper.ps1
@@ -115,6 +115,62 @@ catch {
 }
 Assert-Equal $true $invalidKeepWasRejected 'Package pruning must reject a non-published INF name.'
 
+$originalGetChildItem = ${function:Get-ChildItem}
+$originalSelectString = ${function:Select-String}
+try {
+    $script:fakeInfFiles = @(
+        [pscustomobject]@{ Name = 'oem40.inf'; FullName = 'C:\fake\oem40.inf' },
+        [pscustomobject]@{ Name = 'oem42.inf'; FullName = 'C:\fake\oem42.inf' },
+        [pscustomobject]@{ Name = 'oem43.inf'; FullName = 'C:\fake\oem43.inf' }
+    )
+    function Get-ChildItem {
+        [CmdletBinding()]
+        param([string] $LiteralPath, [string] $Filter, [switch] $File)
+        return @($script:fakeInfFiles)
+    }
+    function Select-String {
+        [CmdletBinding()]
+        param(
+            [string] $LiteralPath,
+            [string] $SimpleMatch,
+            [switch] $Quiet
+        )
+        if ($LiteralPath -like '*oem40.inf') {
+            throw 'simulated unreadable INF'
+        }
+        return $LiteralPath -like '*oem42.inf'
+    }
+
+    $foundPackages = @(Get-PublishedVddPackages `
+        -RequiredInfNames @('oem42.inf'))
+    Assert-Equal 1 $foundPackages.Count 'An unreadable unrelated INF must not abort the package scan.'
+    Assert-Equal 'oem42.inf' $foundPackages[0].InfName 'The readable VDD package must still be detected.'
+
+    $activeReadFailedClosed = $false
+    try {
+        [void] (Get-PublishedVddPackages -RequiredInfNames @('oem40.inf'))
+    }
+    catch {
+        $activeReadFailedClosed = $_.Exception.Message -like '*active VDD package oem40.inf*'
+    }
+    Assert-Equal $true $activeReadFailedClosed 'An unreadable active VDD package must abort the scan.'
+}
+finally {
+    if ($originalGetChildItem) {
+        ${function:Get-ChildItem} = $originalGetChildItem
+    }
+    else {
+        Remove-Item Function:\Get-ChildItem -ErrorAction SilentlyContinue
+    }
+    if ($originalSelectString) {
+        ${function:Select-String} = $originalSelectString
+    }
+    else {
+        Remove-Item Function:\Select-String -ErrorAction SilentlyContinue
+    }
+    Remove-Variable -Name fakeInfFiles -Scope Script -ErrorAction SilentlyContinue
+}
+
 $originalGetVddDevices = ${function:Get-VddDevices}
 try {
     function Get-VddDevices {

--- a/src_assets/windows/misc/vdd/smoke-test-vdd-device-helper.ps1
+++ b/src_assets/windows/misc/vdd/smoke-test-vdd-device-helper.ps1
@@ -199,11 +199,19 @@ try {
     $secondFakeDevice = New-TestDevice '100.0.16.6' 'OK' 'oem42.inf'
     $secondFakeDevice.InstanceId = 'ROOT\DISPLAY\0043'
     $script:fakeDevices = @($firstFakeDevice, $secondFakeDevice)
+    $script:removalCalls = 0
+    $script:pollsAfterRemoval = 0
     function Get-VddDevices {
+        if ($script:removalCalls -gt 0) {
+            $script:pollsAfterRemoval++
+            if ($script:pollsAfterRemoval -ge 3) {
+                $script:fakeDevices = @()
+            }
+        }
         return @($script:fakeDevices)
     }
     function Invoke-NefconRemoval {
-        $script:fakeDevices = @($script:fakeDevices | Select-Object -Skip 1)
+        $script:removalCalls++
         return 0
     }
 
@@ -211,24 +219,34 @@ try {
     $TimeoutSeconds = 2
     [void] (Remove-AllVddDevices)
     Assert-Equal 0 $script:fakeDevices.Count 'All duplicate device nodes must be removed.'
+    Assert-Equal 1 $script:removalCalls 'An asynchronous removal must not receive overlapping requests.'
 
     $script:fakeDevices = @(New-TestDevice '100.0.16.6')
+    $script:removalCalls = 0
+    function Get-VddDevices {
+        return @($script:fakeDevices)
+    }
     function Invoke-NefconRemoval {
+        $script:removalCalls++
         return 1
     }
+    $TimeoutSeconds = 1
     $removalFailedClosed = $false
     try {
         [void] (Remove-AllVddDevices)
     }
     catch {
-        $removalFailedClosed = $_.Exception.Message -like '*made no progress*'
+        $removalFailedClosed = $_.Exception.Message -like '*timed out*'
     }
     Assert-Equal $true $removalFailedClosed 'A failed removal must abort before creating another node.'
+    Assert-Equal 1 $script:removalCalls 'A stalled removal must not repeatedly invoke nefcon.'
 }
 finally {
     ${function:Get-VddDevices} = $originalGetVddDevices
     ${function:Invoke-NefconRemoval} = $originalInvokeNefconRemoval
     Remove-Variable -Name fakeDevices -Scope Script -ErrorAction SilentlyContinue
+    Remove-Variable -Name removalCalls -Scope Script -ErrorAction SilentlyContinue
+    Remove-Variable -Name pollsAfterRemoval -Scope Script -ErrorAction SilentlyContinue
 }
 
 $results | Format-Table -AutoSize

--- a/src_assets/windows/misc/vdd/smoke-test-vdd-device-helper.ps1
+++ b/src_assets/windows/misc/vdd/smoke-test-vdd-device-helper.ps1
@@ -1,0 +1,179 @@
+[CmdletBinding()]
+param(
+    [string] $HelperScript
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $HelperScript) {
+    $HelperScript = Join-Path $PSScriptRoot 'vdd-device-helper.ps1'
+}
+
+function Assert-Equal($Expected, $Actual, [string] $Message) {
+    if ($Expected -ne $Actual) {
+        throw "$Message`nExpected: $Expected`nActual:   $Actual"
+    }
+}
+
+function New-TestDevice(
+    [string] $Version,
+    [string] $Status = 'OK',
+    [string] $InfName = 'oem42.inf') {
+    return [pscustomobject]@{
+        InstanceId = 'ROOT\DISPLAY\0042'
+        Version = $Version
+        Status = $Status
+        InfName = $InfName
+        Problem = $(if ($Status -eq 'OK') { 0 } else { 10 })
+    }
+}
+
+if (-not (Test-Path -LiteralPath $HelperScript)) {
+    throw "VDD helper not found: $HelperScript"
+}
+
+. $HelperScript
+
+$cases = @(
+    @{
+        Name = 'No device requires one install'
+        Devices = @()
+        Count = 0
+        Cleanup = 0
+        Install = 1
+    },
+    @{
+        Name = 'One healthy matching device is a no-op'
+        Devices = @(New-TestDevice '100.0.16.6')
+        Count = 1
+        Cleanup = 0
+        Install = 0
+    },
+    @{
+        Name = 'Version upgrade reconciles the existing device'
+        Devices = @(New-TestDevice '100.0.16.5')
+        Count = 1
+        Cleanup = 1
+        Install = 1
+    },
+    @{
+        Name = 'Unhealthy device is replaced'
+        Devices = @(New-TestDevice '100.0.16.6' 'ERROR')
+        Count = 1
+        Cleanup = 1
+        Install = 1
+    },
+    @{
+        Name = 'Device without a published INF is reconciled'
+        Devices = @(New-TestDevice '100.0.16.6' 'OK' '')
+        Count = 1
+        Cleanup = 1
+        Install = 1
+    },
+    @{
+        Name = 'Duplicate devices are collapsed to one'
+        Devices = @(
+            (New-TestDevice '100.0.16.6' 'OK' 'oem42.inf'),
+            (New-TestDevice '100.0.16.6' 'OK' 'oem42.inf')
+        )
+        Count = 2
+        Cleanup = 1
+        Install = 1
+    }
+)
+
+$results = foreach ($case in $cases) {
+    $decision = Get-VddDecision $case.Devices '100.0.16.6'
+    Assert-Equal $case.Count $decision.DeviceCount "$($case.Name): wrong device count"
+    Assert-Equal $case.Cleanup $decision.CleanupRequired "$($case.Name): wrong cleanup decision"
+    Assert-Equal $case.Install $decision.InstallRequired "$($case.Name): wrong install decision"
+
+    [pscustomobject]@{
+        Case = $case.Name
+        Count = $decision.DeviceCount
+        Cleanup = $decision.CleanupRequired
+        Install = $decision.InstallRequired
+        Status = 'PASS'
+    }
+}
+
+$packages = @(
+    [pscustomobject]@{ InfName = 'oem40.inf' },
+    [pscustomobject]@{ InfName = 'OEM42.INF' },
+    [pscustomobject]@{ InfName = 'oem43.inf' }
+)
+$stalePackages = @(Get-VddPackagesToRemove $packages 'oem42.inf')
+Assert-Equal 2 $stalePackages.Count 'Package pruning must keep exactly the active OEM INF.'
+Assert-Equal 'oem40.inf,oem43.inf' ($stalePackages.InfName -join ',') 'Wrong stale package selection.'
+
+$invalidKeepWasRejected = $false
+try {
+    [void] (Get-VddPackagesToRemove $packages 'ZakoVDD.inf')
+}
+catch {
+    $invalidKeepWasRejected = $true
+}
+Assert-Equal $true $invalidKeepWasRejected 'Package pruning must reject a non-published INF name.'
+
+$originalGetVddDevices = ${function:Get-VddDevices}
+try {
+    function Get-VddDevices {
+        throw 'simulated device enumeration failure'
+    }
+
+    $probeFailedClosed = $false
+    try {
+        $Action = 'Probe'
+        $InfPath = $HelperScript
+        [void] (Invoke-VddDeviceHelper)
+    }
+    catch {
+        $probeFailedClosed = $_.Exception.Message -like '*simulated device enumeration failure*'
+    }
+    Assert-Equal $true $probeFailedClosed 'A device enumeration failure must abort the probe.'
+}
+finally {
+    ${function:Get-VddDevices} = $originalGetVddDevices
+}
+
+$originalGetVddDevices = ${function:Get-VddDevices}
+$originalInvokeNefconRemoval = ${function:Invoke-NefconRemoval}
+try {
+    $firstFakeDevice = New-TestDevice '100.0.16.5' 'OK' 'oem40.inf'
+    $secondFakeDevice = New-TestDevice '100.0.16.6' 'OK' 'oem42.inf'
+    $secondFakeDevice.InstanceId = 'ROOT\DISPLAY\0043'
+    $script:fakeDevices = @($firstFakeDevice, $secondFakeDevice)
+    function Get-VddDevices {
+        return @($script:fakeDevices)
+    }
+    function Invoke-NefconRemoval {
+        $script:fakeDevices = @($script:fakeDevices | Select-Object -Skip 1)
+        return 0
+    }
+
+    $NefconPath = $HelperScript
+    $TimeoutSeconds = 2
+    [void] (Remove-AllVddDevices)
+    Assert-Equal 0 $script:fakeDevices.Count 'All duplicate device nodes must be removed.'
+
+    $script:fakeDevices = @(New-TestDevice '100.0.16.6')
+    function Invoke-NefconRemoval {
+        return 1
+    }
+    $removalFailedClosed = $false
+    try {
+        [void] (Remove-AllVddDevices)
+    }
+    catch {
+        $removalFailedClosed = $_.Exception.Message -like '*made no progress*'
+    }
+    Assert-Equal $true $removalFailedClosed 'A failed removal must abort before creating another node.'
+}
+finally {
+    ${function:Get-VddDevices} = $originalGetVddDevices
+    ${function:Invoke-NefconRemoval} = $originalInvokeNefconRemoval
+    Remove-Variable -Name fakeDevices -Scope Script -ErrorAction SilentlyContinue
+}
+
+$results | Format-Table -AutoSize
+Write-Host 'VDD helper smoke tests passed.'

--- a/src_assets/windows/misc/vdd/uninstall-vdd.bat
+++ b/src_assets/windows/misc/vdd/uninstall-vdd.bat
@@ -1,42 +1,60 @@
 @echo off
+setlocal enabledelayedexpansion
 set "PATH=%SystemRoot%\System32;%SystemRoot%;%SystemRoot%\System32\Wbem;%SystemRoot%\System32\WindowsPowerShell\v1.0"
 chcp 65001 >nul
 
 rem Get sunshine root directory
 for %%I in ("%~dp0\..") do set "ROOT_DIR=%%~fI"
 
-rem uninstall
 set "DIST_DIR=%ROOT_DIR%\tools\vdd"
 set "NEFCON=%ROOT_DIR%\tools\nefconw.exe"
 if not exist "%NEFCON%" set "NEFCON=%DIST_DIR%\nefconw.exe"
-if not exist "%NEFCON%" (
-    echo WARNING: nefconw.exe not found, skipping driver/device removal.
+set "VDD_HELPER=%~dp0vdd-device-helper.ps1"
+set "UNINSTALL_RESULT=0"
+
+if exist "!VDD_HELPER!" (
+    echo Removing all VDD device nodes...
+    powershell -NoProfile -ExecutionPolicy Bypass -File "!VDD_HELPER!" -Action Remove -NefconPath "!NEFCON!" -TimeoutSeconds 30
+    if errorlevel 1 (
+        echo WARNING: Failed to remove every VDD device node; driver packages will be preserved.
+        set "UNINSTALL_RESULT=1"
+    ) else (
+        echo Removing all VDD driver packages...
+        powershell -NoProfile -ExecutionPolicy Bypass -File "!VDD_HELPER!" -Action CleanupPackages
+        if errorlevel 1 (
+            echo WARNING: Failed to remove every VDD driver package.
+            set "UNINSTALL_RESULT=1"
+        )
+    )
     goto :cleanup
 )
 
-rem 1) Remove device node(s) first so the driver is no longer in use
-echo Removing VDD device node...
-"%NEFCON%" --remove-device-node --hardware-id Root\ZakoVDD --class-guid 4d36e968-e325-11ce-bfc1-08002be10318
-
-rem Brief wait so the kernel finishes releasing the device handle before we
-rem attempt to remove the driver package from the DriverStore.
-timeout /t 1 /nobreak >nul 2>&1
-
-rem 2) Uninstall the driver package from the DriverStore (requires INF path)
-if exist "%DIST_DIR%\ZakoVDD.inf" (
-    echo Uninstalling VDD driver package...
-    "%NEFCON%" --uninstall-driver --inf-path "%DIST_DIR%\ZakoVDD.inf"
-) else (
-    echo WARNING: ZakoVDD.inf not found in "%DIST_DIR%", skipping driver package uninstall.
+rem Compatibility fallback for an installation that predates the helper.
+if not exist "!NEFCON!" (
+    echo WARNING: VDD helper and nefconw.exe are unavailable; skipping driver removal.
+    set "UNINSTALL_RESULT=1"
+    goto :cleanup
 )
 
-rem 3) Best-effort second pass in case multiple device instances remain
-"%NEFCON%" --remove-device-node --hardware-id Root\ZakoVDD --class-guid 4d36e968-e325-11ce-bfc1-08002be10318 >nul 2>&1
+echo Removing VDD device node...
+"!NEFCON!" --remove-device-node --hardware-id Root\ZakoVDD --class-guid 4d36e968-e325-11ce-bfc1-08002be10318
+timeout /t 1 /nobreak >nul 2>&1
+
+if exist "!DIST_DIR!\ZakoVDD.inf" (
+    echo Uninstalling VDD driver package...
+    "!NEFCON!" --uninstall-driver --inf-path "!DIST_DIR!\ZakoVDD.inf"
+) else (
+    echo WARNING: ZakoVDD.inf not found in "!DIST_DIR!", skipping driver package uninstall.
+    set "UNINSTALL_RESULT=1"
+)
+
+"!NEFCON!" --remove-device-node --hardware-id Root\ZakoVDD --class-guid 4d36e968-e325-11ce-bfc1-08002be10318 >nul 2>&1
 
 :cleanup
 echo Cleaning registry...
 reg delete "HKLM\SOFTWARE\ZakoTech" /f 2>nul
-if exist "%DIST_DIR%" (
-    rmdir /S /Q "%DIST_DIR%"
+if exist "!DIST_DIR!" (
+    rmdir /S /Q "!DIST_DIR!"
 )
 echo VDD uninstall completed.
+exit /b !UNINSTALL_RESULT!

--- a/src_assets/windows/misc/vdd/uninstall-vdd.bat
+++ b/src_assets/windows/misc/vdd/uninstall-vdd.bat
@@ -14,7 +14,7 @@ set "UNINSTALL_RESULT=0"
 
 if exist "!VDD_HELPER!" (
     echo Removing all VDD device nodes...
-    powershell -NoProfile -ExecutionPolicy Bypass -File "!VDD_HELPER!" -Action Remove -NefconPath "!NEFCON!" -TimeoutSeconds 30
+    powershell -NoProfile -ExecutionPolicy Bypass -File "!VDD_HELPER!" -Action Remove -NefconPath "!NEFCON!" -TimeoutSeconds 120
     if errorlevel 1 (
         echo WARNING: Failed to remove every VDD device node; driver packages will be preserved.
         set "UNINSTALL_RESULT=1"

--- a/src_assets/windows/misc/vdd/vdd-device-helper.ps1
+++ b/src_assets/windows/misc/vdd/vdd-device-helper.ps1
@@ -1,11 +1,12 @@
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory)]
-    [ValidateSet('Probe', 'Ready', 'Removed')]
+    [ValidateSet('Probe', 'Ready', 'Remove', 'CleanupPackages')]
     [string] $Action,
 
     [string] $InfPath,
     [string] $ExpectedVersion,
+    [string] $NefconPath,
+    [switch] $KeepActivePackage,
 
     [ValidateRange(1, 60)]
     [int] $TimeoutSeconds = 10
@@ -13,27 +14,140 @@ param(
 
 $ErrorActionPreference = 'Stop'
 $hardwareId = 'Root\ZakoVDD'
+$displayClassGuid = '4d36e968-e325-11ce-bfc1-08002be10318'
+$deviceEnumPath = 'SYSTEM\CurrentControlSet\Enum\ROOT\DISPLAY'
+$deviceClassPath = 'SYSTEM\CurrentControlSet\Control\Class'
+$dnStarted = 0x00000008
 
-function Get-VddDevice {
-    foreach ($candidate in @(Get-PnpDevice -Class Display -ErrorAction SilentlyContinue)) {
-        if (@($candidate.HardwareID) -contains $hardwareId) {
-            return $candidate
-        }
+function Initialize-CfgMgr32 {
+    if ('SunshineVddCfgMgr32' -as [type]) {
+        return
     }
-    return $null
+
+    Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+
+public static class SunshineVddCfgMgr32
+{
+    [DllImport("cfgmgr32.dll", CharSet = CharSet.Unicode)]
+    public static extern uint CM_Locate_DevNodeW(
+        out uint deviceInstance,
+        string deviceInstanceId,
+        uint flags);
+
+    [DllImport("cfgmgr32.dll")]
+    public static extern uint CM_Get_DevNode_Status(
+        out uint status,
+        out uint problemNumber,
+        uint deviceInstance,
+        uint flags);
+}
+'@
 }
 
-function Get-InstalledVersion([Microsoft.Management.Infrastructure.CimInstance] $Device) {
-    if (-not $Device) {
-        return ''
+function Get-VddDeviceStatus([string] $InstanceId) {
+    Initialize-CfgMgr32
+
+    [uint32] $deviceInstance = 0
+    [uint32] $status = 0
+    [uint32] $problem = 0
+    $locateResult = [SunshineVddCfgMgr32]::CM_Locate_DevNodeW(
+        [ref] $deviceInstance,
+        $InstanceId,
+        0)
+    if ($locateResult -ne 0) {
+        return 'ERROR'
     }
-    return (Get-PnpDeviceProperty `
-        -InstanceId $Device.InstanceId `
-        -KeyName DEVPKEY_Device_DriverVersion `
-        -ErrorAction SilentlyContinue).Data
+
+    $statusResult = [SunshineVddCfgMgr32]::CM_Get_DevNode_Status(
+        [ref] $status,
+        [ref] $problem,
+        $deviceInstance,
+        0)
+    if ($statusResult -eq 0 -and $problem -eq 0 -and ($status -band $dnStarted)) {
+        return 'OK'
+    }
+    return 'ERROR'
+}
+
+function Get-VddDevices {
+    # Get-PnpDevice uses CIM and can fail with 0x800705af under memory pressure.
+    # The registry plus cfgmgr32 gives us locale-independent, fail-closed state.
+    $registryView = if ([Environment]::Is64BitOperatingSystem) {
+        [Microsoft.Win32.RegistryView]::Registry64
+    }
+    else {
+        [Microsoft.Win32.RegistryView]::Default
+    }
+    $baseKey = [Microsoft.Win32.RegistryKey]::OpenBaseKey(
+        [Microsoft.Win32.RegistryHive]::LocalMachine,
+        $registryView)
+    $enumKey = $null
+
+    try {
+        $enumKey = $baseKey.OpenSubKey($deviceEnumPath)
+        if (-not $enumKey) {
+            return @()
+        }
+
+        $devices = foreach ($instanceName in $enumKey.GetSubKeyNames()) {
+            $deviceKey = $null
+            $driverKey = $null
+            try {
+                $deviceKey = $enumKey.OpenSubKey($instanceName)
+                if (-not $deviceKey) {
+                    continue
+                }
+
+                $hardwareIds = @($deviceKey.GetValue('HardwareID', $null))
+                if (-not ($hardwareIds | Where-Object { $_ -ieq $hardwareId })) {
+                    continue
+                }
+
+                $driverVersion = ''
+                $publishedInf = ''
+                $driverKeyName = [string] $deviceKey.GetValue('Driver', '')
+                if ($driverKeyName) {
+                    $driverKey = $baseKey.OpenSubKey("$deviceClassPath\$driverKeyName")
+                    if ($driverKey) {
+                        $driverVersion = [string] $driverKey.GetValue('DriverVersion', '')
+                        $publishedInf = [string] $driverKey.GetValue('InfPath', '')
+                    }
+                }
+
+                $instanceId = "ROOT\DISPLAY\$instanceName"
+                [pscustomobject]@{
+                    InstanceId = $instanceId
+                    Version = $driverVersion
+                    InfName = $publishedInf
+                    Status = Get-VddDeviceStatus $instanceId
+                }
+            }
+            finally {
+                if ($driverKey) {
+                    $driverKey.Dispose()
+                }
+                if ($deviceKey) {
+                    $deviceKey.Dispose()
+                }
+            }
+        }
+        return @($devices)
+    }
+    finally {
+        if ($enumKey) {
+            $enumKey.Dispose()
+        }
+        $baseKey.Dispose()
+    }
 }
 
 function Get-BundledVersion([string] $Path) {
+    if (-not $Path) {
+        throw 'InfPath is required when probing the bundled VDD version.'
+    }
+
     $driverVer = (Select-String `
         -LiteralPath $Path `
         -Pattern '^\s*DriverVer\s*=' `
@@ -42,6 +156,24 @@ function Get-BundledVersion([string] $Path) {
         throw "DriverVer was not found in $Path"
     }
     return ($driverVer -split ',')[-1].Trim()
+}
+
+function Get-VddDecision([object[]] $Devices, [string] $BundledVersion) {
+    $deviceList = @($Devices)
+    $device = if ($deviceList.Count -eq 1) { $deviceList[0] } else { $null }
+    $isReady = $device -and
+        $device.Status -eq 'OK' -and
+        $device.Version -eq $BundledVersion -and
+        $device.InfName -match '(?i)^oem\d+\.inf$'
+
+    return [pscustomobject]@{
+        DeviceCount = $deviceList.Count
+        CleanupRequired = [int]($deviceList.Count -gt 0 -and -not $isReady)
+        InstallRequired = [int](-not $isReady)
+        CurrentVersion = $(if ($device) { $device.Version } else { '' })
+        CurrentStatus = $(if ($device) { $device.Status } else { '' })
+        CurrentInf = $(if ($device) { $device.InfName } else { '' })
+    }
 }
 
 function Wait-Until([scriptblock] $Condition) {
@@ -55,37 +187,164 @@ function Wait-Until([scriptblock] $Condition) {
     return $false
 }
 
-try {
-    switch ($Action) {
-        'Probe' {
-            $device = Get-VddDevice
-            $bundledVersion = Get-BundledVersion $InfPath
-            Write-Output 'VDD_PROBE_OK=1'
-            Write-Output ('VDD_DEVICE_PRESENT=' + [int]($null -ne $device))
-            Write-Output ('CURRENT_VDD_VERSION=' + (Get-InstalledVersion $device))
-            Write-Output ('CURRENT_VDD_STATUS=' + $(if ($device) { $device.Status } else { '' }))
-            Write-Output ('BUNDLED_VDD_VERSION=' + $bundledVersion)
-            exit 0
+function Invoke-NefconRemoval {
+    & $NefconPath `
+        --remove-device-node `
+        --hardware-id $hardwareId `
+        --class-guid $displayClassGuid
+    return $LASTEXITCODE
+}
+
+function Remove-AllVddDevices {
+    $devices = @(Get-VddDevices)
+    if ($devices.Count -eq 0) {
+        return
+    }
+    if (-not $NefconPath -or -not (Test-Path -LiteralPath $NefconPath)) {
+        throw "nefcon is unavailable: $NefconPath"
+    }
+
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    $stalledPasses = 0
+    do {
+        $beforeCount = $devices.Count
+        Write-Output "Removing VDD device node ($beforeCount remaining)..."
+        [void] (Invoke-NefconRemoval)
+        Start-Sleep -Milliseconds 250
+        $devices = @(Get-VddDevices)
+
+        if ($devices.Count -eq 0) {
+            return
         }
-        'Removed' {
-            if (Wait-Until { $null -eq (Get-VddDevice) }) {
-                exit 0
-            }
-            exit 1
+        if ($devices.Count -lt $beforeCount) {
+            $stalledPasses = 0
         }
-        'Ready' {
-            if (Wait-Until {
-                $device = Get-VddDevice
-                $device -and
-                    $device.Status -eq 'OK' -and
-                    (Get-InstalledVersion $device) -eq $ExpectedVersion
-            }) {
-                exit 0
+        else {
+            $stalledPasses++
+            if ($stalledPasses -ge 8) {
+                break
             }
-            exit 1
+        }
+    } while ([DateTime]::UtcNow -lt $deadline)
+
+    throw ("VDD device removal made no progress. Remaining instances: " +
+        ($devices.InstanceId -join ', '))
+}
+
+function Get-PublishedVddPackages {
+    # Match the exact hardware ID instead of parsing localized pnputil output.
+    $infDirectory = Join-Path $env:SystemRoot 'INF'
+    $packages = foreach ($inf in @(Get-ChildItem -LiteralPath $infDirectory -Filter 'oem*.inf' -File)) {
+        if (Select-String -LiteralPath $inf.FullName -SimpleMatch $hardwareId -Quiet -ErrorAction Stop) {
+            [pscustomobject]@{
+                InfName = $inf.Name
+                Path = $inf.FullName
+            }
         }
     }
-} catch {
-    Write-Error $_
-    exit 1
+    return @($packages)
+}
+
+function Get-VddPackagesToRemove([object[]] $Packages, [string] $KeepInfName = '') {
+    if ($KeepInfName -and $KeepInfName -notmatch '(?i)^oem\d+\.inf$') {
+        throw "Invalid active OEM INF name: $KeepInfName"
+    }
+    return @($Packages | Where-Object { -not $KeepInfName -or $_.InfName -ine $KeepInfName })
+}
+
+function Remove-VddPackages([object[]] $Packages) {
+    $pnputil = Join-Path $env:SystemRoot 'System32\pnputil.exe'
+    foreach ($package in @($Packages)) {
+        Write-Output "Removing VDD driver package $($package.InfName)..."
+        & $pnputil /delete-driver $package.InfName /force
+        if ($LASTEXITCODE -notin @(0, 3010)) {
+            throw "Failed to remove VDD package $($package.InfName) (exit code $LASTEXITCODE)."
+        }
+    }
+}
+
+function Cleanup-VddPackages {
+    $devices = @(Get-VddDevices)
+    $keepInfName = ''
+
+    if ($KeepActivePackage) {
+        if (-not $ExpectedVersion) {
+            throw 'ExpectedVersion is required when keeping the active VDD package.'
+        }
+        if ($devices.Count -ne 1 -or
+            $devices[0].Status -ne 'OK' -or
+            $devices[0].Version -ne $ExpectedVersion -or
+            $devices[0].InfName -notmatch '(?i)^oem\d+\.inf$') {
+            throw 'Refusing to keep a package without exactly one ready VDD device at the expected version.'
+        }
+        $keepInfName = $devices[0].InfName
+    }
+    elseif ($devices.Count -ne 0) {
+        throw "Refusing to purge VDD packages while $($devices.Count) device node(s) remain."
+    }
+
+    $packages = @(Get-PublishedVddPackages)
+    Remove-VddPackages @(Get-VddPackagesToRemove $packages $keepInfName)
+
+    $remaining = @(Get-PublishedVddPackages)
+    if ($keepInfName) {
+        if ($remaining.Count -ne 1 -or $remaining[0].InfName -ine $keepInfName) {
+            throw "Expected only active VDD package $keepInfName; found: $($remaining.InfName -join ', ')"
+        }
+        Write-Output "Active VDD driver package: $keepInfName"
+    }
+    elseif ($remaining.Count -ne 0) {
+        throw "VDD packages remain after cleanup: $($remaining.InfName -join ', ')"
+    }
+    Write-Output ('VDD_DRIVER_PACKAGE_COUNT=' + $remaining.Count)
+}
+
+function Invoke-VddDeviceHelper {
+    switch ($Action) {
+        'Probe' {
+            $devices = @(Get-VddDevices)
+            $bundledVersion = Get-BundledVersion $InfPath
+            $decision = Get-VddDecision $devices $bundledVersion
+
+            Write-Output 'VDD_PROBE_OK=1'
+            Write-Output ('VDD_DEVICE_COUNT=' + $decision.DeviceCount)
+            Write-Output ('VDD_CLEANUP_REQUIRED=' + $decision.CleanupRequired)
+            Write-Output ('VDD_INSTALL_REQUIRED=' + $decision.InstallRequired)
+            Write-Output ('CURRENT_VDD_VERSION=' + $decision.CurrentVersion)
+            Write-Output ('CURRENT_VDD_STATUS=' + $decision.CurrentStatus)
+            Write-Output ('CURRENT_VDD_INF=' + $decision.CurrentInf)
+            Write-Output ('BUNDLED_VDD_VERSION=' + $bundledVersion)
+        }
+        'Ready' {
+            if (-not (Wait-Until {
+                $devices = @(Get-VddDevices)
+                $devices.Count -eq 1 -and
+                    $devices[0].Status -eq 'OK' -and
+                    $devices[0].Version -eq $ExpectedVersion -and
+                    $devices[0].InfName -match '(?i)^oem\d+\.inf$'
+            })) {
+                throw "VDD did not become ready at version $ExpectedVersion."
+            }
+        }
+        'Remove' {
+            Remove-AllVddDevices
+        }
+        'CleanupPackages' {
+            Cleanup-VddPackages
+        }
+        default {
+            throw 'Action is required.'
+        }
+    }
+}
+
+if ($MyInvocation.InvocationName -ne '.') {
+    try {
+        Invoke-VddDeviceHelper
+        exit 0
+    }
+    catch {
+        Write-Error $_
+        exit 1
+    }
 }

--- a/src_assets/windows/misc/vdd/vdd-device-helper.ps1
+++ b/src_assets/windows/misc/vdd/vdd-device-helper.ps1
@@ -8,7 +8,7 @@ param(
     [string] $NefconPath,
     [switch] $KeepActivePackage,
 
-    [ValidateRange(1, 60)]
+    [ValidateRange(1, 120)]
     [int] $TimeoutSeconds = 10
 )
 
@@ -18,6 +18,8 @@ $displayClassGuid = '4d36e968-e325-11ce-bfc1-08002be10318'
 $deviceEnumPath = 'SYSTEM\CurrentControlSet\Enum\ROOT\DISPLAY'
 $deviceClassPath = 'SYSTEM\CurrentControlSet\Control\Class'
 $dnStarted = 0x00000008
+$crInvalidDevnode = 0x00000005
+$crNoSuchDevnode = 0x0000000D
 
 function Initialize-CfgMgr32 {
     if ('SunshineVddCfgMgr32' -as [type]) {
@@ -56,6 +58,9 @@ function Get-VddDeviceStatus([string] $InstanceId) {
         [ref] $deviceInstance,
         $InstanceId,
         0)
+    if ($locateResult -in @($crInvalidDevnode, $crNoSuchDevnode)) {
+        return 'MISSING'
+    }
     if ($locateResult -ne 0) {
         return 'ERROR'
     }
@@ -65,6 +70,9 @@ function Get-VddDeviceStatus([string] $InstanceId) {
         [ref] $problem,
         $deviceInstance,
         0)
+    if ($statusResult -in @($crInvalidDevnode, $crNoSuchDevnode)) {
+        return 'MISSING'
+    }
     if ($statusResult -eq 0 -and $problem -eq 0 -and ($status -band $dnStarted)) {
         return 'OK'
     }
@@ -105,6 +113,12 @@ function Get-VddDevices {
                     continue
                 }
 
+                $instanceId = "ROOT\DISPLAY\$instanceName"
+                $deviceStatus = Get-VddDeviceStatus $instanceId
+                if ($deviceStatus -eq 'MISSING') {
+                    continue
+                }
+
                 $driverVersion = ''
                 $publishedInf = ''
                 $driverKeyName = [string] $deviceKey.GetValue('Driver', '')
@@ -116,12 +130,11 @@ function Get-VddDevices {
                     }
                 }
 
-                $instanceId = "ROOT\DISPLAY\$instanceName"
                 [pscustomobject]@{
                     InstanceId = $instanceId
                     Version = $driverVersion
                     InfName = $publishedInf
-                    Status = Get-VddDeviceStatus $instanceId
+                    Status = $deviceStatus
                 }
             }
             finally {
@@ -204,30 +217,21 @@ function Remove-AllVddDevices {
         throw "nefcon is unavailable: $NefconPath"
     }
 
+    Write-Output "Removing VDD device nodes ($($devices.Count) found)..."
+    [void] (Invoke-NefconRemoval)
+
+    # Nefcon removes every matching node in one call, but Windows can finish
+    # the PnP removal asynchronously after nefcon returns.
     $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
-    $stalledPasses = 0
     do {
-        $beforeCount = $devices.Count
-        Write-Output "Removing VDD device node ($beforeCount remaining)..."
-        [void] (Invoke-NefconRemoval)
         Start-Sleep -Milliseconds 250
         $devices = @(Get-VddDevices)
-
         if ($devices.Count -eq 0) {
             return
         }
-        if ($devices.Count -lt $beforeCount) {
-            $stalledPasses = 0
-        }
-        else {
-            $stalledPasses++
-            if ($stalledPasses -ge 8) {
-                break
-            }
-        }
     } while ([DateTime]::UtcNow -lt $deadline)
 
-    throw ("VDD device removal made no progress. Remaining instances: " +
+    throw ("VDD device removal timed out. Remaining instances: " +
         ($devices.InstanceId -join ', '))
 }
 

--- a/src_assets/windows/misc/vdd/vdd-device-helper.ps1
+++ b/src_assets/windows/misc/vdd/vdd-device-helper.ps1
@@ -231,11 +231,27 @@ function Remove-AllVddDevices {
         ($devices.InstanceId -join ', '))
 }
 
-function Get-PublishedVddPackages {
+function Get-PublishedVddPackages([string[]] $RequiredInfNames = @()) {
     # Match the exact hardware ID instead of parsing localized pnputil output.
     $infDirectory = Join-Path $env:SystemRoot 'INF'
     $packages = foreach ($inf in @(Get-ChildItem -LiteralPath $infDirectory -Filter 'oem*.inf' -File)) {
-        if (Select-String -LiteralPath $inf.FullName -SimpleMatch $hardwareId -Quiet -ErrorAction Stop) {
+        $matched = $false
+        try {
+            $matched = [bool] (Select-String `
+                -LiteralPath $inf.FullName `
+                -SimpleMatch $hardwareId `
+                -Quiet `
+                -ErrorAction Stop)
+        }
+        catch {
+            if ($RequiredInfNames -icontains $inf.Name) {
+                throw "Failed to inspect active VDD package $($inf.Name): $($_.Exception.Message)"
+            }
+            Write-Warning "Skipping unreadable unrelated INF $($inf.Name): $($_.Exception.Message)"
+            continue
+        }
+
+        if ($matched) {
             [pscustomobject]@{
                 InfName = $inf.Name
                 Path = $inf.FullName
@@ -283,10 +299,11 @@ function Cleanup-VddPackages {
         throw "Refusing to purge VDD packages while $($devices.Count) device node(s) remain."
     }
 
-    $packages = @(Get-PublishedVddPackages)
+    $requiredInfNames = if ($keepInfName) { @($keepInfName) } else { @() }
+    $packages = @(Get-PublishedVddPackages -RequiredInfNames $requiredInfNames)
     Remove-VddPackages @(Get-VddPackagesToRemove $packages $keepInfName)
 
-    $remaining = @(Get-PublishedVddPackages)
+    $remaining = @(Get-PublishedVddPackages -RequiredInfNames $requiredInfNames)
     if ($keepInfName) {
         if ($remaining.Count -ne 1 -or $remaining[0].InfName -ine $keepInfName) {
             throw "Expected only active VDD package $keepInfName; found: $($remaining.InfName -join ', ')"


### PR DESCRIPTION
## 改了啥呀

- nefcon 删除请求只发一次，然后等待 Windows 真正完成异步 PnP 移除
- 忽略已经离开 PnP 树、但注册表枚举项仍短暂残留的设备
- 安装和卸载等待上限调整为 120 秒，并补上异步删除回归测试

## 为啥要改

另一台机器自动更新时，Windows 大约 68 秒后才真正移除 VDD。旧逻辑在约 2 秒里连发 8 次删除请求后就判定失败，结果旧驱动后来被删掉，新驱动却没有装上。慢吞吞的 PnP 状态有点杂鱼，安装器可不能跟着急眼啦。

## 验证

- PowerShell 语法解析：通过
- `smoke-test-vdd-device-helper.ps1`：通过
- `smoke-test-install-vdd-selection.ps1`：通过
- `git diff --check`：通过
- 本机只读探测：1 个 VDD，版本 `100.0.16.6`，状态 `OK`