### PR TITLE
feat(vdd): advertise host capability

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -69,6 +69,8 @@ set(SUNSHINE_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/display_device/settings.h"
         "${CMAKE_SOURCE_DIR}/src/display_device/to_string.cpp"
         "${CMAKE_SOURCE_DIR}/src/display_device/to_string.h"
+        "${CMAKE_SOURCE_DIR}/src/display_device/vdd_capability.cpp"
+        "${CMAKE_SOURCE_DIR}/src/display_device/vdd_capability.h"
         "${CMAKE_SOURCE_DIR}/src/display_device/vdd_utils.cpp"
         "${CMAKE_SOURCE_DIR}/src/display_device/vdd_utils.h"
         "${CMAKE_SOURCE_DIR}/src/display_device/vdd_ioctl.cpp"

--- a/src/display_device/vdd_capability.cpp
+++ b/src/display_device/vdd_capability.cpp
@@ -1,0 +1,41 @@
+#include "vdd_capability.h"
+
+#ifdef _WIN32
+  #include "vdd_utils.h"
+#endif
+
+namespace display_device::vdd_capability {
+
+  state_e
+  query_state() {
+#ifndef _WIN32
+    return state_e::unsupported_platform;
+#else
+    const auto status = vdd_utils::get_vdd_status();
+    if (!status.installed) {
+      return state_e::driver_missing;
+    }
+    if (status.is_usable() && status.control_available) {
+      return state_e::ready;
+    }
+    return state_e::driver_unreachable;
+#endif
+  }
+
+  std::string_view
+  to_string(state_e state) {
+    switch (state) {
+      case state_e::ready:
+        return "ready";
+      case state_e::driver_missing:
+        return "driver_missing";
+      case state_e::driver_unreachable:
+        return "driver_unreachable";
+      case state_e::unsupported_platform:
+        return "unsupported_platform";
+    }
+
+    return "driver_unreachable";
+  }
+
+}  // namespace display_device::vdd_capability

--- a/src/display_device/vdd_capability.h
+++ b/src/display_device/vdd_capability.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <string_view>
+
+namespace display_device::vdd_capability {
+
+  inline constexpr int capability_version = 1;
+
+  enum class state_e {
+    ready,
+    driver_missing,
+    driver_unreachable,
+    unsupported_platform,
+  };
+
+  /**
+   * Return the current host-side VDD readiness without creating or destroying
+   * a virtual display.
+   */
+  state_e
+  query_state();
+
+  std::string_view
+  to_string(state_e state);
+
+}  // namespace display_device::vdd_capability

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -34,6 +34,7 @@
 #include "config.h"
 #include "confighttp.h"
 #include "display_device/session.h"
+#include "display_device/vdd_capability.h"
 #include "file_handler.h"
 #include "file_mapping/file_mapping_http.h"
 #include "file_mapping/service.h"
@@ -532,6 +533,12 @@ namespace nvhttp {
 
     // AI capability: inform client if AI proxy is available
     tree.put("root.AiCapability", confighttp::isAiEnabled() ? 1 : 0);
+
+#ifdef _WIN32
+    tree.put("root.VddCapabilityVersion", display_device::vdd_capability::capability_version);
+#else
+    tree.put("root.VddCapabilityVersion", 0);
+#endif
 
     std::ostringstream data;
 

--- a/src/nvhttp/display_control.cpp
+++ b/src/nvhttp/display_control.cpp
@@ -11,6 +11,7 @@
 #include "url_utils.h"
 #include "src/config.h"
 #include "src/display_device/display_device.h"
+#include "src/display_device/vdd_capability.h"
 #include "src/logging.h"
 #include "src/platform/common.h"
 
@@ -104,6 +105,16 @@ namespace nvhttp::display_control {
 
       response_json["displays"] = std::move(displays_array);
       response_json["count"] = static_cast<int>(display_names.size());
+
+      const auto vdd_state = display_device::vdd_capability::query_state();
+      response_json["vdd"] = {
+#ifdef _WIN32
+        { "capability_version", display_device::vdd_capability::capability_version },
+#else
+        { "capability_version", 0 },
+#endif
+        { "state", display_device::vdd_capability::to_string(vdd_state) }
+      };
     }
     catch (const std::exception &e) {
       BOOST_LOG(error) << "Error getting display list: " << e.what();

--- a/src/nvhttp_stream_start.cpp
+++ b/src/nvhttp_stream_start.cpp
@@ -16,6 +16,7 @@
 #include "config.h"
 #include "display_device/parsed_config.h"
 #include "display_device/session.h"
+#include "display_device/vdd_capability.h"
 #include "globals.h"
 #include "logging.h"
 #include "video.h"
@@ -255,6 +256,58 @@ namespace nvhttp::stream_start {
     }
 
     bool
+    validate_explicit_vdd_request(pt::ptree &tree, const rtsp_stream::launch_session_t &launch_session) {
+      if (!explicit_vdd_requested_for_launch(launch_session)) {
+        return true;
+      }
+
+      const auto state = display_device::vdd_capability::query_state();
+      using state_e = display_device::vdd_capability::state_e;
+      switch (state) {
+        case state_e::ready:
+          return true;
+        case state_e::unsupported_platform:
+          set_sunshine_error(
+            tree,
+            501,
+            "Virtual display streaming is not supported on this host.",
+            "VDD_NOT_SUPPORTED",
+            "Use a physical display or install a Sunshine build with VDD support.",
+            "use_physical_display",
+            "display",
+            "vdd_preflight",
+            false);
+          return false;
+        case state_e::driver_missing:
+          set_sunshine_error(
+            tree,
+            503,
+            "The virtual display driver is not installed or not running.",
+            "VDD_DRIVER_MISSING",
+            "Install or repair ZakoVDD, then try again.",
+            "repair_vdd_driver",
+            "display",
+            "vdd_preflight",
+            true);
+          return false;
+        case state_e::driver_unreachable:
+          set_sunshine_error(
+            tree,
+            503,
+            "The virtual display driver is currently unreachable.",
+            "VDD_DRIVER_UNREACHABLE",
+            "Restart or repair ZakoVDD, then try again.",
+            "repair_vdd_driver",
+            "display",
+            "vdd_preflight",
+            true);
+          return false;
+      }
+
+      return false;
+    }
+
+    bool
     no_operation_blocks_automatic_vdd_recovery(const rtsp_stream::launch_session_t &launch_session) {
       return display_no_operation_requested(launch_session) && !explicit_vdd_requested_for_launch(launch_session);
     }
@@ -462,6 +515,10 @@ namespace nvhttp::stream_start {
     pt::ptree &tree,
     rtsp_stream::launch_session_t &launch_session,
     bool is_reconfigure) {
+    if (!validate_explicit_vdd_request(tree, launch_session)) {
+      return false;
+    }
+
     // Display configuration can change the active capture target, so probe
     // encoders only after the display stack has settled.
     auto display_result = display_device::session_t::get().configure_display(config::video, launch_session, is_reconfigure);

--- a/tests/unit/test_vdd_safety.cpp
+++ b/tests/unit/test_vdd_safety.cpp
@@ -3,6 +3,7 @@
 #ifdef _WIN32
 
 #include "src/display_device/vdd_control_ioctl.h"
+#include "src/display_device/vdd_capability.h"
 #include "src/display_device/vdd_ioctl.h"
 #include "src/display_device/vdd_utils.h"
 #include "src/platform/windows/display_device/settings_topology.h"
@@ -52,6 +53,16 @@ namespace {
   }
 
 }  // namespace
+
+TEST(VddCapability, ExposesStableStateNames) {
+  using namespace display_device::vdd_capability;
+
+  EXPECT_EQ(to_string(state_e::ready), "ready");
+  EXPECT_EQ(to_string(state_e::driver_missing), "driver_missing");
+  EXPECT_EQ(to_string(state_e::driver_unreachable), "driver_unreachable");
+  EXPECT_EQ(to_string(state_e::unsupported_platform), "unsupported_platform");
+  EXPECT_EQ(capability_version, 1);
+}
 
 TEST(VddBaselineSafety, DetectsVddOnlyTopology) {
   using namespace display_device;


### PR DESCRIPTION
## 改了啥呀

- 在 `serverinfo` 中发布 `VddCapabilityVersion`，非 Windows 主机明确返回 `0`
- 在 `/displays` 中补充 VDD 能力版本与实时状态
- 复用现有只读 `get_vdd_status()`，统一判断驱动缺失、不可达和可用状态
- 显式请求 VDD 时先做前置检查，并返回稳定的 `sunshine_error_code`

## 为啥要改

Moonlight 之前只能假定服务端一定支持 VDD，旧版或驱动异常时会把失败拖到启动流程后面。现在能力和健康状态都由服务端明确告知，客户端不用再猜啦，杂鱼～

## 影响范围

只增加向后兼容的协议字段和显式 VDD 请求的前置校验；物理显示器启动流程不变。

## 配套客户端

- [qiin2333/moonlight-vplus#435](https://github.com/qiin2333/moonlight-vplus/pull/435)

## 验证

- Windows Release 编译命令验证通过：
  - `src/display_device/vdd_capability.cpp`
  - `src/nvhttp.cpp`
  - `src/nvhttp/display_control.cpp`
  - `src/nvhttp_stream_start.cpp`
- `git diff --check origin/master...HEAD`
- 完整 `sunshine` target 在本机仍受现有 FFmpeg 开发头缺失影响：`libavcodec/cbs_h264.h`