### PR TITLE
fix(vdd): remove named pipe fallback

### DIFF
--- a/src/display_device/vdd_control_ioctl.h
+++ b/src/display_device/vdd_control_ioctl.h
@@ -11,14 +11,11 @@
  * Transport summary:
  *   The driver exposes a custom WDF device interface
  *   (`GUID_DEVINTERFACE_ZAKO_VDD_CONTROL`). Opening this interface with
- *   `CreateFileW` PnP-wakes the IddCx driver back into D0, eliminating the
- *   race that the old named pipe transport had with WUDFHost recycling.
+ *   `CreateFileW` PnP-wakes the IddCx driver back into D0 and remains valid
+ *   across WUDFHost recycling.
  *
- *   `IOCTL_VDD_COMMAND` carries the same NUL-terminated UTF-16 command
- *   buffer grammar as the legacy pipe protocol (e.g. `RELOAD_DRIVER`,
- *   `CREATEMONITOR ...`, `DESTROYMONITOR`). The in-driver dispatcher is
- *   shared verbatim between both transports, so callers do not need to
- *   re-encode anything when migrating from pipe to IOCTL.
+ *   `IOCTL_VDD_COMMAND` carries a NUL-terminated UTF-16 command buffer
+ *   (e.g. `RELOAD_DRIVER`, `CREATEMONITOR ...`, `DESTROYMONITOR`).
  *
  *   `IOCTL_VDD_PING` is a cheap liveness probe (no payload).
  *

