### PR TITLE
fix(input): correct batch overflow handling

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1420,10 +1420,10 @@ namespace input {
     short deltaX, deltaY;
 
     // Batching is safe as long as the result doesn't overflow a 16-bit integer
-    if (!__builtin_add_overflow(util::endian::big(dest->deltaX), util::endian::big(src->deltaX), &deltaX)) {
+    if (__builtin_add_overflow(util::endian::big(dest->deltaX), util::endian::big(src->deltaX), &deltaX)) {
       return batch_result_e::terminate_batch;
     }
-    if (!__builtin_add_overflow(util::endian::big(dest->deltaY), util::endian::big(src->deltaY), &deltaY)) {
+    if (__builtin_add_overflow(util::endian::big(dest->deltaY), util::endian::big(src->deltaY), &deltaY)) {
       return batch_result_e::terminate_batch;
     }
 
@@ -1462,7 +1462,7 @@ namespace input {
     short scrollAmt;
 
     // Batching is safe as long as the result doesn't overflow a 16-bit integer
-    if (!__builtin_add_overflow(util::endian::big(dest->scrollAmt1), util::endian::big(src->scrollAmt1), &scrollAmt)) {
+    if (__builtin_add_overflow(util::endian::big(dest->scrollAmt1), util::endian::big(src->scrollAmt1), &scrollAmt)) {
       return batch_result_e::terminate_batch;
     }
 
@@ -1483,7 +1483,7 @@ namespace input {
     short scrollAmt;
 
     // Batching is safe as long as the result doesn't overflow a 16-bit integer
-    if (!__builtin_add_overflow(util::endian::big(dest->scrollAmount), util::endian::big(src->scrollAmount), &scrollAmt)) {
+    if (__builtin_add_overflow(util::endian::big(dest->scrollAmount), util::endian::big(src->scrollAmount), &scrollAmt)) {
       return batch_result_e::terminate_batch;
     }
 


### PR DESCRIPTION
## 改了啥呀

- 同步上游修复：[LizardByte/Sunshine#5456](https://github.com/LizardByte/Sunshine/pull/5456)
- 修正相对鼠标移动、垂直滚轮和水平滚轮合批中的 4 处溢出判断
- 仅在 16 位有符号加法真正溢出时终止合批

## 为啥要改

`__builtin_add_overflow()` 在发生溢出时返回 `true`，原代码却对结果取反了。这个小小的 `!` 把逻辑整个颠倒：正常输入无法合批，极端溢出反而可能写入回绕结果。杂鱼 bug 这次乖乖退场啦。

修复后，高频鼠标和滚轮输入可以按设计合并；发生溢出时则保留两个独立事件，避免位移或滚动量回绕。

## 验证

- `git diff --check`：通过
- 源码检查：4 处正确溢出判断，0 处残留反向判断
- 独立边界测试：正常相加、`SHRT_MAX + 1`、`SHRT_MIN - 1` 均通过
- 完整 GCC 构建未完成：本机 MSYS2 `cc1plus.exe` 启动即返回 `0xC0000139`；备用 Clang 检查被工程现有工具链/依赖兼容问题阻断，未出现由本补丁导致的诊断
