### PR TITLE
fix(hdr): scope luminance EMA per session; fold histogram in pass 1

### DIFF
--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -1679,6 +1679,8 @@ namespace platf::dxgi {
     shader_res_t hdr_group_results_srv;    // SRV view for pass 2 input
     buf_t hdr_final_result_buf;            // Pass 2 output (default usage + UAV)
     uav_t hdr_final_result_uav;            // UAV view for pass 2 output
+    buf_t hdr_global_histogram_buf;        // 128-bin histogram accumulated by pass 1 atomics
+    uav_t hdr_global_histogram_uav;        // Typed R32_UINT UAV (clearable + atomic-capable)
     buf_t hdr_staging_buf;                 // Staging buffer for CPU readback (1 FinalResult)
     buf_t hdr_analysis_cbuf;               // Constant buffer for pass 1 (analysis resolution)
     buf_t hdr_reduce_cbuf;                 // Constant buffer for pass 2 (numGroups)
@@ -1719,15 +1721,20 @@ namespace platf::dxgi {
     static constexpr uint32_t HDR_ANALYSIS_MAX_WIDTH = 1920;
     static constexpr uint32_t HDR_ANALYSIS_MAX_HEIGHT = 1080;
 
+    // Pass 1 per-tile output. Deliberately scalars only: the 128-bin histogram is
+    // accumulated straight into a single global buffer by sparse atomics in pass 1,
+    // instead of being carried per-tile and merged by pass 2. Carrying it here cost
+    // 528 bytes/tile (~4.3 MiB/frame of mostly-zero writes) and forced pass 2 to walk
+    // numGroups x 128 dwords at a 528-byte stride from a single thread group.
     struct GroupResult {
       float minMaxRGB;
       float maxMaxRGB;
       float sumMaxRGB;
       uint32_t pixelCount;
-      uint32_t histogram[HISTOGRAM_BINS];
     };
 
-    // Must match HLSL FinalResult layout exactly (same as GroupResult for merged output)
+    // Must match HLSL FinalResult layout exactly. This one keeps the histogram because
+    // it is what the CPU reads back.
     struct FinalResult {
       float minMaxRGB;
       float maxMaxRGB;
@@ -1899,6 +1906,31 @@ namespace platf::dxgi {
         return -1;
       }
 
+      // --- Global histogram: 128 bins accumulated by pass 1 via InterlockedAdd ---
+      // Typed (non-structured) R32_UINT so ClearUnorderedAccessViewUint() is well-defined
+      // on it; a structured-buffer UAV is not reliably clearable across drivers.
+      D3D11_BUFFER_DESC hist_desc = {};
+      hist_desc.ByteWidth = HISTOGRAM_BINS * sizeof(uint32_t);
+      hist_desc.Usage = D3D11_USAGE_DEFAULT;
+      hist_desc.BindFlags = D3D11_BIND_UNORDERED_ACCESS;
+
+      status = device->CreateBuffer(&hist_desc, nullptr, &hdr_global_histogram_buf);
+      if (FAILED(status)) {
+        BOOST_LOG(warning) << "Failed to create HDR global histogram buffer: " << util::log_hex(status);
+        return -1;
+      }
+
+      D3D11_UNORDERED_ACCESS_VIEW_DESC hist_uav_desc = {};
+      hist_uav_desc.Format = DXGI_FORMAT_R32_UINT;
+      hist_uav_desc.ViewDimension = D3D11_UAV_DIMENSION_BUFFER;
+      hist_uav_desc.Buffer.NumElements = HISTOGRAM_BINS;
+
+      status = device->CreateUnorderedAccessView(hdr_global_histogram_buf.get(), &hist_uav_desc, &hdr_global_histogram_uav);
+      if (FAILED(status)) {
+        BOOST_LOG(warning) << "Failed to create HDR global histogram UAV: " << util::log_hex(status);
+        return -1;
+      }
+
       // --- Constant buffer for pass 2 (numGroups) ---
       D3D11_BUFFER_DESC cb_desc = {};
       cb_desc.ByteWidth = 16;  // 16-byte aligned: uint numGroups + 12 bytes padding
@@ -1955,13 +1987,17 @@ namespace platf::dxgi {
       ID3D11RenderTargetView *null_rtv = nullptr;
       device_ctx->OMSetRenderTargets(1, &null_rtv, nullptr);
 
+      // The global histogram accumulates across the whole frame, so it must start at zero.
+      const UINT hist_clear[4] = { 0, 0, 0, 0 };
+      device_ctx->ClearUnorderedAccessViewUint(hdr_global_histogram_uav.get(), hist_clear);
+
       // ===== Pass 1: Per-tile analysis =====
       device_ctx->CSSetShader(hdr_pass1_cs.get(), nullptr, 0);
       device_ctx->CSSetShaderResources(0, 1, &input_srv);
       ID3D11SamplerState *cs_sampler = sampler_linear.get();
       device_ctx->CSSetSamplers(0, 1, &cs_sampler);
-      ID3D11UnorderedAccessView *uav1 = hdr_group_results_uav.get();
-      device_ctx->CSSetUnorderedAccessViews(0, 1, &uav1, nullptr);
+      ID3D11UnorderedAccessView *pass1_uavs[] = { hdr_group_results_uav.get(), hdr_global_histogram_uav.get() };
+      device_ctx->CSSetUnorderedAccessViews(0, 2, pass1_uavs, nullptr);
       ID3D11Buffer *analysis_cbuf = hdr_analysis_cbuf.get();
       device_ctx->CSSetConstantBuffers(0, 1, &analysis_cbuf);
 
@@ -1971,9 +2007,9 @@ namespace platf::dxgi {
 
       // Unbind pass 1 resources
       ID3D11ShaderResourceView *null_srv = nullptr;
-      ID3D11UnorderedAccessView *null_uav = nullptr;
+      ID3D11UnorderedAccessView *null_uavs[2] = { nullptr, nullptr };
       device_ctx->CSSetShaderResources(0, 1, &null_srv);
-      device_ctx->CSSetUnorderedAccessViews(0, 1, &null_uav, nullptr);
+      device_ctx->CSSetUnorderedAccessViews(0, 2, null_uavs, nullptr);
       ID3D11SamplerState *null_sampler = nullptr;
       device_ctx->CSSetSamplers(0, 1, &null_sampler);
 
@@ -1981,8 +2017,8 @@ namespace platf::dxgi {
       device_ctx->CSSetShader(hdr_pass2_cs.get(), nullptr, 0);
       ID3D11ShaderResourceView *group_srv = hdr_group_results_srv.get();
       device_ctx->CSSetShaderResources(0, 1, &group_srv);
-      ID3D11UnorderedAccessView *uav2 = hdr_final_result_uav.get();
-      device_ctx->CSSetUnorderedAccessViews(0, 1, &uav2, nullptr);
+      ID3D11UnorderedAccessView *pass2_uavs[] = { hdr_final_result_uav.get(), hdr_global_histogram_uav.get() };
+      device_ctx->CSSetUnorderedAccessViews(0, 2, pass2_uavs, nullptr);
       ID3D11Buffer *cbuf = hdr_reduce_cbuf.get();
       device_ctx->CSSetConstantBuffers(0, 1, &cbuf);
 
@@ -1990,7 +2026,7 @@ namespace platf::dxgi {
 
       // Unbind all CS resources
       device_ctx->CSSetShaderResources(0, 1, &null_srv);
-      device_ctx->CSSetUnorderedAccessViews(0, 1, &null_uav, nullptr);
+      device_ctx->CSSetUnorderedAccessViews(0, 2, null_uavs, nullptr);
       ID3D11Buffer *null_cb = nullptr;
       device_ctx->CSSetConstantBuffers(0, 1, &null_cb);
       device_ctx->CSSetShader(nullptr, nullptr, 0);

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -439,6 +439,63 @@ namespace video {
     std::array<entry_t, 256> entries {};
   };
 
+  /**
+   * @brief Temporal EMA (Exponential Moving Average) state for HDR luminance stats.
+   * Prevents frame-to-frame brightness jitter/flicker in tone mapping by smoothing
+   * the raw per-frame GPU statistics over time.
+   *
+   * This state is owned by the encode session. It must not be shared across sessions:
+   * carrying a previous stream's converged luminance into a new one biases the first
+   * frames of dynamic metadata until the EMA re-converges.
+   */
+  struct hdr_luminance_ema_t {
+    float min_maxrgb = 0.0f;
+    float max_maxrgb = 0.0f;
+    float avg_maxrgb = 0.0f;
+    float percentile_95 = 0.0f;
+    float percentile_99 = 0.0f;
+    bool initialized = false;
+
+    /// EMA smoothing factor: 0.15 = responsive to changes while avoiding flicker.
+    /// Lower α = more smoothing (less flicker, slower adaptation).
+    /// Scene cuts are handled by fast-tracking when the change exceeds a threshold.
+    static constexpr float ALPHA = 0.15f;
+    static constexpr float SCENE_CUT_THRESHOLD = 3.0f;  // Ratio threshold for scene cut detection
+
+    /**
+     * @brief Apply EMA smoothing to raw per-frame stats.
+     * On first frame or scene cuts (>3x luminance change), snaps to current value.
+     * Otherwise applies exponential smoothing: smoothed = α·current + (1-α)·previous.
+     */
+    void
+    update(const platf::hdr_frame_luminance_stats_t &raw) {
+      if (!raw.valid) return;
+
+      if (!initialized) {
+        // First frame: snap to current values
+        min_maxrgb = raw.min_maxrgb;
+        max_maxrgb = raw.max_maxrgb;
+        avg_maxrgb = raw.avg_maxrgb;
+        percentile_95 = raw.percentile_95;
+        percentile_99 = raw.percentile_99;
+        initialized = true;
+        return;
+      }
+
+      // Scene cut detection: if peak luminance changes dramatically, snap immediately
+      float ratio = (max_maxrgb > 1.0f) ? raw.max_maxrgb / max_maxrgb : SCENE_CUT_THRESHOLD + 1.0f;
+      float alpha = (ratio > SCENE_CUT_THRESHOLD || ratio < 1.0f / SCENE_CUT_THRESHOLD)
+                    ? 1.0f  // Scene cut: snap to new values
+                    : ALPHA; // Normal: smooth transition
+
+      min_maxrgb = alpha * raw.min_maxrgb + (1.0f - alpha) * min_maxrgb;
+      max_maxrgb = alpha * raw.max_maxrgb + (1.0f - alpha) * max_maxrgb;
+      avg_maxrgb = alpha * raw.avg_maxrgb + (1.0f - alpha) * avg_maxrgb;
+      percentile_95 = alpha * raw.percentile_95 + (1.0f - alpha) * percentile_95;
+      percentile_99 = alpha * raw.percentile_99 + (1.0f - alpha) * percentile_99;
+    }
+  };
+
   class avcodec_encode_session_t: public encode_session_t {
   public:
     avcodec_encode_session_t() = default;
@@ -465,6 +522,7 @@ namespace video {
       avcodec_ctx = std::move(other.avcodec_ctx);
       replacements = std::move(other.replacements);
       frame_timestamps = std::move(other.frame_timestamps);
+      hdr_ema = other.hdr_ema;
       sps = std::move(other.sps);
       vps = std::move(other.vps);
 
@@ -579,6 +637,10 @@ namespace video {
 
     std::vector<packet_raw_t::replace_t> replacements;
     frame_timestamp_ring_t frame_timestamps;
+
+    // Temporal smoothing state for HDR dynamic metadata. Owned per session so a new
+    // stream starts from an unconverged EMA rather than inheriting the previous one's.
+    hdr_luminance_ema_t hdr_ema;
 
     cbs::nal_t sps;
     cbs::nal_t vps;
@@ -1804,59 +1866,6 @@ namespace video {
   }
 
   /**
-   * @brief Temporal EMA (Exponential Moving Average) state for HDR luminance stats.
-   * Prevents frame-to-frame brightness jitter/flicker in tone mapping by smoothing
-   * the raw per-frame GPU statistics over time.
-   */
-  struct hdr_luminance_ema_t {
-    float min_maxrgb = 0.0f;
-    float max_maxrgb = 0.0f;
-    float avg_maxrgb = 0.0f;
-    float percentile_95 = 0.0f;
-    float percentile_99 = 0.0f;
-    bool initialized = false;
-
-    /// EMA smoothing factor: 0.15 = responsive to changes while avoiding flicker.
-    /// Lower α = more smoothing (less flicker, slower adaptation).
-    /// Scene cuts are handled by fast-tracking when the change exceeds a threshold.
-    static constexpr float ALPHA = 0.15f;
-    static constexpr float SCENE_CUT_THRESHOLD = 3.0f;  // Ratio threshold for scene cut detection
-
-    /**
-     * @brief Apply EMA smoothing to raw per-frame stats.
-     * On first frame or scene cuts (>3x luminance change), snaps to current value.
-     * Otherwise applies exponential smoothing: smoothed = α·current + (1-α)·previous.
-     */
-    void
-    update(const platf::hdr_frame_luminance_stats_t &raw) {
-      if (!raw.valid) return;
-
-      if (!initialized) {
-        // First frame: snap to current values
-        min_maxrgb = raw.min_maxrgb;
-        max_maxrgb = raw.max_maxrgb;
-        avg_maxrgb = raw.avg_maxrgb;
-        percentile_95 = raw.percentile_95;
-        percentile_99 = raw.percentile_99;
-        initialized = true;
-        return;
-      }
-
-      // Scene cut detection: if peak luminance changes dramatically, snap immediately
-      float ratio = (max_maxrgb > 1.0f) ? raw.max_maxrgb / max_maxrgb : SCENE_CUT_THRESHOLD + 1.0f;
-      float alpha = (ratio > SCENE_CUT_THRESHOLD || ratio < 1.0f / SCENE_CUT_THRESHOLD)
-                    ? 1.0f  // Scene cut: snap to new values
-                    : ALPHA; // Normal: smooth transition
-
-      min_maxrgb = alpha * raw.min_maxrgb + (1.0f - alpha) * min_maxrgb;
-      max_maxrgb = alpha * raw.max_maxrgb + (1.0f - alpha) * max_maxrgb;
-      avg_maxrgb = alpha * raw.avg_maxrgb + (1.0f - alpha) * avg_maxrgb;
-      percentile_95 = alpha * raw.percentile_95 + (1.0f - alpha) * percentile_95;
-      percentile_99 = alpha * raw.percentile_99 + (1.0f - alpha) * percentile_99;
-    }
-  };
-
-  /**
    * @brief Update per-frame HDR dynamic metadata with smoothed GPU-computed luminance stats.
    *
    * Called before each avcodec_send_frame() to inject accurate per-frame
@@ -1927,9 +1936,6 @@ namespace video {
     }
   }
 
-  // Per-session EMA state for temporal smoothing of HDR luminance stats
-  static thread_local hdr_luminance_ema_t hdr_ema_state;
-
   int
   encode_avcodec(
     int64_t frame_nr,
@@ -1957,7 +1963,7 @@ namespace video {
     {
       auto &raw_stats = session.device->hdr_luminance_stats;
       if (raw_stats.valid) {
-        hdr_ema_state.update(raw_stats);
+        session.hdr_ema.update(raw_stats);
 
         uint16_t max_lum = 1000;
         auto mdm_sd = av_frame_get_side_data(frame, AV_FRAME_DATA_MASTERING_DISPLAY_METADATA);
@@ -1967,7 +1973,7 @@ namespace video {
             max_lum = static_cast<uint16_t>(av_q2d(mdm->max_luminance));
           }
         }
-        update_hdr_dynamic_metadata(frame, hdr_ema_state, max_lum);
+        update_hdr_dynamic_metadata(frame, session.hdr_ema, max_lum);
       }
     }
 

--- a/src_assets/windows/assets/shaders/directx/hdr_luminance_analysis_cs.hlsl
+++ b/src_assets/windows/assets/shaders/directx/hdr_luminance_analysis_cs.hlsl
@@ -9,10 +9,12 @@
  *   - scRGB uses BT.709 primaries in linear light
  *   - 1.0 in scRGB = 80 nits (SDR reference white)
  *
- * Output: Per-group reduction results in a structured buffer.
- *   Each thread group (16x16 = 256 threads) processes one tile and writes
- *   {min, max, sum, count, histogram[128]} of maxRGB values (in nits)
- *   to the output buffer. A second-pass shader reduces all groups to one.
+ * Output: Per-group scalar reductions in a structured buffer, plus a frame-global
+ *   histogram accumulated by atomics.
+ *   Each thread group (16x16 = 256 threads) processes one tile, writes
+ *   {min, max, sum, count} of maxRGB values (in nits) to the output buffer, and folds
+ *   its local 128-bin histogram into the global one with one atomic per occupied bin.
+ *   A second-pass shader reduces the per-tile scalars to one result.
  *
  * Histogram: 128 bins covering 0-10000 nits, each bin = 78.125 nits wide.
  *   Used for P95/P99 percentile computation for stable peak luminance.
@@ -39,16 +41,21 @@ cbuffer AnalysisParams : register(b0) {
     uint2 _pad;
 };
 
-// Per-group reduction results
+// Per-group reduction results (scalars only — the histogram goes straight to the
+// global accumulator below, so it is not carried per tile)
 struct GroupResult {
     float minMaxRGB;                  // Minimum of max(R,G,B) in nits
     float maxMaxRGB;                  // Maximum of max(R,G,B) in nits
     float sumMaxRGB;                  // Sum of max(R,G,B) in nits (for average)
     uint  pixelCount;                 // Number of valid pixels processed
-    uint  histogram[HISTOGRAM_BINS];  // Luminance histogram (128 bins)
 };
 
 RWStructuredBuffer<GroupResult> groupResults : register(u0);
+
+// Frame-global 128-bin histogram. Each group folds its local histogram in with one
+// atomic per *occupied* bin, so pass 2 never has to merge per-tile histograms.
+// Cleared by the host before every dispatch.
+RWBuffer<uint> globalHistogram : register(u1);
 
 // Shared memory for intra-group parallel reduction
 groupshared float gs_min[256];
@@ -116,7 +123,7 @@ void main_cs(uint3 DTid : SV_DispatchThreadID,
         GroupMemoryBarrierWithGroupSync();
     }
 
-    // Thread 0 writes the group's result (including histogram)
+    // Thread 0 writes the group's scalar result
     if (GIndex == 0) {
         // Compute flat group index
         uint dispatchWidth = (analysisWidth + 15) / 16;
@@ -128,11 +135,13 @@ void main_cs(uint3 DTid : SV_DispatchThreadID,
         result.sumMaxRGB = gs_sum[0];
         result.pixelCount = gs_count[0];
 
-        [unroll]
-        for (uint i = 0; i < HISTOGRAM_BINS; i++) {
-            result.histogram[i] = gs_histogram[i];
-        }
-
         groupResults[groupIndex] = result;
+    }
+
+    // Fold this tile's histogram into the frame-global one. Only occupied bins need an
+    // atomic: a 16x16 tile usually spans a handful of bins, not all 128, so in practice
+    // this is a few atomics per group rather than one per bin.
+    if (GIndex < HISTOGRAM_BINS && gs_histogram[GIndex] != 0) {
+        InterlockedAdd(globalHistogram[GIndex], gs_histogram[GIndex]);
     }
 }

--- a/src_assets/windows/assets/shaders/directx/hdr_luminance_reduce_cs.hlsl
+++ b/src_assets/windows/assets/shaders/directx/hdr_luminance_reduce_cs.hlsl
@@ -2,16 +2,18 @@
  * @file hdr_luminance_reduce_cs.hlsl
  * @brief Second-pass GPU reduction shader for HDR luminance analysis.
  *
- * Reduces per-group results from the first-pass analysis shader into a single
- * final result. This eliminates CPU iteration over thousands of groups.
+ * Reduces per-group scalar results from the first-pass analysis shader into a single
+ * final result. The 128-bin histogram is not merged here — pass 1 already accumulated
+ * it into a frame-global buffer via atomics, so this shader only copies it out.
  *
- * Input:  StructuredBuffer of GroupResult from first pass (N groups)
+ * Input:  StructuredBuffer of GroupResult from first pass (N groups, 16 bytes each)
+ *         RWBuffer of the frame-global 128-bin histogram
  * Output: RWStructuredBuffer with 1 FinalResult containing:
  *         - Global min/max/sum/count
- *         - Merged 128-bin histogram
+ *         - The merged 128-bin histogram
  *
  * Dispatch: (1, 1, 1) — single thread group of 256 threads
- * Each thread processes ceil(N/256) groups.
+ * Threads walk the group array with a grid-stride loop so the loads coalesce.
  *
  * cbuffer provides numGroups so the shader knows how many to reduce.
  */
@@ -23,7 +25,6 @@ struct GroupResult {
     float maxMaxRGB;
     float sumMaxRGB;
     uint  pixelCount;
-    uint  histogram[HISTOGRAM_BINS];
 };
 
 struct FinalResult {
@@ -40,6 +41,9 @@ StructuredBuffer<GroupResult> groupResults : register(t0);
 // Output: single merged result (UAV)
 RWStructuredBuffer<FinalResult> finalResult : register(u0);
 
+// Frame-global histogram already accumulated by pass 1's atomics — just copied out here.
+RWBuffer<uint> globalHistogram : register(u1);
+
 // Number of groups to reduce
 cbuffer ReduceParams : register(b0) {
     uint numGroups;
@@ -51,28 +55,19 @@ groupshared float gs_min[256];
 groupshared float gs_max[256];
 groupshared float gs_sum[256];
 groupshared uint  gs_count[256];
-groupshared uint  gs_histogram[HISTOGRAM_BINS];
 
 [numthreads(256, 1, 1)]
 void main_cs(uint GIndex : SV_GroupIndex)
 {
-    // Initialize histogram bins (256 threads > 128 bins, first 128 threads init)
-    if (GIndex < HISTOGRAM_BINS) {
-        gs_histogram[GIndex] = 0;
-    }
-
-    // Each thread sequentially processes its assigned groups
     float local_min = 100000.0;
     float local_max = 0.0;
     float local_sum = 0.0;
     uint  local_count = 0;
 
-    // Distribute groups across 256 threads
-    uint groupsPerThread = (numGroups + 255) / 256;
-    uint startGroup = GIndex * groupsPerThread;
-    uint endGroup = min(startGroup + groupsPerThread, numGroups);
-
-    for (uint g = startGroup; g < endGroup; g++) {
+    // Grid-stride loop: at each step the 256 threads read 256 *consecutive* GroupResults,
+    // so the loads coalesce. Partitioning into contiguous per-thread blocks instead would
+    // make every thread in the wave touch a different cache line on every iteration.
+    for (uint g = GIndex; g < numGroups; g += 256) {
         GroupResult gr = groupResults[g];
         if (gr.pixelCount > 0) {
             local_min = min(local_min, gr.minMaxRGB);
@@ -89,18 +84,6 @@ void main_cs(uint GIndex : SV_GroupIndex)
 
     GroupMemoryBarrierWithGroupSync();
 
-    // Merge histogram bins: each of the first 128 threads handles one bin
-    // across all groups (sequential accumulation per bin)
-    if (GIndex < HISTOGRAM_BINS) {
-        uint binSum = 0;
-        for (uint g = 0; g < numGroups; g++) {
-            binSum += groupResults[g].histogram[GIndex];
-        }
-        gs_histogram[GIndex] = binSum;
-    }
-
-    GroupMemoryBarrierWithGroupSync();
-
     // Parallel reduction of min/max/sum/count (log2(256) = 8 steps)
     [unroll]
     for (uint stride = 128; stride > 0; stride >>= 1) {
@@ -113,7 +96,7 @@ void main_cs(uint GIndex : SV_GroupIndex)
         GroupMemoryBarrierWithGroupSync();
     }
 
-    // Thread 0 writes final merged result (scalars only; histogram written below by 128 threads)
+    // Thread 0 writes the reduced scalars
     if (GIndex == 0) {
         finalResult[0].minMaxRGB = gs_min[0];
         finalResult[0].maxMaxRGB = gs_max[0];
@@ -121,10 +104,8 @@ void main_cs(uint GIndex : SV_GroupIndex)
         finalResult[0].pixelCount = gs_count[0];
     }
 
-    GroupMemoryBarrierWithGroupSync();
-
-    // First 128 threads write histogram bins to output
+    // First 128 threads copy the already-merged global histogram into the readback struct
     if (GIndex < HISTOGRAM_BINS) {
-        finalResult[0].histogram[GIndex] = gs_histogram[GIndex];
+        finalResult[0].histogram[GIndex] = globalHistogram[GIndex];
     }
 }


### PR DESCRIPTION
Two fixes to the HDR luminance analyzer, found while tracing why the HarmonyOS client wasn't detecting CUVA metadata. Reviewable as separate commits.

> **Opening this primarily for CI compile coverage** — both files are Windows-only and were changed on macOS with no build tree. See [Testing](#testing) for what CI does and does not cover.

## 1. EMA state leaked across streaming sessions

The temporal EMA that smooths HDR dynamic metadata lived in a `static thread_local hdr_luminance_ema_t` with **no reset anywhere**. Encode threads are reused across streams, so a new session started with `initialized == true` and the previous stream's converged luminance still in place — biasing the first frames of CUVA/HDR10+ metadata by whatever was last on screen, until the EMA re-converged.

Moved into `avcodec_encode_session_t`, which is per-session by construction. This makes the bug structurally impossible rather than adding a reset call a future path could miss. The struct definition moves ahead of the session class so it can be a member; **the body is unchanged**. Also added `hdr_ema` to the session's move-assignment operator, which enumerates members explicitly.

## 2. Pass 2's histogram merge was the analyzer's bottleneck

Pass 1 carried a 128-bin histogram inside every per-tile `GroupResult`, and pass 2 merged them:

```hlsl
if (GIndex < HISTOGRAM_BINS) {
    for (uint g = 0; g < numGroups; g++)
        binSum += groupResults[g].histogram[GIndex];
}
```

At the capped 1920×1080 analysis grid `numGroups` is 120×68 = 8160 and `sizeof(GroupResult)` was 528 B, so this walks **4.18 MiB** of histogram data.

The loads themselves are fine — for a fixed `g` the 128 threads read 128 consecutive dwords, which coalesces. The problems are elsewhere:

- it all runs inside a single `Dispatch(1,1,1)`, so **one SM pulls the entire 4.18 MiB** at a small fraction of device bandwidth while every other SM idles, and only 128 of the group's 256 threads participate
- **most of what it reads is zero** — a 16×16 tile typically occupies a handful of the 128 bins

The *write* side was genuinely uncoalesced: thread 0 alone stored all 132 dwords of its `GroupResult`, so 4.11 MiB went out at 1/32 lane utilization.

Instead, pass 1 now folds each tile's histogram straight into one frame-global buffer with an `InterlockedAdd` per **occupied** bin, and `GroupResult` drops the histogram. Pass 2 no longer merges histograms at all.

| | before | after |
|---|---|---|
| `sizeof(GroupResult)` | 528 B | **16 B** |
| pass-1 output buffer (1080p grid) | 4.11 MiB | **127 KiB** (33×) |
| pass-1 store by thread 0 | 132 dwords | **4 dwords** |
| pass-2 histogram merge | 4.18 MiB single-SM traffic | **removed** |
| pass-2 scalar reduction | contiguous block partition | **grid-stride** |

Note I did *not* simply transpose the histogram layout — that keeps the traffic serialized in one thread group. The win comes from removing the cross-tile merge, not reordering it.

The global buffer is a typed `R32_UINT` UAV rather than structured, so `ClearUnorderedAccessViewUint()` is well-defined across drivers. The host clears it before each dispatch since it accumulates over the frame.

## Expected cost reduction

Enabling the analyzer previously measured **~0.4 ms**. First-principles estimate of where that goes and what changes (assuming ~360 GB/s device, ~15–25 GB/s achievable from a single SM):

| | before | after |
|---|---|---|
| pass-1 sampling (2.07M bilinear FP16, all SMs) | ~150 µs | ~150 µs — **untouched** |
| pass-1 histogram store | ~50 µs | ~25 µs (incl. atomics) |
| pass-2 merge (single SM) | **~200 µs** | ~6 µs |
| sync / other | ~30 µs | ~30 µs |
| **total** | **~430 µs** | **~210 µs** |

So roughly **halved**. Three caveats:

1. **The floor is set by what I didn't change.** Pass-1 sampling is ~70% of the post-change cost. Going further means touching sampling (lower analysis resolution, a mip chain, or a larger `HDR_ANALYSIS_INTERVAL` — currently 4).
2. **Worst-case content may see little gain.** 904K atomics over 128 addresses could add back 100–300 µs for high-noise, wide-dynamic-range content.
3. **Wide error bars.** Single-SM bandwidth, atomic contention, and texture-cache hit rate are all estimated; real numbers could differ ~2×. Also unclear whether the 0.4 ms baseline is per *analyzed* frame or amortized — `HDR_ANALYSIS_INTERVAL = 4` puts a 4× factor between those readings (ratios hold either way).

## Testing

**Algorithmic equivalence is verified.** I simulated both the old and new pass-1/pass-2 pipelines natively (256-thread groups, tree reduction, block vs grid-stride partitioning, sparse atomic folding) and compared outputs across 14 cases: 1/255/256/257/8160 tiles, the 511/512/513 and n<256 partition edges, and tight / full-spread / mixed luminance distributions.

- merged histograms match **bit-exactly**, pixel counts agree in every case
- min/max/sum agree within float tolerance (grid-stride changes summation order)

Atomic count vs the old load count, from that simulation:

| content | old loads | new atomics | |
|---|---|---|---|
| tight per-tile luminance (common) | 1,044,480 | 8,166 | **128× fewer** |
| every tile spans all 128 bins (worst) | 1,044,480 | 904,326 | 1.2× fewer |

### What CI will and will not catch

`main.yml` builds Windows on `pull_request`, covering the **C++** changes in `video.cpp` and `display_vram.cpp` — including the struct-layout and member-ordering changes, which is the main thing I want checked.

**CI will not validate the HLSL.** These shaders are compiled at *runtime* via `D3DCompileFromFile` ([display_vram.cpp:3936](../blob/master/src/platform/windows/display_vram.cpp#L3936)); there is no fxc/dxc build step. A shader error would surface only when the analyzer initializes on a real machine. Specifically unverified:

- `InterlockedAdd` on a `RWBuffer<uint>` typed UAV under `cs_5_0`
- `ClearUnorderedAccessViewUint()` on a typed buffer UAV
- the two-UAV binding (`u0` + `u1`) in both passes

Structural checks that did run: braces balanced in all four files, register bindings `u0`/`u1`/`t0`/`b0` match the host-side slot assignments, no remaining CPU-side references to the removed field.

### Runtime verification needed

The analyzer is **off by default** ([config.cpp:477](../blob/master/src/config.cpp#L477)), so none of this is exercised unless enabled:

```
hdr_luminance_analysis = enabled
```

1. Confirm `HDR luminance analyzer initialized (two-pass)` appears with **no shader-compile error after it**.
2. Stream HDR (HEVC + HLG or PQ) and confirm dynamic metadata still reaches the client — on HarmonyOS the client logs `HDR Vivid CUVA dynamic metadata detected in HEVC SEI`.
3. Sanity-check reported luminance stats look plausible rather than zeroed or saturated.
4. Measure GPU time in `convert()` before/after using the existing `vram_timing_enabled` instrumentation, and compare against the estimate above. The point of this change is for the feature to stop needing to be default-off.

## Not addressed

- **`max_maxrgb` is not the true frame maximum.** Pass 1 samples a downsampled grid with a *linear* sampler, so for non-integer ratios (e.g. 1440p → 1920×1080 analysis) some texels are never sampled and peaks can be missed. Confirmed it only feeds scene-cut detection (`ratio = raw.max_maxrgb / max_maxrgb`) while emitted metadata uses `percentile_95`, so it affects cut sensitivity rather than output correctness.
- **HDR10+ SEI is emitted in HLG mode** ([nvenc_base.cpp:850](../blob/master/src/nvenc/common_impl/nvenc_base.cpp#L850)). The "PQ only" restriction exists only as a comment; there is no PQ check at the call site or inside `serialize_hdr10plus_sei`, and `nvenc_base` doesn't store the transfer function to make that decision. The avcodec path gates it correctly. HDR10+ is PQ-only by spec, so this is invalid output — an independent bug, belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)