### PR TITLE
fix(windows): rebuild VDD monitors for dynamic modes

### DIFF
--- a/src/display_device/session.cpp
+++ b/src/display_device/session.cpp
@@ -7,7 +7,6 @@
 // local includes
 #include "parsed_config.h"
 #include "session.h"
-#include "src/confighttp.h"
 #include "src/globals.h"
 #include "src/platform/common.h"
 #include "src/platform/windows/display_device/session_listener.h"
@@ -171,7 +170,6 @@ namespace display_device {
 
   void
   session_t::clear_vdd_state() {
-    last_vdd_setting.clear();
     current_device_prep.reset();
     current_vdd_prep.reset();
     current_use_vdd.reset();
@@ -241,6 +239,20 @@ namespace display_device {
           .initial_delay = initial_delay,
           .max_delay = max_delay,
           .context = "Waiting for VDD device availability" });
+    }
+
+    bool
+    wait_for_vdd_device_departure(int max_attempts,
+      std::chrono::milliseconds initial_delay,
+      std::chrono::milliseconds max_delay) {
+      return vdd_utils::retry_with_backoff(
+        []() {
+          return display_device::find_device_by_friendlyname(ZAKO_NAME).empty();
+        },
+        { .max_attempts = max_attempts,
+          .initial_delay = initial_delay,
+          .max_delay = max_delay,
+          .context = "Waiting for VDD monitor departure" });
     }
 
     /**
@@ -529,49 +541,54 @@ namespace display_device {
     return vdd_utils::toggle_display_power();
   }
 
-  void
+  session_t::vdd_mode_update_e
   session_t::update_vdd_resolution(const parsed_config_t &config,
-    const vdd_utils::VddSettings &vdd_settings) {
+    const vdd_utils::VddSettings &vdd_settings,
+    const std::string &vdd_device_id) {
     if (!config.resolution || !config.refresh_rate) {
       BOOST_LOG(debug) << "VDD session mode update skipped: resolution or refresh rate is not set";
-      return;
+      return vdd_mode_update_e::failed;
     }
 
     const auto new_setting = to_string(*config.resolution) + "@" + to_string(*config.refresh_rate);
 
-    if (last_vdd_setting == new_setting) {
-      BOOST_LOG(debug) << "VDD session mode unchanged; resyncing full driver mode list: " << new_setting;
-    }
-
     const auto setmodes_result = vdd_utils::set_vdd_session_mode(config, vdd_settings);
     switch (setmodes_result) {
-      case vdd_utils::set_vdd_result::ok:
-        last_vdd_setting = new_setting;
+      case vdd_utils::set_vdd_result::ok: {
         BOOST_LOG(info) << "VDD会话模式列表更新完成（未写入XML）: " << new_setting;
-        return;
+        const display_mode_t requested_mode {*config.resolution, *config.refresh_rate};
+        const bool mode_advertised =
+          !vdd_device_id.empty() && vdd_utils::is_mode_advertised(vdd_device_id, requested_mode);
+        if (vdd_device_id.empty() || mode_advertised) {
+          // A monitor created below will publish both monitor and target mode
+          // lists from the new in-memory settings. An existing monitor can
+          // switch live when Windows already exposes the requested mode.
+          if (!vdd_device_id.empty()) {
+            BOOST_LOG(debug) << "VDD monitor already advertises " << new_setting << "; live mode switch is safe";
+          }
+          return vdd_mode_update_e::ready;
+        }
+
+        // IddCxMonitorUpdateModes2 refreshes target modes, but a live console
+        // monitor can retain its old monitor-description modes. Recreate only
+        // this monitor so Windows republishes the complete intersection and
+        // builds a correctly sized swapchain producer.
+        BOOST_LOG(info) << "VDD monitor does not advertise " << new_setting
+                        << "; recreating the monitor through IOCTL";
+        return vdd_mode_update_e::recreate_monitor;
+      }
       case vdd_utils::set_vdd_result::failed:
-        BOOST_LOG(warning) << "VDD SETMODES 更新失败，回退 XML+reload 路径: " << new_setting;
-        break;
+        BOOST_LOG(error) << "VDD SETMODES IOCTL failed for " << new_setting;
+        return vdd_mode_update_e::failed;
       case vdd_utils::set_vdd_result::invalid_config:
-        BOOST_LOG(warning) << "VDD 会话模式参数无效，跳过更新: " << new_setting;
-        return;
+        BOOST_LOG(error) << "VDD session mode is invalid: " << new_setting;
+        return vdd_mode_update_e::failed;
       case vdd_utils::set_vdd_result::interface_missing:
-        // Old driver without IOCTL: fall through to persistent XML + reload path below.
-        break;
+        BOOST_LOG(error) << "VDD SETMODES IOCTL is unavailable; install a current ZakoVDD build";
+        return vdd_mode_update_e::failed;
     }
 
-    if (!confighttp::saveVddSettings(vdd_settings.resolutions, vdd_settings.fps, config::video.adapter_name)) {
-      BOOST_LOG(error) << "VDD配置保存失败 [resolutions: " << vdd_settings.resolutions
-                       << " fps: " << vdd_settings.fps << "]";
-      return;
-    }
-
-    last_vdd_setting = new_setting;
-    BOOST_LOG(info) << "VDD配置更新完成: " << new_setting;
-
-    BOOST_LOG(info) << "重新加载VDD驱动...";
-    vdd_utils::reload_driver();
-    std::this_thread::sleep_for(1200ms);
+    return vdd_mode_update_e::failed;
   }
 
   bool
@@ -637,10 +654,33 @@ namespace display_device {
       }
     }
 
+    std::string mode_rebuild_old_vdd_id;
+    bool verify_mode_publication_after_create = false;
+
     // Update VDD resolution configuration
     if (auto vdd_settings = vdd_utils::prepare_vdd_settings(config);
       config.resolution && config.refresh_rate) {
-      update_vdd_resolution(config, vdd_settings);
+      const auto mode_update = update_vdd_resolution(config, vdd_settings, device_zako);
+      if (mode_update == vdd_mode_update_e::failed) {
+        return false;
+      }
+
+      verify_mode_publication_after_create = device_zako.empty();
+      if (mode_update == vdd_mode_update_e::recreate_monitor) {
+        mode_rebuild_old_vdd_id = device_zako;
+        verify_mode_publication_after_create = true;
+        if (!vdd_utils::destroy_vdd_monitor()) {
+          BOOST_LOG(error) << "Failed to destroy the VDD monitor for an IOCTL mode-list rebuild";
+          return false;
+        }
+        if (!wait_for_vdd_device_departure(5, 100ms, 1000ms)) {
+          // The driver has already removed its monitor object synchronously.
+          // Continue with recreation so a delayed Windows device-interface
+          // update cannot leave a headless host without a recovery attempt.
+          BOOST_LOG(warning) << "VDD monitor departure is not visible yet; continuing the IOCTL rebuild";
+        }
+        device_zako.clear();
+      }
     }
 
     // Create VDD device if not present
@@ -692,6 +732,29 @@ namespace display_device {
 
     if (device_zako.empty()) {
       return false;
+    }
+
+    if (verify_mode_publication_after_create) {
+      const display_mode_t requested_mode {*config.resolution, *config.refresh_rate};
+      const bool mode_advertised = vdd_utils::retry_with_backoff(
+        [&]() {
+          return vdd_utils::is_mode_advertised(device_zako, requested_mode);
+        },
+        { .max_attempts = 5,
+          .initial_delay = 100ms,
+          .max_delay = 1000ms,
+          .context = "Waiting for VDD mode publication" });
+      if (!mode_advertised) {
+        BOOST_LOG(error) << "VDD monitor did not publish "
+                         << to_string(*config.resolution) << "@" << to_string(*config.refresh_rate);
+        return false;
+      }
+    }
+
+    if (!mode_rebuild_old_vdd_id.empty() && mode_rebuild_old_vdd_id != device_zako) {
+      BOOST_LOG(info) << "Replacing VDD ID after mode-list rebuild: "
+                      << mode_rebuild_old_vdd_id << " -> " << device_zako;
+      settings.replace_vdd_id(mode_rebuild_old_vdd_id, device_zako);
     }
 
     if (original_output_name.empty()) {

--- a/src/display_device/session.h
+++ b/src/display_device/session.h
@@ -274,7 +274,6 @@ namespace display_device {
 
     settings_t settings; /**< A class for managing display device settings. */
     std::mutex mutex; /**< A mutex for ensuring thread-safety. */
