### PR TITLE
fix(windows): correct DDA cursor blending and bounds-check format lookup

### DIFF
--- a/src/platform/windows/display_base.cpp
+++ b/src/platform/windows/display_base.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cmath>
 #include <initguid.h>
+#include <iterator>
 #include <thread>
 
 #include <boost/algorithm/string/join.hpp>
@@ -1058,6 +1059,15 @@ namespace platf::dxgi {
 
   const char *
   display_base_t::dxgi_format_to_string(DXGI_FORMAT format) {
+    // The table is indexed directly by the DXGI_FORMAT value, but it only covers the
+    // contiguous range of documented formats and contains NULL holes for the reserved
+    // values between B4G4R4A4_UNORM (115) and P208 (130). Formats outside that range
+    // (e.g. A4B4G4R4_UNORM = 191, the sampler feedback opaque formats, or a bogus value
+    // from a driver) would otherwise read out of bounds, and the NULL holes would be
+    // streamed as a null char pointer, which is undefined behavior.
+    if (format >= std::size(format_str) || !format_str[format]) {
+      return "DXGI_FORMAT_UNRECOGNIZED";
+    }
     return format_str[format];
   }
 

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -2823,13 +2823,18 @@ namespace platf::dxgi {
         // We got a new frame from DesktopDuplication...
         if (blend_mouse_cursor_flag) {
           // ...and we need to blend the mouse cursor onto it.
-          // Optimization: Directly copy to target image and blend cursor, avoiding intermediate surface copy.
-          // This reduces one texture copy operation when we have a new frame.
-          // We still use intermediate surface for cursor-only updates (no new frame) to avoid
-          // memory overhead from sharing images between direct3d devices.
-          last_frame_action = lfa::copy_src_to_img;
-          // Blend cursor directly onto the image we just copied to.
-          out_frame_action = ofa::copy_last_surface_and_blend_cursor;  // Reused for direct blend
+          // Copy the frame to intermediate surface so we can blend this and future mouse cursor updates
+          // without new frames from DesktopDuplication. We use direct3d surface directly here and not
+          // an image from pull_free_image_cb mainly because it's lighter (surface sharing between
+          // direct3d devices produce significant memory overhead).
+          //
+          // The intermediate surface must hold a *cursor-free* copy of the desktop frame: every output
+          // image is built as "clean frame copy + this frame's cursor". Blending directly into the image
+          // saved in last_frame_variant would bake the cursor into it and leave a trail behind the cursor
+          // on subsequent cursor-only updates.
+          last_frame_action = lfa::copy_src_to_surface;
+          // Copy the intermediate surface to a new image from pull_free_image_cb and blend the mouse cursor onto it.
+          out_frame_action = ofa::copy_last_surface_and_blend_cursor;
         }
         else {
           // ...and we don't need to blend the mouse cursor.
@@ -3032,59 +3037,23 @@ namespace platf::dxgi {
       }
 
       case ofa::copy_last_surface_and_blend_cursor: {
+        auto p_surface = std::get_if<texture2d_t>(&last_frame_variant);
+        if (!p_surface) {
+          BOOST_LOG(error) << "Logical error at " << __FILE__ << ":" << __LINE__;
+          return capture_e::error;
+        }
         if (!blend_mouse_cursor_flag) {
           BOOST_LOG(error) << "Logical error at " << __FILE__ << ":" << __LINE__;
           return capture_e::error;
         }
 
-        // Optimization: Check if we have an image (from direct copy) or surface (from previous frame)
-        auto p_img = std::get_if<std::shared_ptr<platf::img_t>>(&last_frame_variant);
-        auto p_surface = std::get_if<texture2d_t>(&last_frame_variant);
-        
-        if (p_img && p_img->use_count() == 1) {
-          // Optimization: We have a direct image copy that's not yet used by encoder,
-          // blend cursor directly onto it to avoid an extra texture copy.
-          img_out = *p_img;
-          auto d3d_img = std::static_pointer_cast<img_d3d_t>(img_out);
-          texture_lock_helper lock_helper(d3d_img->capture_mutex.get());
-          if (!lock_helper.lock()) {
-            BOOST_LOG(error) << "Failed to lock capture texture for cursor blend";
-            return capture_e::error;
-          }
-          blend_cursor(*d3d_img);
-        }
-        else if (p_surface) {
-          // We have an intermediate surface, copy it first then blend
-          if (!pull_free_image_cb(img_out)) return capture_e::interrupted;
+        if (!pull_free_image_cb(img_out)) return capture_e::interrupted;
 
-          auto [d3d_img, lock] = get_locked_d3d_img(img_out);
-          if (!d3d_img) return capture_e::error;
+        auto [d3d_img, lock] = get_locked_d3d_img(img_out);
+        if (!d3d_img) return capture_e::error;
 
-          device_ctx->CopyResource(d3d_img->capture_texture.get(), p_surface->get());
-          blend_cursor(*d3d_img);
-        }
-        else if (p_img) {
-          // Image is already in use by encoder, we need to get a new one
-          // This case is rare and indicates the image was consumed before cursor blend
-          // Fall back to creating a surface and copying (original behavior)
-          if (!pull_free_image_cb(img_out)) return capture_e::interrupted;
-
-          auto [d3d_img, lock] = get_locked_d3d_img(img_out);
-          if (!d3d_img) return capture_e::error;
-
-          // Copy from the image that's in use (it should still be valid for reading)
-          // Note: This creates an extra copy, but it's a rare edge case
-          auto d3d_img_src = std::static_pointer_cast<img_d3d_t>(*p_img);
-          texture_lock_helper src_lock_helper(d3d_img_src->capture_mutex.get());
-          if (src_lock_helper.lock()) {
-            device_ctx->CopyResource(d3d_img->capture_texture.get(), d3d_img_src->capture_texture.get());
-          }
-          blend_cursor(*d3d_img);
-        }
-        else {
-          BOOST_LOG(error) << "Logical error at " << __FILE__ << ":" << __LINE__;
-          return capture_e::error;
-        }
+        device_ctx->CopyResource(d3d_img->capture_texture.get(), p_surface->get());
+        blend_cursor(*d3d_img);
         break;
       }
 


### PR DESCRIPTION
Two independent fixes in the Windows DXGI Desktop Duplication capture path, found while auditing it against upstream Sunshine. Reviewable as separate commits.

## 1. Restore the cursor-free intermediate surface

`a3bd8799` replaced the intermediate surface used as the cursor blending base with a direct copy into the output image, to save a texture copy and shorten the capture thread's hold on the D3D11 device lock.

**The fast path is dead code.** It is gated on `p_img->use_count() == 1`, which can never hold — both image sources keep a second reference alive across the call:

| path | second reference |
|---|---|
| async pool ([video.cpp:1619](../blob/master/src/video.cpp#L1619)) | `img_out = *it` while the list keeps its entry |
| sync ([video.cpp:3374](../blob/master/src/video.cpp#L3374)) | assigned from a still-live local |

Every frame fell through to the third branch — the one commented "rare edge case". The intended copy was never saved.

**It would also be incorrect if it did fire.** `last_frame_variant` must stay a cursor-free copy of the desktop, because each output image is built as *clean frame + this frame's cursor*. Blending into the saved image bakes the cursor in, so the next cursor-only update (mouse moving over a static screen) composites a second cursor over the stale one and leaves an accumulating trail. The dead branch was the only thing preventing that.

Net effect was a regression against upstream in the very dimension it targeted:

- the fallback branch nests **two cross-device keyed mutexes per frame**; the upstream surface has `BindFlags = 0` and no mutex
- `last_frame_variant` alternates image↔surface whenever the cursor is visible, adding a full-screen copy per transition
- a failed `src_lock_helper.lock()` still ran `blend_cursor()` on uncopied contents, silently

Reverted to the upstream form — the restored block is byte-identical to `a3bd8799^`. The comment now records *why* the surface must stay cursor-free, so this is not reattempted the same way.

The lock-starvation concern is already handled by the short-timeout polling loop added in the same commit. Moving cursor composition into the encoder's existing shader pass would remove the copy without the correctness problem, but that touches the encode hot path and should be driven by measurement.

## 2. Bounds-check `dxgi_format_to_string`

`format_str[]` is indexed directly by the `DXGI_FORMAT` value with no validation. It holds 133 entries (max valid index 132) and has **14 NULL holes at indices 116–129** — the reserved gap between `B4G4R4A4_UNORM` (115) and `P208` (130).

- NULL holes return a null `char*`, streamed directly into `BOOST_LOG` → undefined behavior
- values above 132 read past the array; `A4B4G4R4_UNORM` (191) and the sampler feedback opaque formats (189, 190) are real enum values there

The sibling `colorspace_to_string` right below already guards with `ARRAYSIZE` ([display_base.cpp:1094](../blob/master/src/platform/windows/display_base.cpp#L1094)); this one was missed.

Returns a static literal rather than a shared buffer — five call sites invoke the function **twice in one log statement** (e.g. [display_vram.cpp:2794](../blob/master/src/platform/windows/display_vram.cpp#L2794)), which a shared buffer would clobber.

## Testing

**Fix 2 is verified.** The table and function have no Windows dependencies, so I extracted both verbatim into a native harness and ran it under ASan+UBSan with real DXGI enum values: **32 checks pass** — all 119 named formats, the 14 NULL holes, the out-of-range values, and a 0..300 sweep confirming a non-NULL return.

The harness was validated against the bug rather than assumed correct. Reverting the guard and rerunning reproduces it:

```
[3] FAIL reserved hole (116..129)      -> returned NULL          (14x)
[4] FAIL SAMPLER_FEEDBACK_MIN_MIP (189) -> returned NULL
    FAIL SAMPLER_FEEDBACK_MIP_REGION (190) -> got "fmt_test_old.cpp"   <- adjacent literal, OOB read
    AddressSanitizer: SEGV at index 191, ABORTING
```

**Fix 1 is not compile-verified or behaviorally tested.** It is a Windows-only translation unit and the change was made on macOS with no build tree. Verified structurally only: byte-identical to upstream, all six `lfa`/`ofa` cases still defined and reachable, `snapshot()` braces balanced (2708–3094).

### What a reviewer should check on Windows

1. **Build** — neither file was compiled.
2. **Cursor trail regression** — stream, then move the mouse across a static screen. Confirm no trailing or duplicated cursors. This is the exact failure the old fast path would have caused, so it is the key check.
3. Cursor appearing/disappearing over a static screen (exercises the `replace_*` transitions).
4. Cursor hidden entirely (`forward_last_img` path).

## Not addressed

Also found while auditing, left for separate changes:

- `AccumulatedFrames` is part of the frame-update test in [display_ram.cpp:193](../blob/master/src/platform/windows/display_ram.cpp#L193) but not in [display_vram.cpp:2721](../blob/master/src/platform/windows/display_vram.cpp#L2721) — the inconsistency suggests one is unintentional
- the 1 ms sleep in the short-timeout polling loop is a pure loss; `AcquireNextFrame` has already released the lock when it returns on timeout
- no dirty-rect usage (`GetFrameDirtyRects`/`GetFrameMoveRects`) anywhere — every frame is a full-screen `CopyResource`. Reasonable for game streaming, wasteful for static desktops. Upstream does not do this either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)