### PR TITLE
fix(vdd): require the control interface before treating a driver as usable

### DIFF
--- a/docs/vdd-prerequisite-closure.md
+++ b/docs/vdd-prerequisite-closure.md
@@ -64,6 +64,14 @@ facts:
 derived from `state`; the backend does not need a second recommended-action
 enum.
 
+`control_available` reports whether the driver published its control interface
+(`GUID_DEVINTERFACE_ZAKO_VDD_CONTROL`). A present but silent adapter cannot be
+driven, so the fact is part of the usable invariant rather than advisory
+metadata: `is_usable()`, the Web `vddReady` computed property, and the
+installer's reconciliation decision all require it. An installed and running
+adapter that never publishes the interface classifies as `degraded` and is
+reconciled instead of being preserved as a healthy existing installation.
+
 ## Architecture
 
 ### Desktop management path

--- a/src/display_device/vdd_capability.cpp
+++ b/src/display_device/vdd_capability.cpp
@@ -15,7 +15,8 @@ namespace display_device::vdd_capability {
     if (!status.installed) {
       return state_e::driver_missing;
     }
-    if (status.is_usable() && status.control_available) {
+    // is_usable() already requires control_available.
+    if (status.is_usable()) {
       return state_e::ready;
     }
     return state_e::driver_unreachable;

--- a/src/display_device/vdd_utils.h
+++ b/src/display_device/vdd_utils.h
@@ -93,7 +93,7 @@ namespace display_device::vdd_utils {
 
     constexpr bool
     is_usable() const {
-      return installed && problem_code_valid && running;
+      return installed && problem_code_valid && running && control_available;
     }
   };
 

--- a/src_assets/common/assets/web/composables/useVddStatus.js
+++ b/src_assets/common/assets/web/composables/useVddStatus.js
@@ -51,6 +51,7 @@ export function useVddStatus() {
   const vddReady = computed(() =>
     vddStatus.value.installed &&
     vddStatus.value.running &&
+    vddStatus.value.control_available &&
     ['ready', 'degraded'].includes(vddStatus.value.state)
   )
 

--- a/src_assets/common/assets/web/tests/vddStatus.test.js
+++ b/src_assets/common/assets/web/tests/vddStatus.test.js
@@ -44,6 +44,7 @@ test('VDD status preserves real desktop version probe results', async (t) => {
         state: 'ready',
         installed: true,
         running: true,
+        control_available: true,
         installed_version: '1.2.3',
         bundled_version: '1.2.3',
         version_match: true,
@@ -77,10 +78,11 @@ test('VDD status prefers the desktop bridge and verifies installation', async (t
         state: installed ? 'ready' : 'not_installed',
         installed,
         running: installed,
+        control_available: installed,
       }),
       install: async () => {
         installed = true
-        return { state: 'ready', installed: true, running: true }
+        return { state: 'ready', installed: true, running: true, control_available: true }
       },
     },
   }
@@ -104,11 +106,16 @@ test('VDD installation cancellation keeps state visible and allows retry', async
   let attempts = 0
   globalThis.window = {
     vddDriver: {
-      getStatus: async () => ({ state: 'not_installed', installed: false, running: false }),
+      getStatus: async () => ({
+        state: 'not_installed',
+        installed: false,
+        running: false,
+        control_available: false,
+      }),
       install: async () => {
         attempts += 1
         if (attempts === 1) throw new Error('UAC request was cancelled')
-        return { state: 'ready', installed: true, running: true }
+        return { state: 'ready', installed: true, running: true, control_available: true }
       },
     },
   }
@@ -124,4 +131,28 @@ test('VDD installation cancellation keeps state visible and allows retry', async
   await vdd.installVdd()
   assert.equal(vdd.vddReady.value, true)
   assert.equal(vdd.vddStatusError.value, '')
+})
+
+test('VDD without its required control interface is not ready', async (t) => {
+  const originalWindow = globalThis.window
+  t.after(() => {
+    globalThis.window = originalWindow
+  })
+
+  globalThis.window = {
+    vddDriver: {
+      getStatus: async () => ({
+        state: 'degraded',
+        installed: true,
+        running: true,
+        control_available: false,
+      }),
+    },
+  }
+
+  const vdd = useVddStatus()
+  await vdd.refreshVddStatus()
+
+  assert.equal(vdd.vddStatus.value.state, 'degraded')
+  assert.equal(vdd.vddReady.value, false)
 })

--- a/src_assets/windows/misc/vdd/smoke-test-vdd-device-helper.ps1
+++ b/src_assets/windows/misc/vdd/smoke-test-vdd-device-helper.ps1
@@ -52,6 +52,14 @@ $cases = @(
         Install = 0
     },
     @{
+        Name = 'A matching device without its control interface is reconciled'
+        Devices = @(New-TestDevice '100.0.16.6')
+        ControlAvailable = $false
+        Count = 1
+        Cleanup = 1
+        Install = 1
+    },
+    @{
         Name = 'Version upgrade reconciles the existing device'
         Devices = @(New-TestDevice '100.0.16.5')
         Count = 1
@@ -92,10 +100,18 @@ $cases = @(
 )
 
 $results = foreach ($case in $cases) {
-    $decision = Get-VddDecision $case.Devices '100.0.16.6'
+    $controlAvailable = if ($case.ContainsKey('ControlAvailable')) {
+        [bool] $case.ControlAvailable
+    }
+    else {
+        $true
+    }
+    $decision = Get-VddDecision $case.Devices '100.0.16.6' $controlAvailable
     Assert-Equal $case.Count $decision.DeviceCount "$($case.Name): wrong device count"
     Assert-Equal $case.Cleanup $decision.CleanupRequired "$($case.Name): wrong cleanup decision"
     Assert-Equal $case.Install $decision.InstallRequired "$($case.Name): wrong install decision"
+    Assert-Equal ([int]$controlAvailable) $decision.ControlAvailable `
+        "$($case.Name): wrong control-interface decision"
 
     [pscustomobject]@{
         Case = $case.Name
@@ -516,6 +532,7 @@ try {
         CleanupRequired = 0
         InstallRequired = 0
         HealthyExisting = 1
+        ControlAvailable = 1
         CurrentVersion = '100.0.16.6'
         CurrentStatus = 'OK'
         CurrentInf = 'oem42.inf'
@@ -531,6 +548,7 @@ try {
         CleanupRequired = 1
         InstallRequired = 1
         HealthyExisting = 1
+        ControlAvailable = 1
         CurrentVersion = '100.0.16.5'
         CurrentStatus = 'OK'
         CurrentInf = 'oem40.inf'
@@ -544,6 +562,34 @@ try {
     Assert-Equal 'Stage,Configure' ($script:workflowCalls -join ',') `
         'An unattended upgrade must preserve a healthy mismatched driver for later GUI maintenance.'
 
+    $script:workflowCalls = @()
+    $script:workflowDevices = @(New-TestDevice '100.0.16.6')
+    $script:workflowDecision = [pscustomobject]@{
+        DeviceCount = 1
+        CleanupRequired = 1
+        InstallRequired = 1
+        HealthyExisting = 1
+        ControlAvailable = 0
+        CurrentVersion = '100.0.16.6'
+        CurrentStatus = 'OK'
+        CurrentInf = 'oem42.inf'
+    }
+    Invoke-VddInstall $PSScriptRoot 'Run' -PreserveHealthyExisting
+    Assert-Equal 'Stage,Configure,Package,Journal,Remove,Install,Clear,Cleanup:100.0.16.6' `
+        ($script:workflowCalls -join ',') `
+        'An unattended upgrade must repair a driver whose required control interface is missing.'
+
+    $script:workflowDevices = @(New-TestDevice '100.0.16.5' 'OK' 'oem40.inf')
+    $script:workflowDecision = [pscustomobject]@{
+        DeviceCount = 1
+        CleanupRequired = 1
+        InstallRequired = 1
+        HealthyExisting = 1
+        ControlAvailable = 1
+        CurrentVersion = '100.0.16.5'
+        CurrentStatus = 'OK'
+        CurrentInf = 'oem40.inf'
+    }
     $script:workflowCalls = @()
     $script:failWorkflowPackage = $true
     $packageValidationFailed = $false

--- a/src_assets/windows/misc/vdd/vdd-device-helper.ps1
+++ b/src_assets/windows/misc/vdd/vdd-device-helper.ps1
@@ -24,9 +24,11 @@ $deviceClassPath = 'SYSTEM\CurrentControlSet\Control\Class'
 $dnStarted = 0x00000008
 $crInvalidDevnode = 0x00000005
 $crNoSuchDevnode = 0x0000000D
+$crBufferSmall = 0x0000001A
 $deviceTimeoutSeconds = 120
 $targetedRemovalTimeoutSeconds = 10
 $win32ErrorTimeout = 1460
+$vddControlInterfaceGuid = 'DA9F8C2B-7E4F-49A1-9D4E-6F2B0E1A0C4D'
 $requiredDriverFiles = @('ZakoVDD.inf', 'ZakoVDD.dll', 'zakovdd.cat', 'ZakoVDD.cer')
 
 function Initialize-CfgMgr32 {
@@ -51,6 +53,21 @@ public static class SunshineVddCfgMgr32
         out uint status,
         out uint problemNumber,
         uint deviceInstance,
+        uint flags);
+
+    [DllImport("cfgmgr32.dll", CharSet = CharSet.Unicode)]
+    public static extern uint CM_Get_Device_Interface_List_SizeW(
+        out uint bufferLength,
+        ref Guid interfaceClassGuid,
+        string deviceInstanceId,
+        uint flags);
+
+    [DllImport("cfgmgr32.dll", CharSet = CharSet.Unicode)]
+    public static extern uint CM_Get_Device_Interface_ListW(
+        ref Guid interfaceClassGuid,
+        string deviceInstanceId,
+        [Out] char[] buffer,
+        uint bufferLength,
         uint flags);
 }
 '@
@@ -85,6 +102,42 @@ function Get-VddDeviceStatus([string] $InstanceId) {
         return [pscustomobject]@{ State = 'OK'; Problem = [int]$problem }
     }
     return [pscustomobject]@{ State = 'ERROR'; Problem = [int]$problem }
+}
+
+function Test-VddControlInterfaceAvailable(
+    [int] $Attempts = 3,
+    [int] $DelayMilliseconds = 200) {
+    Initialize-CfgMgr32
+
+    $interfaceGuid = [Guid] $vddControlInterfaceGuid
+    for ($attempt = 0; $attempt -lt [Math]::Max(1, $Attempts); $attempt++) {
+        [uint32] $bufferLength = 0
+        $sizeResult = [SunshineVddCfgMgr32]::CM_Get_Device_Interface_List_SizeW(
+            [ref] $bufferLength,
+            [ref] $interfaceGuid,
+            $null,
+            0)
+        if ($sizeResult -eq 0 -and $bufferLength -gt 1) {
+            $buffer = New-Object char[] $bufferLength
+            $listResult = [SunshineVddCfgMgr32]::CM_Get_Device_Interface_ListW(
+                [ref] $interfaceGuid,
+                $null,
+                $buffer,
+                $bufferLength,
+                0)
+            if ($listResult -eq 0 -and $buffer[0] -ne [char]0) {
+                return $true
+            }
+            if ($listResult -eq $crBufferSmall) {
+                continue
+            }
+        }
+
+        if ($attempt + 1 -lt $Attempts -and $DelayMilliseconds -gt 0) {
+            Start-Sleep -Milliseconds $DelayMilliseconds
+        }
+    }
+    return $false
 }
 
 function Get-VddDevices {
@@ -188,17 +241,21 @@ function Test-VddDeviceReady([object] $Device, [string] $ExpectedVersion = '') {
         (-not $ExpectedVersion -or $Device.Version -eq $ExpectedVersion))
 }
 
-function Get-VddDecision([object[]] $Devices, [string] $BundledVersion) {
+function Get-VddDecision(
+    [object[]] $Devices,
+    [string] $BundledVersion,
+    [bool] $ControlAvailable = $true) {
     $deviceList = @($Devices)
     $device = if ($deviceList.Count -eq 1) { $deviceList[0] } else { $null }
     $isHealthy = Test-VddDeviceReady $device
-    $isReady = Test-VddDeviceReady $device $BundledVersion
+    $isReady = (Test-VddDeviceReady $device $BundledVersion) -and $ControlAvailable
 
     return [pscustomobject]@{
         DeviceCount = $deviceList.Count
         CleanupRequired = [int]($deviceList.Count -gt 0 -and -not $isReady)
         InstallRequired = [int](-not $isReady)
         HealthyExisting = [int]$isHealthy
+        ControlAvailable = [int]$ControlAvailable
         CurrentVersion = $(if ($device) { $device.Version } else { '' })
         CurrentStatus = $(if ($device) { $device.Status } else { '' })
         CurrentInf = $(if ($device) { $device.InfName } else { '' })
@@ -303,10 +360,12 @@ function Resolve-VddPayload([string] $Directory, [string] $BuildOverride) {
 function Get-VddState([string] $InfPath) {
     $devices = @(Get-VddDevices)
     $bundledVersion = Get-BundledVersion $InfPath
+    $controlAvailable = Test-VddControlInterfaceAvailable
     return [pscustomobject]@{
         Devices = $devices
         BundledVersion = $bundledVersion
-        Decision = Get-VddDecision $devices $bundledVersion
+        ControlAvailable = $controlAvailable
+        Decision = Get-VddDecision $devices $bundledVersion $controlAvailable
     }
 }
 
@@ -592,7 +651,8 @@ function Add-VddDriverPackage([object] $Payload) {
 function Install-VddDeviceFromInf(
     [string] $NefconPath,
     [string] $InfPath,
-    [string] $ExpectedVersion) {
+    [string] $ExpectedVersion,
+    [bool] $RequireControlInterface = $true) {
     foreach ($requiredPath in @($NefconPath, $InfPath)) {
         if (-not (Test-Path -LiteralPath $requiredPath)) {
             throw "Required VDD installer file is unavailable: $requiredPath"
@@ -618,9 +678,12 @@ function Install-VddDeviceFromInf(
     if (-not (Wait-Until {
         $devices = @(Get-VddDevices)
         $devices.Count -eq 1 -and
-            (Test-VddDeviceReady $devices[0] $ExpectedVersion)
+            (Test-VddDeviceReady $devices[0] $ExpectedVersion) -and
+            (-not $RequireControlInterface -or
+                (Test-VddControlInterfaceAvailable 1 0))
     } $deviceTimeoutSeconds)) {
-        throw "VDD did not become ready at version $ExpectedVersion."
+        $readiness = if ($RequireControlInterface) { ' with its control interface' } else { '' }
+        throw "VDD did not become ready$readiness at version $ExpectedVersion."
     }
 }
 
@@ -649,7 +712,8 @@ function Restore-VddDevice([object] $Payload, [object] $PreviousDevice) {
         Install-VddDeviceFromInf `
             $Payload.Paths.Nefcon `
             $previousInf `
-            $PreviousDevice.Version
+            $PreviousDevice.Version `
+            $false
     }
 
     try {
@@ -756,6 +820,7 @@ function Invoke-VddInstall(
     if ($decision.CurrentVersion) { Write-Output "Installed VDD version: $($decision.CurrentVersion)" }
     if ($decision.CurrentStatus) { Write-Output "Installed VDD status: $($decision.CurrentStatus)" }
     if ($decision.CurrentInf) { Write-Output "Active VDD package: $($decision.CurrentInf)" }
+    Write-Output "VDD control interface available: $([bool]$decision.ControlAvailable)"
     Write-Output "Bundled VDD version: $($state.BundledVersion)"
     if ($decision.InstallRequired) {
         Write-Output 'VDD state requires reconciliation before installation.'
@@ -765,10 +830,11 @@ function Invoke-VddInstall(
     }
     if ($InstallMode -eq 'ProbeOnly') {
         $devices = @($state.Devices)
-        $decision = Get-VddDecision $devices $state.BundledVersion
+        $decision = Get-VddDecision $devices $state.BundledVersion $state.ControlAvailable
         $device = if ($decision.DeviceCount -eq 1) { $devices[0] } else { $null }
         Write-Output 'VDD_PROBE_OK=1'
         Write-Output ('VDD_DEVICE_PRESENT=' + [int]($decision.DeviceCount -gt 0))
+        Write-Output ('VDD_CONTROL_AVAILABLE=' + $decision.ControlAvailable)
         Write-Output ('CURRENT_VDD_VERSION=' + $decision.CurrentVersion)
         Write-Output ('CURRENT_VDD_STATUS=' + $decision.CurrentStatus)
         Write-Output ('CURRENT_VDD_PROBLEM=' + $(if ($device) { [int]$device.Problem } else { '' }))
@@ -781,7 +847,8 @@ function Invoke-VddInstall(
 
     if ($PreserveHealthyExisting -and
         $decision.InstallRequired -and
-        $decision.HealthyExisting) {
+        $decision.HealthyExisting -and
+        $decision.ControlAvailable) {
         Write-Output 'A healthy VDD is already active; deferring the bundled driver update.'
         Write-Output 'VDD_DRIVER_UPDATE_DEFERRED=1'
         return

--- a/tests/unit/test_vdd_prerequisite.cpp
+++ b/tests/unit/test_vdd_prerequisite.cpp
@@ -15,7 +15,7 @@ TEST(VddPrerequisiteSafety, ClassifiesEveryCoreState) {
   EXPECT_EQ(classify_vdd_state(true, true, true, true, 0), "ready");
 }
 
-TEST(VddPrerequisiteSafety, OnlyInstalledRunningDriversAreUsable) {
+TEST(VddPrerequisiteSafety, OnlyInstalledRunningDriversWithControlAreUsable) {
   display_device::vdd_utils::vdd_status_t status;
   EXPECT_FALSE(status.is_usable());
 
@@ -26,6 +26,9 @@ TEST(VddPrerequisiteSafety, OnlyInstalledRunningDriversAreUsable) {
   EXPECT_FALSE(status.is_usable());
 
   status.problem_code_valid = true;
+  EXPECT_FALSE(status.is_usable());
+
+  status.control_available = true;
   EXPECT_TRUE(status.is_usable());
 }
 
@@ -41,6 +44,9 @@ TEST(VddPrerequisiteSafety, SharesPrerequisiteClassificationAcrossCallers) {
 
   status.problem_code_valid = true;
   status.running = true;
+  EXPECT_EQ(classify_vdd_prerequisite(status), vdd_prerequisite_e::unavailable);
+
+  status.control_available = true;
   EXPECT_EQ(classify_vdd_prerequisite(status), vdd_prerequisite_e::usable);
 }
 


### PR DESCRIPTION
## Problem

An adapter can be installed, running, and free of PnP problems while never
publishing `GUID_DEVINTERFACE_ZAKO_VDD_CONTROL`. Such a driver cannot be driven
at all, but `is_usable()` and the Web `vddReady` property both reported it ready,
so callers proceeded and failed later with a generic stream error.

`control_available` already reached the status contract, the fast probe
(`vdd_ioctl::ping()`), and the `/api/vdd/status` payload — it simply was not
binding anywhere.

The subtlety is that `degraded` covers two different situations: a version
mismatch, which is still drivable and is expected to keep the editor available,
and a missing control interface, which is not. Narrowing the accepted state set
would have broken the first case, so the fact has to be checked on its own.

## Change

- `is_usable()` and the Web `vddReady` now require `control_available`.
- `vdd-device-helper.ps1` probes the interface through cfgmgr32
  (`CM_Get_Device_Interface_List`), using the same GUID as the C++ ioctl path so
  the two cannot disagree, and feeds it into the install decision — a silent
  adapter is reconciled instead of being preserved as a healthy existing
  installation.
- `vdd_capability.cpp` drops its now-redundant second check.
- `docs/vdd-prerequisite-closure.md` records that the fact is part of the usable
  invariant rather than advisory metadata.

## Verification

| Layer | Result |
| --- | --- |
| `ninja sunshine` (full link, MSYS2 UCRT64) | pass |
| `vdd_prerequisite_unit_tests` | 3/3 pass |
| `npm run test:webui` | 86/86 pass |
| `smoke-test-vdd-device-helper.ps1` | 8/8 pass |

Three cases were added, one per layer: a C++ assertion that a driver without its
control interface is not usable, a Web test that such a driver is not
`vddReady`, and a helper smoke case that it is reconciled rather than preserved.

## Scope

The desktop app owns a third copy of this gate — `VddStatus::is_usable()` plus
the `vddReady` computed properties in `VddSettings.vue` and `StreamView.vue`.
Those already require `control_available` on the control panel's `main`
(verified there: `cargo test vdd` 11 passed, `npm run build:renderer` passes), so
this PR completes the Core and browser Web UI halves and the gate is consistent
across all three surfaces.

Still open, and not addressable from a development host: the destructive
clean-host checklist at the end of `docs/vdd-prerequisite-closure.md` — install
from absent, UAC cancellation, unhealthy-adapter routing, refusal during an
active stream, and the uninstall lifecycle. `scripts/vdd_rc_smoke.ps1` refuses to
run its destructive path when `Root\ZakoVDD` is already present, so those checks
need a disposable Windows host.
