### PR TITLE
fix(vdd): preserve working driver during upgrades

### DIFF
--- a/cmake/packaging/sunshine.iss.in
+++ b/cmake/packaging/sunshine.iss.in
@@ -281,7 +281,8 @@ Filename: "{cmd}"; Parameters: "/c icacls ""{app}"" /reset /T /C > ""{tmp}\sunsh
 Filename: "{app}\scripts\update-path.bat"; Parameters: "add"; StatusMsg: "{cm:StatusUpdatePath}"; Flags: runhidden waituntilterminated
 Filename: "{app}\scripts\migrate-config.bat"; StatusMsg: "{cm:StatusMigrateConfig}"; Flags: runhidden waituntilterminated
 Filename: "{app}\scripts\add-firewall-rule.bat"; StatusMsg: "{cm:StatusFirewall}"; Flags: runhidden waituntilterminated; Components: firewall
-Filename: "{app}\scripts\install-vdd.bat"; StatusMsg: "{cm:StatusInstallVDD}"; Flags: runhidden waituntilterminated; Components: vdd
+; Leave a healthy older VDD active during unattended upgrades; the GUI offers an explicit repair action.
+Filename: "{app}\scripts\install-vdd.bat"; Parameters: "--preserve-healthy-existing"; StatusMsg: "{cm:StatusInstallVDD}"; Flags: runhidden waituntilterminated; Components: vdd
 Filename: "{app}\scripts\install-gamepad.bat"; StatusMsg: "{cm:StatusInstallGamepad}"; Flags: runhidden waituntilterminated; Components: gamepad
 Filename: "{app}\scripts\vmouse\install-vmouse.bat"; StatusMsg: "{cm:StatusInstallVmouse}"; Flags: runhidden waituntilterminated; Components: vmouse
 Filename: "{app}\scripts\install-service.bat"; StatusMsg: "{cm:StatusInstallService}"; Flags: runhidden waituntilterminated; AfterInstall: VerifyServiceInstalled

--- a/src_assets/windows/misc/vdd/install-vdd.bat
+++ b/src_assets/windows/misc/vdd/install-vdd.bat
@@ -3,10 +3,12 @@ setlocal
 set "PATH=%SystemRoot%\System32;%SystemRoot%;%SystemRoot%\System32\Wbem;%SystemRoot%\System32\WindowsPowerShell\v1.0"
 
 set "INSTALL_MODE=Run"
+set "PRESERVE_HEALTHY_EXISTING="
 for %%A in (%*) do (
     if /i "%%~A"=="--resolve-only" set "INSTALL_MODE=ResolveOnly"
     if /i "%%~A"=="--probe-only" set "INSTALL_MODE=ProbeOnly"
+    if /i "%%~A"=="--preserve-healthy-existing" set "PRESERVE_HEALTHY_EXISTING=-PreserveHealthyExisting"
 )
 
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0vdd-device-helper.ps1" -Action Install -Mode "%INSTALL_MODE%"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0vdd-device-helper.ps1" -Action Install -Mode "%INSTALL_MODE%" %PRESERVE_HEALTHY_EXISTING%
 exit /b %ERRORLEVEL%

--- a/src_assets/windows/misc/vdd/smoke-test-install-vdd-selection.ps1
+++ b/src_assets/windows/misc/vdd/smoke-test-install-vdd-selection.ps1
@@ -54,7 +54,7 @@ function Invoke-ResolveOnly {
         $wrapperLines += ('set "VDD_TEST_WIN_BUILD={0}"' -f $BuildOverride)
     }
 
-    $wrapperLines += ('call "{0}" --resolve-only' -f $ScriptCopy)
+    $wrapperLines += ('call "{0}" --resolve-only --preserve-healthy-existing' -f $ScriptCopy)
     $wrapperLines += 'exit /b %ERRORLEVEL%'
 
     Set-Content -Path $wrapper -Value $wrapperLines -Encoding Ascii

--- a/src_assets/windows/misc/vdd/smoke-test-vdd-device-helper.ps1
+++ b/src_assets/windows/misc/vdd/smoke-test-vdd-device-helper.ps1
@@ -393,15 +393,71 @@ finally {
     Remove-Variable -Name removedHardwareIds -Scope Script -ErrorAction SilentlyContinue
 }
 
