### PR TITLE
fix(windows): preserve large virtual mouse scroll input

### DIFF
--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -717,12 +717,16 @@ namespace platf {
           127
         );
         if (!raw.vmouse_dev->scroll(static_cast<int8_t>(notches))) {
+          raw.vmouse_vscroll_accum = 0;
           break;
         }
         raw.vmouse_vscroll_accum -= notches * WHEEL_DELTA;
       }
       return;
     }
+
+    // Do not replay stale virtual-device deltas after switching back from SendInput.
+    raw.vmouse_vscroll_accum = 0;
 
     INPUT i {};
 
@@ -748,12 +752,16 @@ namespace platf {
           127
         );
         if (!raw.vmouse_dev->hscroll(static_cast<int8_t>(notches))) {
+          raw.vmouse_hscroll_accum = 0;
           break;
         }
         raw.vmouse_hscroll_accum -= notches * WHEEL_DELTA;
       }
       return;
     }
+
+    // Do not replay stale virtual-device deltas after switching back from SendInput.
+    raw.vmouse_hscroll_accum = 0;
 
     INPUT i {};
 

--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -709,10 +709,17 @@ namespace platf {
       // HID wheel uses notch units; distance is in WHEEL_DELTA (120) units.
       // Accumulate sub-notch deltas for high-resolution scrolling support.
       raw.vmouse_vscroll_accum += distance;
-      int notches = raw.vmouse_vscroll_accum / WHEEL_DELTA;
-      if (notches != 0) {
+      while (raw.vmouse_vscroll_accum <= -WHEEL_DELTA ||
+             raw.vmouse_vscroll_accum >= WHEEL_DELTA) {
+        const auto notches = std::clamp(
+          raw.vmouse_vscroll_accum / WHEEL_DELTA,
+          -127,
+          127
+        );
+        if (!raw.vmouse_dev->scroll(static_cast<int8_t>(notches))) {
+          break;
+        }
         raw.vmouse_vscroll_accum -= notches * WHEEL_DELTA;
-        raw.vmouse_dev->scroll((int8_t) std::clamp(notches, -127, 127));
       }
       return;
     }
@@ -733,10 +740,17 @@ namespace platf {
     auto &raw = *(input_raw_t *) input.get();
     if (current_mouse_mode.load(std::memory_order_relaxed) != 2 && raw.vmouse_dev && raw.vmouse_dev->is_available()) {
       raw.vmouse_hscroll_accum += distance;
-      int notches = raw.vmouse_hscroll_accum / WHEEL_DELTA;
-      if (notches != 0) {
+      while (raw.vmouse_hscroll_accum <= -WHEEL_DELTA ||
+             raw.vmouse_hscroll_accum >= WHEEL_DELTA) {
+        const auto notches = std::clamp(
+          raw.vmouse_hscroll_accum / WHEEL_DELTA,
+          -127,
+          127
+        );
+        if (!raw.vmouse_dev->hscroll(static_cast<int8_t>(notches))) {
+          break;
+        }
         raw.vmouse_hscroll_accum -= notches * WHEEL_DELTA;
-        raw.vmouse_dev->hscroll((int8_t) std::clamp(notches, -127, 127));
       }
       return;
     }


### PR DESCRIPTION
## 说明

修复 Zako 虚拟鼠标在大幅垂直或水平滚动时丢失输入的问题。

原实现会从累计值中扣除全部滚轮格数，但 HID 实际发送值会被限制到 `[-127, 127]`，导致超出单次报告范围的滚动量被永久丢弃。

Fixes #849

## 修改

- 垂直和水平滚轮按照 HID 单次范围分片发送。
- 每个分片发送成功后才从累计值中扣除。
- 发送失败时停止发送并保留尚未发送的累计量。
- 保留不足一个 `WHEEL_DELTA` 的高精度滚动余量。