### PR TITLE
fix(input): make batch result logic consistent with comment

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1420,10 +1420,10 @@ namespace input {
     short deltaX, deltaY;
 
     // Batching is safe as long as the result doesn't overflow a 16-bit integer
-    if (!__builtin_add_overflow(util::endian::big(dest->deltaX), util::endian::big(src->deltaX), &deltaX)) {
+    if (__builtin_add_overflow(util::endian::big(dest->deltaX), util::endian::big(src->deltaX), &deltaX)) {
       return batch_result_e::terminate_batch;
     }
-    if (!__builtin_add_overflow(util::endian::big(dest->deltaY), util::endian::big(src->deltaY), &deltaY)) {
+    if (__builtin_add_overflow(util::endian::big(dest->deltaY), util::endian::big(src->deltaY), &deltaY)) {
       return batch_result_e::terminate_batch;
     }
 
@@ -1462,7 +1462,7 @@ namespace input {
     short scrollAmt;
 
     // Batching is safe as long as the result doesn't overflow a 16-bit integer
-    if (!__builtin_add_overflow(util::endian::big(dest->scrollAmt1), util::endian::big(src->scrollAmt1), &scrollAmt)) {
+    if (__builtin_add_overflow(util::endian::big(dest->scrollAmt1), util::endian::big(src->scrollAmt1), &scrollAmt)) {
       return batch_result_e::terminate_batch;
     }
 
@@ -1483,7 +1483,7 @@ namespace input {
     short scrollAmt;
 
     // Batching is safe as long as the result doesn't overflow a 16-bit integer
-    if (!__builtin_add_overflow(util::endian::big(dest->scrollAmount), util::endian::big(src->scrollAmount), &scrollAmt)) {
+    if (__builtin_add_overflow(util::endian::big(dest->scrollAmount), util::endian::big(src->scrollAmount), &scrollAmt)) {
       return batch_result_e::terminate_batch;
     }
 


### PR DESCRIPTION
## 说明

同步上游修复 [LizardByte/Sunshine#5456](https://github.com/LizardByte/Sunshine/pull/5456)。

`__builtin_add_overflow` 在发生溢出时返回 `true`。原有判断取反后，会在没有溢出时终止批处理，与注释及函数语义相反。

本 PR 修正以下批处理路径：

- 相对鼠标移动的 X/Y 增量
- 垂直滚轮增量
- 水平滚轮增量

补丁通过 `cherry-pick -x` 引入，保留上游作者和原始提交来源。

## 验证

- 已确认可无冲突应用到当前 `master`
- `git diff --check` 通过
- 未执行编译、构建或测试命令