+$transactionTestRoot = Join-Path ([IO.Path]::GetTempPath()) "sunshine-vdd-transaction-$([Guid]::NewGuid().ToString('N'))"
+[void] [IO.Directory]::CreateDirectory($transactionTestRoot)
+$transactionPayload = [pscustomobject]@{
+    Paths = [pscustomobject]@{
+        ConfigDir = $transactionTestRoot
+        Nefcon = $HelperScript
+    }
+}
+$transactionPreviousDevice = New-TestDevice '100.0.16.5' 'OK' 'oem40.inf'
+$originalGetVddDevices = ${function:Get-VddDevices}
+$originalRestoreVddDevice = ${function:Restore-VddDevice}
+try {
+    $script:transactionDevices = @()
+    $script:transactionRestoreCalls = 0
+    function Get-VddDevices { return @($script:transactionDevices) }
+    function Restore-VddDevice { $script:transactionRestoreCalls++ }
+
+    Save-VddTransaction $transactionPayload $transactionPreviousDevice
+    Recover-VddTransaction $transactionPayload '100.0.16.6'
+    Assert-Equal 1 $script:transactionRestoreCalls `
+        'An interrupted replacement without a ready VDD must restore the previous package.'
+    Assert-Equal $false (Test-Path -LiteralPath (Get-VddTransactionPath $transactionPayload)) `
+        'A recovered VDD transaction must be cleared.'
+
+    Save-VddTransaction $transactionPayload $transactionPreviousDevice
+    $script:transactionDevices = @(New-TestDevice '100.0.16.6')
+    Recover-VddTransaction $transactionPayload '100.0.16.6'
+    Assert-Equal 1 $script:transactionRestoreCalls `
+        'A completed replacement must not roll back the new ready VDD.'
+
+    Save-VddTransaction $transactionPayload $transactionPreviousDevice
+    $script:transactionDevices = @(New-TestDevice '100.0.17.0')
+    $unexpectedDriverWasRejected = $false
+    try {
+        Recover-VddTransaction $transactionPayload '100.0.16.6'
+    }
+    catch {
+        $unexpectedDriverWasRejected = $_.Exception.Message -like '*different healthy driver*'
+    }
+    Assert-Equal $true $unexpectedDriverWasRejected `
+        'Recovery must not replace a different healthy VDD automatically.'
+}
+finally {
+    ${function:Get-VddDevices} = $originalGetVddDevices
+    ${function:Restore-VddDevice} = $originalRestoreVddDevice
+    if (Test-Path -LiteralPath $transactionTestRoot) {
+        Remove-Item -LiteralPath $transactionTestRoot -Recurse -Force
+    }
+    Remove-Variable -Name transactionDevices -Scope Script -ErrorAction SilentlyContinue
+    Remove-Variable -Name transactionRestoreCalls -Scope Script -ErrorAction SilentlyContinue
+}
+
 $originalResolveVddPayload = ${function:Resolve-VddPayload}
 $originalGetVddPaths = ${function:Get-VddPaths}
 $originalGetVddState = ${function:Get-VddState}
 $originalStageVddPayload = ${function:Stage-VddPayload}
+$originalAddVddDriverPackage = ${function:Add-VddDriverPackage}
 $originalRemoveAllVddDevices = ${function:Remove-AllVddDevices}
 $originalRemoveVddRegistry = ${function:Remove-VddRegistry}
 $originalCleanupVddPackages = ${function:Cleanup-VddPackages}
 $originalSetVddConfiguration = ${function:Set-VddConfiguration}
 $originalInstallVddDevice = ${function:Install-VddDevice}
