### PR TITLE
fix(pairing): match client certificates by identity

### DIFF
--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -437,6 +437,16 @@ namespace crypto {
     return p;
   }
 
+  bool
+  x509_matches_pem(const X509 *cert, const std::string_view &pem) {
+    if (!cert) {
+      return false;
+    }
+
+    auto pem_cert = x509(pem);
+    return pem_cert && X509_cmp(cert, pem_cert.get()) == 0;
+  }
+
   pkey_t
   pkey(const std::string_view &k) {
     bio_t io { BIO_new(BIO_s_mem()) };

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -47,6 +47,19 @@ namespace crypto {
 
   x509_t
   x509(const std::string_view &x);
+  /**
+   * @brief Compares a parsed certificate with a PEM-encoded certificate.
+   *
+   * PEM is a textual envelope, so equivalent certificates may differ in line
+   * endings, wrapping, or trailing whitespace. This compares the parsed X.509
+   * objects instead of their PEM strings.
+   *
+   * @param cert Parsed certificate to compare.
+   * @param pem PEM-encoded certificate.
+   * @return true when both inputs are valid and represent the same certificate.
+   */
+  bool
+  x509_matches_pem(const X509 *cert, const std::string_view &pem);
   pkey_t
   pkey(const std::string_view &k);
   std::string

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -165,8 +165,7 @@ namespace nvhttp {
 #endif
                   };
                   if (x509) {
-                    std::string client_cert_pem = crypto::pem(x509);
-                    if (auto uuid = pairing::client_uuid_for_cert(client_cert_pem); !uuid.empty()) {
+                    if (auto uuid = pairing::client_uuid_for_cert(x509.get()); !uuid.empty()) {
                       // Client authentication belongs to the TLS connection,
                       // not to the first HTTP Request object created for it.
                       // Simple-Web-Server replaces Request objects between

--- a/src/nvhttp/pairing.cpp
+++ b/src/nvhttp/pairing.cpp
@@ -463,10 +463,14 @@ namespace nvhttp {
     }
 
     std::string
-    client_uuid_for_cert(const std::string &cert) {
+    client_uuid_for_cert(const X509 *cert) {
+      if (!cert) {
+        return {};
+      }
+
       std::shared_lock<std::shared_mutex> cl(client_state_mutex);
       for (const auto &named_cert : client_root.named_devices) {
-        if (named_cert.cert == cert) {
+        if (crypto::x509_matches_pem(cert, named_cert.cert)) {
           return named_cert.uuid;
         }
       }

--- a/src/nvhttp/pairing.h
+++ b/src/nvhttp/pairing.h
@@ -21,7 +21,7 @@ namespace nvhttp::pairing {
   load_state();
 
   std::string
-  client_uuid_for_cert(const std::string &cert);
+  client_uuid_for_cert(const X509 *cert);
 
   const char *
   verify_client_certificate(X509 *cert, bool close_verify_safe);

--- a/tests/unit/test_crypto.cpp
+++ b/tests/unit/test_crypto.cpp
@@ -1,0 +1,60 @@
+/**
+ * @file tests/unit/test_crypto.cpp
+ * @brief Tests for cryptography helpers.
+ */
+
+#include <string>
+#include <string_view>
+
+#include <gtest/gtest.h>
+
+#include "src/crypto.h"
+
+namespace {
+  std::string
+  without_trailing_line_endings(std::string pem) {
+    while (!pem.empty() && (pem.back() == '\n' || pem.back() == '\r')) {
+      pem.pop_back();
+    }
+    return pem;
+  }
+
+  std::string
+  with_crlf_line_endings(const std::string_view pem) {
+    std::string result;
+    result.reserve(pem.size() + 32);
+    for (const char ch : pem) {
+      if (ch == '\n') {
+        result.push_back('\r');
+      }
+      result.push_back(ch);
+    }
+    return result;
+  }
+}  // namespace
+
+TEST(CryptoX509, MatchesEquivalentPemFormatting) {
+  const auto credentials = crypto::gen_creds("format-test-client", 2048);
+  const auto certificate = crypto::x509(credentials.x509);
+  ASSERT_TRUE(certificate);
+  ASSERT_TRUE(credentials.x509.ends_with('\n'));
+
+  EXPECT_TRUE(crypto::x509_matches_pem(certificate.get(), credentials.x509));
+
+  const auto without_trailing_newline = without_trailing_line_endings(credentials.x509);
+  EXPECT_TRUE(crypto::x509_matches_pem(certificate.get(), without_trailing_newline));
+
+  const auto with_crlf = with_crlf_line_endings(credentials.x509);
+  EXPECT_TRUE(crypto::x509_matches_pem(certificate.get(), with_crlf));
+}
+
+TEST(CryptoX509, RejectsInvalidOrDifferentCertificates) {
+  const auto first_credentials = crypto::gen_creds("same-subject", 2048);
+  const auto second_credentials = crypto::gen_creds("same-subject", 2048);
+  const auto first_certificate = crypto::x509(first_credentials.x509);
+  ASSERT_TRUE(first_certificate);
+
+  EXPECT_FALSE(crypto::x509_matches_pem(first_certificate.get(), second_credentials.x509));
+  EXPECT_FALSE(crypto::x509_matches_pem(first_certificate.get(), "not a certificate"));
+  EXPECT_FALSE(crypto::x509_matches_pem(nullptr, first_credentials.x509));
+}

--- a/tests/unit/test_crypto.cpp
+++ b/tests/unit/test_crypto.cpp
@@ -3,14 +3,26 @@
  * @brief Tests for cryptography helpers.
  */
 
+#include <chrono>
+#include <filesystem>
 #include <string>
 #include <string_view>
+
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
 
 #include <gtest/gtest.h>
 
 #include "src/crypto.h"
+#include "src/config.h"
+#include "src/httpcommon.h"
+#include "src/nvhttp.h"
+#include "src/nvhttp/pairing.h"
 
 namespace {
+  namespace fs = std::filesystem;
+  namespace pt = boost::property_tree;
+
   std::string
   without_trailing_line_endings(std::string pem) {
     while (!pem.empty() && (pem.back() == '\n' || pem.back() == '\r')) {
@@ -31,6 +43,43 @@ namespace {
     }
     return result;
   }
+
+  class PairingStateGuard {
+  public:
+    PairingStateGuard(const std::string &cert, const std::string &uuid):
+        state_file_(fs::temp_directory_path() / ("sunshine_pairing_test_" + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()) + ".json")),
+        previous_state_file_(config::nvhttp.file_state),
+        previous_unique_id_(http::unique_id) {
+      pt::ptree device;
+      device.put("name", "test-client");
+      device.put("cert", cert);
+      device.put("uuid", uuid);
+
+      pt::ptree state;
+      state.put("root.uniqueid", "test-host");
+      pt::ptree devices;
+      devices.push_back({ "", device });
+      state.add_child("root.named_devices", devices);
+      pt::write_json(state_file_.string(), state);
+
+      config::nvhttp.file_state = state_file_.string();
+      nvhttp::pairing::load_state();
+    }
+
+    ~PairingStateGuard() {
+      nvhttp::erase_all_clients();
+      config::nvhttp.file_state = previous_state_file_;
+      http::unique_id = previous_unique_id_;
+
+      std::error_code ec;
+      fs::remove(state_file_, ec);
+    }
+
+  private:
+    fs::path state_file_;
+    std::string previous_state_file_;
+    std::string previous_unique_id_;
+  };
 }  // namespace
 
 TEST(CryptoX509, MatchesEquivalentPemFormatting) {
@@ -57,4 +106,18 @@ TEST(CryptoX509, RejectsInvalidOrDifferentCertificates) {
   EXPECT_FALSE(crypto::x509_matches_pem(first_certificate.get(), second_credentials.x509));
   EXPECT_FALSE(crypto::x509_matches_pem(first_certificate.get(), "not a certificate"));
   EXPECT_FALSE(crypto::x509_matches_pem(nullptr, first_credentials.x509));
+}
+
+TEST(NvhttpPairing, ResolvesUuidForVerifiedPeerCertificate) {
+  const auto credentials = crypto::gen_creds("paired-client", 2048);
+  auto certificate = crypto::x509(credentials.x509);
+  ASSERT_TRUE(certificate);
+
+  const std::string expected_uuid = "paired-client-uuid";
+  const auto stored_cert = without_trailing_line_endings(with_crlf_line_endings(credentials.x509));
+  PairingStateGuard state { stored_cert, expected_uuid };
+
+  // This mirrors the X509 pointer passed from the TLS handshake callback.
+  EXPECT_EQ(nvhttp::pairing::verify_client_certificate(certificate.get(), true), nullptr);
+  EXPECT_EQ(nvhttp::pairing::client_uuid_for_cert(certificate.get()), expected_uuid);
 }


### PR DESCRIPTION
## 改了啥

- 将客户端证书匹配从 PEM 文本比较改为解析后的 X.509 对象比较。
- TLS 握手后直接使用 peer certificate，避免重新序列化导致的格式差异。
- 增加 LF、CRLF、无结尾换行、无效证书和不同证书的单元测试。

## 为啥要改

PEM 只是文本封装，同一张证书可能因为换行符或末尾换行不同而文本不一致。旧逻辑因此可能匹配不到客户端 UUID，导致鸿蒙 V+ 退出串流后的清理链路异常；日志中也会出现 `client_uuid=` 为空。这个换行小妖怪现在按证书身份比较了。

Fixes #832

## 验证

- Windows Release 完整编译通过。
- X.509 单元测试通过：2/2。
- 已打包 ZIP 和 Windows 安装包。
- 用户在鸿蒙 V+ 上验证退出串流问题已恢复正常。