### PR TITLE
fix(windows): correct capture PTS and host latency

### DIFF
--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -412,6 +412,15 @@ namespace platf::dxgi {
         }
       }
 
+      if (status == capture_e::ok && img_out) {
+        // Keep the encoder-ready time separate from the producer's presentation
+        // timestamp: the former measures host processing, while the latter drives RTP PTS.
+        if (!img_out->pipeline_trace) {
+          img_out->pipeline_trace.emplace();
+        }
+        img_out->pipeline_trace->capture_ready = std::chrono::steady_clock::now();
+      }
+
       switch (status) {
         case platf::capture_e::reinit:
         case platf::capture_e::error:

--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -5,6 +5,7 @@
 #include <csignal>
 #include <filesystem>
 #include <iomanip>
+#include <limits>
 #include <set>
 #include <sstream>
 #include <vector>
@@ -2129,37 +2130,77 @@ namespace platf {
 
   namespace {
     std::chrono::nanoseconds
-    qpc_ticks_to_duration_with_scale(int64_t ticks, double nanoseconds_per_tick) {
-      return std::chrono::nanoseconds {
-        static_cast<int64_t>(static_cast<double>(ticks) * nanoseconds_per_tick)
-      };
+    qpc_tick_magnitude_to_duration(std::uint64_t tick_magnitude, bool negative, int64_t frequency) {
+      if (frequency <= 0) {
+        return {};
+      }
+
+      constexpr std::uint64_t nanoseconds_per_second = std::nano::den;
+      constexpr std::uint64_t positive_limit = std::numeric_limits<int64_t>::max();
+      constexpr std::uint64_t negative_limit = positive_limit + 1;
+      const std::uint64_t result_limit = negative ? negative_limit : positive_limit;
+      const auto unsigned_frequency = static_cast<std::uint64_t>(frequency);
+
+      const auto whole_seconds = tick_magnitude / unsigned_frequency;
+      const auto remaining_ticks = tick_magnitude % unsigned_frequency;
+      if (whole_seconds > result_limit / nanoseconds_per_second) {
+        return negative ? std::chrono::nanoseconds::min() : std::chrono::nanoseconds::max();
+      }
+
+      const auto whole_nanoseconds = whole_seconds * nanoseconds_per_second;
+      std::uint64_t remaining_nanoseconds;
+      if (remaining_ticks <= std::numeric_limits<std::uint64_t>::max() / nanoseconds_per_second) {
+        remaining_nanoseconds = remaining_ticks * nanoseconds_per_second / unsigned_frequency;
+      }
+      else {
+        // QueryPerformanceFrequency is far below this branch in practice. Keep
+        // the fallback bounded for synthetic inputs that cannot be multiplied safely.
+        remaining_nanoseconds = std::min<std::uint64_t>(
+          static_cast<std::uint64_t>(
+            static_cast<long double>(remaining_ticks) * nanoseconds_per_second /
+            static_cast<long double>(unsigned_frequency)),
+          nanoseconds_per_second - 1);
+      }
+
+      if (remaining_nanoseconds > result_limit - whole_nanoseconds) {
+        return negative ? std::chrono::nanoseconds::min() : std::chrono::nanoseconds::max();
+      }
+
+      const auto nanosecond_magnitude = whole_nanoseconds + remaining_nanoseconds;
+      if (!negative) {
+        return std::chrono::nanoseconds { static_cast<int64_t>(nanosecond_magnitude) };
+      }
+      if (nanosecond_magnitude == negative_limit) {
+        return std::chrono::nanoseconds::min();
+      }
+      return std::chrono::nanoseconds { -static_cast<int64_t>(nanosecond_magnitude) };
     }
   }  // namespace
 
   std::chrono::nanoseconds
   qpc_ticks_to_duration(int64_t ticks, int64_t frequency) {
-    if (frequency <= 0) {
-      return {};
-    }
-
-    return qpc_ticks_to_duration_with_scale(
-      ticks,
-      static_cast<double>(std::nano::den) / static_cast<double>(frequency));
+    const bool negative = ticks < 0;
+    const auto tick_magnitude = negative ?
+                                  std::uint64_t { 0 } - static_cast<std::uint64_t>(ticks) :
+                                  static_cast<std::uint64_t>(ticks);
+    return qpc_tick_magnitude_to_duration(tick_magnitude, negative, frequency);
   }
 
   std::chrono::nanoseconds
   qpc_time_difference(int64_t performance_counter1, int64_t performance_counter2) {
-    static const double nanoseconds_per_tick = []() {
-      LARGE_INTEGER frequency;
-      if (!QueryPerformanceFrequency(&frequency) || frequency.QuadPart <= 0) {
-        return 0.0;
+    static const int64_t frequency = []() {
+      LARGE_INTEGER qpc_frequency;
+      if (!QueryPerformanceFrequency(&qpc_frequency) || qpc_frequency.QuadPart <= 0) {
+        return int64_t { 0 };
       }
-      return static_cast<double>(std::nano::den) / static_cast<double>(frequency.QuadPart);
+      return qpc_frequency.QuadPart;
     }();
 
-    return qpc_ticks_to_duration_with_scale(
-      performance_counter1 - performance_counter2,
-      nanoseconds_per_tick);
+    const bool negative = performance_counter1 < performance_counter2;
+    const auto tick_magnitude = negative ?
+                                  static_cast<std::uint64_t>(performance_counter2) - static_cast<std::uint64_t>(performance_counter1) :
+                                  static_cast<std::uint64_t>(performance_counter1) - static_cast<std::uint64_t>(performance_counter2);
+    return qpc_tick_magnitude_to_duration(tick_magnitude, negative, frequency);
   }
 
   std::wstring

--- a/src/platform/windows/misc.cpp
+++ b/src/platform/windows/misc.cpp
@@ -2127,19 +2127,39 @@ namespace platf {
     return 0;
   }
 
+  namespace {
+    std::chrono::nanoseconds
+    qpc_ticks_to_duration_with_scale(int64_t ticks, double nanoseconds_per_tick) {
+      return std::chrono::nanoseconds {
+        static_cast<int64_t>(static_cast<double>(ticks) * nanoseconds_per_tick)
+      };
+    }
+  }  // namespace
+
+  std::chrono::nanoseconds
+  qpc_ticks_to_duration(int64_t ticks, int64_t frequency) {
+    if (frequency <= 0) {
+      return {};
+    }
+
+    return qpc_ticks_to_duration_with_scale(
+      ticks,
+      static_cast<double>(std::nano::den) / static_cast<double>(frequency));
+  }
+
   std::chrono::nanoseconds
   qpc_time_difference(int64_t performance_counter1, int64_t performance_counter2) {
-    auto get_frequency = []() {
+    static const double nanoseconds_per_tick = []() {
       LARGE_INTEGER frequency;
-      frequency.QuadPart = 0;
-      QueryPerformanceFrequency(&frequency);
-      return frequency.QuadPart;
-    };
-    static const double frequency = get_frequency();
-    if (frequency) {
-      return std::chrono::nanoseconds((int64_t) ((performance_counter1 - performance_counter2) * frequency / std::nano::den));
-    }
-    return {};
+      if (!QueryPerformanceFrequency(&frequency) || frequency.QuadPart <= 0) {
+        return 0.0;
+      }
+      return static_cast<double>(std::nano::den) / static_cast<double>(frequency.QuadPart);
+    }();
+
+    return qpc_ticks_to_duration_with_scale(
+      performance_counter1 - performance_counter2,
+      nanoseconds_per_tick);
   }
 
   std::wstring

--- a/src/platform/windows/misc.h
+++ b/src/platform/windows/misc.h
@@ -20,6 +20,15 @@ namespace platf {
   int64_t
   qpc_counter();
 
+  /**
+   * @brief Convert a QueryPerformanceCounter tick delta to nanoseconds.
+   * @param ticks The signed difference between two QPC readings.
+   * @param frequency The QueryPerformanceFrequency value in ticks per second.
+   * @return The equivalent signed duration, or zero if frequency is invalid.
+   */
+  std::chrono::nanoseconds
+  qpc_ticks_to_duration(int64_t ticks, int64_t frequency);
+
   std::chrono::nanoseconds
   qpc_time_difference(int64_t performance_counter1, int64_t performance_counter2);
 

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -2473,9 +2473,9 @@ namespace stream {
 
         // RTP video timestamps use the 90 kHz media clock and the original
         // capture presentation timestamp. Frames without a capture timestamp
-        // (intentional duplicates) use this frame's pacing start instead.
+        // (intentional duplicates) retain the next scheduled pacing time.
         const bool frame_is_dupe = !packet->frame_timestamp;
-        const auto presentation_time = packet->frame_timestamp.value_or(ratecontrol_frame_start);
+        const auto presentation_time = packet->frame_timestamp.value_or(ratecontrol_next_frame_start);
         const auto timestamp = video_rtp_timestamp(presentation_time, video_epoch);
 
         auto blockIndex = 0;

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -108,6 +108,15 @@ using namespace std::literals;
 
 namespace stream {
 
+  std::uint32_t
+  video_rtp_timestamp(
+    std::chrono::steady_clock::time_point presentation_time,
+    std::chrono::steady_clock::time_point epoch) {
+    using signed_rtp_tick = std::chrono::duration<std::int64_t, std::ratio<1, 90000>>;
+    return static_cast<std::uint32_t>(
+      std::chrono::round<signed_rtp_tick>(presentation_time - epoch).count());
+  }
+
   namespace {
     std::int64_t
     steady_now_ms() {
@@ -2336,40 +2345,47 @@ namespace stream {
         frame_header.lastPayloadLen = session->config.packetsize - sizeof(NV_VIDEO_PACKET);
       }
 
-      if (packet->frame_timestamp) {
+      const auto now = std::chrono::steady_clock::now();
+      auto processing_start = packet->frame_timestamp;
+      if (packet->pipeline_trace && packet->pipeline_trace->capture_ready) {
+        // Presentation time belongs to the RTP clock. Host processing starts
+        // when the captured frame is ready for conversion and encoding.
+        processing_start = packet->pipeline_trace->capture_ready;
+      }
+
+      if (processing_start) {
         auto duration_to_latency = [](const std::chrono::steady_clock::duration &duration) {
           const auto duration_us = std::chrono::duration_cast<std::chrono::microseconds>(duration).count();
           return (uint16_t) std::clamp<decltype(duration_us)>((duration_us + 50) / 100, 0, std::numeric_limits<uint16_t>::max());
         };
 
-        auto now = std::chrono::steady_clock::now();
-        uint16_t latency = duration_to_latency(now - *packet->frame_timestamp);
+        uint16_t latency = duration_to_latency(now - *processing_start);
         frame_header.frame_processing_latency = latency;
         frame_processing_latency_logger.collect_and_log(latency / 10.);
         perf::record_host_latency(session->launch_session_id, latency / 10., now);
-
-        if (packet->pipeline_trace) {
-          const auto &trace = *packet->pipeline_trace;
-          const auto elapsed_ms = [](const auto &begin, const auto &end) -> std::optional<double> {
-            if (!begin || !end) {
-              return std::nullopt;
-            }
-
-            return std::chrono::duration<double, std::milli>(*end - *begin).count();
-          };
-
-          perf::pipeline_sample_t sample;
-          sample.capture_to_convert_ms = elapsed_ms(trace.capture_ready, trace.convert_begin);
-          sample.convert_ms = elapsed_ms(trace.convert_begin, trace.convert_end);
-          sample.encode_queue_ms = elapsed_ms(trace.convert_end, trace.encode_submit);
-          sample.encode_ms = elapsed_ms(trace.encode_submit, trace.packet_ready);
-          sample.packet_to_broadcast_ms = elapsed_ms(trace.packet_ready, std::optional { now });
-          sample.total_ms = elapsed_ms(trace.capture_ready, std::optional { now });
-          perf::record_pipeline_sample(session->launch_session_id, sample, now);
-        }
       }
       else {
         frame_header.frame_processing_latency = 0;
+      }
+
+      if (packet->pipeline_trace) {
+        const auto &trace = *packet->pipeline_trace;
+        const auto elapsed_ms = [](const auto &begin, const auto &end) -> std::optional<double> {
+          if (!begin || !end) {
+            return std::nullopt;
+          }
+
+          return std::chrono::duration<double, std::milli>(*end - *begin).count();
+        };
+
+        perf::pipeline_sample_t sample;
+        sample.capture_to_convert_ms = elapsed_ms(trace.capture_ready, trace.convert_begin);
+        sample.convert_ms = elapsed_ms(trace.convert_begin, trace.convert_end);
+        sample.encode_queue_ms = elapsed_ms(trace.convert_end, trace.encode_submit);
+        sample.encode_ms = elapsed_ms(trace.encode_submit, trace.packet_ready);
+        sample.packet_to_broadcast_ms = elapsed_ms(trace.packet_ready, std::optional { now });
+        sample.total_ms = elapsed_ms(trace.capture_ready, std::optional { now });
+        perf::record_pipeline_sample(session->launch_session_id, sample, now);
       }
 
       auto fecPercentage = config::stream.fec_percentage;
@@ -2455,6 +2471,13 @@ namespace stream {
         size_t ratecontrol_frame_packets_sent = 0;
         size_t ratecontrol_group_packets_sent = 0;
 
+        // RTP video timestamps use the 90 kHz media clock and the original
+        // capture presentation timestamp. Frames without a capture timestamp
+        // (intentional duplicates) use this frame's pacing start instead.
+        const bool frame_is_dupe = !packet->frame_timestamp;
+        const auto presentation_time = packet->frame_timestamp.value_or(ratecontrol_frame_start);
+        const auto timestamp = video_rtp_timestamp(presentation_time, video_epoch);
+
         auto blockIndex = 0;
         std::for_each(fec_blocks_begin, fec_blocks_end, [&](std::string_view &current_payload) {
           auto packets = (current_payload.size() + (blocksize - 1)) / blocksize;
@@ -2499,16 +2522,6 @@ namespace stream {
           };
 
           size_t next_shard_to_send = 0;
-
-          // RTP video timestamps use a 90 KHz clock and the frame_timestamp from when the frame was captured
-          // When a timestamp isn't available (duplicate frames), the timestamp from rate control is used instead.
-          bool frame_is_dupe = false;
-          if (!packet->frame_timestamp) {
-            packet->frame_timestamp = ratecontrol_next_frame_start;
-            frame_is_dupe = true;
-          }
-          using rtp_tick = std::chrono::duration<uint32_t, std::ratio<1, 90000>>;
-          uint32_t timestamp = std::chrono::round<rtp_tick>(*packet->frame_timestamp - video_epoch).count();
 
           // set FEC info now that we know for sure what our percentage will be for this frame
           for (auto x = 0; x < shards.size(); ++x) {

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -2345,7 +2345,7 @@ namespace stream {
         frame_header.lastPayloadLen = session->config.packetsize - sizeof(NV_VIDEO_PACKET);
       }
 
-      const auto now = std::chrono::steady_clock::now();
+      const auto frame_dequeue_time = std::chrono::steady_clock::now();
       auto processing_start = packet->frame_timestamp;
       if (packet->pipeline_trace && packet->pipeline_trace->capture_ready) {
         // Presentation time belongs to the RTP clock. Host processing starts
@@ -2359,10 +2359,10 @@ namespace stream {
           return (uint16_t) std::clamp<decltype(duration_us)>((duration_us + 50) / 100, 0, std::numeric_limits<uint16_t>::max());
         };
 
-        uint16_t latency = duration_to_latency(now - *processing_start);
+        uint16_t latency = duration_to_latency(frame_dequeue_time - *processing_start);
         frame_header.frame_processing_latency = latency;
         frame_processing_latency_logger.collect_and_log(latency / 10.);
-        perf::record_host_latency(session->launch_session_id, latency / 10., now);
+        perf::record_host_latency(session->launch_session_id, latency / 10., frame_dequeue_time);
       }
       else {
         frame_header.frame_processing_latency = 0;
@@ -2383,9 +2383,9 @@ namespace stream {
         sample.convert_ms = elapsed_ms(trace.convert_begin, trace.convert_end);
         sample.encode_queue_ms = elapsed_ms(trace.convert_end, trace.encode_submit);
         sample.encode_ms = elapsed_ms(trace.encode_submit, trace.packet_ready);
-        sample.packet_to_broadcast_ms = elapsed_ms(trace.packet_ready, std::optional { now });
-        sample.total_ms = elapsed_ms(trace.capture_ready, std::optional { now });
-        perf::record_pipeline_sample(session->launch_session_id, sample, now);
+        sample.packet_to_broadcast_ms = elapsed_ms(trace.packet_ready, std::optional { frame_dequeue_time });
+        sample.total_ms = elapsed_ms(trace.capture_ready, std::optional { frame_dequeue_time });
+        perf::record_pipeline_sample(session->launch_session_id, sample, frame_dequeue_time);
       }
 
       auto fecPercentage = config::stream.fec_percentage;

--- a/src/stream.h
+++ b/src/stream.h
@@ -4,6 +4,7 @@
  */
 #pragma once
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <mutex>
 #include <string>
@@ -26,6 +27,17 @@ namespace stream {
   constexpr auto CONTROL_PORT = 10;
   constexpr auto AUDIO_STREAM_PORT = 11;
   constexpr auto MIC_STREAM_PORT = 12;  // Port for microphone streaming
+
+  /**
+   * @brief Convert a steady-clock presentation time to the 90 kHz RTP video clock.
+   *
+   * The conversion is performed with a signed intermediate so timestamps just
+   * before the epoch round correctly before the final RTP modulo-2^32 cast.
+   */
+  std::uint32_t
+  video_rtp_timestamp(
+    std::chrono::steady_clock::time_point presentation_time,
+    std::chrono::steady_clock::time_point epoch);
 
   struct session_t;
   struct config_t {

--- a/tests/unit/platform/windows/test_misc.cpp
+++ b/tests/unit/platform/windows/test_misc.cpp
@@ -6,6 +6,7 @@
 
   #include <chrono>
   #include <cstdint>
+  #include <limits>
 
   #include <src/platform/windows/misc.h>
 
@@ -30,6 +31,30 @@ TEST(WindowsQpcTiming, PreservesSubMillisecondPrecision) {
 TEST(WindowsQpcTiming, RejectsInvalidFrequency) {
   EXPECT_EQ(platf::qpc_ticks_to_duration(123, 0), 0ns);
   EXPECT_EQ(platf::qpc_ticks_to_duration(123, -1), 0ns);
+}
+
+TEST(WindowsQpcTiming, SaturatesExtremeTicksAtLowFrequency) {
+  EXPECT_EQ(platf::qpc_ticks_to_duration(2, 1), 2s);
+  EXPECT_EQ(platf::qpc_ticks_to_duration(-2, 1), -2s);
+  EXPECT_EQ(
+    platf::qpc_ticks_to_duration(std::numeric_limits<std::int64_t>::max(), 1),
+    std::chrono::nanoseconds::max());
+  EXPECT_EQ(
+    platf::qpc_ticks_to_duration(std::numeric_limits<std::int64_t>::min(), 1),
+    std::chrono::nanoseconds::min());
+}
+
+TEST(WindowsQpcTiming, SaturatesExtremeCounterDifferences) {
+  EXPECT_EQ(
+    platf::qpc_time_difference(
+      std::numeric_limits<std::int64_t>::max(),
+      std::numeric_limits<std::int64_t>::min()),
+    std::chrono::nanoseconds::max());
+  EXPECT_EQ(
+    platf::qpc_time_difference(
+      std::numeric_limits<std::int64_t>::min(),
+      std::numeric_limits<std::int64_t>::max()),
+    std::chrono::nanoseconds::min());
 }
 
 #endif

--- a/tests/unit/platform/windows/test_misc.cpp
+++ b/tests/unit/platform/windows/test_misc.cpp
@@ -1,0 +1,35 @@
+/**
+ * @file tests/unit/platform/windows/test_misc.cpp
+ * @brief Test Windows timing helpers.
+ */
+#ifdef _WIN32
+
+  #include <chrono>
+  #include <cstdint>
+
+  #include <src/platform/windows/misc.h>
+
+  #include "../../../tests_common.h"
+
+using namespace std::chrono_literals;
+
+TEST(WindowsQpcTiming, ConvertsTicksUsingTicksPerSecond) {
+  constexpr std::int64_t frequency = 10'000'000;
+
+  EXPECT_EQ(platf::qpc_ticks_to_duration(100'000, frequency), 10ms);
+  EXPECT_EQ(platf::qpc_ticks_to_duration(-100'000, frequency), -10ms);
+}
+
+TEST(WindowsQpcTiming, PreservesSubMillisecondPrecision) {
+  constexpr std::int64_t frequency = 10'000'000;
+
+  EXPECT_EQ(platf::qpc_ticks_to_duration(1, frequency), 100ns);
+  EXPECT_EQ(platf::qpc_ticks_to_duration(15, frequency), 1500ns);
+}
+
+TEST(WindowsQpcTiming, RejectsInvalidFrequency) {
+  EXPECT_EQ(platf::qpc_ticks_to_duration(123, 0), 0ns);
+  EXPECT_EQ(platf::qpc_ticks_to_duration(123, -1), 0ns);
+}
+
+#endif

--- a/tests/unit/test_stream.cpp
+++ b/tests/unit/test_stream.cpp
@@ -3,10 +3,14 @@
  * @brief Test src/stream.*
  */
 
+#include <chrono>
 #include <cstdint>
 #include <functional>
+#include <limits>
 #include <string>
 #include <vector>
+
+#include <src/stream.h>
 
 namespace stream {
   std::vector<uint8_t>
@@ -37,4 +41,20 @@ TEST(ConcatAndInsertTests, ConcatSmallStrideTest) {
   auto res = stream::concat_and_insert(1, 1, std::string_view { b1, sizeof(b1) }, std::string_view { b2, sizeof(b2) });
   auto expected = std::vector<uint8_t> { 0, 'a', 0, 'b', 0, 'c', 0, 'd', 0, 'e' };
   ASSERT_EQ(res, expected);
+}
+
+TEST(VideoRtpTimestampTests, UsesNinetyKilohertzClock) {
+  const auto epoch = std::chrono::steady_clock::time_point {};
+
+  EXPECT_EQ(stream::video_rtp_timestamp(epoch + std::chrono::seconds(1), epoch), 90'000u);
+  EXPECT_EQ(stream::video_rtp_timestamp(epoch + std::chrono::milliseconds(20), epoch), 1'800u);
+}
+
+TEST(VideoRtpTimestampTests, RoundsBeforeApplyingRtpWraparound) {
+  const auto epoch = std::chrono::steady_clock::time_point {};
+
+  EXPECT_EQ(stream::video_rtp_timestamp(epoch - std::chrono::microseconds(1), epoch), 0u);
+  EXPECT_EQ(
+    stream::video_rtp_timestamp(epoch - std::chrono::milliseconds(20), epoch),
+    std::numeric_limits<std::uint32_t>::max() - 1'799u);
 }

--- a/tests/unit/test_stream.cpp
+++ b/tests/unit/test_stream.cpp
@@ -58,3 +58,13 @@ TEST(VideoRtpTimestampTests, RoundsBeforeApplyingRtpWraparound) {
     stream::video_rtp_timestamp(epoch - std::chrono::milliseconds(20), epoch),
     std::numeric_limits<std::uint32_t>::max() - 1'799u);
 }
+
+TEST(VideoRtpTimestampTests, WrapsForwardPastUint32Max) {
+  using rtp_tick = std::chrono::duration<std::int64_t, std::ratio<1, 90'000>>;
+  const auto epoch = std::chrono::steady_clock::time_point {};
+  const auto wrap_time = epoch +
+                         std::chrono::round<std::chrono::steady_clock::duration>(
+                           rtp_tick { std::int64_t { 1 } << 32 });
+
+  EXPECT_EQ(stream::video_rtp_timestamp(wrap_time, epoch), 0u);
+}


### PR DESCRIPTION
## 改了啥呀

- 修正 Windows `QueryPerformanceCounter` tick 到纳秒的换算方向，使用带符号幅值的饱和有理数换算，避免极端 tick、极低频率及 counter 相减溢出。
- 保留 DDA/WGC/VDD 提供的真实 presentation timestamp 给 90 kHz RTP PTS，同时独立记录 `capture_ready` 作为 Host Processing Latency 起点。
- 使用有符号中间值生成 RTP 时间戳，正确处理 epoch 前时间、正向跨越 `2^32` 以及 modulo-2^32 回绕。
- 将 RTP PTS 从“每个 FEC block 计算一次”收敛为“每帧计算一次”，重复帧继续使用 rate-control 时间。
- 区分帧 dequeue 时间与 pacing-loop 的当前时间，避免同名 `now` 遮蔽。
- 增加 Windows QPC 正常、低频率、极值饱和测试，以及 RTP 90 kHz 正负向回绕测试。

## 为啥要改

原公式是 `ticks * frequency / 1e9`，量纲方向写反啦。以 Windows 常见的 10 MHz QPC 为例，真实 10 ms 会变成 1 µs——这只作用于从 `now()` 回退的 capture delay，所以这个小杂鱼 bug 长期伪装成“接近当前时间”，没有直接把整条 RTP 时间轴压缩 10,000 倍。

直接修正公式又会让历史 HPL 突然混入 presentation-to-capture 延迟。因此这里把两个语义拆开：

- RTP PTS：使用 OS producer presentation timestamp；
- HPL：使用 capture-ready 到 packet broadcast 的主机处理时间。

review 还发现浮点结果直接转 `int64_t` 在合成极端输入下可能越界。现在先以无符号幅值表达完整 counter 差，再做有界的整数商/余数换算；超出 `std::chrono::nanoseconds` 范围时按符号饱和，不再让这个边界小杂鱼钻空子。

## 影响

- Windows 捕获 PTS 能反映真实的 DDA/WGC/VDD presentation timing；90 kHz RTP 的理论量化误差仍为最多约 ±5.56 µs。
- HPL 继续表示捕获完成后的转换、编码、排队和广播前处理，不包含 DWM/捕获 API 等待。
- QPC 频率只读取一次；正常 Windows 频率走整数有理数路径，PTS 仍只在每帧计算一次。
- 极端正负 tick 和 counter 差会稳定饱和到纳秒 duration 的 `min()`/`max()`。

## 验证

- `ninja -C build tests/CMakeFiles/test_sunshine.dir/unit/platform/windows/test_misc.cpp.obj tests/CMakeFiles/test_sunshine.dir/unit/test_stream.cpp.obj tests/CMakeFiles/test_sunshine.dir/__/src/platform/windows/misc.cpp.obj tests/CMakeFiles/test_sunshine.dir/__/src/platform/windows/display_base.cpp.obj tests/CMakeFiles/test_sunshine.dir/__/src/stream.cpp.obj` ✅
- `git diff --check` ✅
- GitHub Actions `Windows` 全量构建、原生测试与打包 ✅（review-fix 提交 `3f64622`）。
- CodeRabbit 复检 ✅；两条 inline comment 均已自动标记为 Addressed。
- `cmake --build build --target test_sunshine -j 2` ⚠️ 本地仓库现有的 webhook 测试无法编译：`test_webhook.cpp` 缺少 `webhook.h`，`test_webhook_config.cpp` 引用不存在的 `config::apply_config`；本 PR 涉及的生产与测试对象均已单独编译通过。