-    std::string last_vdd_setting; /**< Last VDD resolution and refresh rate setting. */
     std::string current_vdd_client_id; /**< Current client ID associated with VDD monitor. */
     std::string original_output_name; /**< Original output_name value before VDD device ID was set. */
     boost::optional<parsed_config_t::device_prep_e> current_device_prep; /**< Current device preparation mode, respecting client overrides. */
@@ -291,11 +290,19 @@ namespace display_device {
      */
     std::unique_ptr<StateRetryTimer> timer;
 
-    void
-    update_vdd_resolution(const parsed_config_t &config, const vdd_utils::VddSettings &vdd_settings);
+    enum class vdd_mode_update_e {
+      ready,
+      recreate_monitor,
+      failed,
+    };
+
+    vdd_mode_update_e
+    update_vdd_resolution(const parsed_config_t &config,
+      const vdd_utils::VddSettings &vdd_settings,
+      const std::string &vdd_device_id);
 
     /**
-     * @brief Clear VDD state (client ID and last setting)
+     * @brief Clear VDD session state.
      * @note This method does NOT acquire the mutex! It is intended to be used from places
      *       where the mutex has already been locked.
      */

--- a/src/display_device/vdd_utils.cpp
+++ b/src/display_device/vdd_utils.cpp
@@ -24,7 +24,6 @@
 #include <unordered_set>
 #include <vector>
 
-#include "src/confighttp.h"
 #include "src/globals.h"
 #include "src/platform/common.h"
 #include "src/platform/run_command.h"
@@ -270,36 +269,6 @@ namespace display_device {
     }
 
     bool
-    reload_driver() {
-      // Preferred path: IOCTL device interface (PnP-wakes the driver,
-      // immune to WUDFHost recycle races).
-      switch (vdd_ioctl::send_command(L"RELOAD_DRIVER")) {
-        case vdd_ioctl::result::success:
-          BOOST_LOG(info) << "Reload VDD driver requested (IOCTL)";
-          return true;
-        case vdd_ioctl::result::failed:
-          // Driver is present but rejected the IOCTL -- propagate so the
-          // caller doesn't waste a ~6s pipe timeout retrying the same
-          // command on a transport the driver already answered.
-          BOOST_LOG(error) << "Reload VDD driver via IOCTL failed; not falling back to pipe";
-          return false;
-        case vdd_ioctl::result::interface_missing:
-          // Driver too old to expose the IOCTL interface -- fall through
-          // to the legacy pipe transport.
-          break;
-      }
-
-      // [LEGACY-PIPE] Fallback for older driver builds that do not
-      // expose the IOCTL device interface.
-      std::string response;
-      const bool ok = execute_pipe_command(kVddPipeName, L"RELOAD_DRIVER", &response);
-      if (ok) {
-        BOOST_LOG(info) << "Reload VDD driver requested (PIPE)";
-      }
-      return ok;
-    }
-
-    bool
     set_hardware_cursor_enabled(bool enabled) {
       const wchar_t *command = enabled ? L"HARDWARECURSOR true" : L"HARDWARECURSOR false";
 
@@ -539,7 +508,7 @@ namespace display_device {
       const auto command_string = command.str();
       if (command_string.size() >= 2048) {
         BOOST_LOG(warning) << "SETMODES command too large (" << command_string.size()
-                           << " wchar_t); XML fallback will be used";
+                           << " wchar_t); refusing a partial mode-list update";
         return set_vdd_result::failed;
       }
 
@@ -550,10 +519,10 @@ namespace display_device {
                           << "@" << *session_refresh_hz << "Hz";
           return set_vdd_result::ok;
         case vdd_ioctl::result::failed:
-          BOOST_LOG(warning) << "VDD SETMODES IOCTL failed; XML fallback will be used";
+          BOOST_LOG(warning) << "VDD SETMODES IOCTL failed";
           return set_vdd_result::failed;
         case vdd_ioctl::result::interface_missing:
-          BOOST_LOG(debug) << "VDD SETMODES unavailable: IOCTL interface missing; XML fallback will be used";
+          BOOST_LOG(debug) << "VDD SETMODES unavailable: IOCTL interface missing";
           return set_vdd_result::interface_missing;
       }
 
@@ -960,45 +929,18 @@ namespace display_device {
 
     VddSettings
     prepare_vdd_settings(const parsed_config_t &config) {
-      auto is_res_cached = false;
-      auto is_fps_cached = false;
-      std::ostringstream res_stream, fps_stream;
       std::vector<resolution_t> resolution_modes;
       std::vector<unsigned int> refresh_rates_hz;
 
-      res_stream << '[';
-      fps_stream << '[';
-
-      // 检查分辨率是否已缓存
       for (const auto &res : config::nvhttp.resolutions) {
-        res_stream << res << ',';
         if (const auto parsed_resolution = parse_vdd_resolution(res)) {
           append_unique_resolution(resolution_modes, *parsed_resolution);
         }
-        if (config.resolution && res == to_string(*config.resolution)) {
-          is_res_cached = true;
-        }
       }
 
-      // 检查帧率是否已缓存
       for (const auto &fps : config::nvhttp.fps) {
-        fps_stream << fps << ',';
         if (const auto parsed_refresh_hz = parse_vdd_refresh_hz(fps)) {
           append_unique_refresh_rate(refresh_rates_hz, *parsed_refresh_hz);
-        }
-        if (config.refresh_rate && fps == to_string(*config.refresh_rate)) {
-          is_fps_cached = true;
-        }
-      }
-
-      // 如果需要更新设置
-      bool needs_update = config.resolution && (!is_res_cached || (config.refresh_rate && !is_fps_cached));
-      if (needs_update) {
-        if (!is_res_cached) {
-          res_stream << to_string(*config.resolution);
-        }
-        if (!is_fps_cached && config.refresh_rate) {
-          fps_stream << to_string(*config.refresh_rate);
         }
       }
 
@@ -1011,15 +953,40 @@ namespace display_device {
         }
       }
 
-      // 移除最后的逗号并添加结束括号
-      auto res_str = res_stream.str();
-      auto fps_str = fps_stream.str();
-      if (res_str.back() == ',') res_str.pop_back();
-      if (fps_str.back() == ',') fps_str.pop_back();
-      res_str += ']';
-      fps_str += ']';
+      return { std::move(resolution_modes), std::move(refresh_rates_hz) };
+    }
 
-      return { res_str, fps_str, resolution_modes, refresh_rates_hz, needs_update };
+    bool
+    is_mode_advertised(const std::string &device_id, const display_mode_t &requested_mode) {
+      if (device_id.empty() || requested_mode.refresh_rate.denominator == 0) {
+        return false;
+      }
+
+      const auto devices = enum_available_devices();
+      const auto device_it = devices.find(device_id);
+      if (device_it == std::end(devices) || device_it->second.display_name.empty()) {
+        return false;
+      }
+
+      const auto &display_name = device_it->second.display_name;
+      const std::wstring wide_display_name(display_name.begin(), display_name.end());
+      for (DWORD index = 0; index < 4096; ++index) {
+        DEVMODEW mode {};
+        mode.dmSize = sizeof(mode);
+        if (!EnumDisplaySettingsW(wide_display_name.c_str(), index, &mode)) {
+          break;
+        }
+
+        if (advertised_mode_matches(
+              mode.dmPelsWidth,
+              mode.dmPelsHeight,
+              mode.dmDisplayFrequency,
+              requested_mode)) {
+          return true;
+        }
+      }
+
+      return false;
     }
 
     bool

--- a/src/display_device/vdd_utils.h
+++ b/src/display_device/vdd_utils.h
@@ -51,12 +51,39 @@ namespace display_device::vdd_utils {
 
   // VDD设置结构
   struct VddSettings {
-    std::string resolutions;
-    std::string fps;
     std::vector<resolution_t> resolution_modes;
     std::vector<unsigned int> refresh_rates_hz;
-    bool needs_update = false;
   };
+
+  constexpr bool
+  advertised_mode_matches(unsigned int width,
+    unsigned int height,
+    unsigned int refresh_hz,
+    const display_mode_t &requested_mode) {
+    if (requested_mode.refresh_rate.denominator == 0 ||
+        width != requested_mode.resolution.width ||
+        height != requested_mode.resolution.height) {
+      return false;
+    }
+
+    const auto advertised_scaled =
+      static_cast<std::uint64_t>(refresh_hz) * requested_mode.refresh_rate.denominator;
+    const auto requested_scaled =
+      static_cast<std::uint64_t>(requested_mode.refresh_rate.numerator);
+    const auto difference = advertised_scaled > requested_scaled ?
+                              advertised_scaled - requested_scaled :
+                              requested_scaled - advertised_scaled;
+    return difference <= requested_mode.refresh_rate.denominator;
+  }
+
+  /**
+   * @brief Check whether Windows exposes a requested mode for a display device.
+   * @details SETMODES updates the driver mode list, but an existing IddCx
+   *          monitor can retain a stale monitor-description list. This checks
+   *          the effective modes published to Windows, not just IOCTL success.
+   */
+  bool
+  is_mode_advertised(const std::string &device_id, const display_mode_t &requested_mode);
 
   struct vdd_status_t {
     std::string state;
@@ -124,10 +151,6 @@ namespace display_device::vdd_utils {
   bool
   execute_pipe_command(const wchar_t *pipe_name, const wchar_t *command, std::string *response = nullptr, bool *timed_out = nullptr);
 
-  // 驱动重载函数
-  bool
-  reload_driver();
-
   /**
    * @brief Ensure ZakoVDD renders the cursor into the framebuffer instead of exposing a hardware cursor plane.
    * @details Sunshine's direct VDD capture backend consumes only the shared frame texture exported by ZakoVDD.
@@ -141,13 +164,13 @@ namespace display_device::vdd_utils {
   /**
    * @brief Outcome of attempting a live SETMODES update.
    * @details Lets callers distinguish "driver accepted" / "driver rejected" /
-   *          "feature not present" / "config is unusable" so the persistent
-   *          XML fallback can be used when the live path is not available.
+   *          "feature not present" / "config is unusable" without conflating
+   *          transport failure with invalid input.
    */
   enum class set_vdd_result {
     ok,                 ///< Driver accepted the live mode update.
     failed,             ///< Driver reachable but rejected the IOCTL.
-    interface_missing,  ///< IOCTL interface not present (old driver) -> safe to XML-fallback.
+    interface_missing,  ///< IOCTL interface not present (old driver).
     invalid_config,     ///< Resolution/refresh rate missing or unusable; nothing was sent.
   };
 
@@ -157,7 +180,7 @@ namespace display_device::vdd_utils {
    *          This does not persist the session resolution to vdd_settings.xml.
    * @param config Parsed display configuration containing the requested session mode.
    * @param settings Full standard mode list plus the requested session mode.
-   * @return Typed outcome; callers can XML-fallback when the live path is unavailable.
+   * @return Typed outcome describing whether the complete live update was accepted.
    */
   set_vdd_result
   set_vdd_session_mode(const parsed_config_t &config, const VddSettings &settings);

--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -1129,6 +1129,11 @@ namespace platf {
       BOOST_LOG(warning) << "WGC capture is not available in service mode. Automatically switching to DDX capture."sv;
       try_types = { "ddx" };
     }
+    else if (capture_backend == "vdd") {
+      // Direct VDD capture is preferred, but DDX remains a safe last resort
+      // when the producer cannot represent the selected desktop mode.
+      try_types = { "vdd", "ddx" };
+    }
     else {
       try_types = { capture_backend };
     }
@@ -1164,6 +1169,10 @@ namespace platf {
 
       if (ret) {
         return ret;
+      }
+
+      if (type == "vdd") {
+        BOOST_LOG(warning) << "[vdd] direct capture initialization failed; trying DDX capture for the selected VDD output"sv;
       }
     }
 

--- a/src/platform/windows/display_device/device_modes.cpp
+++ b/src/platform/windows/display_device/device_modes.cpp
@@ -198,109 +198,6 @@ namespace display_device {
       return true;
     };
 
-    /**
-     * @brief Attempt to set display modes by explicitly specifying both source and target mode parameters.
-     *
-     * This is a fallback for cases where Windows CCD cannot automatically match source modes to target modes
-     * (e.g., non-standard resolutions like 2560x1600 on newly created virtual display paths).
-     * Instead of clearing the target mode index and relying on Windows' mode matching algorithm,
-     * this function directly modifies the existing target mode entry with the desired parameters.
-     *
-     * @param modes The desired display modes to set.
-     * @return True if successfully applied, false otherwise.
-     */
-    bool
-    do_set_modes_with_explicit_target(const device_display_mode_map_t &modes) {
-      auto display_data { w_utils::query_display_config(w_utils::ACTIVE_ONLY_DEVICES) };
-      if (!display_data) {
-        return false;
-      }
-
-      bool changes_applied { false };
-      for (const auto &[device_id, mode] : modes) {
-        auto path { w_utils::get_active_path(device_id, display_data->paths) };
-        if (!path) {
-          BOOST_LOG(error) << "Failed to find device for explicit target mode set: " << device_id << "!";
-          return false;
-        }
-
-        auto source_mode { w_utils::get_source_mode(w_utils::get_source_index(*path, display_data->modes), display_data->modes) };
-        if (!source_mode) {
-          BOOST_LOG(error) << "Active device does not have a source mode: " << device_id << "!";
-          return false;
-        }
-
-        // Update source mode with desired resolution
-        const bool resolution_changed { source_mode->width != mode.resolution.width || source_mode->height != mode.resolution.height };
-        if (resolution_changed) {
-          source_mode->width = mode.resolution.width;
-          source_mode->height = mode.resolution.height;
-          changes_applied = true;
-        }
-
-        // Update path refresh rate
-        const bool refresh_rate_changed { path->targetInfo.refreshRate.Numerator != mode.refresh_rate.numerator ||
-                                          path->targetInfo.refreshRate.Denominator != mode.refresh_rate.denominator };
-        if (refresh_rate_changed) {
-          path->targetInfo.refreshRate = { mode.refresh_rate.numerator, mode.refresh_rate.denominator };
-          changes_applied = true;
-        }
-
-        // Instead of clearing the target index, try to update the target mode entry in-place.
-        // This avoids relying on Windows CCD's automatic source-to-target mode matching,
-        // which can fail for non-standard resolutions on newly created virtual display paths.
-        const UINT32 target_idx { path->targetInfo.targetModeInfoIdx };
-        if (target_idx == DISPLAYCONFIG_PATH_TARGET_MODE_IDX_INVALID || target_idx >= display_data->modes.size()) {
-          BOOST_LOG(warning) << "Explicit target mode fallback: no valid target mode entry for " << device_id << ", skipping.";
-          return false;
-        }
-
-        auto &target_mode_info = display_data->modes[target_idx];
-        if (target_mode_info.infoType != DISPLAYCONFIG_MODE_INFO_TYPE_TARGET) {
-          BOOST_LOG(warning) << "Explicit target mode fallback: mode entry is not a TARGET type for " << device_id << ", skipping.";
-          return false;
-        }
-
-        auto &signal = target_mode_info.targetMode.targetVideoSignalInfo;
-        const UINT32 width = mode.resolution.width;
-        const UINT32 height = mode.resolution.height;
-        const UINT32 vsync_num = mode.refresh_rate.numerator;
-        const UINT32 vsync_den = mode.refresh_rate.denominator > 0 ? mode.refresh_rate.denominator : 1;
-
-        signal.activeSize.cx = width;
-        signal.activeSize.cy = height;
-        signal.totalSize.cx = width;
-        signal.totalSize.cy = height;
-        signal.vSyncFreq.Numerator = vsync_num;
-        signal.vSyncFreq.Denominator = vsync_den;
-        signal.hSyncFreq.Numerator = vsync_num * height;
-        signal.hSyncFreq.Denominator = vsync_den;
-        signal.pixelRate = static_cast<UINT64>(vsync_num) * width * height / vsync_den;
-        signal.scanLineOrdering = DISPLAYCONFIG_SCANLINE_ORDERING_PROGRESSIVE;
-
-        // Clear the desktop image index so Windows reselects it.
-        // A stale DISPLAYCONFIG_MODE_INFO_TYPE_DESKTOP_IMAGE entry (with old size)
-        // can cause SetDisplayConfig to fail with ERROR_GEN_FAILURE when using
-        // SDC_VIRTUAL_MODE_AWARE, even though we are keeping the target index.
-        w_utils::set_desktop_index(*path, boost::none);
-
-        changes_applied = true;
-      }
-
-      if (!changes_applied) {
-        return false;
-      }
-
-      const UINT32 flags { SDC_APPLY | SDC_USE_SUPPLIED_DISPLAY_CONFIG | SDC_SAVE_TO_DATABASE | SDC_VIRTUAL_MODE_AWARE };
-      const LONG result { SetDisplayConfig(display_data->paths.size(), display_data->paths.data(), display_data->modes.size(), display_data->modes.data(), flags) };
-      if (result != ERROR_SUCCESS) {
-        BOOST_LOG(warning) << w_utils::get_error_string(result) << " failed to set display mode with explicit target!";
-        return false;
-      }
-
-      return true;
-    }
-
   }  // namespace
 
   device_display_mode_map_t
@@ -428,18 +325,6 @@ namespace display_device {
     // flag.
     BOOST_LOG(info) << "Failed to change display modes using Windows recommended modes, trying to set modes more strictly!";
     if (do_set_modes(modes, !allow_changes)) {
-      current_modes = get_current_display_modes(device_ids);
-      if (!current_modes.empty() && all_modes_match(current_modes)) {
-        return true;
-      }
-    }
-
-    // Fallback: explicitly set target mode parameters instead of relying on Windows CCD mode matching.
-    // This helps with non-standard resolutions (e.g. 16:10 like 2560x1600) on newly created virtual
-    // display paths where the CCD topology database has no matching mode entries.
-    // This also handles the case where the first attempt fails with ERROR_GEN_FAILURE.
-    BOOST_LOG(info) << "CCD mode matching failed, trying to set modes with explicit target mode parameters.";
-    if (do_set_modes_with_explicit_target(modes)) {
       current_modes = get_current_display_modes(device_ids);
       if (!current_modes.empty() && all_modes_match(current_modes)) {
         return true;

--- a/src/platform/windows/display_vdd.cpp
+++ b/src/platform/windows/display_vdd.cpp
@@ -807,10 +807,10 @@ namespace platf::dxgi {
   };
 
   // A display-mode commit and the first frame from the replacement VDD swap
-  // chain are separate asynchronous events. Windows can therefore expose the
-  // old producer for a few seconds after SetDisplayConfig() reports success.
-  // Keep the exact-dimension safety check, but give the replacement producer
-  // a bounded window to become visible before failing video initialization.
+  // chain are separate asynchronous events. Wait when no producer exists yet.
+  // A sole mismatched producer is unambiguous but cannot represent the DXGI
+  // desktop mode; report it immediately so the display factory can use DDX
+  // instead of waiting here and then ending the video session.
   static constexpr auto vdd_producer_discovery_window = 8s;
   static constexpr auto vdd_producer_discovery_retry_delay = 100ms;
 
@@ -920,11 +920,9 @@ namespace platf::dxgi {
     return result;
   }
 
-  // Probes Global\ZakoVDD_Meta_<i> for valid producers and returns the index
-  // whose Width/Height exactly match target. A stale sole producer is not safe:
-  // the encoder and capture surfaces are already sized for the requested mode,
-  // so opening a mismatched producer can spin the stream in a reinit loop.
-  static int
+  // Prefer an exact producer match. A sole mismatched producer is returned as
+  // an explicit mismatch so the caller can fail over to DDX without waiting.
+  static vdd_frame_channel::producer_selection
   resolve_vdd_monitor_index(unsigned int target_w,
                             unsigned int target_h,
                             unsigned int max_probe = 16,
@@ -934,10 +932,23 @@ namespace platf::dxgi {
 
     for (;;) {
       last_result = probe_vdd_monitor_index(target_w, target_h, max_probe);
-      if (last_result.exact >= 0) {
-        BOOST_LOG(info) << "[vdd] resolved monitor index "sv << last_result.exact
+      const auto selection = vdd_frame_channel::select_producer(
+        last_result.exact,
+        last_result.only_valid,
+        static_cast<unsigned int>(last_result.valid_count)
+      );
+      if (selection.match == vdd_frame_channel::producer_match::exact) {
+        BOOST_LOG(info) << "[vdd] resolved monitor index "sv << selection.index
                         << " for "sv << target_w << "x"sv << target_h << " (exact match)"sv;
-        return last_result.exact;
+        return selection;
+      }
+      if (selection.match == vdd_frame_channel::producer_match::sole_mismatch) {
+        BOOST_LOG(warning) << "[vdd] sole producer monitor "sv << selection.index
+                           << " is "sv << last_result.only_valid_width
+                           << "x"sv << last_result.only_valid_height
+                           << ", while DXGI reports "sv << target_w << "x"sv << target_h
+                           << "; direct capture cannot represent this desktop mode"sv;
+        return selection;
       }
 
       if (std::chrono::steady_clock::now() >= deadline) {
@@ -951,23 +962,16 @@ namespace platf::dxgi {
       BOOST_LOG(warning) << "[vdd] no valid VDD producer found (no Meta_* mappings). "sv
                          << "Is the ZakoVDD driver installed and running?"sv;
     }
-    else if (last_result.valid_count == 1 && last_result.only_valid >= 0) {
-      BOOST_LOG(warning) << "[vdd] sole VDD producer monitor "sv << last_result.only_valid
-                         << " is "sv << last_result.only_valid_width
-                         << "x"sv << last_result.only_valid_height
-                         << ", but requested "sv << target_w << "x"sv << target_h
-                         << "; refusing stale producer to avoid black screen/reinit loop."sv;
-    }
     else {
       BOOST_LOG(warning) << "[vdd] "sv << last_result.valid_count
                          << " VDD producers present but none match "sv
                          << target_w << "x"sv << target_h
                          << "."sv;
     }
-    return -1;
+    return {};
   }
 
-  static int
+  static vdd_frame_channel::producer_selection
   resolve_sealed_vdd_monitor_index(ID3D11Device *d3d_device,
                                    unsigned int target_w,
                                    unsigned int target_h,
@@ -975,12 +979,12 @@ namespace platf::dxgi {
                                    std::optional<std::chrono::steady_clock::time_point> deadline_override = std::nullopt) {
     const auto device_luid = vdd_device_adapter_luid(d3d_device);
     if (!device_luid) {
-      return -1;
+      return {};
     }
 
     display_device::vdd_ioctl::frame_channel_caps sealed_caps {};
     if (probe_sealed_frame_channel(sealed_caps) != vdd_frame_channel::channel_selection::unknown) {
-      return -1;
+      return {};
     }
 
     vdd_probe_result_t last_result;
@@ -988,10 +992,23 @@ namespace platf::dxgi {
 
     for (;;) {
       last_result = probe_sealed_vdd_monitor_index(*device_luid, sealed_caps, target_w, target_h, max_probe);
-      if (last_result.exact >= 0) {
-        BOOST_LOG(info) << "[vdd] resolved sealed monitor index "sv << last_result.exact
+      const auto selection = vdd_frame_channel::select_producer(
+        last_result.exact,
+        last_result.only_valid,
+        static_cast<unsigned int>(last_result.valid_count)
+      );
+      if (selection.match == vdd_frame_channel::producer_match::exact) {
+        BOOST_LOG(info) << "[vdd] resolved sealed monitor index "sv << selection.index
                         << " for "sv << target_w << "x"sv << target_h << " (exact match)"sv;
-        return last_result.exact;
+        return selection;
+      }
+      if (selection.match == vdd_frame_channel::producer_match::sole_mismatch) {
+        BOOST_LOG(warning) << "[vdd] sole sealed producer monitor "sv << selection.index
+                           << " is "sv << last_result.only_valid_width
+                           << "x"sv << last_result.only_valid_height
+                           << ", while DXGI reports "sv << target_w << "x"sv << target_h
+                           << "; direct capture cannot represent this desktop mode"sv;
+        return selection;
       }
 
       if (std::chrono::steady_clock::now() >= deadline) {
@@ -1005,20 +1022,13 @@ namespace platf::dxgi {
       BOOST_LOG(warning) << "[vdd] no valid sealed VDD producer found for "sv
                          << target_w << "x"sv << target_h << "."sv;
     }
-    else if (last_result.valid_count == 1 && last_result.only_valid >= 0) {
-      BOOST_LOG(warning) << "[vdd] sole sealed VDD producer monitor "sv << last_result.only_valid
-                         << " is "sv << last_result.only_valid_width
-                         << "x"sv << last_result.only_valid_height
-                         << ", but requested "sv << target_w << "x"sv << target_h
-                         << "; refusing stale producer to avoid black screen/reinit loop."sv;
-    }
     else {
       BOOST_LOG(warning) << "[vdd] "sv << last_result.valid_count
                          << " sealed VDD producers present but none match "sv
                          << target_w << "x"sv << target_h
                          << "."sv;
     }
-    return -1;
+    return {};
   }
 
   int
@@ -1040,28 +1050,37 @@ namespace platf::dxgi {
       vdd_frame_channel_mode_env_override().value_or(vdd_frame_channel::channel_mode::auto_probe);
     const auto producer_discovery_deadline = std::chrono::steady_clock::now() + vdd_producer_discovery_window;
 
-    int idx = -1;
+    vdd_frame_channel::producer_selection producer_selection;
     if (frame_channel_mode != vdd_frame_channel::channel_mode::legacy_named) {
-      idx = resolve_sealed_vdd_monitor_index(device.get(), target_w, target_h, 16, producer_discovery_deadline);
-      if (idx < 0 && frame_channel_mode == vdd_frame_channel::channel_mode::sealed_required) {
+      producer_selection = resolve_sealed_vdd_monitor_index(device.get(), target_w, target_h, 16, producer_discovery_deadline);
+      if (producer_selection.match == vdd_frame_channel::producer_match::sole_mismatch) {
+        BOOST_LOG(warning) << "[vdd] sealed producer resolution differs from the selected desktop; requesting DDX fallback"sv;
+        return -1;
+      }
+      if (producer_selection.match == vdd_frame_channel::producer_match::unavailable &&
+          frame_channel_mode == vdd_frame_channel::channel_mode::sealed_required) {
         BOOST_LOG(error) << "[vdd] SUNSHINE_VDD_FRAME_CHANNEL=sealed requested, "
                          << "but sealed producer discovery failed or found no matching producer for "sv
                          << target_w << "x"sv << target_h;
         return -1;
       }
-      if (idx < 0) {
+      if (producer_selection.match == vdd_frame_channel::producer_match::unavailable) {
         BOOST_LOG(warning) << "[vdd] sealed producer discovery was unavailable or found no matching monitor; "
                            << "falling back to legacy Meta_* discovery"sv;
       }
     }
 
-    if (idx < 0) {
-      idx = resolve_vdd_monitor_index(target_w, target_h, 16, producer_discovery_deadline);
+    if (producer_selection.match == vdd_frame_channel::producer_match::unavailable) {
+      producer_selection = resolve_vdd_monitor_index(target_w, target_h, 16, producer_discovery_deadline);
     }
-    if (idx < 0) {
+    if (producer_selection.match == vdd_frame_channel::producer_match::sole_mismatch) {
+      BOOST_LOG(warning) << "[vdd] legacy producer resolution differs from the selected desktop; requesting DDX fallback"sv;
       return -1;
     }
-    monitor_idx = static_cast<unsigned int>(idx);
+    if (producer_selection.match == vdd_frame_channel::producer_match::unavailable) {
+      return -1;
+    }
+    monitor_idx = static_cast<unsigned int>(producer_selection.index);
 
     for (;;) {
       if (dup.init(device.get(), monitor_idx) == 0) {

--- a/src/platform/windows/vdd_frame_channel.h
+++ b/src/platform/windows/vdd_frame_channel.h
@@ -111,6 +111,28 @@ namespace platf::dxgi::vdd_frame_channel {
     }
   };
 
+  enum class producer_match {
+    unavailable,
+    exact,
+    sole_mismatch,
+  };
+
+  struct producer_selection {
+    int index = -1;
+    producer_match match = producer_match::unavailable;
+  };
+
+  inline producer_selection
+  select_producer(int exact_index, int only_valid_index, unsigned int valid_count) {
+    if (exact_index >= 0) {
+      return {exact_index, producer_match::exact};
+    }
+    if (valid_count == 1 && only_valid_index >= 0) {
+      return {only_valid_index, producer_match::sole_mismatch};
+    }
+    return {};
+  }
+
   inline bool
   luid_equal(const LUID &a, const LUID &b) {
     return a.LowPart == b.LowPart && a.HighPart == b.HighPart;

--- a/tests/unit/test_vdd_safety.cpp
+++ b/tests/unit/test_vdd_safety.cpp
@@ -4,6 +4,7 @@
 
 #include "src/display_device/vdd_control_ioctl.h"
 #include "src/display_device/vdd_ioctl.h"
+#include "src/display_device/vdd_utils.h"
 #include "src/platform/windows/display_device/settings_topology.h"
 #include "src/platform/windows/vdd_frame_channel.h"
 
@@ -158,6 +159,39 @@ TEST(VddFrameChannelSafety, BoundsPostEventAcquireWait) {
             consumer_acquire_wait_budget_ms);
   EXPECT_EQ(bounded_consumer_acquire_timeout_ms(1000),
             consumer_acquire_wait_budget_ms);
+}
+
+TEST(VddModeRefreshSafety, MatchesAdvertisedModesWithRefreshTolerance) {
+  using namespace display_device;
+
+  const display_mode_t requested {
+    {2340, 1080},
+    {11988, 100},
+  };
+
+  EXPECT_TRUE(vdd_utils::advertised_mode_matches(2340, 1080, 120, requested));
+  EXPECT_TRUE(vdd_utils::advertised_mode_matches(2340, 1080, 119, requested));
+  EXPECT_FALSE(vdd_utils::advertised_mode_matches(2560, 1440, 120, requested));
+  EXPECT_FALSE(vdd_utils::advertised_mode_matches(2340, 1080, 60, requested));
+
+  auto invalid = requested;
+  invalid.refresh_rate.denominator = 0;
+  EXPECT_FALSE(vdd_utils::advertised_mode_matches(2340, 1080, 120, invalid));
+}
+
+TEST(VddFrameChannelSafety, SelectsExactOrSoleProducerWithoutAmbiguity) {
+  using namespace platf::dxgi::vdd_frame_channel;
+
+  auto selection = select_producer(3, 7, 2);
+  EXPECT_EQ(selection.index, 3);
+  EXPECT_EQ(selection.match, producer_match::exact);
+
+  selection = select_producer(-1, 7, 1);
+  EXPECT_EQ(selection.index, 7);
+  EXPECT_EQ(selection.match, producer_match::sole_mismatch);
+
+  EXPECT_EQ(select_producer(-1, -1, 0).match, producer_match::unavailable);
+  EXPECT_EQ(select_producer(-1, 7, 2).match, producer_match::unavailable);
 }
 
 TEST(VddFrameChannelSafety, ReadsOnlyStableMetadataSnapshots) {


### PR DESCRIPTION
## 改了啥呀

- 会话分辨率先通过 `SETMODES` IOCTL 写入 ZakoVDD 的完整内存模式列表，不再写 `vdd_settings.xml`，也不 reload 整个驱动。
- 新增 Windows 实际公布模式检查：现有 monitor 已经暴露目标模式时直接复用；只有目标模式缺失时，才用 `DESTROYMONITOR` / `CREATEMONITOR` IOCTL 重建这一块虚拟屏，并在继续前复验模式是否真的发布。
- 把模式枚举封装到 `vdd_utils::is_mode_advertised()`，会话层只保留重建策略、GUID/持久化 ID 处理和失败路径，别再让杂鱼状态机到处乱跑啦。
- 删除无效的手工 CCD target timing fallback；它不能补出驱动未公布的 monitor mode，还会触发 `ERROR 1610`。
- 保留 direct VDD producer 的精确匹配与 DDX 安全兜底，避免外部残留状态再次把串流拖进黑屏/`video_ended`。

## 为啥要改

ZakoVDD v0.16.6 的 `SETMODES` 会更新 target mode，但已经存在的 IddCx monitor 可能继续保留旧的 monitor-description mode。Windows 只能从两边模式列表的交集中选 target，所以 2340×1080 / 3024×1964 虽然进了驱动内存，现有 monitor 仍不会真正公布它们。结果就是桌面尺寸变了，活动信号和 shared-frame producer 还停在旧尺寸——这个坏状态才是切分辨率后黑屏的根因呀。

## 验证

- `cmake --build build --target sunshine -j 2`
- `cmake --build build --target tests/CMakeFiles/test_sunshine.dir/unit/test_vdd_safety.cpp.obj -j 2`
- 本机安装最终构建，SHA-256 与 `C:\Program Files\Sunshine\sunshine.exe` 一致。
- 实机从 3840×2160@120 切到 2340×1080@120：首次缺失模式时只重建 monitor；CCD 实测 desktop/signal 均为 2340×1080@120，sealed producer、direct capture、编码尺寸均精确匹配。
- 再切到 3024×1964@120：CCD desktop/signal 均为 3024×1964@120，producer/capture/encode 再次精确匹配。
- 完全退出后用同一 3024×1964@120 重连：没有 DESTROY/CREATE，复用现有 monitor 并直接精确命中。
- 上述动态切换日志中没有 XML 写入、driver reload、`ERROR 1610`、运行时 DDX 降级或 `video_ended`。