### PR TITLE
fix(vdd): reconcile legacy driver installations

### DIFF
--- a/src_assets/windows/misc/vdd/smoke-test-vdd-device-helper.ps1
+++ b/src_assets/windows/misc/vdd/smoke-test-vdd-device-helper.ps1
@@ -18,9 +18,11 @@ function Assert-Equal($Expected, $Actual, [string] $Message) {
 function New-TestDevice(
     [string] $Version,
     [string] $Status = 'OK',
-    [string] $InfName = 'oem42.inf') {
+    [string] $InfName = 'oem42.inf',
+    [string] $HardwareId = 'Root\ZakoVDD') {
     return [pscustomobject]@{
         InstanceId = 'ROOT\DISPLAY\0042'
+        HardwareId = $HardwareId
         Version = $Version
         Status = $Status
         InfName = $InfName
@@ -79,6 +81,13 @@ $cases = @(
         Count = 2
         Cleanup = 1
         Install = 1
+    },
+    @{
+        Name = 'A disconnected legacy device is reconciled'
+        Devices = @(New-TestDevice '100.0.16.5' 'MISSING' 'oem40.inf' 'ZakoVDD')
+        Count = 1
+        Cleanup = 1
+        Install = 1
     }
 )
 
@@ -132,9 +141,11 @@ try {
         [CmdletBinding()]
         param(
             [string] $LiteralPath,
-            [string] $SimpleMatch,
+            [string[]] $Pattern,
+            [switch] $SimpleMatch,
             [switch] $Quiet
         )
+        $script:lastInfPatterns = @($Pattern)
         if ($LiteralPath -like '*oem40.inf') {
             throw 'simulated unreadable INF'
         }
@@ -145,6 +156,8 @@ try {
         -RequiredInfNames @('oem42.inf'))
     Assert-Equal 1 $foundPackages.Count 'An unreadable unrelated INF must not abort the package scan.'
     Assert-Equal 'oem42.inf' $foundPackages[0].InfName 'The readable VDD package must still be detected.'
+    Assert-Equal 'Root\ZakoVDD,ZakoVDD' ($script:lastInfPatterns -join ',') `
+        'Package discovery must recognize current and legacy hardware IDs.'
 
     $activeReadFailedClosed = $false
     try {
@@ -169,6 +182,7 @@ finally {
         Remove-Item Function:\Select-String -ErrorAction SilentlyContinue
     }
     Remove-Variable -Name fakeInfFiles -Scope Script -ErrorAction SilentlyContinue
+    Remove-Variable -Name lastInfPatterns -Scope Script -ErrorAction SilentlyContinue
 }
 
 $originalGetVddDevices = ${function:Get-VddDevices}
@@ -192,12 +206,14 @@ finally {
 
 $originalGetVddDevices = ${function:Get-VddDevices}
 $originalInvokeNefconRemoval = ${function:Invoke-NefconRemoval}
+$originalInvokePnpUtilDeviceRemoval = ${function:Invoke-PnpUtilDeviceRemoval}
 try {
     $firstFakeDevice = New-TestDevice '100.0.16.5' 'OK' 'oem40.inf'
     $secondFakeDevice = New-TestDevice '100.0.16.6' 'OK' 'oem42.inf'
     $secondFakeDevice.InstanceId = 'ROOT\DISPLAY\0043'
     $script:fakeDevices = @($firstFakeDevice, $secondFakeDevice)
     $script:removalCalls = 0
+    $script:targetedRemovalCalls = 0
     $script:pollsAfterRemoval = 0
     function Get-VddDevices {
         if ($script:removalCalls -gt 0) {
@@ -208,21 +224,54 @@ try {
         }
         return @($script:fakeDevices)
     }
-    function Invoke-NefconRemoval {
+    function Invoke-NefconRemoval([string] $Path, [string] $TargetHardwareId) {
         $script:removalCalls++
+        return 0
+    }
+    function Invoke-PnpUtilDeviceRemoval {
+        $script:targetedRemovalCalls++
         return 0
     }
 
     [void] (Remove-AllVddDevices $HelperScript 2)
     Assert-Equal 0 $script:fakeDevices.Count 'All duplicate device nodes must be removed.'
     Assert-Equal 1 $script:removalCalls 'An asynchronous removal must not receive overlapping requests.'
+    Assert-Equal 0 $script:targetedRemovalCalls 'Live nodes must not receive overlapping targeted removal requests.'
 
-    $script:fakeDevices = @(New-TestDevice '100.0.16.6')
+    $legacyDevice = New-TestDevice '100.0.16.5' 'MISSING' 'oem40.inf' 'ZakoVDD'
+    $legacyDevice.InstanceId = 'ROOT\DISPLAY\0043'
+    $script:fakeDevices = @((New-TestDevice '100.0.16.6'), $legacyDevice)
+    $script:removalCalls = 0
+    $script:targetedRemovalCalls = 0
+    $script:pollsAfterRemoval = 0
+    $script:removedHardwareIds = @()
+    function Get-VddDevices {
+        if ($script:removalCalls -gt 0) {
+            $script:pollsAfterRemoval++
+            if ($script:pollsAfterRemoval -ge 2) {
+                $script:fakeDevices = @()
+            }
+        }
+        return @($script:fakeDevices)
+    }
+    function Invoke-NefconRemoval([string] $Path, [string] $TargetHardwareId) {
+        $script:removalCalls++
+        $script:removedHardwareIds += $TargetHardwareId
+        return 0
+    }
+
+    [void] (Remove-AllVddDevices $HelperScript 2)
+    Assert-Equal 2 $script:removalCalls 'Root and legacy hardware IDs must both be reconciled.'
+    Assert-Equal 'Root\ZakoVDD,ZakoVDD' ($script:removedHardwareIds -join ',') `
+        'Removal must target both managed hardware IDs.'
+    Assert-Equal 1 $script:targetedRemovalCalls 'A disconnected legacy node must receive targeted cleanup.'
+
+    $script:fakeDevices = @(New-TestDevice '100.0.16.6' 'MISSING')
     $script:removalCalls = 0
     function Get-VddDevices {
         return @($script:fakeDevices)
     }
-    function Invoke-NefconRemoval {
+    function Invoke-NefconRemoval([string] $Path, [string] $TargetHardwareId) {
         $script:removalCalls++
         return 1
     }
@@ -237,27 +286,44 @@ try {
     Assert-Equal 1 $script:removalCalls 'A stalled removal must not repeatedly invoke nefcon.'
 
     $script:removalCalls = 0
-    function Invoke-NefconRemoval {
+    function Invoke-NefconRemoval([string] $Path, [string] $TargetHardwareId) {
         $script:removalCalls++
         return 0
     }
-    $removalTimedOut = $false
+    $removalMadeNoProgress = $false
     try {
         [void] (Remove-AllVddDevices $HelperScript 1)
     }
     catch {
-        $removalTimedOut = $_.Exception.Message -like '*timed out*'
+        $removalMadeNoProgress = $_.Exception.Message -like '*made no progress*pnputil=0*'
     }
-    Assert-Equal $true $removalTimedOut 'A successful request without PnP progress must time out.'
-    Assert-Equal 1 $script:removalCalls 'A timed-out removal must not repeatedly invoke nefcon.'
+    Assert-Equal $true $removalMadeNoProgress 'A successful request without PnP progress must fail with diagnostics.'
+    Assert-Equal 1 $script:removalCalls 'A stalled removal must not repeatedly invoke nefcon.'
+
+    $script:fakeDevices = @(New-TestDevice '100.0.16.6' 'OK')
+    $script:removalCalls = 0
+    $script:targetedRemovalCalls = 0
+    $liveRemovalTimedOut = $false
+    try {
+        [void] (Remove-AllVddDevices $HelperScript 1)
+    }
+    catch {
+        $liveRemovalTimedOut = $_.Exception.Message -like '*timed out*'
+    }
+    Assert-Equal $true $liveRemovalTimedOut 'A live asynchronous removal must keep the normal timeout path.'
+    Assert-Equal 0 $script:targetedRemovalCalls 'A live node must not receive the disconnected-node fallback.'
 }
 finally {
     ${function:Get-VddDevices} = $originalGetVddDevices
     ${function:Invoke-NefconRemoval} = $originalInvokeNefconRemoval
+    ${function:Invoke-PnpUtilDeviceRemoval} = $originalInvokePnpUtilDeviceRemoval
     Remove-Variable -Name fakeDevices -Scope Script -ErrorAction SilentlyContinue
     Remove-Variable -Name removalCalls -Scope Script -ErrorAction SilentlyContinue
     Remove-Variable -Name pollsAfterRemoval -Scope Script -ErrorAction SilentlyContinue
-    Remove-Variable -Name removalTimedOut -ErrorAction SilentlyContinue
+    Remove-Variable -Name removalMadeNoProgress -ErrorAction SilentlyContinue
+    Remove-Variable -Name liveRemovalTimedOut -ErrorAction SilentlyContinue
+    Remove-Variable -Name targetedRemovalCalls -Scope Script -ErrorAction SilentlyContinue
+    Remove-Variable -Name removedHardwareIds -Scope Script -ErrorAction SilentlyContinue
 }
 
 $originalResolveVddPayload = ${function:Resolve-VddPayload}

--- a/src_assets/windows/misc/vdd/smoke-test-vdd-device-helper.ps1
+++ b/src_assets/windows/misc/vdd/smoke-test-vdd-device-helper.ps1
@@ -204,6 +204,73 @@ finally {
     ${function:Get-VddDevices} = $originalGetVddDevices
 }
 
+$originalStartProcess = ${function:Start-Process}
+$originalWaitProcess = ${function:Wait-Process}
+$originalStopProcess = ${function:Stop-Process}
+try {
+    $script:fakePnpProcess = [pscustomobject]@{
+        HasExited = $false
+        ExitCode = 0
+    }
+    $script:pnpWaitTimesOut = $true
+    $script:stoppedPnpProcesses = 0
+    function Start-Process {
+        [CmdletBinding()]
+        param(
+            [string] $FilePath,
+            [object[]] $ArgumentList,
+            [switch] $NoNewWindow,
+            [switch] $PassThru)
+        return $script:fakePnpProcess
+    }
+    function Wait-Process {
+        [CmdletBinding()]
+        param(
+            [object] $InputObject,
+            [int] $Timeout)
+        if ($script:pnpWaitTimesOut) {
+            throw 'simulated timeout'
+        }
+    }
+    function Stop-Process {
+        [CmdletBinding()]
+        param(
+            [object] $InputObject,
+            [switch] $Force)
+        $script:stoppedPnpProcesses++
+    }
+
+    $timedOutExitCode = Invoke-PnpUtilDeviceRemoval 'ROOT\DISPLAY\0042'
+    Assert-Equal $win32ErrorTimeout $timedOutExitCode `
+        'A hung pnputil process must return the Windows timeout error.'
+    Assert-Equal 1 $script:stoppedPnpProcesses `
+        'A hung pnputil process must be force-stopped.'
+
+    $script:fakePnpProcess = [pscustomobject]@{
+        HasExited = $true
+        ExitCode = 3010
+    }
+    $script:pnpWaitTimesOut = $false
+    $completedExitCode = Invoke-PnpUtilDeviceRemoval 'ROOT\DISPLAY\0042'
+    Assert-Equal 3010 $completedExitCode `
+        'A completed pnputil process must preserve its exit code.'
+}
+finally {
+    foreach ($name in @('Start-Process', 'Wait-Process', 'Stop-Process')) {
+        $originalName = 'original' + $name.Replace('-', '')
+        $original = Get-Variable -Name $originalName -ValueOnly
+        if ($original) {
+            Set-Item -Path "Function:\$name" -Value $original
+        }
+        else {
+            Remove-Item -Path "Function:\$name" -ErrorAction SilentlyContinue
+        }
+    }
+    Remove-Variable -Name fakePnpProcess -Scope Script -ErrorAction SilentlyContinue
+    Remove-Variable -Name pnpWaitTimesOut -Scope Script -ErrorAction SilentlyContinue
+    Remove-Variable -Name stoppedPnpProcesses -Scope Script -ErrorAction SilentlyContinue
+}
+
 $originalGetVddDevices = ${function:Get-VddDevices}
 $originalInvokeNefconRemoval = ${function:Invoke-NefconRemoval}
 $originalInvokePnpUtilDeviceRemoval = ${function:Invoke-PnpUtilDeviceRemoval}

--- a/src_assets/windows/misc/vdd/vdd-device-helper.ps1
+++ b/src_assets/windows/misc/vdd/vdd-device-helper.ps1
@@ -14,6 +14,7 @@ if (-not $ScriptDirectory) {
     $ScriptDirectory = $PSScriptRoot
 }
 $hardwareId = 'Root\ZakoVDD'
+$managedHardwareIds = @($hardwareId, 'ZakoVDD')
 $displayClassGuid = '4d36e968-e325-11ce-bfc1-08002be10318'
 $serviceName = 'ZAKO_HDR_FOR_SUNSHINE'
 $deviceEnumPath = 'SYSTEM\CurrentControlSet\Enum\ROOT\DISPLAY'
@@ -22,6 +23,7 @@ $dnStarted = 0x00000008
 $crInvalidDevnode = 0x00000005
 $crNoSuchDevnode = 0x0000000D
 $deviceTimeoutSeconds = 120
+$targetedRemovalTimeoutSeconds = 10
 
 function Initialize-CfgMgr32 {
     if ('SunshineVddCfgMgr32' -as [type]) {
@@ -111,15 +113,15 @@ function Get-VddDevices {
                 }
 
                 $hardwareIds = @($deviceKey.GetValue('HardwareID', $null))
-                if (-not ($hardwareIds | Where-Object { $_ -ieq $hardwareId })) {
+                $matchedHardwareId = @($hardwareIds | Where-Object {
+                    $managedHardwareIds -icontains $_
+                } | Select-Object -First 1)
+                if ($matchedHardwareId.Count -eq 0) {
                     continue
                 }
 
                 $instanceId = "ROOT\DISPLAY\$instanceName"
                 $deviceStatus = Get-VddDeviceStatus $instanceId
-                if ($deviceStatus.State -eq 'MISSING') {
-                    continue
-                }
 
                 $driverVersion = ''
                 $publishedInf = ''
@@ -134,6 +136,7 @@ function Get-VddDevices {
 
                 [pscustomobject]@{
                     InstanceId = $instanceId
+                    HardwareId = [string] $matchedHardwareId[0]
                     Version = $driverVersion
                     InfName = $publishedInf
                     Status = $deviceStatus.State
@@ -308,11 +311,17 @@ function Wait-Until([scriptblock] $Condition, [int] $WaitSeconds) {
     return $false
 }
 
-function Invoke-NefconRemoval([string] $Path) {
+function Invoke-NefconRemoval([string] $Path, [string] $TargetHardwareId = $hardwareId) {
     & $Path `
         --remove-device-node `
-        --hardware-id $hardwareId `
+        --hardware-id $TargetHardwareId `
         --class-guid $displayClassGuid
+    return $LASTEXITCODE
+}
+
+function Invoke-PnpUtilDeviceRemoval([string] $InstanceId) {
+    $pnputil = Join-Path $env:SystemRoot 'System32\pnputil.exe'
+    & $pnputil /remove-device $InstanceId
     return $LASTEXITCODE
 }
 
@@ -326,24 +335,64 @@ function Remove-AllVddDevices([string] $NefconPath, [int] $WaitSeconds = $device
     }
 
     Write-Output "Removing VDD device nodes ($($devices.Count) found)..."
-    $exitCode = Invoke-NefconRemoval $NefconPath
-    if ($exitCode -notin @(0, 3010)) {
-        throw "nefcon failed to remove VDD device nodes (exit code $exitCode)."
+    $targetHardwareIds = @($devices | ForEach-Object {
+        if ($_.HardwareId) { $_.HardwareId } else { $hardwareId }
+    } | Sort-Object -Unique)
+    foreach ($targetHardwareId in $targetHardwareIds) {
+        $exitCode = Invoke-NefconRemoval $NefconPath $targetHardwareId
+        if ($exitCode -notin @(0, 3010)) {
+            throw "nefcon failed to remove VDD device nodes for $targetHardwareId (exit code $exitCode)."
+        }
     }
 
     # Nefcon removes every matching node in one call, but Windows can finish
-    # the PnP removal asynchronously after nefcon returns.
+    # the PnP removal asynchronously after nefcon returns. Only disconnected
+    # nodes need a targeted fallback; issuing a second request for live nodes can
+    # race the asynchronous nefcon removal.
     $deadline = [DateTime]::UtcNow.AddSeconds($WaitSeconds)
+    $targetedAttempts = @{}
     do {
         Start-Sleep -Milliseconds 250
         $devices = @(Get-VddDevices)
         if ($devices.Count -eq 0) {
             return
         }
+
+        foreach ($device in $devices) {
+            if ($device.Status -ne 'MISSING' -or
+                $targetedAttempts.ContainsKey($device.InstanceId)) {
+                continue
+            }
+            Write-Output "Removing remaining VDD instance $($device.InstanceId) ($($device.Status))..."
+            $targetedDeadline = [DateTime]::UtcNow.AddSeconds($targetedRemovalTimeoutSeconds)
+            if ($targetedDeadline -gt $deadline) {
+                $targetedDeadline = $deadline
+            }
+            $targetedAttempts[$device.InstanceId] = [pscustomobject]@{
+                ExitCode = Invoke-PnpUtilDeviceRemoval $device.InstanceId
+                Deadline = $targetedDeadline
+            }
+        }
+
+        $stalledTargetedDevices = @($devices | Where-Object {
+            $attempt = $targetedAttempts[$_.InstanceId]
+            $_.Status -eq 'MISSING' -and
+                $null -ne $attempt -and
+                [DateTime]::UtcNow -ge $attempt.Deadline
+        })
+        if ($stalledTargetedDevices.Count -gt 0) {
+            $details = @($stalledTargetedDevices | ForEach-Object {
+                $targetedExitCode = $targetedAttempts[$_.InstanceId].ExitCode
+                "$($_.InstanceId)[$($_.HardwareId),$($_.Status),pnputil=$targetedExitCode]"
+            }) -join ', '
+            throw "VDD device removal made no progress. Remaining instances: $details"
+        }
     } while ([DateTime]::UtcNow -lt $deadline)
 
     throw ("VDD device removal timed out. Remaining instances: " +
-        ($devices.InstanceId -join ', '))
+        (@($devices | ForEach-Object {
+            "$($_.InstanceId)[$($_.HardwareId),$($_.Status)]"
+        }) -join ', '))
 }
 
 function Get-PublishedVddPackages([string[]] $RequiredInfNames = @()) {
@@ -354,7 +403,8 @@ function Get-PublishedVddPackages([string[]] $RequiredInfNames = @()) {
         try {
             $matched = [bool] (Select-String `
                 -LiteralPath $inf.FullName `
-                -SimpleMatch $hardwareId `
+                -Pattern $managedHardwareIds `
+                -SimpleMatch `
                 -Quiet `
                 -ErrorAction Stop)
         }

--- a/src_assets/windows/misc/vdd/vdd-device-helper.ps1
+++ b/src_assets/windows/misc/vdd/vdd-device-helper.ps1
@@ -24,6 +24,7 @@ $crInvalidDevnode = 0x00000005
 $crNoSuchDevnode = 0x0000000D
 $deviceTimeoutSeconds = 120
 $targetedRemovalTimeoutSeconds = 10
+$win32ErrorTimeout = 1460
 
 function Initialize-CfgMgr32 {
     if ('SunshineVddCfgMgr32' -as [type]) {
@@ -321,8 +322,25 @@ function Invoke-NefconRemoval([string] $Path, [string] $TargetHardwareId = $hard
 
 function Invoke-PnpUtilDeviceRemoval([string] $InstanceId) {
     $pnputil = Join-Path $env:SystemRoot 'System32\pnputil.exe'
-    & $pnputil /remove-device $InstanceId
-    return $LASTEXITCODE
+    $process = Start-Process `
+        -FilePath $pnputil `
+        -ArgumentList @('/remove-device', $InstanceId) `
+        -NoNewWindow `
+        -PassThru
+    try {
+        Wait-Process `
+            -InputObject $process `
+            -Timeout $targetedRemovalTimeoutSeconds `
+            -ErrorAction Stop
+    }
+    catch {
+        if ($process.HasExited) {
+            return $process.ExitCode
+        }
+        Stop-Process -InputObject $process -Force -ErrorAction SilentlyContinue
+        return $win32ErrorTimeout
+    }
+    return $process.ExitCode
 }
 
 function Remove-AllVddDevices([string] $NefconPath, [int] $WaitSeconds = $deviceTimeoutSeconds) {


### PR DESCRIPTION
## 改了啥呀

- 枚举 `Root\ZakoVDD` 与旧式 `ZakoVDD`，不再把断开的幽灵节点当作不存在。
- 正常节点仍只交给 nefcon 异步移除；仅对 `MISSING` 节点按实例 ID 调用一次 pnputil 兜底。
- 幽灵节点兜底失败会快速返回实例、硬件 ID、状态和退出码，正常节点继续保留原有 120 秒兼容窗口。
- 清理驱动包时同时识别新旧硬件 ID，并补齐重复、旧式、幽灵与正常慢速移除测试。
- 更新 GUI 子模块，配套保留真实失败日志并区分 UAC/脚本失败。

依赖 GUI PR：qiin2333/sunshine-control-panel#61

## 为啥要改

从旧版升级时，断开的 VDD 节点会被探测逻辑跳过，于是安装流程可能再创建一个基地显示器，喜提没有人想要的驱动分身。残留节点清理失败时又可能等很久，GUI 最后还给出一个根本不存在的日志路径。

这次只收敛仍在管理范围内的新旧 VDD 节点，不重复轰炸正常 PnP 移除，也不改动既有安装策略。

## 验证

- `powershell -NoProfile -ExecutionPolicy Bypass -File .\src_assets\windows\misc\vdd\smoke-test-vdd-device-helper.ps1`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\src_assets\windows\misc\vdd\smoke-test-install-vdd-selection.ps1`
- `npm ci`
- `npm run build`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `git diff --check origin/master...HEAD`