### PR TITLE
fix(nvhttp): preserve client identity across keep-alive requests

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -10,9 +10,7 @@
 #include <array>
 #include <chrono>
 #include <filesystem>
-#include <map>
 #include <memory>
-#include <mutex>
 #include <shared_mutex>
 #include <sstream>
 #include <string>
@@ -53,6 +51,7 @@
 #include "nvhttp/dynamic_params.h"
 #include "nvhttp/pairing.h"
 #include "nvhttp/sessions.h"
+#include "nvhttp/tls_client_identity_store.h"
 #include "nvhttp_stream_start.h"
 #include "platform/common.h"
 #include "platform/run_command.h"
@@ -81,10 +80,22 @@ namespace nvhttp {
 
   std::atomic<uint32_t> session_id_counter;
 
-  // Map to store certificate UUIDs keyed by request pointer
-  // Using weak_ptr to track request lifetime and prevent memory leaks
-  static std::map<const void *, std::pair<std::weak_ptr<void>, std::string>> request_cert_uuid_map;
-  static std::mutex request_cert_uuid_map_mutex;
+  static tls_client_identity_store_t tls_client_identities;
+
+  template <class Request>
+  std::string
+  get_tls_connection_key(const std::shared_ptr<Request> &request) {
+    const auto remote = request->remote_endpoint();
+    const auto local = request->local_endpoint();
+    if (remote.port() == 0 || local.port() == 0) {
+      return {};
+    }
+
+    std::ostringstream key;
+    key << '[' << remote.address().to_string() << "]:" << remote.port()
+        << ">[" << local.address().to_string() << "]:" << local.port();
+    return key.str();
+  }
 
   class SunshineHTTPSServer: public SimpleWeb::ServerBase<SunshineHTTPS> {
   public:
@@ -156,24 +167,14 @@ namespace nvhttp {
                   if (x509) {
                     std::string client_cert_pem = crypto::pem(x509);
                     if (auto uuid = pairing::client_uuid_for_cert(client_cert_pem); !uuid.empty()) {
-                      // Store UUID in map using request pointer as key.
-                      // Opportunistically sweep expired entries on every
-                      // insert so that requests which never reach
-                      // get_client_cert_uuid_from_request() (e.g. serverinfo
-                      // polling, applist) and never trigger on_error don't
-                      // accumulate forever. This bounds the map size at
-                      // ~(live requests + recently completed requests).
-                      std::lock_guard<std::mutex> lock(request_cert_uuid_map_mutex);
-                      for (auto it = request_cert_uuid_map.begin(); it != request_cert_uuid_map.end();) {
-                        if (it->second.first.expired()) {
-                          it = request_cert_uuid_map.erase(it);
-                        }
-                        else {
-                          ++it;
-                        }
-                      }
-                      request_cert_uuid_map[session->request.get()] =
-                        std::make_pair(std::weak_ptr<void>(std::static_pointer_cast<void>(session->request)), std::move(uuid));
+                      // Client authentication belongs to the TLS connection,
+                      // not to the first HTTP Request object created for it.
+                      // Simple-Web-Server replaces Request objects between
+                      // keep-alive requests while retaining the connection.
+                      tls_client_identities.remember(
+                        get_tls_connection_key(session->request),
+                        std::weak_ptr<void>(std::static_pointer_cast<void>(session->connection)),
+                        std::move(uuid));
                     }
                   }
                 }
@@ -206,27 +207,11 @@ namespace nvhttp {
   using resp_http_t = std::shared_ptr<typename SimpleWeb::ServerBase<SimpleWeb::HTTP>::Response>;
   using req_http_t = std::shared_ptr<typename SimpleWeb::ServerBase<SimpleWeb::HTTP>::Request>;
 
-  // Get client certificate UUID from request
+  // Get the client certificate UUID authenticated on this request's TLS connection.
   std::string
   get_client_cert_uuid_from_request(req_https_t request) {
     try {
-      // Retrieve UUID from map using request pointer as key
-      std::lock_guard<std::mutex> lock(request_cert_uuid_map_mutex);
-      auto it = request_cert_uuid_map.find(request.get());
-      if (it != request_cert_uuid_map.end()) {
-        // Check if request is still valid (not expired)
-        if (!it->second.first.expired()) {
-          std::string uuid = it->second.second;
-          // Clean up after retrieval to prevent memory leaks
-          // (assuming UUID is only needed once per request)
-          request_cert_uuid_map.erase(it);
-          return uuid;
-        }
-        else {
-          // Request expired, remove from map
-          request_cert_uuid_map.erase(it);
-        }
-      }
+      return tls_client_identities.lookup(get_tls_connection_key(request));
     }
     catch (const std::exception &e) {
       BOOST_LOG(debug) << "Failed to get client certificate UUID: " << e.what();
@@ -1074,20 +1059,10 @@ namespace nvhttp {
     // threads keep the listener responsive under such conditions.
     https_server.config.thread_pool_size = 4;
 
-    // Clean up request_cert_uuid_map entries when a request fails before
-    // get_client_cert_uuid_from_request() is reached, otherwise stale entries
-    // (with expired weak_ptr) accumulate over the lifetime of the process.
+    // A transport error ends the authenticated connection context. Expired
+    // identities for any other connections are pruned opportunistically too.
     https_server.on_error = [](req_https_t request, const SimpleWeb::error_code & /*ec*/) {
-      std::lock_guard<std::mutex> lock(request_cert_uuid_map_mutex);
-      request_cert_uuid_map.erase(request.get());
-      // Opportunistic sweep of any other entries whose request has gone away.
-      for (auto it = request_cert_uuid_map.begin(); it != request_cert_uuid_map.end();) {
-        if (it->second.first.expired()) {
-          it = request_cert_uuid_map.erase(it);
-        } else {
-          ++it;
-        }
-      }
+      tls_client_identities.forget(get_tls_connection_key(request));
     };
 
     http_server.default_resource["GET"] = not_found<SimpleWeb::HTTP>;

--- a/src/nvhttp/tls_client_identity_store.h
+++ b/src/nvhttp/tls_client_identity_store.h
@@ -1,0 +1,80 @@
+/**
+ * @file src/nvhttp/tls_client_identity_store.h
+ * @brief Connection-scoped authenticated client identity storage.
+ */
+#pragma once
+
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace nvhttp {
+  /**
+   * Keeps the authenticated client identity for the lifetime of a TLS
+   * connection. HTTP keep-alive creates a new Request object for every request,
+   * so request object addresses cannot be used as authentication state keys.
+   */
+  class tls_client_identity_store_t {
+  public:
+    void
+    remember(std::string connection_key, std::weak_ptr<void> connection_lifetime, std::string client_uuid) {
+      if (connection_key.empty() || connection_lifetime.expired() || client_uuid.empty()) {
+        return;
+      }
+
+      std::lock_guard lock(_mutex);
+      prune_expired_locked();
+      _identities.insert_or_assign(
+        std::move(connection_key),
+        entry_t { std::move(connection_lifetime), std::move(client_uuid) });
+    }
+
+    std::string
+    lookup(std::string_view connection_key) {
+      if (connection_key.empty()) {
+        return {};
+      }
+
+      std::lock_guard lock(_mutex);
+      auto it = _identities.find(connection_key);
+      if (it == _identities.end()) {
+        return {};
+      }
+      if (it->second.connection_lifetime.expired()) {
+        _identities.erase(it);
+        return {};
+      }
+      return it->second.client_uuid;
+    }
+
+    void
+    forget(std::string_view connection_key) {
+      std::lock_guard lock(_mutex);
+      if (!connection_key.empty()) {
+        if (auto it = _identities.find(connection_key); it != _identities.end()) {
+          _identities.erase(it);
+        }
+      }
+      prune_expired_locked();
+    }
+
+  private:
+    struct entry_t {
+      std::weak_ptr<void> connection_lifetime;
+      std::string client_uuid;
+    };
+
+    void
+    prune_expired_locked() {
+      std::erase_if(_identities, [](const auto &entry) {
+        return entry.second.connection_lifetime.expired();
+      });
+    }
+
+    std::mutex _mutex;
+    std::map<std::string, entry_t, std::less<>> _identities;
+  };
+}  // namespace nvhttp

--- a/tests/unit/test_tls_client_identity_store.cpp
+++ b/tests/unit/test_tls_client_identity_store.cpp
@@ -1,0 +1,53 @@
+/**
+ * @file tests/unit/test_tls_client_identity_store.cpp
+ * @brief Tests for connection-scoped nvhttp client identities.
+ */
+
+#include <gtest/gtest.h>
+
+#include "src/nvhttp/tls_client_identity_store.h"
+
+TEST(TlsClientIdentityStore, IdentitySurvivesMultipleRequestsOnOneConnection) {
+  nvhttp::tls_client_identity_store_t store;
+  auto connection = std::make_shared<int>(1);
+
+  store.remember("connection-a", connection, "client-a");
+
+  EXPECT_EQ(store.lookup("connection-a"), "client-a");
+  EXPECT_EQ(store.lookup("connection-a"), "client-a");
+}
+
+TEST(TlsClientIdentityStore, DropsIdentityAfterConnectionExpires) {
+  nvhttp::tls_client_identity_store_t store;
+  auto connection = std::make_shared<int>(1);
+  store.remember("connection-a", connection, "client-a");
+
+  connection.reset();
+
+  EXPECT_TRUE(store.lookup("connection-a").empty());
+}
+
+TEST(TlsClientIdentityStore, ReusedConnectionKeyKeepsNewestIdentity) {
+  nvhttp::tls_client_identity_store_t store;
+  auto old_connection = std::make_shared<int>(1);
+  auto new_connection = std::make_shared<int>(2);
+  store.remember("connection-a", old_connection, "client-a");
+  store.remember("connection-a", new_connection, "client-b");
+
+  old_connection.reset();
+
+  EXPECT_EQ(store.lookup("connection-a"), "client-b");
+}
+
+TEST(TlsClientIdentityStore, ForgetRemovesOnlyTheSelectedConnection) {
+  nvhttp::tls_client_identity_store_t store;
+  auto connection_a = std::make_shared<int>(1);
+  auto connection_b = std::make_shared<int>(2);
+  store.remember("connection-a", connection_a, "client-a");
+  store.remember("connection-b", connection_b, "client-b");
+
+  store.forget("connection-a");
+
+  EXPECT_TRUE(store.lookup("connection-a").empty());
+  EXPECT_EQ(store.lookup("connection-b"), "client-b");
+}

--- a/tests/unit/test_tls_client_identity_store.cpp
+++ b/tests/unit/test_tls_client_identity_store.cpp
@@ -17,6 +17,25 @@ TEST(TlsClientIdentityStore, IdentitySurvivesMultipleRequestsOnOneConnection) {
   EXPECT_EQ(store.lookup("connection-a"), "client-a");
 }
 
+TEST(TlsClientIdentityStore, RejectsInvalidRememberInputs) {
+  nvhttp::tls_client_identity_store_t store;
+  auto connection = std::make_shared<int>(1);
+  std::weak_ptr<void> expired_connection;
+  {
+    auto lifetime = std::make_shared<int>(2);
+    expired_connection = lifetime;
+  }
+
+  ASSERT_TRUE(expired_connection.expired());
+  store.remember("", connection, "client-without-key");
+  store.remember("expired-connection", expired_connection, "client-expired");
+  store.remember("empty-uuid", connection, "");
+
+  EXPECT_TRUE(store.lookup("").empty());
+  EXPECT_TRUE(store.lookup("expired-connection").empty());
+  EXPECT_TRUE(store.lookup("empty-uuid").empty());
+}
+
 TEST(TlsClientIdentityStore, DropsIdentityAfterConnectionExpires) {
   nvhttp::tls_client_identity_store_t store;
   auto connection = std::make_shared<int>(1);

--- a/tests/unit/test_tls_client_identity_store.cpp
+++ b/tests/unit/test_tls_client_identity_store.cpp
@@ -17,9 +17,11 @@ TEST(TlsClientIdentityStore, IdentitySurvivesMultipleRequestsOnOneConnection) {
   EXPECT_EQ(store.lookup("connection-a"), "client-a");
 }
 
-TEST(TlsClientIdentityStore, RejectsInvalidRememberInputs) {
+TEST(TlsClientIdentityStore, ExpiredConnectionAndEmptyUuidDoNotOverwriteIdentity) {
   nvhttp::tls_client_identity_store_t store;
   auto connection = std::make_shared<int>(1);
+  store.remember("connection-a", connection, "client-a");
+
   std::weak_ptr<void> expired_connection;
   {
     auto lifetime = std::make_shared<int>(2);
@@ -27,13 +29,11 @@ TEST(TlsClientIdentityStore, RejectsInvalidRememberInputs) {
   }
 
   ASSERT_TRUE(expired_connection.expired());
-  store.remember("", connection, "client-without-key");
-  store.remember("expired-connection", expired_connection, "client-expired");
-  store.remember("empty-uuid", connection, "");
+  store.remember("connection-a", expired_connection, "client-expired");
+  EXPECT_EQ(store.lookup("connection-a"), "client-a");
 
-  EXPECT_TRUE(store.lookup("").empty());
-  EXPECT_TRUE(store.lookup("expired-connection").empty());
-  EXPECT_TRUE(store.lookup("empty-uuid").empty());
+  store.remember("connection-a", connection, "");
+  EXPECT_EQ(store.lookup("connection-a"), "client-a");
 }
 
 TEST(TlsClientIdentityStore, DropsIdentityAfterConnectionExpires) {


### PR DESCRIPTION
## 改了啥呀

- 将 nvhttp 客户端证书 UUID 从一次性 `Request*` 缓存提升为 TLS 连接级身份
- 允许 HTTP keep-alive 后续请求重复读取同一认证 UUID
- 在连接失效或传输错误后清理身份，并防止连接键复用串号
- 补充连接身份生命周期单元测试

## 为啥要改

鸿蒙客户端启用 RCP SessionPool 后会复用 HTTPS 连接。Simple-Web-Server 会为 keep-alive 后续请求创建新的 Request 对象，旧实现却把 UUID 绑在首个 Request 指针上并在读取后删除。于是 `/cancel` 可能拿不到 UUID，返回 `cancel=0`，串流实际上也不会停止。杂鱼 Request 换了个壳，认证身份可不能跟着丢啦。

现在认证身份跟随 TLS 连接生命周期，客户端级 cancel 和连接复用可以同时保留，也不需要信任 query 里的 uniqueid。

## 验证

- `cmake --build build --target sunshine -j 4`
- `ctest --test-dir build -R "tls_client_identity_store_unit_tests|launch_session_manager_unit_tests" --output-on-failure`
- `clang-format --dry-run --Werror`（新增文件及 nvhttp 变更区间）
- `git diff --check`