--- a/src/display_device/vdd_ioctl.cpp
+++ b/src/display_device/vdd_ioctl.cpp
@@ -178,9 +178,7 @@ namespace display_device::vdd_ioctl {
 
         if (m_handle == INVALID_HANDLE_VALUE) {
           // Interface was enumerated (path resolved) but the kernel still
-          // refused to give us a handle. The driver is present, so the
-          // pipe fallback would either deadlock on the same WUDFHost or
-          // duplicate-execute the command -- propagate failure instead.
+          // refused to give us a handle. Propagate the failure.
           BOOST_LOG(warning) << "vdd_ioctl: CreateFileW failed (err=" << GetLastError() << ")";
           return open_result::failed;
         }
@@ -347,11 +345,8 @@ namespace display_device::vdd_ioctl {
       nullptr);
 
     if (!ok) {
-      // The driver answered the IRP with an error status. Do NOT retry
-      // on the legacy pipe: the kernel-side handler may have partially
-      // applied the command (e.g. CREATEMONITOR allocated state before
-      // failing) and re-running it via pipe could double-create or leave
-      // the device in a worse spot than just surfacing the failure.
+      // The driver answered the IRP with an error status. Surface it to
+      // the caller without retrying a potentially state-changing command.
       BOOST_LOG(warning) << "vdd_ioctl: DeviceIoControl(IOCTL_VDD_COMMAND) failed (err=" << GetLastError() << ")";
       return result::failed;
     }

--- a/src/display_device/vdd_ioctl.cpp
+++ b/src/display_device/vdd_ioctl.cpp
@@ -159,8 +159,7 @@ namespace display_device::vdd_ioctl {
         if (path.empty()) {
           // Empty path = SetupDi enumeration found no instance of our
           // GUID. This is the "driver isn't installed / hasn't registered
-          // yet" case and the only one where falling back to the legacy
-          // pipe is correct.
+          // yet" case.
           return open_result::interface_missing;
         }
 

--- a/src/display_device/vdd_ioctl.h
+++ b/src/display_device/vdd_ioctl.h
@@ -2,18 +2,7 @@
  * @file vdd_ioctl.h
  * @brief Self-contained IOCTL transport for the ZakoVDD control channel.
  *
- * This module is the *forward-looking* transport for VDD commands.
- *
- * Co-existing with it (intentionally, transitionally) is the named-pipe
- * code in `vdd_utils.cpp`. Once every Sunshine release in the wild bundles
- * a driver build that exposes the IOCTL device interface, the pipe code
- * can be deleted in a single mechanical pass — every pipe-only call site
- * in `vdd_utils.cpp` is bracketed with `LEGACY-PIPE` markers.
- *
- * Design rationale: the entire IOCTL implementation lives in its own
- * translation unit (header + cpp), with no contamination of `vdd_utils.cpp`,
- * so the eventual cleanup is "delete pipe code from vdd_utils.cpp; collapse
- * the dispatch wrapper". The IOCTL module does not need to be touched.
+ * This is the sole transport for VDD control commands.
  */
 
 #pragma once
@@ -27,17 +16,13 @@ namespace display_device::vdd_ioctl {
   /**
    * @brief Outcome of an IOCTL transport attempt.
    *
-   * Three-state so callers can distinguish "transport unavailable, fall
-   * back to the legacy pipe" from "transport reached the driver but the
-   * command itself failed". The latter must NOT silently retry on the
-   * pipe -- the driver already saw the request and a duplicate could
-   * change device state (e.g. CREATEMONITOR twice -> two phantom panels)
-   * or just waste the ~6s pipe-connect timeout while the user waits.
+   * Three-state so callers can distinguish an unavailable device interface
+   * from a command rejected by a reachable driver.
    */
   enum class result {
     success,           ///< IOCTL completed with STATUS_SUCCESS.
-    interface_missing, ///< No registered device interface (driver too old / not installed). Safe to fall back.
-    failed,            ///< Driver was reached but rejected the IOCTL or returned an error. Do NOT fall back.
+    interface_missing, ///< No registered device interface (driver too old / not installed).
+    failed,            ///< Driver was reached but rejected the IOCTL or returned an error.
   };
 
   /**
@@ -124,9 +109,8 @@ namespace display_device::vdd_ioctl {
   /**
    * @brief Check whether the ZakoVDD display adapter is present in Plug and Play.
    *
-   * Unlike `ping()`, this also recognizes older driver builds that do not expose
-   * the control IOCTL interface and therefore remain usable through the legacy
-   * named-pipe fallback.
+   * Unlike `ping()`, this also recognizes an installed adapter whose control
+   * IOCTL interface is unavailable.
    */
   bool adapter_present();
 
@@ -137,8 +121,7 @@ namespace display_device::vdd_ioctl {
    * opens the first interface instance with `CreateFileW`, and issues
    * `IOCTL_VDD_COMMAND`.
    *
-   * @param command UTF-16 command string identical in grammar to the
-   *                legacy pipe protocol (e.g. `L"RELOAD_DRIVER"`,
+   * @param command UTF-16 VDD command string (e.g. `L"RELOAD_DRIVER"`,
    *                `L"CREATEMONITOR {GUID}:[..]"`, `L"DESTROYMONITOR"`).
    * @return tri-state result; see `enum class result`.
    */

--- a/src/display_device/vdd_utils.cpp
+++ b/src/display_device/vdd_utils.cpp
@@ -39,31 +39,6 @@ namespace pt = boost::property_tree;
 namespace display_device {
   namespace vdd_utils {
 
-    // ===========================================================
-    // [LEGACY-PIPE] Transitional named-pipe transport
-    // -----------------------------------------------------------
-    // The named pipe was the only way Sunshine talked to ZakoVDD
-    // before the IOCTL device interface (`vdd_ioctl.cpp`) landed.
-    // It is kept as a fallback so this Sunshine build still works
-    // against older driver releases that don't expose the IOCTL
-    // interface yet.
-    //
-    // Once every driver release in the wild speaks IOCTL, the
-    // entire pipe code path can be removed mechanically:
-    //   1. grep -nE '\[LEGACY-PIPE\]' vdd_utils.cpp and delete
-    //      every tagged block (constants, helpers, fallback calls).
-    //   2. Drop kVddPipeName, kPipeTimeoutMs, kPipeBufferSize,
-    //      connect_to_pipe_with_retry, execute_pipe_command, the
-    //      pipe-write half of destroy_vdd_monitor_nolog.
-    // The IOCTL primitives in vdd_ioctl.{h,cpp} stay untouched.
-    // ===========================================================
-
-    // [LEGACY-PIPE]
-    const wchar_t *kVddPipeName = L"\\\\.\\pipe\\ZakoVDDPipe";
-    // [LEGACY-PIPE]
-    const DWORD kPipeTimeoutMs = 3000;
-    // [LEGACY-PIPE]
-    const DWORD kPipeBufferSize = 4096;
     const std::chrono::milliseconds kDefaultDebounceInterval { 2000 };
 
     // 上次切换显示器的时间点
@@ -84,8 +59,6 @@ namespace display_device {
       status.control_available = status.installed && vdd_ioctl::ping();
       status.monitor_active = !display_device::find_device_by_friendlyname(ZAKO_NAME).empty();
 
-      // Older bundled drivers without the modern control interface remain
-      // usable through the named-pipe compatibility path.
       status.state = classify_vdd_state(
         status.installed,
         status.running,
@@ -161,113 +134,6 @@ namespace display_device {
       return false;
     }
 
-    // [LEGACY-PIPE] entire function
-    HANDLE
-    connect_to_pipe_with_retry(const wchar_t *pipe_name, int max_retries) {
-      HANDLE hPipe = INVALID_HANDLE_VALUE;
-      int attempt = 0;
-      auto retry_delay = kInitialRetryDelay;
-
-      while (attempt < max_retries) {
-        hPipe = CreateFileW(
-          pipe_name,
-          GENERIC_READ | GENERIC_WRITE,
-          0,
-          NULL,
-          OPEN_EXISTING,
-          // Never let a squatted legacy pipe impersonate the LocalSystem client.
-          FILE_FLAG_OVERLAPPED | SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION,
-          NULL);
-
-        if (hPipe != INVALID_HANDLE_VALUE) {
-          DWORD mode = PIPE_READMODE_MESSAGE;
-          if (SetNamedPipeHandleState(hPipe, &mode, NULL, NULL)) {
-            return hPipe;
-          }
-          CloseHandle(hPipe);
-        }
-
-        ++attempt;
-        retry_delay = calculate_exponential_backoff(attempt);
-        std::this_thread::sleep_for(retry_delay);
-      }
-      return INVALID_HANDLE_VALUE;
-    }
-
-    // [LEGACY-PIPE] entire function
-    bool
-    execute_pipe_command(const wchar_t *pipe_name, const wchar_t *command, std::string *response, bool *timed_out) {
-      auto hPipe = connect_to_pipe_with_retry(pipe_name);
-      if (hPipe == INVALID_HANDLE_VALUE) {
-        BOOST_LOG(error) << "连接MTT虚拟显示管道失败，已重试多次";
-        return false;
-      }
-
-      // RAII guard for pipe handle to prevent handle leak
-      struct HandleGuard {
-        HANDLE handle;
-        ~HandleGuard() {
-          if (handle && handle != INVALID_HANDLE_VALUE) CloseHandle(handle);
-        }
-      } pipe_guard { hPipe };
-
-      // 异步IO结构体
-      OVERLAPPED overlapped = { 0 };
-      overlapped.hEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
-
-      HandleGuard event_guard { overlapped.hEvent };
-
-      // 发送命令（使用宽字符版本）
-      DWORD bytesWritten;
-      size_t cmd_len = (wcslen(command) + 1) * sizeof(wchar_t);  // 包含终止符
-      if (!WriteFile(hPipe, command, (DWORD) cmd_len, &bytesWritten, &overlapped)) {
-        if (GetLastError() != ERROR_IO_PENDING) {
-          BOOST_LOG(error) << L"发送" << command << L"命令失败，错误代码: " << GetLastError();
-          return false;
-        }
-
-        // 等待写入完成
-        DWORD waitResult = WaitForSingleObject(overlapped.hEvent, kPipeTimeoutMs);
-        if (waitResult != WAIT_OBJECT_0) {
-          BOOST_LOG(error) << L"发送" << command << L"命令超时";
-          return false;
-        }
-      }
-
-      // 读取响应
-      bool read_timed_out = false;
-      if (response) {
-        char buffer[kPipeBufferSize];
-        DWORD bytesRead = 0;
-        if (!ReadFile(hPipe, buffer, sizeof(buffer) - 1, &bytesRead, &overlapped)) {
-          if (GetLastError() != ERROR_IO_PENDING) {
-            BOOST_LOG(warning) << "读取响应失败，错误代码: " << GetLastError();
-            return false;
-          }
-
-          DWORD waitResult = WaitForSingleObject(overlapped.hEvent, kPipeTimeoutMs);
-          if (waitResult == WAIT_OBJECT_0 && GetOverlappedResult(hPipe, &overlapped, &bytesRead, FALSE)) {
-            buffer[bytesRead] = '\0';
-            *response = std::string(buffer, bytesRead);
-          }
-          else {
-            read_timed_out = true;
-            CancelIo(hPipe);
-          }
-        }
-        else {
-          // ReadFile completed synchronously
-          buffer[bytesRead] = '\0';
-          *response = std::string(buffer, bytesRead);
-        }
-      }
-
-      if (timed_out) {
-        *timed_out = read_timed_out;
-      }
-      return true;
-    }
-
     bool
     set_hardware_cursor_enabled(bool enabled) {
       const wchar_t *command = enabled ? L"HARDWARECURSOR true" : L"HARDWARECURSOR false";
@@ -277,18 +143,13 @@ namespace display_device {
           BOOST_LOG(info) << "VDD hardware cursor " << (enabled ? "enabled" : "disabled") << " (IOCTL)";
           return true;
         case vdd_ioctl::result::failed:
-          BOOST_LOG(error) << "VDD hardware cursor command was rejected by driver; not falling back to pipe";
+          BOOST_LOG(error) << "VDD hardware cursor command was rejected by driver";
           return false;
         case vdd_ioctl::result::interface_missing:
-          break;
+          BOOST_LOG(error) << "VDD hardware cursor command unavailable: IOCTL interface missing";
+          return false;
       }
-
-      std::string response;
-      const bool ok = execute_pipe_command(kVddPipeName, command, &response);
-      if (ok) {
-        BOOST_LOG(info) << "VDD hardware cursor " << (enabled ? "enabled" : "disabled") << " (PIPE)";
-      }
-      return ok;
+      return false;
     }
 
     bool
@@ -591,7 +452,6 @@ namespace display_device {
         return false;
       }
 
-      std::string response;
       std::wstring command = L"CREATEMONITOR";
 
       // 如果没有提供UUID，使用上一次的UUID
@@ -638,8 +498,7 @@ namespace display_device {
         last_used_client_uuid = identifier_to_use;
       }
 
-      // 尝试发送命令（带GUID或不带GUID）
-      // Preferred path: IOCTL device interface. On success skip pipe entirely.
+      // 尝试通过 IOCTL 发送命令（带 GUID 或不带 GUID）
       switch (vdd_ioctl::send_command(command)) {
         case vdd_ioctl::result::success:
           tray_state::set_vdd_state(true, config::video.vdd_keep_enabled, config::video.vdd_headless_create_enabled, false);
@@ -649,37 +508,13 @@ namespace display_device {
           BOOST_LOG(info) << "创建虚拟显示器完成 (IOCTL)";
           return true;
         case vdd_ioctl::result::failed:
-          // Driver answered but rejected CREATEMONITOR -- avoid the pipe
-          // retry (could double-allocate monitor state on a partially
-          // applied request).
-          BOOST_LOG(error) << "创建虚拟显示器失败 (IOCTL); not falling back to pipe";
+          BOOST_LOG(error) << "创建虚拟显示器失败 (IOCTL)";
           return false;
         case vdd_ioctl::result::interface_missing:
-          break;
+          BOOST_LOG(error) << "创建虚拟显示器失败: VDD IOCTL interface missing";
+          return false;
       }
-
-      // [LEGACY-PIPE] Fallback for older driver builds.
-      bool read_timed_out = false;
-      bool success = execute_pipe_command(kVddPipeName, command.c_str(), &response, &read_timed_out);
-
-      // 如果带GUID的命令失败，降级为不带GUID的命令（兼容旧版驱动）
-      if (!success && !guid_str.empty()) {
-        BOOST_LOG(warning) << "带GUID的命令失败，尝试降级为不带GUID的命令";
-        read_timed_out = false;
-        success = execute_pipe_command(kVddPipeName, L"CREATEMONITOR", &response, &read_timed_out);
-      }
-
-      if (!success) {
-        BOOST_LOG(error) << "创建虚拟显示器失败";
-        return false;
-      }
-
-      tray_state::set_vdd_state(true, config::video.vdd_keep_enabled, config::video.vdd_headless_create_enabled, false);
-#if defined SUNSHINE_TRAY && SUNSHINE_TRAY >= 1
-      system_tray::update_vdd_menu();
-#endif
-      BOOST_LOG(info) << "创建虚拟显示器完成，响应: " << response << " [return=" << (read_timed_out ? 1 : 0) << "]";
-      return true;
+      return false;
     }
 
     bool
@@ -690,26 +525,16 @@ namespace display_device {
         return true;
       }
 
-      // Preferred path: IOCTL.
       switch (vdd_ioctl::send_command(L"DESTROYMONITOR")) {
         case vdd_ioctl::result::success:
           BOOST_LOG(info) << "销毁虚拟显示器完成 (IOCTL)";
           break;
         case vdd_ioctl::result::failed:
-          // Driver answered but DESTROYMONITOR errored -- don't redo it
-          // on the pipe (state may already be torn down).
-          BOOST_LOG(error) << "销毁虚拟显示器失败 (IOCTL); not falling back to pipe";
+          BOOST_LOG(error) << "销毁虚拟显示器失败 (IOCTL)";
           return false;
-        case vdd_ioctl::result::interface_missing: {
-          // [LEGACY-PIPE] Fallback for older driver builds.
-          std::string response;
-          if (!execute_pipe_command(kVddPipeName, L"DESTROYMONITOR", &response)) {
-            BOOST_LOG(error) << "销毁虚拟显示器失败";
-            return false;
-          }
-          BOOST_LOG(info) << "销毁虚拟显示器完成 (PIPE)，响应: " << response;
-          break;
-        }
+        case vdd_ioctl::result::interface_missing:
+          BOOST_LOG(error) << "销毁虚拟显示器失败: VDD IOCTL interface missing";
+          return false;
       }
 
       // 等待驱动程序完全卸载，避免WUDFHost.exe崩溃
@@ -725,32 +550,7 @@ namespace display_device {
 
     void
     destroy_vdd_monitor_nolog() {
-      // Preferred path: IOCTL. Both success and "driver said no" stop
-      // here -- the latter would just churn through a stale pipe handle
-      // during shutdown, which we explicitly do not want to log about.
-      switch (vdd_ioctl::send_command(L"DESTROYMONITOR")) {
-        case vdd_ioctl::result::success:
-        case vdd_ioctl::result::failed:
-          return;
-        case vdd_ioctl::result::interface_missing:
-          break;
-      }
-
-      // [LEGACY-PIPE] Best-effort pipe write for shutdown / process-exit
-      // paths where we don't want to log a failure if the pipe is gone.
-      HANDLE hPipe = CreateFileW(
-        kVddPipeName,
-        GENERIC_READ | GENERIC_WRITE,
-        0, NULL, OPEN_EXISTING,
-        SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION, NULL);
-      if (hPipe != INVALID_HANDLE_VALUE) {
-        DWORD mode = PIPE_READMODE_MESSAGE;
-        SetNamedPipeHandleState(hPipe, &mode, NULL, NULL);
-        const wchar_t cmd[] = L"DESTROYMONITOR";
-        DWORD bytesWritten;
-        WriteFile(hPipe, cmd, sizeof(cmd), &bytesWritten, NULL);
-        CloseHandle(hPipe);
-      }
+      (void) vdd_ioctl::send_command(L"DESTROYMONITOR");
     }
 
     void

--- a/src/display_device/vdd_utils.h
+++ b/src/display_device/vdd_utils.h
@@ -23,9 +23,6 @@ namespace display_device::vdd_utils {
   inline constexpr auto kInitialRetryDelay = 500ms;
   inline constexpr auto kMaxRetryDelay = 3000ms;
 
-  extern const wchar_t *kVddPipeName;
-  extern const DWORD kPipeTimeoutMs;
-  extern const DWORD kPipeBufferSize;
   extern const std::chrono::milliseconds kDefaultDebounceInterval;
 
   // HDR亮度范围结构
@@ -130,8 +127,8 @@ namespace display_device::vdd_utils {
 
   /**
    * @brief Return a fast, read-only VDD prerequisite snapshot.
-   * @details This never connects to the legacy named pipe, so callers can use
-   *          it in Web status polling and stream startup without timeout risk.
+   * @details This only performs read-only device and IOCTL probes, so callers
+   *          can use it in Web status polling and stream startup.
    */
   vdd_status_t
   get_vdd_status();
@@ -143,13 +140,6 @@ namespace display_device::vdd_utils {
   // VDD命令执行
   bool
   execute_vdd_command(const std::string &action);
-
-  // 管道相关函数
-  HANDLE
-  connect_to_pipe_with_retry(const wchar_t *pipe_name, int max_retries = 3);
-
-  bool
-  execute_pipe_command(const wchar_t *pipe_name, const wchar_t *command, std::string *response = nullptr, bool *timed_out = nullptr);
 
   /**
    * @brief Ensure ZakoVDD renders the cursor into the framebuffer instead of exposing a hardware cursor plane.


### PR DESCRIPTION
## 改了什么

- 删除 Sunshine 的 `ZakoVDDPipe` 连接、重试、读写和静默退出回退
- 创建/销毁显示器与硬件光标命令统一只走 IOCTL，并明确传播 interface missing / driver failure
- 清理迁移期常量、声明和注释
- 更新 GUI 子模块到 qiin2333/sunshine-control-panel#62
- 与驱动 qiin2333/zako-vdd#22 保持同一份 IOCTL ABI 头

## 为什么

旧 Pipe 服务会在 WUDFHost 卸载时卡住 60 秒，导致设备重启、重新连接和分辨率切换后的恢复变得又慢又脆。既然 IOCTL 已经能通过 PnP 唤醒设备，继续保留旧回退只会让失败路径重复执行状态命令，甚至再次走进已经确认的卸载死锁。

现在控制链只有一条：GUI / Sunshine -> IOCTL -> ZakoVDD，错误也不会被第二种传输掩盖。

## 验证

- 驱动与 Sunshine 的 `vdd_control_ioctl.h` Git blob 完全一致
- GUI：`cargo fmt --all -- --check`、`cargo check`、`npm run build:renderer`
- 驱动：Release x64 构建、Signability、`vdd_command` consumer 构建通过
- 本机最终驱动 IOCTL、设备重启及 UMDF 事件回归通过
- 三仓库源码扫描无 Named Pipe API/旧命名残留
- `git diff --check` 通过

完整 Sunshine 构建在配置阶段被工作区原有缺失的 `third-party/build-deps/dist/Windows-AMD64` FFmpeg 预编译包阻断；未修改或重置这些用户本地依赖。