+$originalRestoreVddDevice = ${function:Restore-VddDevice}
+$originalSaveVddTransaction = ${function:Save-VddTransaction}
+$originalClearVddTransaction = ${function:Clear-VddTransaction}
 try {
     function Resolve-VddPayload {
         return [pscustomobject]@{
@@ -409,7 +465,10 @@ try {
             BuildNumber = 22000
             DriverDir = $PSScriptRoot
             ConfigSource = $HelperScript
-            Paths = [pscustomobject]@{ Nefcon = $HelperScript }
+            Paths = [pscustomobject]@{
+                Nefcon = $HelperScript
+                ConfigDir = $PSScriptRoot
+            }
         }
     }
     function Get-VddPaths {
@@ -420,48 +479,102 @@ try {
     }
     function Get-VddState {
         return [pscustomobject]@{
+            Devices = @($script:workflowDevices)
             BundledVersion = '100.0.16.6'
             Decision = $script:workflowDecision
         }
     }
     function Stage-VddPayload { $script:workflowCalls += 'Stage' }
+    function Add-VddDriverPackage {
+        $script:workflowCalls += 'Package'
+        if ($script:failWorkflowPackage) {
+            throw 'simulated package validation failure'
+        }
+    }
     function Remove-AllVddDevices { $script:workflowCalls += 'Remove' }
     function Remove-VddRegistry { $script:workflowCalls += 'Registry' }
     function Cleanup-VddPackages([string] $ExpectedVersion = '') {
         $script:workflowCalls += "Cleanup:$ExpectedVersion"
     }
     function Set-VddConfiguration { $script:workflowCalls += 'Configure' }
-    function Install-VddDevice { $script:workflowCalls += 'Install' }
+    function Install-VddDevice {
+        $script:workflowCalls += 'Install'
+        if ($script:failWorkflowInstall) {
+            throw 'simulated install failure'
+        }
+    }
+    function Restore-VddDevice { $script:workflowCalls += 'Restore' }
+    function Save-VddTransaction { $script:workflowCalls += 'Journal' }
+    function Clear-VddTransaction { $script:workflowCalls += 'Clear' }
 
     $script:workflowCalls = @()
+    $script:workflowDevices = @(New-TestDevice '100.0.16.6')
+    $script:failWorkflowInstall = $false
+    $script:failWorkflowPackage = $false
     $script:workflowDecision = [pscustomobject]@{
         DeviceCount = 1
         CleanupRequired = 0
         InstallRequired = 0
+        HealthyExisting = 1
         CurrentVersion = '100.0.16.6'
         CurrentStatus = 'OK'
         CurrentInf = 'oem42.inf'
     }
     Invoke-VddInstall $PSScriptRoot 'Run'
-    Assert-Equal 'Stage,Cleanup:100.0.16.6,Configure' ($script:workflowCalls -join ',') `
+    Assert-Equal 'Stage,Configure,Cleanup:100.0.16.6' ($script:workflowCalls -join ',') `
         'A healthy matching device must keep its package and skip reinstall.'
 
     $script:workflowCalls = @()
+    $script:workflowDevices = @(New-TestDevice '100.0.16.5' 'OK' 'oem40.inf')
     $script:workflowDecision = [pscustomobject]@{
         DeviceCount = 1
         CleanupRequired = 1
         InstallRequired = 1
+        HealthyExisting = 1
         CurrentVersion = '100.0.16.5'
         CurrentStatus = 'OK'
         CurrentInf = 'oem40.inf'
     }
     Invoke-VddInstall $PSScriptRoot 'Run'
-    Assert-Equal 'Stage,Remove,Registry,Cleanup:,Configure,Install' ($script:workflowCalls -join ',') `
-        'An upgrade must remove, prune, configure, and install in order.'
+    Assert-Equal 'Stage,Configure,Package,Journal,Remove,Install,Clear,Cleanup:100.0.16.6' ($script:workflowCalls -join ',') `
+        'An upgrade must stage the replacement before removing the working device and prune only after verification.'
+
+    $script:workflowCalls = @()
+    Invoke-VddInstall $PSScriptRoot 'Run' -PreserveHealthyExisting
+    Assert-Equal 'Stage,Configure' ($script:workflowCalls -join ',') `
+        'An unattended upgrade must preserve a healthy mismatched driver for later GUI maintenance.'
+
+    $script:workflowCalls = @()
+    $script:failWorkflowPackage = $true
+    $packageValidationFailed = $false
+    try {
+        Invoke-VddInstall $PSScriptRoot 'Run'
+    }
+    catch {
+        $packageValidationFailed = $_.Exception.Message -like '*simulated package validation failure*'
+    }
+    Assert-Equal $true $packageValidationFailed 'A rejected replacement package must abort the update.'
+    Assert-Equal 'Stage,Configure,Package' ($script:workflowCalls -join ',') `
+        'A rejected replacement package must not remove the working VDD.'
+    $script:failWorkflowPackage = $false
+
+    $script:workflowCalls = @()
+    $script:failWorkflowInstall = $true
+    $installFailed = $false
+    try {
+        Invoke-VddInstall $PSScriptRoot 'Run'
+    }
+    catch {
+        $installFailed = $_.Exception.Message -like '*simulated install failure*'
+    }
+    Assert-Equal $true $installFailed 'A failed driver replacement must report the original failure.'
+    Assert-Equal 'Stage,Configure,Package,Journal,Remove,Install,Restore,Clear' ($script:workflowCalls -join ',') `
+        'A failed driver replacement must restore the previous healthy driver.'
+    $script:failWorkflowInstall = $false
 
     $script:workflowCalls = @()
     Invoke-VddUninstall $PSScriptRoot
-    Assert-Equal 'Remove,Cleanup:,Registry' ($script:workflowCalls -join ',') `
+    Assert-Equal 'Remove,Cleanup:,Clear,Registry' ($script:workflowCalls -join ',') `
         'Uninstall must remove devices before packages and always clean the registry.'
 }
 finally {
@@ -469,13 +582,20 @@ finally {
     ${function:Get-VddPaths} = $originalGetVddPaths
     ${function:Get-VddState} = $originalGetVddState
     ${function:Stage-VddPayload} = $originalStageVddPayload
+    ${function:Add-VddDriverPackage} = $originalAddVddDriverPackage
     ${function:Remove-AllVddDevices} = $originalRemoveAllVddDevices
     ${function:Remove-VddRegistry} = $originalRemoveVddRegistry
     ${function:Cleanup-VddPackages} = $originalCleanupVddPackages
     ${function:Set-VddConfiguration} = $originalSetVddConfiguration
     ${function:Install-VddDevice} = $originalInstallVddDevice
+    ${function:Restore-VddDevice} = $originalRestoreVddDevice
+    ${function:Save-VddTransaction} = $originalSaveVddTransaction
+    ${function:Clear-VddTransaction} = $originalClearVddTransaction
     Remove-Variable -Name workflowCalls -Scope Script -ErrorAction SilentlyContinue
     Remove-Variable -Name workflowDecision -Scope Script -ErrorAction SilentlyContinue
+    Remove-Variable -Name workflowDevices -Scope Script -ErrorAction SilentlyContinue
+    Remove-Variable -Name failWorkflowInstall -Scope Script -ErrorAction SilentlyContinue
+    Remove-Variable -Name failWorkflowPackage -Scope Script -ErrorAction SilentlyContinue
 }
 
 $results | Format-Table -AutoSize

--- a/src_assets/windows/misc/vdd/vdd-device-helper.ps1
+++ b/src_assets/windows/misc/vdd/vdd-device-helper.ps1
@@ -6,7 +6,9 @@ param(
     [ValidateSet('Run', 'ProbeOnly', 'ResolveOnly')]
     [string] $Mode = 'Run',
 
-    [string] $ScriptDirectory
+    [string] $ScriptDirectory,
+
+    [switch] $PreserveHealthyExisting
 )
 
 $ErrorActionPreference = 'Stop'
@@ -25,6 +27,7 @@ $crNoSuchDevnode = 0x0000000D
 $deviceTimeoutSeconds = 120
 $targetedRemovalTimeoutSeconds = 10
 $win32ErrorTimeout = 1460
+$requiredDriverFiles = @('ZakoVDD.inf', 'ZakoVDD.dll', 'zakovdd.cat', 'ZakoVDD.cer')
 
 function Initialize-CfgMgr32 {
     if ('SunshineVddCfgMgr32' -as [type]) {
@@ -178,18 +181,24 @@ function Get-BundledVersion([string] $Path) {
     return ($driverVer -split ',')[-1].Trim()
 }
 
+function Test-VddDeviceReady([object] $Device, [string] $ExpectedVersion = '') {
+    return [bool]($Device -and
+        $Device.Status -eq 'OK' -and
+        $Device.InfName -match '(?i)^oem\d+\.inf$' -and
+        (-not $ExpectedVersion -or $Device.Version -eq $ExpectedVersion))
+}
+
 function Get-VddDecision([object[]] $Devices, [string] $BundledVersion) {
     $deviceList = @($Devices)
     $device = if ($deviceList.Count -eq 1) { $deviceList[0] } else { $null }
-    $isReady = $device -and
-        $device.Status -eq 'OK' -and
-        $device.Version -eq $BundledVersion -and
-        $device.InfName -match '(?i)^oem\d+\.inf$'
+    $isHealthy = Test-VddDeviceReady $device
+    $isReady = Test-VddDeviceReady $device $BundledVersion
 
     return [pscustomobject]@{
         DeviceCount = $deviceList.Count
         CleanupRequired = [int]($deviceList.Count -gt 0 -and -not $isReady)
         InstallRequired = [int](-not $isReady)
+        HealthyExisting = [int]$isHealthy
         CurrentVersion = $(if ($device) { $device.Version } else { '' })
         CurrentStatus = $(if ($device) { $device.Status } else { '' })
         CurrentInf = $(if ($device) { $device.InfName } else { '' })
@@ -468,9 +477,7 @@ function Cleanup-VddPackages([string] $ExpectedVersion = '') {
 
     if ($ExpectedVersion) {
         if ($devices.Count -ne 1 -or
-            $devices[0].Status -ne 'OK' -or
-            $devices[0].Version -ne $ExpectedVersion -or
-            $devices[0].InfName -notmatch '(?i)^oem\d+\.inf$') {
+            -not (Test-VddDeviceReady $devices[0] $ExpectedVersion)) {
             throw 'Refusing to keep a package without exactly one ready VDD device at the expected version.'
         }
         $keepInfName = $devices[0].InfName
@@ -497,6 +504,16 @@ function Cleanup-VddPackages([string] $ExpectedVersion = '') {
 }
 
 function Stage-VddPayload([object] $Payload) {
+    foreach ($fileName in $requiredDriverFiles) {
+        $sourcePath = Join-Path $Payload.DriverDir $fileName
+        if (-not (Test-Path -LiteralPath $sourcePath)) {
+            throw "Required VDD payload file is unavailable: $sourcePath"
+        }
+    }
+    if (-not (Test-Path -LiteralPath $Payload.Paths.Nefcon)) {
+        throw "Required VDD installer file is unavailable: $($Payload.Paths.Nefcon)"
+    }
+
     $destination = $Payload.Paths.Dist
     if (Test-Path -LiteralPath $destination) {
         $preservedNefcon = [IO.Path]::GetFullPath($Payload.Paths.Nefcon)
@@ -513,14 +530,15 @@ function Stage-VddPayload([object] $Payload) {
     foreach ($file in @(Get-ChildItem -LiteralPath $Payload.DriverDir -File)) {
         Copy-Item -LiteralPath $file.FullName -Destination $destination -Force
     }
-    if (-not (Test-Path -LiteralPath (Join-Path $destination 'ZakoVDD.inf'))) {
-        throw "Failed to stage the VDD payload in $destination"
+    foreach ($fileName in $requiredDriverFiles) {
+        if (-not (Test-Path -LiteralPath (Join-Path $destination $fileName))) {
+            throw "Failed to stage the VDD payload in $destination"
+        }
     }
 }
 
-function Remove-VddRegistry([switch] $All) {
-    $subKey = if ($All) { 'SOFTWARE\ZakoTech' } else { 'SOFTWARE\ZakoTech\ZakoDisplayAdapter' }
-    [Microsoft.Win32.Registry]::LocalMachine.DeleteSubKeyTree($subKey, $false)
+function Remove-VddRegistry {
+    [Microsoft.Win32.Registry]::LocalMachine.DeleteSubKeyTree('SOFTWARE\ZakoTech', $false)
 }
 
 function Set-VddConfiguration([object] $Payload) {
@@ -546,11 +564,10 @@ function Set-VddConfiguration([object] $Payload) {
     }
 }
 
-function Install-VddDevice([object] $Payload, [string] $ExpectedVersion) {
+function Add-VddDriverPackage([object] $Payload) {
     $certificate = Join-Path $Payload.Paths.Dist 'ZakoVDD.cer'
     $inf = Join-Path $Payload.Paths.Dist 'ZakoVDD.inf'
-    $nefcon = $Payload.Paths.Nefcon
-    foreach ($requiredPath in @($certificate, $inf, $nefcon)) {
+    foreach ($requiredPath in @($certificate, $inf)) {
         if (-not (Test-Path -LiteralPath $requiredPath)) {
             throw "Required VDD installer file is unavailable: $requiredPath"
         }
@@ -570,9 +587,20 @@ function Install-VddDevice([object] $Payload, [string] $ExpectedVersion) {
     if ($pnputilExitCode -eq 3010) {
         Write-Output 'VDD driver package staged; Windows reports that a reboot is required.'
     }
+}
+
+function Install-VddDeviceFromInf(
+    [string] $NefconPath,
+    [string] $InfPath,
+    [string] $ExpectedVersion) {
+    foreach ($requiredPath in @($NefconPath, $InfPath)) {
+        if (-not (Test-Path -LiteralPath $requiredPath)) {
+            throw "Required VDD installer file is unavailable: $requiredPath"
+        }
+    }
 
     Write-Output 'Creating VDD adapter...'
-    & $nefcon `
+    & $NefconPath `
         --create-device-node `
         --hardware-id $hardwareId `
         --service-name $serviceName `
@@ -582,7 +610,7 @@ function Install-VddDevice([object] $Payload, [string] $ExpectedVersion) {
         throw "Failed to create the VDD device node (exit code $LASTEXITCODE)."
     }
 
-    & $nefcon --install-driver --inf-path $inf
+    & $NefconPath --install-driver --inf-path $InfPath
     if ($LASTEXITCODE -ne 0) {
         throw "Failed to bind the VDD driver (exit code $LASTEXITCODE)."
     }
@@ -590,15 +618,116 @@ function Install-VddDevice([object] $Payload, [string] $ExpectedVersion) {
     if (-not (Wait-Until {
         $devices = @(Get-VddDevices)
         $devices.Count -eq 1 -and
-            $devices[0].Status -eq 'OK' -and
-            $devices[0].Version -eq $ExpectedVersion -and
-            $devices[0].InfName -match '(?i)^oem\d+\.inf$'
+            (Test-VddDeviceReady $devices[0] $ExpectedVersion)
     } $deviceTimeoutSeconds)) {
         throw "VDD did not become ready at version $ExpectedVersion."
     }
 }
 
-function Invoke-VddInstall([string] $Directory, [string] $InstallMode) {
+function Install-VddDevice([object] $Payload, [string] $ExpectedVersion) {
+    Install-VddDeviceFromInf `
+        $Payload.Paths.Nefcon `
+        (Join-Path $Payload.Paths.Dist 'ZakoVDD.inf') `
+        $ExpectedVersion
+}
+
+function Restore-VddDevice([object] $Payload, [object] $PreviousDevice) {
+    $previousInf = Join-Path (Join-Path $env:SystemRoot 'INF') $PreviousDevice.InfName
+    if (-not (Test-Path -LiteralPath $previousInf)) {
+        throw "Previous VDD package is unavailable: $previousInf"
+    }
+
+    $devices = @(Get-VddDevices)
+    $previousDeviceStillReady = $devices.Count -eq 1 -and
+        (Test-VddDeviceReady $devices[0] $PreviousDevice.Version) -and
+        $devices[0].InfName -ieq $PreviousDevice.InfName
+    if (-not $previousDeviceStillReady) {
+        if ($devices.Count -gt 0) {
+            Remove-AllVddDevices $Payload.Paths.Nefcon
+        }
+        Write-Output "Restoring previous VDD version $($PreviousDevice.Version)..."
+        Install-VddDeviceFromInf `
+            $Payload.Paths.Nefcon `
+            $previousInf `
+            $PreviousDevice.Version
+    }
+
+    try {
+        Cleanup-VddPackages $PreviousDevice.Version
+    }
+    catch {
+        Write-Warning "Previous VDD was restored, but staged package cleanup failed: $($_.Exception.Message)"
+    }
+}
+
+function Get-VddTransactionPath([object] $Payload) {
+    return Join-Path $Payload.Paths.ConfigDir 'vdd-driver-update.json'
+}
+
+function Save-VddTransaction([object] $Payload, [object] $PreviousDevice) {
+    [void] [IO.Directory]::CreateDirectory($Payload.Paths.ConfigDir)
+    $transactionPath = Get-VddTransactionPath $Payload
+    $temporaryPath = "$transactionPath.$([Guid]::NewGuid().ToString('N')).tmp"
+    try {
+        [pscustomobject]@{
+            Version = 1
+            PreviousVersion = [string] $PreviousDevice.Version
+            PreviousInf = [string] $PreviousDevice.InfName
+        } | ConvertTo-Json | Set-Content -LiteralPath $temporaryPath -Encoding UTF8
+        Move-Item -LiteralPath $temporaryPath -Destination $transactionPath -Force
+    }
+    finally {
+        Remove-Item -LiteralPath $temporaryPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Clear-VddTransaction([object] $Payload) {
+    Remove-Item -LiteralPath (Get-VddTransactionPath $Payload) -Force -ErrorAction SilentlyContinue
+}
+
+function Recover-VddTransaction([object] $Payload, [string] $BundledVersion) {
+    $transactionPath = Get-VddTransactionPath $Payload
+    if (-not (Test-Path -LiteralPath $transactionPath)) {
+        return
+    }
+
+    try {
+        $transaction = Get-Content -LiteralPath $transactionPath -Raw | ConvertFrom-Json
+    }
+    catch {
+        throw "Cannot read the pending VDD update transaction: $($_.Exception.Message)"
+    }
+    if ($transaction.Version -ne 1 -or
+        -not $transaction.PreviousVersion -or
+        $transaction.PreviousInf -notmatch '(?i)^oem\d+\.inf$') {
+        throw 'The pending VDD update transaction is invalid; refusing to modify the driver.'
+    }
+
+    $devices = @(Get-VddDevices)
+    $readyDevice = if ($devices.Count -eq 1 -and
+        (Test-VddDeviceReady $devices[0])) {
+        $devices[0]
+    }
+    if ($readyDevice) {
+        if ($readyDevice.Version -in @($BundledVersion, $transaction.PreviousVersion)) {
+            Clear-VddTransaction $Payload
+            return
+        }
+        throw 'A pending VDD update exists, but a different healthy driver is active; refusing automatic recovery.'
+    }
+
+    Write-Output 'Recovering an interrupted VDD driver update...'
+    Restore-VddDevice $Payload ([pscustomobject]@{
+        Version = [string] $transaction.PreviousVersion
+        InfName = [string] $transaction.PreviousInf
+    })
+    Clear-VddTransaction $Payload
+}
+
+function Invoke-VddInstall(
+    [string] $Directory,
+    [string] $InstallMode,
+    [switch] $PreserveHealthyExisting) {
     $payload = Resolve-VddPayload $Directory $env:VDD_TEST_WIN_BUILD
     if ($null -ne $payload.BuildNumber) {
         Write-Output "Detected Windows build: $($payload.BuildNumber)"
@@ -617,6 +746,11 @@ function Invoke-VddInstall([string] $Directory, [string] $InstallMode) {
     }
 
     $state = Get-VddState (Join-Path $payload.DriverDir 'ZakoVDD.inf')
+    if ($InstallMode -eq 'Run' -and
+        (Test-Path -LiteralPath (Get-VddTransactionPath $payload))) {
+        Recover-VddTransaction $payload $state.BundledVersion
+        $state = Get-VddState (Join-Path $payload.DriverDir 'ZakoVDD.inf')
+    }
     $decision = $state.Decision
     Write-Output "Existing VDD devices: $($decision.DeviceCount)"
     if ($decision.CurrentVersion) { Write-Output "Installed VDD version: $($decision.CurrentVersion)" }
@@ -643,23 +777,65 @@ function Invoke-VddInstall([string] $Directory, [string] $InstallMode) {
     }
 
     Stage-VddPayload $payload
-    if ($decision.CleanupRequired) {
-        Remove-AllVddDevices $payload.Paths.Nefcon
-        Remove-VddRegistry
+    Set-VddConfiguration $payload
+
+    if ($PreserveHealthyExisting -and
+        $decision.InstallRequired -and
+        $decision.HealthyExisting) {
+        Write-Output 'A healthy VDD is already active; deferring the bundled driver update.'
+        Write-Output 'VDD_DRIVER_UPDATE_DEFERRED=1'
+        return
     }
 
     if ($decision.InstallRequired) {
-        Write-Output 'Removing superseded VDD driver packages before installation...'
-        Cleanup-VddPackages
+        # Validate the signed package with Windows before touching the working
+        # device, and retain its OEM INF until the replacement is verified.
+        Add-VddDriverPackage $payload
+
+        $previousDevice = if ($decision.HealthyExisting) { $state.Devices[0] } else { $null }
+        if ($previousDevice) {
+            Save-VddTransaction $payload $previousDevice
+        }
+        try {
+            if ($decision.CleanupRequired) {
+                Remove-AllVddDevices $payload.Paths.Nefcon
+            }
+            Install-VddDevice $payload $state.BundledVersion
+            if ($previousDevice) {
+                Clear-VddTransaction $payload
+            }
+        }
+        catch {
+            $installFailure = $_
+            if ($previousDevice) {
+                try {
+                    Restore-VddDevice $payload $previousDevice
+                    Clear-VddTransaction $payload
+                    Write-Warning 'The VDD update failed; the previous working driver was restored.'
+                }
+                catch {
+                    throw "$($installFailure.Exception.Message) Rollback also failed: $($_.Exception.Message)"
+                }
+            }
+            throw $installFailure
+        }
+
+        try {
+            Write-Output 'Pruning superseded VDD driver packages...'
+            Cleanup-VddPackages $state.BundledVersion
+        }
+        catch {
+            Write-Warning "VDD is ready, but stale package cleanup failed: $($_.Exception.Message)"
+        }
     }
     else {
-        Write-Output 'Pruning stale VDD driver packages...'
-        Cleanup-VddPackages $state.BundledVersion
-    }
-
-    Set-VddConfiguration $payload
-    if ($decision.InstallRequired) {
-        Install-VddDevice $payload $state.BundledVersion
+        try {
+            Write-Output 'Pruning stale VDD driver packages...'
+            Cleanup-VddPackages $state.BundledVersion
+        }
+        catch {
+            Write-Warning "The active VDD is ready, but stale package cleanup failed: $($_.Exception.Message)"
+        }
     }
     Write-Output 'VDD installation completed.'
 }
@@ -688,7 +864,8 @@ function Invoke-VddUninstall([string] $Directory) {
     }
 
     Write-Output 'Cleaning VDD files and registry...'
-    Remove-VddRegistry -All
+    Clear-VddTransaction ([pscustomobject]@{ Paths = $paths })
+    Remove-VddRegistry
     if (Test-Path -LiteralPath $paths.Dist) {
         Remove-Item -LiteralPath $paths.Dist -Recurse -Force
     }
@@ -700,7 +877,7 @@ function Invoke-VddUninstall([string] $Directory) {
 
 function Invoke-VddDeviceHelper {
     switch ($Action) {
-        'Install' { Invoke-VddInstall $ScriptDirectory $Mode }
+        'Install' { Invoke-VddInstall $ScriptDirectory $Mode -PreserveHealthyExisting:$PreserveHealthyExisting }
         'Uninstall' { Invoke-VddUninstall $ScriptDirectory }
         default { throw 'Action is required.' }
     }


### PR DESCRIPTION
## 改了啥呀

- 安装器升级时，如果现有 VDD 健康但版本不同，保留当前驱动并让 GUI 提示用户主动修复。
- 主动修复时先验证并暂存新驱动包，再切换设备；新驱动确认可用后才清理旧 OEM INF。
- 记录一个很小的更新事务：普通失败立即恢复旧驱动，进程中断后下次安装也会先完成恢复。
- 统一健康设备判断，探测、等待、回滚和包清理使用同一套条件。
- 不恢复已经废弃的 named pipe 通道。

## 为啥要改

旧流程会先删除设备和旧驱动包，再验证并安装新包。升级过程中只要旧驱动卸载变慢、包验证失败或设备创建失败，就可能把原本可用的 VDD 直接折腾没啦，杂鱼失败路径还不给退路。

新驱动删除 named pipe 能解决后续版本的卸载问题，但第一次升级卸载的仍然是已安装的旧驱动。因此无人值守升级先保留健康旧版本，用户主动维护时再执行可恢复的切换。

## 用户体验

- Sunshine 自动升级不会因为 VDD 版本不同而中断现有可用驱动。
- 设置页仍会显示版本不一致，并保留“安装 / 修复驱动”入口。
- 手动修复失败时优先回到升级前的可用版本，而不是留下无设备状态。
- 新装、损坏设备和重复设备仍沿用现有协调流程。

## 验证

- `src_assets/windows/misc/vdd/smoke-test-vdd-device-helper.ps1`
- `src_assets/windows/misc/vdd/smoke-test-install-vdd-selection.ps1`
- Windows PowerShell AST 语法解析
- `git diff --check origin/master`
- 本机只读 ProbeOnly 验证健康但版本不一致状态

烟雾测试覆盖新包验证失败不删除旧设备、安装失败回滚、事务中断恢复、已完成事务收尾，以及检测到其他健康版本时拒绝自动覆盖。

尚未在本 PR 阶段执行真实驱动替换，避免未经确认中断本机显示环境。
