### PR TITLE
fix(webhook): address remaining review findings

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -1679,7 +1679,7 @@ namespace confighttp {
           .timestamp = webhook::get_current_timestamp(),
           .client_ip = net::addr_to_normalized_string(request->remote_endpoint().address()),
           .server_ip = net::addr_to_normalized_string(request->local_endpoint().address()),
-          .extra_data = {{"error", e.what()}}
+          .extra_data = {{"error", "invalid_request"}}
         });
       }
       catch (...) {

--- a/src/webhook/webhook_httpsclient.cpp
+++ b/src/webhook/webhook_httpsclient.cpp
@@ -147,14 +147,17 @@ namespace webhook {
   ):
       base_t(server_port_path, 443),
 #if BOOST_ASIO_VERSION >= 101300
-      context_(boost::asio::ssl::context::tls_client) {
+      context_(boost::asio::ssl::context::tls_client)
+#else
+      context_(boost::asio::ssl::context::tlsv12)
+#endif
+  {
+#if BOOST_ASIO_VERSION >= 101300
     context_.set_options(boost::asio::ssl::context::no_tlsv1);
     context_.set_options(boost::asio::ssl::context::no_tlsv1_1);
-#else
-      context_(boost::asio::ssl::context::tlsv12) {
 #endif
     if (verify_certificate) {
-#if BOOST_ASIO_VERSION >= 103300
+#if BOOST_ASIO_VERSION >= 101601
       context_.set_verify_callback(boost::asio::ssl::host_name_verification(host));
 #else
       context_.set_verify_callback(boost::asio::ssl::rfc2818_verification(host));


### PR DESCRIPTION
## 说明

跟进 Webhook 评审中确认需要处理的两项问题：

- 将 `host_name_verification` 的 Boost.Asio 版本阈值调整为 `101601`（Boost 1.73 / Asio 1.16.1），更旧版本继续使用 `rfc2818_verification`。
- 将 HTTPS client 构造函数体移出条件编译分支，避免在 `#if/#else` 中分别打开函数体。
- 配对请求解析失败时，Webhook payload 只发送稳定错误分类 `invalid_request`，不再外发解析器的 `e.what()`；详细异常仍保留在本地日志和当前 HTTP 响应中。

## 验证

- `git diff --check` 通过
- 已确认提交仅包含两个目标文件
- 未执行编译、构建或测试命令

## 关联评审

- https://github.com/AlkaidLab/foundation-sunshine/pull/848#discussion_r3653114499
- https://github.com/AlkaidLab/foundation-sunshine/pull/848#discussion_r3653114510