### PR TITLE
fix(hdr): align Vivid metadata with GB/T 46269

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -176,6 +176,7 @@ set(SUNSHINE_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/clipboard_http.h"
         "${CMAKE_SOURCE_DIR}/src/video.cpp"
         "${CMAKE_SOURCE_DIR}/src/video.h"
+        "${CMAKE_SOURCE_DIR}/src/video_hdr_metadata.h"
         "${CMAKE_SOURCE_DIR}/src/video_colorspace.cpp"
         "${CMAKE_SOURCE_DIR}/src/video_colorspace.h"
         "${CMAKE_SOURCE_DIR}/src/input.cpp"

--- a/src/nvenc/common_impl/nvenc_base.cpp
+++ b/src/nvenc/common_impl/nvenc_base.cpp
@@ -105,6 +105,7 @@ namespace nvenc {
 
     if (encoder) destroy_encoder();
     auto fail_guard = util::fail_guard([this] { destroy_encoder(); });
+    dynamic_hdr_formats = video::hdr_metadata::formats_for(sunshine_colorspace);
 
     auto colorspace = nvenc_colorspace_from_sunshine_colorspace(sunshine_colorspace);
     auto buffer_format = nvenc_format_from_sunshine_format(sunshine_buffer_format);
@@ -757,6 +758,9 @@ namespace nvenc {
 
     encoder_state = {};
     encoder_params = {};
+    dynamic_hdr_formats = {};
+    luminance_stats = {};
+    vivid_filter.reset();
   }
 
   nvenc_encoded_frame
@@ -845,9 +849,11 @@ namespace nvenc {
 
     if (luminance_stats.valid && hdr_metadata && (video_format == 1 || video_format == 2)) {
       uint16_t max_lum = hdr_metadata->maxDisplayLuminance;
+      const auto vivid_metadata = vivid_filter.update(luminance_stats);
 
       // HDR10+ (PQ only — HDR10+ requires absolute luminance)
-      if (serialize_hdr10plus_sei(luminance_stats, max_lum, hdr10plus_payload) > 0) {
+      if (dynamic_hdr_formats.hdr10plus &&
+          serialize_hdr10plus_sei(luminance_stats, max_lum, hdr10plus_payload) > 0) {
         sei_payloads[sei_count].payloadSize = static_cast<uint32_t>(hdr10plus_payload.size());
         sei_payloads[sei_count].payloadType = 4;  // user_data_registered_itu_t_t35
         sei_payloads[sei_count].payload = hdr10plus_payload.data();
@@ -855,7 +861,8 @@ namespace nvenc {
       }
 
       // HDR Vivid (both PQ and HLG)
-      if (serialize_vivid_sei(luminance_stats, max_lum, vivid_payload) > 0) {
+      if (dynamic_hdr_formats.vivid &&
+          video::hdr_metadata::serialize_vivid_t35(vivid_metadata, vivid_payload) > 0) {
         sei_payloads[sei_count].payloadSize = static_cast<uint32_t>(vivid_payload.size());
         sei_payloads[sei_count].payloadType = 4;  // user_data_registered_itu_t_t35
         sei_payloads[sei_count].payload = vivid_payload.data();
@@ -1175,99 +1182,6 @@ namespace nvenc {
     // In 0.0001 cd/m² units
     uint32_t target_lum = static_cast<uint32_t>(peak_nits * 10000);
     bw.write(target_lum, 27);
-
-    bw.flush();
-
-    return payload.size();
-  }
-
-  size_t
-  nvenc_base::serialize_vivid_sei(const platf::hdr_frame_luminance_stats_t &stats,
-    uint16_t max_display_luminance,
-    std::vector<uint8_t> &payload) {
-    // HDR Vivid (CUVA / T/UWA 005.3) ITU-T T.35 registered SEI payload:
-    //   country_code:          0x26 (China)
-    //   terminal_provider_code: 0x0004 (CUVA HDR)
-    //   terminal_provider_oriented_code: 0x0005
-    //   system_start_code:     0x01
-    //   Then per-window: minimum_maxrgb, average_maxrgb, variance_maxrgb, maximum_maxrgb
-    //   tone_mapping_mode, color_saturation_mapping
-
-    float peak_nits = max_display_luminance > 0 ? static_cast<float>(max_display_luminance) : 1000.0f;
-
-    payload.clear();
-    payload.reserve(64);
-
-    // ITU-T T.35 header for CUVA HDR Vivid
-    payload.push_back(0x26);        // country_code (China)
-    payload.push_back(0x00);        // terminal_provider_code high byte
-    payload.push_back(0x04);        // terminal_provider_code low byte (CUVA)
-    payload.push_back(0x00);        // terminal_provider_oriented_code high byte
-    payload.push_back(0x05);        // terminal_provider_oriented_code low byte
-
-    // system_start_code: 8 bits
-    payload.push_back(0x01);
-
-    // Bitstream-packed fields
-    struct bitwriter {
-      std::vector<uint8_t> &buf;
-      uint32_t accumulator = 0;
-      int bits_pending = 0;
-
-      void write(uint32_t value, int num_bits) {
-        for (int i = num_bits - 1; i >= 0; --i) {
-          accumulator = (accumulator << 1) | ((value >> i) & 1);
-          bits_pending++;
-          if (bits_pending == 8) {
-            buf.push_back(static_cast<uint8_t>(accumulator));
-            accumulator = 0;
-            bits_pending = 0;
-          }
-        }
-      }
-
-      void flush() {
-        if (bits_pending > 0) {
-          accumulator <<= (8 - bits_pending);
-          buf.push_back(static_cast<uint8_t>(accumulator));
-          accumulator = 0;
-          bits_pending = 0;
-        }
-      }
-    };
-
-    bitwriter bw { payload };
-
-    // num_windows: 3 bits (value = 1)
-    bw.write(1, 3);
-
-    // For window 0:
-    // CUVA uses Q4.12 format (denominator 4095) for normalized values
-
-    // minimum_maxrgb: 12 bits
-    float min_norm = std::clamp(stats.min_maxrgb / peak_nits, 0.0f, 1.0f);
-    bw.write(static_cast<uint32_t>(min_norm * 4095), 12);
-
-    // average_maxrgb: 12 bits
-    float avg_norm = std::clamp(stats.avg_maxrgb / peak_nits, 0.0f, 1.0f);
-    bw.write(static_cast<uint32_t>(avg_norm * 4095), 12);
-
-    // variance_maxrgb: 12 bits
-    float variance_norm = std::clamp((stats.percentile_99 - stats.min_maxrgb) / peak_nits, 0.0f, 1.0f);
-    bw.write(static_cast<uint32_t>(variance_norm * 4095), 12);
-
-    // maximum_maxrgb: 12 bits
-    float max_norm = std::clamp(stats.percentile_95 / peak_nits, 0.0f, 1.0f);
-    bw.write(static_cast<uint32_t>(max_norm * 4095), 12);
-
-    // tone_mapping_mode_flag: 1 bit (= 0, no tone mapping)
-    bw.write(0, 1);
-
-    // tone_mapping_param_num: 1 bit (= 0)
-    bw.write(0, 1);
-
-    // color_saturation_mapping_flag: 1 bit (= 0)
-    bw.write(0, 1);
 
     bw.flush();
 

--- a/src/nvenc/common_impl/nvenc_base.h
+++ b/src/nvenc/common_impl/nvenc_base.h
@@ -11,6 +11,7 @@
 #include "src/config.h"
 #include "src/logging.h"
 #include "src/video.h"
+#include "src/video_hdr_metadata.h"
 
 #include <vector>
 
@@ -138,11 +139,13 @@ namespace nvenc {
 
     // Per-frame HDR luminance stats for dynamic metadata
     platf::hdr_frame_luminance_stats_t luminance_stats;
+    video::hdr_metadata::formats_t dynamic_hdr_formats;
+    video::hdr_metadata::vivid_temporal_filter_t vivid_filter;
 
     /**
      * @brief Serialize HDR10+ dynamic metadata into ITU-T T.35 SEI payload.
      *        Format follows ST 2094-40 (Samsung HDR10+).
-     * @param stats EMA-smoothed luminance statistics.
+     * @param stats Per-frame luminance statistics.
      * @param max_display_luminance Display peak luminance in nits.
      * @param[out] payload Output buffer for serialized payload.
      * @return Size of serialized payload in bytes, or 0 on failure.
@@ -152,17 +155,5 @@ namespace nvenc {
       uint16_t max_display_luminance,
       std::vector<uint8_t> &payload);
 
-    /**
-     * @brief Serialize HDR Vivid (CUVA) dynamic metadata into ITU-T T.35 SEI payload.
-     *        Format follows T/UWA 005.3 (China Ultrahigh-definition Video Association).
-     * @param stats EMA-smoothed luminance statistics.
-     * @param max_display_luminance Display peak luminance in nits.
-     * @param[out] payload Output buffer for serialized payload.
-     * @return Size of serialized payload in bytes, or 0 on failure.
-     */
-    size_t
-    serialize_vivid_sei(const platf::hdr_frame_luminance_stats_t &stats,
-      uint16_t max_display_luminance,
-      std::vector<uint8_t> &payload);
   };
 }

--- a/src/nvenc/nvenc_encoder.h
+++ b/src/nvenc/nvenc_encoder.h
@@ -83,8 +83,8 @@ namespace nvenc {
 
     /**
      * @brief Set per-frame HDR luminance statistics for dynamic metadata injection.
-     *        When valid stats are provided, the encoder will generate HDR10+ SEI/OBU
-     *        payloads and inject them into each encoded frame.
+     *        When valid stats are provided, the encoder injects HDR10+ for PQ and
+     *        HDR Vivid for PQ or HLG into each encoded HEVC/AV1 frame.
      * @param stats Per-frame luminance statistics from GPU analysis.
      */
     virtual void

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -474,22 +474,18 @@ namespace platf {
    * by a D3D11 compute shader and used to generate accurate per-frame
    * HDR dynamic metadata (CUVA HDR Vivid / HDR10+).
    *
-   * Values are in nits (cd/m²). scRGB 1.0 = 80 nits.
+   * Scalar luminance and HDR10+ percentile values are in nits (cd/m²);
+   * HDR Vivid P10/P90 values are in normalized PQ signal space.
+   * scRGB 1.0 = 80 nits.
    */
-  /// Number of luminance histogram bins (each bin = 78.125 nits, covering 0-10000 nits)
-  static constexpr uint32_t HDR_HISTOGRAM_BINS = 128;
-  /// Maximum nits covered by the histogram
-  static constexpr float HDR_HISTOGRAM_MAX_NITS = 10000.0f;
-  /// Nits per histogram bin
-  static constexpr float HDR_NITS_PER_BIN = HDR_HISTOGRAM_MAX_NITS / HDR_HISTOGRAM_BINS;
-
   struct hdr_frame_luminance_stats_t {
     float min_maxrgb = 0.0f;    ///< Minimum of max(R,G,B) across all pixels (nits)
     float max_maxrgb = 0.0f;    ///< Maximum of max(R,G,B) across all pixels (nits)
     float avg_maxrgb = 0.0f;    ///< Average of max(R,G,B) across all pixels (nits)
-    float percentile_95 = 0.0f; ///< 95th percentile of maxRGB (nits) — stable peak estimate
-    float percentile_99 = 0.0f; ///< 99th percentile of maxRGB (nits) — near-peak estimate
-    uint32_t histogram[HDR_HISTOGRAM_BINS] = {};  ///< Luminance histogram (128 bins × 78.125 nits)
+    float percentile_10_pq = 0.0f;  ///< 10th percentile in normalized PQ signal space
+    float percentile_90_pq = 0.0f;  ///< 90th percentile in normalized PQ signal space
+    float percentile_95 = 0.0f;     ///< 95th percentile of maxRGB (nits), for HDR10+
+    float percentile_99 = 0.0f;     ///< 99th percentile of maxRGB (nits), for HDR10+
     bool valid = false;         ///< Whether stats are available (false on first frame)
   };
 

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -27,6 +27,7 @@ extern "C" {
 #include "src/nvenc/win/nvenc_dynamic_factory.h"
 #include "src/amf/amf_d3d11.h"
 #include "src/video.h"
+#include "src/video_hdr_metadata.h"
 
 #include <AMF/components/DisplayCapture.h>
 #include <AMF/core/Factory.h>
@@ -1667,7 +1668,7 @@ namespace platf::dxgi {
     bool gpu_timing_disabled = false;
 
     // ===== HDR Luminance Analyzer (Two-Pass GPU Reduction) =====
-    // Pass 1: Per-tile CS — each 16x16 group produces {min, max, sum, count, histogram[128]}
+    // Pass 1: Per-tile CS — each 16x16 group produces {min, max, sum, count}
     // Pass 2: Single-group CS — reduces all groups to one final result on GPU
     // CPU only reads 1 FinalResult (no iteration over thousands of groups)
     cs_t hdr_pass1_cs;                     // First pass: per-tile analysis
@@ -1679,7 +1680,7 @@ namespace platf::dxgi {
     shader_res_t hdr_group_results_srv;    // SRV view for pass 2 input
     buf_t hdr_final_result_buf;            // Pass 2 output (default usage + UAV)
     uav_t hdr_final_result_uav;            // UAV view for pass 2 output
-    buf_t hdr_global_histogram_buf;        // 128-bin histogram accumulated by pass 1 atomics
+    buf_t hdr_global_histogram_buf;        // 256-bin PQ histogram accumulated by pass 1 atomics
     uav_t hdr_global_histogram_uav;        // Typed R32_UINT UAV (clearable + atomic-capable)
     buf_t hdr_staging_buf;                 // Staging buffer for CPU readback (1 FinalResult)
     buf_t hdr_analysis_cbuf;               // Constant buffer for pass 1 (analysis resolution)
@@ -1716,16 +1717,16 @@ namespace platf::dxgi {
     bool cs_writes_output_directly = false; // True when UAV is bound directly to output_texture (no scratch + CopyResource)
 
     // Must match HLSL GroupResult layout exactly
-    static constexpr uint32_t HISTOGRAM_BINS = 128;
+    static constexpr uint32_t HISTOGRAM_BINS = 256;
     static constexpr uint32_t HDR_ANALYSIS_INTERVAL = 4;
     static constexpr uint32_t HDR_ANALYSIS_MAX_WIDTH = 1920;
     static constexpr uint32_t HDR_ANALYSIS_MAX_HEIGHT = 1080;
 
-    // Pass 1 per-tile output. Deliberately scalars only: the 128-bin histogram is
+    // Pass 1 per-tile output. Deliberately scalars only: the PQ histogram is
     // accumulated straight into a single global buffer by sparse atomics in pass 1,
     // instead of being carried per-tile and merged by pass 2. Carrying it here cost
-    // 528 bytes/tile (~4.3 MiB/frame of mostly-zero writes) and forced pass 2 to walk
-    // numGroups x 128 dwords at a 528-byte stride from a single thread group.
+    // hundreds of bytes per tile and would force pass 2 to walk a large sparse
+    // array from a single thread group.
     struct GroupResult {
       float minMaxRGB;
       float maxMaxRGB;
@@ -1906,7 +1907,7 @@ namespace platf::dxgi {
         return -1;
       }
 
-      // --- Global histogram: 128 bins accumulated by pass 1 via InterlockedAdd ---
+      // --- Global PQ-domain histogram accumulated by pass 1 via InterlockedAdd ---
       // Typed (non-structured) R32_UINT so ClearUnorderedAccessViewUint() is well-defined
       // on it; a structured-buffer UAV is not reliably clearable across drivers.
       D3D11_BUFFER_DESC hist_desc = {};
@@ -2040,7 +2041,7 @@ namespace platf::dxgi {
     /**
      * @brief Read HDR analysis results from the staging buffer (previous frame).
      * GPU has already reduced all groups to one FinalResult — CPU just reads it
-     * and computes percentiles from the histogram.
+     * and computes PQ-domain percentiles from the histogram.
      */
     void
     read_hdr_analysis_results() {
@@ -2064,27 +2065,38 @@ namespace platf::dxgi {
         hdr_luminance_stats_out.max_maxrgb = result->maxMaxRGB;
         hdr_luminance_stats_out.avg_maxrgb = result->sumMaxRGB / static_cast<float>(result->pixelCount);
 
-        // Copy histogram to stats
-        for (uint32_t i = 0; i < HISTOGRAM_BINS; i++) {
-          hdr_luminance_stats_out.histogram[i] = result->histogram[i];
-        }
-
-        // Compute P95 and P99 percentiles from histogram
-        uint32_t total = result->pixelCount;
-        uint32_t target_95 = static_cast<uint32_t>(total * 0.95);
-        uint32_t target_99 = static_cast<uint32_t>(total * 0.99);
+        // HDR Vivid defines variance as P90-P10 in normalized PQ signal space.
+        // Retain P95/P99 in nits for the independent HDR10+ path.
+        const uint32_t total = result->pixelCount;
+        const uint32_t target_10 = static_cast<uint32_t>(std::ceil(total * 0.10f));
+        const uint32_t target_90 = static_cast<uint32_t>(std::ceil(total * 0.90f));
+        const uint32_t target_95 = static_cast<uint32_t>(std::ceil(total * 0.95f));
+        const uint32_t target_99 = static_cast<uint32_t>(std::ceil(total * 0.99f));
         uint32_t cumulative = 0;
-        bool found_95 = false, found_99 = false;
+        bool found_10 = false;
+        bool found_90 = false;
+        bool found_95 = false;
+        bool found_99 = false;
 
         for (uint32_t i = 0; i < HISTOGRAM_BINS; i++) {
           cumulative += result->histogram[i];
+          const float pq_bin_center = (static_cast<float>(i) + 0.5f) / HISTOGRAM_BINS;
+          if (!found_10 && cumulative >= target_10) {
+            hdr_luminance_stats_out.percentile_10_pq = pq_bin_center;
+            found_10 = true;
+          }
+          if (!found_90 && cumulative >= target_90) {
+            hdr_luminance_stats_out.percentile_90_pq = pq_bin_center;
+            found_90 = true;
+          }
           if (!found_95 && cumulative >= target_95) {
-            // P95 is the upper edge of this bin
-            hdr_luminance_stats_out.percentile_95 = (i + 1) * platf::HDR_NITS_PER_BIN;
+            hdr_luminance_stats_out.percentile_95 =
+              ::video::hdr_metadata::pq_to_nits(pq_bin_center);
             found_95 = true;
           }
           if (!found_99 && cumulative >= target_99) {
-            hdr_luminance_stats_out.percentile_99 = (i + 1) * platf::HDR_NITS_PER_BIN;
+            hdr_luminance_stats_out.percentile_99 =
+              ::video::hdr_metadata::pq_to_nits(pq_bin_center);
             found_99 = true;
             break;
           }

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -36,6 +36,7 @@ extern "C" {
 #include "platform/common.h"
 #include "sync.h"
 #include "video.h"
+#include "video_hdr_metadata.h"
 
 #ifdef _WIN32
 extern "C" {
@@ -638,9 +639,10 @@ namespace video {
     std::vector<packet_raw_t::replace_t> replacements;
     frame_timestamp_ring_t frame_timestamps;
 
-    // Temporal smoothing state for HDR dynamic metadata. Owned per session so a new
-    // stream starts from an unconverged EMA rather than inheriting the previous one's.
+    // Temporal filters are session-local so a new stream cannot inherit metadata
+    // history from the previous stream.
     hdr_luminance_ema_t hdr_ema;
+    hdr_metadata::vivid_temporal_filter_t vivid_filter;
 
     cbs::nal_t sps;
     cbs::nal_t vps;
@@ -1866,61 +1868,56 @@ namespace video {
   }
 
   /**
-   * @brief Update per-frame HDR dynamic metadata with smoothed GPU-computed luminance stats.
+   * @brief Update HDR Vivid and HDR10+ side data before encoding a frame.
    *
-   * Called before each avcodec_send_frame() to inject accurate per-frame
-   * maxRGB statistics into HDR Vivid and HDR10+ side data.
-   * Uses P95 percentile for peak luminance (more stable than raw max) and
-   * EMA-smoothed values to prevent frame-to-frame flicker.
+   * HDR Vivid receives its GB/T 46269.1-2025 content-domain statistics after
+   * the recommended 32-frame mean. HDR10+ keeps its independent EMA path.
    *
    * @param frame The AVFrame with pre-allocated dynamic HDR side data
-   * @param ema Temporally-smoothed luminance statistics
-   * @param max_display_luminance Display peak luminance in nits (from EDID)
+   * @param ema Temporally-smoothed HDR10+ luminance statistics
+   * @param vivid_metadata Filtered HDR Vivid statistics in normalized PQ space
+   * @param max_display_luminance Mapped client display peak luminance in nits
    */
   void
-  update_hdr_dynamic_metadata(AVFrame *frame, const hdr_luminance_ema_t &ema, uint16_t max_display_luminance) {
-    if (!ema.initialized || !frame) return;
-
-    float peak_nits = max_display_luminance > 0 ? static_cast<float>(max_display_luminance) : 1000.0f;
-
-    // Use P95 as the "effective peak" for metadata — more stable than raw max,
-    // avoids single-pixel HDR highlights distorting global tone mapping
-    float effective_max = ema.percentile_95;
+  update_hdr_dynamic_metadata(
+    AVFrame *frame,
+    const hdr_luminance_ema_t &ema,
+    const hdr_metadata::vivid_metadata_t &vivid_metadata,
+    uint16_t max_display_luminance) {
+    if (!frame) return;
 
     // Update HDR Vivid (CUVA) dynamic metadata
     auto vivid_sd = av_frame_get_side_data(frame, AV_FRAME_DATA_DYNAMIC_HDR_VIVID);
-    if (vivid_sd) {
+    if (vivid_sd && vivid_metadata.valid) {
       auto *vivid = reinterpret_cast<AVDynamicHDRVivid *>(vivid_sd->data);
       if (vivid && vivid->num_windows > 0) {
         auto &params = vivid->params[0];
 
-        // Normalize to [0, 1] range relative to peak luminance
-        // CUVA spec uses Q4.12 representation via AVRational with denominator 4095
-        float min_norm = std::clamp(ema.min_maxrgb / peak_nits, 0.0f, 1.0f);
-        float avg_norm = std::clamp(ema.avg_maxrgb / peak_nits, 0.0f, 1.0f);
-        float max_norm = std::clamp(effective_max / peak_nits, 0.0f, 1.0f);
+        params.minimum_maxrgb = av_make_q(vivid_metadata.minimum_maxrgb_pq, 4095);
+        params.average_maxrgb = av_make_q(vivid_metadata.average_maxrgb_pq, 4095);
+        params.variance_maxrgb = av_make_q(vivid_metadata.variance_maxrgb_pq, 4095);
+        params.maximum_maxrgb = av_make_q(vivid_metadata.maximum_maxrgb_pq, 4095);
 
-        // Variance: spread between P99 and min, normalized
-        float variance_norm = std::clamp((ema.percentile_99 - ema.min_maxrgb) / peak_nits, 0.0f, 1.0f);
-
-        params.minimum_maxrgb = av_make_q(static_cast<int>(min_norm * 4095), 4095);
-        params.average_maxrgb = av_make_q(static_cast<int>(avg_norm * 4095), 4095);
-        params.variance_maxrgb = av_make_q(static_cast<int>(variance_norm * 4095), 4095);
-        params.maximum_maxrgb = av_make_q(static_cast<int>(max_norm * 4095), 4095);
-
-        // Update targeted display luminance in tone mapping params
+        const float target_display_nits =
+          max_display_luminance > 0 ? static_cast<float>(max_display_luminance) : 1000.0f;
+        const int target_display_pq = hdr_metadata::pq_to_u12(
+          hdr_metadata::nits_to_pq(target_display_nits));
         for (int i = 0; i < 2; i++) {
-          params.tm_params[i].targeted_system_display_maximum_luminance = av_make_q(max_display_luminance, 1);
+          params.tm_params[i].targeted_system_display_maximum_luminance =
+            av_make_q(target_display_pq, 4095);
         }
       }
     }
 
     // Update HDR10+ dynamic metadata
     auto hdr10plus_sd = av_frame_get_side_data(frame, AV_FRAME_DATA_DYNAMIC_HDR_PLUS);
-    if (hdr10plus_sd) {
+    if (hdr10plus_sd && ema.initialized) {
       auto *hdr10plus = reinterpret_cast<AVDynamicHDRPlus *>(hdr10plus_sd->data);
       if (hdr10plus && hdr10plus->num_windows > 0) {
         auto &params = hdr10plus->params[0];
+        const float peak_nits =
+          max_display_luminance > 0 ? static_cast<float>(max_display_luminance) : 1000.0f;
+        const float effective_max = ema.percentile_95;
 
         // HDR10+ maxscl: use P95 for stability
         float max_norm = std::clamp(effective_max / peak_nits, 0.0f, 1.0f);
@@ -1958,12 +1955,13 @@ namespace video {
     auto &sps = session.sps;
     auto &vps = session.vps;
 
-    // Update per-frame HDR dynamic metadata with GPU-computed luminance stats
-    // Apply temporal EMA smoothing to prevent brightness jitter between frames
+    // Update per-frame dynamic metadata. HDR10+ and HDR Vivid intentionally use
+    // their own temporal models because their standards define different fields.
     {
       auto &raw_stats = session.device->hdr_luminance_stats;
       if (raw_stats.valid) {
         session.hdr_ema.update(raw_stats);
+        const auto vivid_metadata = session.vivid_filter.update(raw_stats);
 
         uint16_t max_lum = 1000;
         auto mdm_sd = av_frame_get_side_data(frame, AV_FRAME_DATA_MASTERING_DISPLAY_METADATA);
@@ -1973,7 +1971,7 @@ namespace video {
             max_lum = static_cast<uint16_t>(av_q2d(mdm->max_luminance));
           }
         }
-        update_hdr_dynamic_metadata(frame, session.hdr_ema, max_lum);
+        update_hdr_dynamic_metadata(frame, session.hdr_ema, vivid_metadata, max_lum);
       }
     }
 
@@ -2577,7 +2575,7 @@ namespace video {
           }
         }
 
-        // HDR Vivid (CUVA HDR / T/UWA 3.137) dynamic metadata - both PQ and HLG
+        // HDR Vivid dynamic metadata (GB/T 46269.1-2025) - both PQ and HLG
         // HDR Vivid supports both transfer functions:
         //   - PQ mode: absolute luminance tone mapping
         //   - HLG mode: scene-referred relative luminance tone mapping
@@ -2610,9 +2608,15 @@ namespace video {
           }
 
           // Initialize tone mapping params structure (even if not used)
+          const float target_display_nits = hdr_metadata.maxDisplayLuminance > 0
+                                              ? static_cast<float>(hdr_metadata.maxDisplayLuminance)
+                                              : 1000.0f;
+          const int target_display_pq = video::hdr_metadata::pq_to_u12(
+            video::hdr_metadata::nits_to_pq(target_display_nits));
           for (int i = 0; i < 2; i++) {
             auto &tm_params = params.tm_params[i];
-            tm_params.targeted_system_display_maximum_luminance = av_make_q(hdr_metadata.maxDisplayLuminance, 1);
+            tm_params.targeted_system_display_maximum_luminance =
+              av_make_q(target_display_pq, 4095);
             tm_params.base_enable_flag = 0;
             tm_params.base_param_m_p = av_make_q(0, 16383);
             tm_params.base_param_m_m = av_make_q(0, 10);

--- a/src/video_hdr_metadata.h
+++ b/src/video_hdr_metadata.h
@@ -16,6 +16,14 @@
 
 namespace video::hdr_metadata {
 
+  namespace detail {
+    constexpr double st2084_m1 = 2610.0 / 4096.0 / 4.0;
+    constexpr double st2084_m2 = 2523.0 / 4096.0 * 128.0;
+    constexpr double st2084_c1 = 3424.0 / 4096.0;
+    constexpr double st2084_c2 = 2413.0 / 4096.0 * 32.0;
+    constexpr double st2084_c3 = 2392.0 / 4096.0 * 32.0;
+  }  // namespace detail
+
   struct formats_t {
     bool hdr10plus = false;
     bool vivid = false;
@@ -42,38 +50,33 @@ namespace video::hdr_metadata {
    */
   inline float
   nits_to_pq(float nits) {
-    constexpr double m1 = 2610.0 / 4096.0 / 4.0;
-    constexpr double m2 = 2523.0 / 4096.0 * 128.0;
-    constexpr double c1 = 3424.0 / 4096.0;
-    constexpr double c2 = 2413.0 / 4096.0 * 32.0;
-    constexpr double c3 = 2392.0 / 4096.0 * 32.0;
-
     if (!std::isfinite(nits)) {
       return 0.0f;
     }
 
     const double normalized = std::clamp(static_cast<double>(nits) / 10000.0, 0.0, 1.0);
-    const double powered = std::pow(normalized, m1);
-    return static_cast<float>(std::pow((c1 + c2 * powered) / (1.0 + c3 * powered), m2));
+    const double powered = std::pow(normalized, detail::st2084_m1);
+    return static_cast<float>(std::pow(
+      (detail::st2084_c1 + detail::st2084_c2 * powered) /
+        (1.0 + detail::st2084_c3 * powered),
+      detail::st2084_m2
+    ));
   }
 
   inline float
   pq_to_nits(float pq) {
-    constexpr double m1 = 2610.0 / 4096.0 / 4.0;
-    constexpr double m2 = 2523.0 / 4096.0 * 128.0;
-    constexpr double c1 = 3424.0 / 4096.0;
-    constexpr double c2 = 2413.0 / 4096.0 * 32.0;
-    constexpr double c3 = 2392.0 / 4096.0 * 32.0;
-
     if (!std::isfinite(pq)) {
       return 0.0f;
     }
 
     const double powered =
-      std::pow(std::clamp(static_cast<double>(pq), 0.0, 1.0), 1.0 / m2);
-    const double numerator = std::max(powered - c1, 0.0);
-    const double denominator = std::max(c2 - c3 * powered, 1.0e-12);
-    return static_cast<float>(10000.0 * std::pow(numerator / denominator, 1.0 / m1));
+      std::pow(std::clamp(static_cast<double>(pq), 0.0, 1.0), 1.0 / detail::st2084_m2);
+    const double numerator = std::max(powered - detail::st2084_c1, 0.0);
+    const double denominator =
+      std::max(detail::st2084_c2 - detail::st2084_c3 * powered, 1.0e-12);
+    return static_cast<float>(
+      10000.0 * std::pow(numerator / denominator, 1.0 / detail::st2084_m1)
+    );
   }
 
   inline uint16_t

--- a/src/video_hdr_metadata.h
+++ b/src/video_hdr_metadata.h
@@ -1,0 +1,267 @@
+/**
+ * @file src/video_hdr_metadata.h
+ * @brief Helpers for generating and stabilizing HDR dynamic metadata.
+ */
+#pragma once
+
+#include "platform/common.h"
+#include "video_colorspace.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace video::hdr_metadata {
+
+  struct formats_t {
+    bool hdr10plus = false;
+    bool vivid = false;
+  };
+
+  /**
+   * HDR10+ is defined for PQ content. HDR Vivid can accompany either PQ or HLG.
+   */
+  inline formats_t
+  formats_for(const sunshine_colorspace_t &colorspace) {
+    switch (colorspace.colorspace) {
+      case colorspace_e::bt2020:
+        return { .hdr10plus = true, .vivid = true };
+      case colorspace_e::bt2020hlg:
+        return { .hdr10plus = false, .vivid = true };
+      default:
+        return {};
+    }
+  }
+
+  /**
+   * Convert absolute display luminance to the normalized SMPTE ST 2084 signal
+   * used by GB/T 46269.1-2025 (equivalent to T/UWA 005.1-2024).
+   */
+  inline float
+  nits_to_pq(float nits) {
+    constexpr double m1 = 2610.0 / 4096.0 / 4.0;
+    constexpr double m2 = 2523.0 / 4096.0 * 128.0;
+    constexpr double c1 = 3424.0 / 4096.0;
+    constexpr double c2 = 2413.0 / 4096.0 * 32.0;
+    constexpr double c3 = 2392.0 / 4096.0 * 32.0;
+
+    if (!std::isfinite(nits)) {
+      return 0.0f;
+    }
+
+    const double normalized = std::clamp(static_cast<double>(nits) / 10000.0, 0.0, 1.0);
+    const double powered = std::pow(normalized, m1);
+    return static_cast<float>(std::pow((c1 + c2 * powered) / (1.0 + c3 * powered), m2));
+  }
+
+  inline float
+  pq_to_nits(float pq) {
+    constexpr double m1 = 2610.0 / 4096.0 / 4.0;
+    constexpr double m2 = 2523.0 / 4096.0 * 128.0;
+    constexpr double c1 = 3424.0 / 4096.0;
+    constexpr double c2 = 2413.0 / 4096.0 * 32.0;
+    constexpr double c3 = 2392.0 / 4096.0 * 32.0;
+
+    if (!std::isfinite(pq)) {
+      return 0.0f;
+    }
+
+    const double powered =
+      std::pow(std::clamp(static_cast<double>(pq), 0.0, 1.0), 1.0 / m2);
+    const double numerator = std::max(powered - c1, 0.0);
+    const double denominator = std::max(c2 - c3 * powered, 1.0e-12);
+    return static_cast<float>(10000.0 * std::pow(numerator / denominator, 1.0 / m1));
+  }
+
+  inline uint16_t
+  pq_to_u12(float pq) {
+    if (!std::isfinite(pq)) {
+      return 0;
+    }
+    return static_cast<uint16_t>(std::clamp(pq, 0.0f, 1.0f) * 4095.0f);
+  }
+
+  struct vivid_metadata_t {
+    uint16_t minimum_maxrgb_pq = 0;
+    uint16_t average_maxrgb_pq = 0;
+    uint16_t variance_maxrgb_pq = 0;
+    uint16_t maximum_maxrgb_pq = 0;
+    bool valid = false;
+  };
+
+  /**
+   * Generate the four statistics-mode HDR Vivid fields from content values.
+   *
+   * The fields describe the content in the PQ signal domain. Target display
+   * luminance is intentionally not an input: it belongs to display adaptation
+   * and optional curve parameters, not to these content statistics.
+   */
+  inline vivid_metadata_t
+  vivid_from_stats(const platf::hdr_frame_luminance_stats_t &stats) {
+    if (!stats.valid) {
+      return {};
+    }
+
+    vivid_metadata_t result;
+    result.minimum_maxrgb_pq = pq_to_u12(nits_to_pq(stats.min_maxrgb));
+    result.average_maxrgb_pq = pq_to_u12(nits_to_pq(stats.avg_maxrgb));
+    result.variance_maxrgb_pq = pq_to_u12(
+      std::max(stats.percentile_90_pq - stats.percentile_10_pq, 0.0f));
+    result.maximum_maxrgb_pq = pq_to_u12(nits_to_pq(stats.max_maxrgb));
+    result.valid = true;
+    return result;
+  }
+
+  /**
+   * GB/T 46269.1-2025 Annex A.9 recommends a 32-frame arithmetic mean over
+   * generated dynamic metadata. Reused analyzer samples are deliberately added
+   * once per encoded frame so the window remains 32 video frames even when GPU
+   * analysis runs at a lower cadence. reset() is available for a future reliable
+   * scene-cut signal; this layer deliberately does not guess one from brightness.
+   */
+  class vivid_temporal_filter_t {
+  public:
+    vivid_metadata_t
+    update(const platf::hdr_frame_luminance_stats_t &stats) {
+      return update(vivid_from_stats(stats));
+    }
+
+    vivid_metadata_t
+    update(const vivid_metadata_t &metadata) {
+      if (!metadata.valid) {
+        return {};
+      }
+
+      if (count_ == WINDOW_SIZE) {
+        subtract(samples_[next_]);
+      }
+      else {
+        ++count_;
+      }
+
+      samples_[next_] = metadata;
+      add(metadata);
+      next_ = (next_ + 1) % WINDOW_SIZE;
+
+      vivid_metadata_t result;
+      result.minimum_maxrgb_pq = static_cast<uint16_t>(minimum_sum_ / count_);
+      result.average_maxrgb_pq = static_cast<uint16_t>(average_sum_ / count_);
+      result.variance_maxrgb_pq = static_cast<uint16_t>(variance_sum_ / count_);
+      result.maximum_maxrgb_pq = static_cast<uint16_t>(maximum_sum_ / count_);
+      result.valid = true;
+      return result;
+    }
+
+    void
+    reset() {
+      *this = {};
+    }
+
+  private:
+    static constexpr size_t WINDOW_SIZE = 32;
+
+    void
+    add(const vivid_metadata_t &metadata) {
+      minimum_sum_ += metadata.minimum_maxrgb_pq;
+      average_sum_ += metadata.average_maxrgb_pq;
+      variance_sum_ += metadata.variance_maxrgb_pq;
+      maximum_sum_ += metadata.maximum_maxrgb_pq;
+    }
+
+    void
+    subtract(const vivid_metadata_t &metadata) {
+      minimum_sum_ -= metadata.minimum_maxrgb_pq;
+      average_sum_ -= metadata.average_maxrgb_pq;
+      variance_sum_ -= metadata.variance_maxrgb_pq;
+      maximum_sum_ -= metadata.maximum_maxrgb_pq;
+    }
+
+    std::array<vivid_metadata_t, WINDOW_SIZE> samples_ {};
+    size_t next_ = 0;
+    uint32_t count_ = 0;
+    uint32_t minimum_sum_ = 0;
+    uint32_t average_sum_ = 0;
+    uint32_t variance_sum_ = 0;
+    uint32_t maximum_sum_ = 0;
+  };
+
+  namespace detail {
+
+    class bit_writer_t {
+    public:
+      explicit bit_writer_t(std::vector<uint8_t> &buffer):
+          buffer_(buffer) {
+      }
+
+      void
+      write(uint32_t value, int bit_count) {
+        for (int bit = bit_count - 1; bit >= 0; --bit) {
+          accumulator_ = (accumulator_ << 1) | ((value >> bit) & 1U);
+          ++pending_bits_;
+          if (pending_bits_ == 8) {
+            buffer_.push_back(static_cast<uint8_t>(accumulator_));
+            accumulator_ = 0;
+            pending_bits_ = 0;
+          }
+        }
+      }
+
+      void
+      flush() {
+        if (pending_bits_ == 0) {
+          return;
+        }
+
+        accumulator_ <<= 8 - pending_bits_;
+        buffer_.push_back(static_cast<uint8_t>(accumulator_));
+        accumulator_ = 0;
+        pending_bits_ = 0;
+      }
+
+    private:
+      std::vector<uint8_t> &buffer_;
+      uint32_t accumulator_ = 0;
+      int pending_bits_ = 0;
+    };
+
+  }  // namespace detail
+
+  /**
+   * Serialize a CUVA HDR Vivid ITU-T T.35 payload.
+   *
+   * For system_start_code 0x01, T/UWA 005.1 fixes num_windows to one; it is not
+   * present in the bitstream. tone_mapping_param_num is likewise absent when
+   * tone_mapping_mode_flag is zero.
+   */
+  inline size_t
+  serialize_vivid_t35(const vivid_metadata_t &metadata, std::vector<uint8_t> &payload) {
+    if (!metadata.valid) {
+      payload.clear();
+      return 0;
+    }
+
+    payload.clear();
+    payload.reserve(16);
+    payload.push_back(0x26);  // itu_t_t35_country_code: China
+    payload.push_back(0x00);
+    payload.push_back(0x04);  // itu_t_t35_terminal_provider_code: CUVA
+    payload.push_back(0x00);
+    payload.push_back(0x05);  // itu_t_t35_terminal_provider_oriented_code
+    payload.push_back(0x01);  // system_start_code
+
+    detail::bit_writer_t writer { payload };
+    writer.write(metadata.minimum_maxrgb_pq, 12);
+    writer.write(metadata.average_maxrgb_pq, 12);
+    writer.write(metadata.variance_maxrgb_pq, 12);
+    writer.write(metadata.maximum_maxrgb_pq, 12);
+    writer.write(0, 1);  // tone_mapping_mode_flag
+    writer.write(0, 1);  // color_saturation_mapping_flag
+    writer.flush();
+
+    return payload.size();
+  }
+
+}  // namespace video::hdr_metadata

--- a/src_assets/windows/assets/shaders/directx/hdr_luminance_analysis_cs.hlsl
+++ b/src_assets/windows/assets/shaders/directx/hdr_luminance_analysis_cs.hlsl
@@ -13,23 +13,24 @@
  *   histogram accumulated by atomics.
  *   Each thread group (16x16 = 256 threads) processes one tile, writes
  *   {min, max, sum, count} of maxRGB values (in nits) to the output buffer, and folds
- *   its local 128-bin histogram into the global one with one atomic per occupied bin.
+ *   its local PQ-domain histogram into the global one with one atomic per occupied bin.
  *   A second-pass shader reduces the per-tile scalars to one result.
  *
- * Histogram: 128 bins covering 0-10000 nits, each bin = 78.125 nits wide.
- *   Used for P95/P99 percentile computation for stable peak luminance.
+ * Histogram: 256 uniform bins in normalized PQ signal space.
+ *   HDR Vivid variance is P90-P10 in PQ space; PQ-domain bins retain useful
+ *   precision in dark regions that a linear-nits histogram would discard.
  *
  * Thread group size: 16x16 = 256 threads
  * Dispatch: (ceil(analysisWidth/16), ceil(analysisHeight/16), 1)
  */
 
+#include "include/common.hlsl"
+
 // scRGB to nits conversion factor
 static const float SCRGB_NITS_PER_UNIT = 80.0;
 
 // Histogram parameters
-static const uint HISTOGRAM_BINS = 128;
-static const float HISTOGRAM_MAX_NITS = 10000.0;
-static const float NITS_PER_BIN = HISTOGRAM_MAX_NITS / HISTOGRAM_BINS;  // 78.125
+static const uint HISTOGRAM_BINS = 256;
 
 // Input texture (scRGB FP16)
 Texture2D<float4> inputTexture : register(t0);
@@ -52,7 +53,7 @@ struct GroupResult {
 
 RWStructuredBuffer<GroupResult> groupResults : register(u0);
 
-// Frame-global 128-bin histogram. Each group folds its local histogram in with one
+// Frame-global 256-bin histogram. Each group folds its local histogram in with one
 // atomic per *occupied* bin, so pass 2 never has to merge per-tile histograms.
 // Cleared by the host before every dispatch.
 RWBuffer<uint> globalHistogram : register(u1);
@@ -70,7 +71,7 @@ void main_cs(uint3 DTid : SV_DispatchThreadID,
              uint3 Gid  : SV_GroupID,
              uint  GIndex : SV_GroupIndex)
 {
-    // Initialize shared histogram bins (each thread zeroes ~1 bin, 256 threads > 128 bins)
+    // Initialize shared histogram bins (one bin per thread).
     if (GIndex < HISTOGRAM_BINS) {
         gs_histogram[GIndex] = 0;
     }
@@ -84,15 +85,13 @@ void main_cs(uint3 DTid : SV_DispatchThreadID,
         float2 uv = (float2(DTid.xy) + 0.5) / float2(analysisWidth, analysisHeight);
         float4 pixel = inputTexture.SampleLevel(linearSampler, uv, 0.0);
 
-        // maxRGB = max(R, G, B) — the brightest channel per pixel
-        // This is the key statistic used by CUVA HDR Vivid and HDR10+
-        float maxRGB = max(max(pixel.r, pixel.g), pixel.b);
-
-        // Clamp negative values (out-of-gamut in scRGB)
-        maxRGB = max(maxRGB, 0.0);
-
-        // Convert to nits: scRGB 1.0 = 80 nits
-        maxRGB_nits = maxRGB * SCRGB_NITS_PER_UNIT;
+        // Match the encoder's scRGB (display-linear Rec.709) to Rec.2020 before
+        // extracting maxRGB. For an HLG source, Windows composition has already
+        // produced the display-linear result of inverse OETF + OOTF, so converting
+        // these absolute nits to PQ matches GB/T 46269.1-2025 Annex A.2.
+        // PQ is monotonic, so max(PQ(R),PQ(G),PQ(B)) equals PQ(max(R,G,B)).
+        float3 rec2020_nits = max(Rec709toRec2020(pixel.rgb) * SCRGB_NITS_PER_UNIT, 0.0);
+        maxRGB_nits = max(max(rec2020_nits.r, rec2020_nits.g), rec2020_nits.b);
     }
 
     // Initialize shared memory for min/max/sum/count reduction
@@ -105,7 +104,8 @@ void main_cs(uint3 DTid : SV_DispatchThreadID,
 
     // Accumulate into shared histogram using atomic add
     if (valid) {
-        uint bin = min((uint)(maxRGB_nits / NITS_PER_BIN), HISTOGRAM_BINS - 1);
+        float maxRGB_pq = NitsToPQ(maxRGB_nits.xxx).x;
+        uint bin = min((uint)(maxRGB_pq * HISTOGRAM_BINS), HISTOGRAM_BINS - 1);
         InterlockedAdd(gs_histogram[bin], 1);
     }
 

--- a/src_assets/windows/assets/shaders/directx/hdr_luminance_reduce_cs.hlsl
+++ b/src_assets/windows/assets/shaders/directx/hdr_luminance_reduce_cs.hlsl
@@ -3,14 +3,14 @@
  * @brief Second-pass GPU reduction shader for HDR luminance analysis.
  *
  * Reduces per-group scalar results from the first-pass analysis shader into a single
- * final result. The 128-bin histogram is not merged here — pass 1 already accumulated
+ * final result. The 256-bin histogram is not merged here — pass 1 already accumulated
  * it into a frame-global buffer via atomics, so this shader only copies it out.
  *
  * Input:  StructuredBuffer of GroupResult from first pass (N groups, 16 bytes each)
- *         RWBuffer of the frame-global 128-bin histogram
+ *         RWBuffer of the frame-global 256-bin PQ-domain histogram
  * Output: RWStructuredBuffer with 1 FinalResult containing:
  *         - Global min/max/sum/count
- *         - The merged 128-bin histogram
+ *         - The merged 256-bin histogram
  *
  * Dispatch: (1, 1, 1) — single thread group of 256 threads
  * Threads walk the group array with a grid-stride loop so the loads coalesce.
@@ -18,7 +18,7 @@
  * cbuffer provides numGroups so the shader knows how many to reduce.
  */
 
-static const uint HISTOGRAM_BINS = 128;
+static const uint HISTOGRAM_BINS = 256;
 
 struct GroupResult {
     float minMaxRGB;
@@ -104,7 +104,7 @@ void main_cs(uint GIndex : SV_GroupIndex)
         finalResult[0].pixelCount = gs_count[0];
     }
 
-    // First 128 threads copy the already-merged global histogram into the readback struct
+    // All 256 threads copy the already-merged global histogram into the readback struct
     if (GIndex < HISTOGRAM_BINS) {
         finalResult[0].histogram[GIndex] = globalHistogram[GIndex];
     }

--- a/tests/unit/test_video_hdr_metadata.cpp
+++ b/tests/unit/test_video_hdr_metadata.cpp
@@ -1,0 +1,137 @@
+/**
+ * @file tests/unit/test_video_hdr_metadata.cpp
+ * @brief Tests for HDR Vivid metadata generation and temporal filtering.
+ */
+#include <src/video_hdr_metadata.h>
+
+#include <limits>
+
+#include "../tests_common.h"
+
+namespace {
+
+  uint32_t
+  read_bits(const std::vector<uint8_t> &data, size_t &bit_offset, int bit_count) {
+    uint32_t value = 0;
+    for (int bit = 0; bit < bit_count; ++bit) {
+      const size_t byte_index = bit_offset / 8;
+      const int bit_index = 7 - static_cast<int>(bit_offset % 8);
+      value = (value << 1) | ((data.at(byte_index) >> bit_index) & 1U);
+      ++bit_offset;
+    }
+    return value;
+  }
+
+}  // namespace
+
+TEST(HdrDynamicMetadata, RoutesFormatsByTransferFunction) {
+  using video::colorspace_e;
+  using video::hdr_metadata::formats_for;
+  using video::sunshine_colorspace_t;
+
+  const auto pq = formats_for(sunshine_colorspace_t { colorspace_e::bt2020, false, 10 });
+  EXPECT_TRUE(pq.hdr10plus);
+  EXPECT_TRUE(pq.vivid);
+
+  const auto hlg = formats_for(sunshine_colorspace_t { colorspace_e::bt2020hlg, true, 10 });
+  EXPECT_FALSE(hlg.hdr10plus);
+  EXPECT_TRUE(hlg.vivid);
+
+  const auto sdr = formats_for(sunshine_colorspace_t { colorspace_e::rec709, false, 8 });
+  EXPECT_FALSE(sdr.hdr10plus);
+  EXPECT_FALSE(sdr.vivid);
+}
+
+TEST(HdrDynamicMetadata, GeneratesVividFieldsInPqContentDomain) {
+  platf::hdr_frame_luminance_stats_t stats;
+  stats.min_maxrgb = 0.0f;
+  stats.avg_maxrgb = 100.0f;
+  stats.max_maxrgb = 1000.0f;
+  stats.percentile_10_pq = 0.1f;
+  stats.percentile_90_pq = 0.9f;
+  stats.percentile_95 = 400.0f;  // Must not replace the actual maximum.
+  stats.valid = true;
+
+  const auto metadata = video::hdr_metadata::vivid_from_stats(stats);
+  ASSERT_TRUE(metadata.valid);
+  EXPECT_EQ(metadata.minimum_maxrgb_pq, 0);
+  EXPECT_EQ(metadata.average_maxrgb_pq,
+    video::hdr_metadata::pq_to_u12(video::hdr_metadata::nits_to_pq(100.0f)));
+  EXPECT_EQ(metadata.variance_maxrgb_pq,
+    video::hdr_metadata::pq_to_u12(stats.percentile_90_pq - stats.percentile_10_pq));
+  EXPECT_EQ(metadata.maximum_maxrgb_pq,
+    video::hdr_metadata::pq_to_u12(video::hdr_metadata::nits_to_pq(1000.0f)));
+}
+
+TEST(HdrDynamicMetadata, PqConversionMatchesSt2084ReferencePoints) {
+  EXPECT_NEAR(video::hdr_metadata::nits_to_pq(100.0f), 0.5080784f, 0.000001f);
+  EXPECT_NEAR(video::hdr_metadata::nits_to_pq(1000.0f), 0.7518271f, 0.000001f);
+  EXPECT_NEAR(video::hdr_metadata::pq_to_nits(
+                video::hdr_metadata::nits_to_pq(1000.0f)),
+    1000.0f,
+    0.1f);
+  EXPECT_EQ(video::hdr_metadata::pq_to_u12(
+              std::numeric_limits<float>::quiet_NaN()),
+    0);
+}
+
+TEST(HdrDynamicMetadata, SerializesVividStatisticsModeSyntax) {
+  video::hdr_metadata::vivid_metadata_t metadata;
+  metadata.minimum_maxrgb_pq = 1;
+  metadata.average_maxrgb_pq = 2;
+  metadata.variance_maxrgb_pq = 3;
+  metadata.maximum_maxrgb_pq = 4;
+  metadata.valid = true;
+
+  std::vector<uint8_t> payload;
+  ASSERT_EQ(video::hdr_metadata::serialize_vivid_t35(metadata, payload), 13U);
+
+  const std::vector<uint8_t> expected_header { 0x26, 0x00, 0x04, 0x00, 0x05, 0x01 };
+  ASSERT_TRUE(std::equal(expected_header.begin(), expected_header.end(), payload.begin()));
+
+  // GB/T 46269.1-2025 Table 11 derives num_windows=1; it is not a syntax element.
+  size_t bit_offset = expected_header.size() * 8;
+  EXPECT_EQ(read_bits(payload, bit_offset, 12), 1U);
+  EXPECT_EQ(read_bits(payload, bit_offset, 12), 2U);
+  EXPECT_EQ(read_bits(payload, bit_offset, 12), 3U);
+  EXPECT_EQ(read_bits(payload, bit_offset, 12), 4U);
+  EXPECT_EQ(read_bits(payload, bit_offset, 1), 0U);  // tone_mapping_enable_mode_flag
+  EXPECT_EQ(read_bits(payload, bit_offset, 1), 0U);  // color_saturation_mapping_enable_flag
+
+  while (bit_offset < payload.size() * 8) {
+    EXPECT_EQ(read_bits(payload, bit_offset, 1), 0U);
+  }
+}
+
+TEST(HdrDynamicMetadata, AppliesAnnexA9ThirtyTwoFrameMean) {
+  video::hdr_metadata::vivid_temporal_filter_t filter;
+
+  video::hdr_metadata::vivid_metadata_t dark;
+  dark.minimum_maxrgb_pq = 100;
+  dark.average_maxrgb_pq = 100;
+  dark.variance_maxrgb_pq = 100;
+  dark.maximum_maxrgb_pq = 100;
+  dark.valid = true;
+
+  for (int frame = 0; frame < 32; ++frame) {
+    EXPECT_EQ(filter.update(dark).average_maxrgb_pq, 100);
+  }
+
+  auto bright = dark;
+  bright.minimum_maxrgb_pq = 3300;
+  bright.average_maxrgb_pq = 3300;
+  bright.variance_maxrgb_pq = 3300;
+  bright.maximum_maxrgb_pq = 3300;
+
+  // One bright frame replaces one of 32 dark frames.
+  EXPECT_EQ(filter.update(bright).average_maxrgb_pq, 200);
+
+  video::hdr_metadata::vivid_metadata_t filtered;
+  for (int frame = 1; frame < 32; ++frame) {
+    filtered = filter.update(bright);
+  }
+  EXPECT_EQ(filtered.average_maxrgb_pq, 3300);
+
+  filter.reset();
+  EXPECT_EQ(filter.update(dark).average_maxrgb_pq, 100);
+}


### PR DESCRIPTION
## 改了啥呢

- 按 `GB/T 46269.1-2025` 重做 HDR Vivid 统计模式：最小、平均、最大 maxRGB 使用 ST 2084 PQ 码值，方差使用 PQ 域 `P90 - P10`
- 把 HDR 分析直方图改成 256 档 PQ 域，并在分析前将 scRGB 的 Rec.709 线性值转换到 Rec.2020；HLG 捕获结果按显示线性亮度再转 PQ
- 使用附录 A.9 建议的 32 帧算术均值稳定 Vivid 元数据，移除会在亮场跳变时放大闪烁的 Vivid 场景阈值/EMA 混用
- 修正 CUVA T.35 统计模式语法：`system_start_code=0x01` 时不再写不存在的 `num_windows`，关闭 tone mapping 时也不再写条件字段
- 统一 NVENC HEVC/AV1 与 FFmpeg side-data 两条生成路径；PQ 保留 HDR10+，PQ/HLG 生成 HDR Vivid
- 增加格式路由、ST 2084、统计字段、T.35 位流和 32 帧滤波单测

## 为啥要改

之前把四项内容统计按目标显示峰值做线性归一化，还用 P95 代替内容最大值、用 `P99 - min` 代替标准方差。客户端峰值映射到虚拟显示器本身是合理的，但它属于目标显示能力，不该再次改写内容统计；再叠加亮度突变时直接跳变，就让大面积亮场里的元数据来回抽动了，闪烁这只小杂鱼才会这么嚣张。

修复后，客户端屏幕参数仍通过虚拟显示器决定服务端的显示映射和静态 HDR 能力；动态四项统计只描述映射后实际捕获到的内容，不再被目标峰值二次归一化。

## 影响范围

- Sunshine 服务端 Windows D3D HDR 分析
- FFmpeg 编码路径的 HDR Vivid side-data
- NVENC HEVC/AV1 的 T.35 SEI/metadata OBU
- 不修改 Moonlight 客户端、传输协议或 `moonlight-common-c`
- AMF 直连编码器本次仍只有静态 HDR 元数据，不在这次动态 Vivid 注入范围内

## 验证

- `5/5` HDR 动态元数据 GoogleTest 通过
- `hdr_luminance_analysis_cs.hlsl`、`hdr_luminance_reduce_cs.hlsl` 均通过 `fxc /T cs_5_0`
- `video.cpp`、`nvenc_base.cpp`、`display_vram.cpp` 均通过 C++23 严格语法检查
- `git diff --check` 通过
