### PR TITLE
fix(hdr): route avcodec Vivid path through formats_for, drop invented defaults

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1893,18 +1893,16 @@ namespace video {
       if (vivid && vivid->num_windows > 0) {
         auto &params = vivid->params[0];
 
-        params.minimum_maxrgb = av_make_q(vivid_metadata.minimum_maxrgb_pq, 4095);
-        params.average_maxrgb = av_make_q(vivid_metadata.average_maxrgb_pq, 4095);
-        params.variance_maxrgb = av_make_q(vivid_metadata.variance_maxrgb_pq, 4095);
-        params.maximum_maxrgb = av_make_q(vivid_metadata.maximum_maxrgb_pq, 4095);
+        params.minimum_maxrgb = av_make_q(vivid_metadata.minimum_maxrgb_pq, hdr_metadata::pq_u12_den);
+        params.average_maxrgb = av_make_q(vivid_metadata.average_maxrgb_pq, hdr_metadata::pq_u12_den);
+        params.variance_maxrgb = av_make_q(vivid_metadata.variance_maxrgb_pq, hdr_metadata::pq_u12_den);
+        params.maximum_maxrgb = av_make_q(vivid_metadata.maximum_maxrgb_pq, hdr_metadata::pq_u12_den);
 
-        const float target_display_nits =
-          max_display_luminance > 0 ? static_cast<float>(max_display_luminance) : 1000.0f;
-        const int target_display_pq = hdr_metadata::pq_to_u12(
-          hdr_metadata::nits_to_pq(target_display_nits));
+        const auto target_display_pq =
+          hdr_metadata::target_display_pq_u12(static_cast<float>(max_display_luminance));
         for (int i = 0; i < 2; i++) {
           params.tm_params[i].targeted_system_display_maximum_luminance =
-            av_make_q(target_display_pq, 4095);
+            av_make_q(target_display_pq, hdr_metadata::pq_u12_den);
         }
       }
     }
@@ -2610,22 +2608,19 @@ namespace video {
             params.color_saturation_mapping_flag = 0;
             params.color_saturation_num = 0;
 
-            const float target_display_nits = hdr_metadata.maxDisplayLuminance > 0
-                                                ? static_cast<float>(hdr_metadata.maxDisplayLuminance)
-                                                : 1000.0f;
-            const int target_display_pq = video::hdr_metadata::pq_to_u12(
-              video::hdr_metadata::nits_to_pq(target_display_nits));
+            const auto target_display_pq =
+              hdr_metadata::target_display_pq_u12(static_cast<float>(hdr_metadata.maxDisplayLuminance));
             for (int i = 0; i < 2; i++) {
               auto &tm_params = params.tm_params[i];
               tm_params.targeted_system_display_maximum_luminance =
-                av_make_q(target_display_pq, 4095);
+                av_make_q(target_display_pq, hdr_metadata::pq_u12_den);
               tm_params.base_enable_flag = 0;
             }
-          }
 
-          BOOST_LOG(debug) << "Attached HDR Vivid side data to frame"
-                           << (colorspace_is_hlg(colorspace) ? " (HLG mode)" : " (PQ mode)")
-                           << " - note: no FFmpeg encoder serializes it yet";
+            BOOST_LOG(debug) << "Attached HDR Vivid side data to frame"
+                             << (colorspace_is_hlg(colorspace) ? " (HLG mode)" : " (PQ mode)")
+                             << " - note: no FFmpeg encoder serializes it yet";
+          }
         }
       }
       else {

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -2490,6 +2490,10 @@ namespace video {
     // HLG uses scene-referred relative luminance but benefits from HDR Vivid (CUVA)
     // dynamic metadata for enhanced tone mapping on capable displays.
     if (colorspace_is_hdr(colorspace)) {
+      // Single source of truth for which dynamic formats this transfer function allows,
+      // shared with the native NVENC path so the two cannot drift apart.
+      const auto dynamic_hdr_formats = hdr_metadata::formats_for(colorspace);
+
       SS_HDR_METADATA hdr_metadata;
       bool has_metadata = disp->get_hdr_metadata(hdr_metadata);
 
@@ -2522,7 +2526,7 @@ namespace video {
         }
 
         // HDR10+ dynamic metadata - PQ only (Samsung ST 2094-40, uses absolute luminance)
-        if (colorspace_is_pq(colorspace)) {
+        if (dynamic_hdr_formats.hdr10plus) {
           auto hdr10plus = av_dynamic_hdr_plus_create_side_data(frame.get());
           if (hdr10plus) {
             // Set default values for HDR10+
@@ -2575,75 +2579,53 @@ namespace video {
           }
         }
 
-        // HDR Vivid dynamic metadata (GB/T 46269.1-2025) - both PQ and HLG
-        // HDR Vivid supports both transfer functions:
-        //   - PQ mode: absolute luminance tone mapping
-        //   - HLG mode: scene-referred relative luminance tone mapping
-        // The CUVA metadata is carried as ITU-T T.35 registered SEI/OBU, independent
-        // of the underlying transfer function.
-        auto vivid = av_dynamic_hdr_vivid_create_side_data(frame.get());
-        if (vivid) {
-          // Set default values for HDR Vivid
-          vivid->system_start_code = 0x01;
-          vivid->num_windows = 0x01;  // Single processing window
+        // HDR Vivid dynamic metadata (GB/T 46269.1-2025) - both PQ and HLG.
+        //
+        // NOTE: this side data currently cannot reach the bitstream on the avcodec path.
+        // FFmpeg ships a serializer for HDR10+ (av_dynamic_hdr_plus_to_t35) but has no
+        // CUVA counterpart: libavcodec/dynamic_hdr_vivid.c defines only
+        // ff_parse_itu_t_t35_to_dynamic_hdr_vivid, i.e. parsing for decode. So no FFmpeg
+        // encoder turns AV_FRAME_DATA_DYNAMIC_HDR_VIVID into an SEI/OBU today.
+        //
+        // We still attach and maintain it so the metadata is correct the moment a
+        // serializer exists, but HDR Vivid output is in practice only produced by the
+        // native NVENC path (see nvenc_base.cpp, which hand-writes the T.35 payload).
+        // Encoders routed through avcodec (QSV, AMF, software) will not emit it.
+        //
+        // Field values are deliberately left zero-initialized rather than filled with
+        // invented defaults: update_hdr_dynamic_metadata() populates them from real
+        // analyzer statistics once the 32-frame filter reports valid output, and a
+        // fabricated "average 0.5 / maximum 1.0" frame is worse than an absent one.
+        if (dynamic_hdr_formats.vivid) {
+          auto vivid = av_dynamic_hdr_vivid_create_side_data(frame.get());
+          if (vivid) {
+            vivid->system_start_code = 0x01;
+            vivid->num_windows = 0x01;  // Fixed at one for system_start_code 0x01
 
-          // Initialize the first (and only) processing window
-          auto &params = vivid->params[0];
+            auto &params = vivid->params[0];
 
-          // Initialize maxrgb values (simplified - use full range)
-          params.minimum_maxrgb = av_make_q(0, 4095);
-          params.average_maxrgb = av_make_q(2047, 4095);  // 0.5
-          params.variance_maxrgb = av_make_q(0, 4095);
-          params.maximum_maxrgb = av_make_q(4095, 4095);  // 1.0
+            // Statistics mode only: no tone mapping curve, no saturation mapping.
+            params.tone_mapping_mode_flag = 0;
+            params.tone_mapping_param_num = 0;
+            params.color_saturation_mapping_flag = 0;
+            params.color_saturation_num = 0;
 
-          // Initialize tone mapping parameters (simplified - no tone mapping)
-          params.tone_mapping_mode_flag = 0;
-          params.tone_mapping_param_num = 0;
-
-          // Initialize color saturation mapping (disabled)
-          params.color_saturation_mapping_flag = 0;
-          params.color_saturation_num = 0;
-          for (int j = 0; j < 8; j++) {
-            params.color_saturation_gain[j] = av_make_q(128, 128);  // 1.0 (no adjustment)
-          }
-
-          // Initialize tone mapping params structure (even if not used)
-          const float target_display_nits = hdr_metadata.maxDisplayLuminance > 0
-                                              ? static_cast<float>(hdr_metadata.maxDisplayLuminance)
-                                              : 1000.0f;
-          const int target_display_pq = video::hdr_metadata::pq_to_u12(
-            video::hdr_metadata::nits_to_pq(target_display_nits));
-          for (int i = 0; i < 2; i++) {
-            auto &tm_params = params.tm_params[i];
-            tm_params.targeted_system_display_maximum_luminance =
-              av_make_q(target_display_pq, 4095);
-            tm_params.base_enable_flag = 0;
-            tm_params.base_param_m_p = av_make_q(0, 16383);
-            tm_params.base_param_m_m = av_make_q(0, 10);
-            tm_params.base_param_m_a = av_make_q(0, 1023);
-            tm_params.base_param_m_b = av_make_q(0, 1023);
-            tm_params.base_param_m_n = av_make_q(0, 10);
-            tm_params.base_param_k1 = 0;
-            tm_params.base_param_k2 = 0;
-            tm_params.base_param_k3 = 0;
-            tm_params.base_param_Delta_enable_mode = 0;
-            tm_params.base_param_Delta = av_make_q(0, 127);
-            tm_params.three_Spline_enable_flag = 0;
-            tm_params.three_Spline_num = 0;
-            // Initialize three spline parameters
-            for (int j = 0; j < 2; j++) {
-              auto &spline = tm_params.three_spline[j];
-              spline.th_mode = 0;
-              spline.th_enable_mb = av_make_q(0, 255);
-              spline.th_enable = av_make_q(0, 4095);
-              spline.th_delta1 = av_make_q(0, 1023);
-              spline.th_delta2 = av_make_q(0, 1023);
-              spline.enable_strength = av_make_q(0, 255);
+            const float target_display_nits = hdr_metadata.maxDisplayLuminance > 0
+                                                ? static_cast<float>(hdr_metadata.maxDisplayLuminance)
+                                                : 1000.0f;
+            const int target_display_pq = video::hdr_metadata::pq_to_u12(
+              video::hdr_metadata::nits_to_pq(target_display_nits));
+            for (int i = 0; i < 2; i++) {
+              auto &tm_params = params.tm_params[i];
+              tm_params.targeted_system_display_maximum_luminance =
+                av_make_q(target_display_pq, 4095);
+              tm_params.base_enable_flag = 0;
             }
           }
 
-          BOOST_LOG(debug) << "Added HDR Vivid dynamic metadata to frame"
-                           << (colorspace_is_hlg(colorspace) ? " (HLG mode)" : " (PQ mode)");
+          BOOST_LOG(debug) << "Attached HDR Vivid side data to frame"
+                           << (colorspace_is_hlg(colorspace) ? " (HLG mode)" : " (PQ mode)")
+                           << " - note: no FFmpeg encoder serializes it yet";
         }
       }
       else {

--- a/src/video_hdr_metadata.h
+++ b/src/video_hdr_metadata.h
@@ -87,6 +87,29 @@ namespace video::hdr_metadata {
     return static_cast<uint16_t>(std::clamp(pq, 0.0f, 1.0f) * 4095.0f);
   }
 
+  /**
+   * Denominator paired with every 12-bit code value in this namespace.
+   *
+   * FFmpeg parses the CUVA fields as `(AVRational){get_bits(gb, 12), 4095}` — see
+   * maxrgb_den and maximum_luminance_den in libavcodec/dynamic_hdr_vivid.c.
+   */
+  constexpr int pq_u12_den = 4095;
+
+  /**
+   * @brief Target display peak luminance as a 12-bit PQ code value.
+   *
+   * Pair with pq_u12_den when building an AVRational. Returning the raw code rather
+   * than an AVRational keeps this header free of FFmpeg includes, which is what lets
+   * it be unit-tested without the full media stack.
+   *
+   * @param nits Display peak luminance; values at or below zero fall back to 1000 nits,
+   *             matching what the rest of the pipeline assumes for an unreported peak.
+   */
+  inline uint16_t
+  target_display_pq_u12(float nits) {
+    return pq_to_u12(nits_to_pq(nits > 0.0f ? nits : 1000.0f));
+  }
+
   struct vivid_metadata_t {
     uint16_t minimum_maxrgb_pq = 0;
     uint16_t average_maxrgb_pq = 0;

--- a/tests/unit/test_video_hdr_metadata.cpp
+++ b/tests/unit/test_video_hdr_metadata.cpp
@@ -157,11 +157,27 @@ TEST(HdrDynamicMetadata, TargetDisplayLuminanceIsPqCodeNotNits) {
       EXPECT_LT(static_cast<float>(code), nits) << "nits=" << nits;
     }
 
-    // Round-trips back to the requested luminance within one code step.
-    const float decoded = video::hdr_metadata::pq_to_nits(static_cast<float>(code) / 4095.0f);
-    const float step = video::hdr_metadata::pq_to_nits(static_cast<float>(code + 1) / 4095.0f) -
-                       video::hdr_metadata::pq_to_nits(static_cast<float>(code) / 4095.0f);
-    EXPECT_NEAR(decoded, nits, std::max(step, 1.0f)) << "nits=" << nits;
+    // pq_to_u12 truncates, so `code` is the floor of the exact PQ position. That
+    // brackets the requested luminance: decoding `code` lands at or below it, and
+    // decoding the next code lands above it. Only float round-trip error needs a
+    // tolerance here — measured worst case is ~7.3e-07 in PQ, about 0.07 nits at the
+    // top of the range — not a whole quantization step, which near 10000 nits is 23
+    // nits wide and would let a genuinely wrong code pass.
+    const float tolerance = std::max(nits * 1e-5f, 0.001f);
+    const float decoded = video::hdr_metadata::pq_to_nits(
+      static_cast<float>(code) / video::hdr_metadata::pq_u12_den);
+    EXPECT_LE(decoded, nits + tolerance) << "nits=" << nits;
+
+    if (code < video::hdr_metadata::pq_u12_den) {
+      const float next = video::hdr_metadata::pq_to_nits(
+        static_cast<float>(code + 1) / video::hdr_metadata::pq_u12_den);
+      EXPECT_GT(next, nits - tolerance) << "nits=" << nits;
+    }
+    else {
+      // Saturated at the top of the 12-bit range. 10000 nits is the PQ ceiling, so
+      // there is no next code to bracket against and none should be read.
+      EXPECT_NEAR(decoded, 10000.0f, tolerance) << "nits=" << nits;
+    }
   }
 
   // PQ is monotonic, so ordering of target luminances must be preserved.

--- a/tests/unit/test_video_hdr_metadata.cpp
+++ b/tests/unit/test_video_hdr_metadata.cpp
@@ -171,3 +171,27 @@ TEST(HdrDynamicMetadata, TargetDisplayLuminanceIsPqCodeNotNits) {
   EXPECT_EQ(
     video::hdr_metadata::pq_to_u12(video::hdr_metadata::nits_to_pq(10000.0f)), 4095u);
 }
+
+// target_display_pq_u12() is the single conversion used by both the frame-setup and
+// per-frame metadata paths, so its <= 0 fallback is behavioral, not cosmetic: a display
+// that reports no peak luminance must still yield the 1000-nit code both places agree on.
+TEST(HdrDynamicMetadata, TargetDisplayHelperMatchesManualChainAndFallsBackTo1000Nits) {
+  using video::hdr_metadata::nits_to_pq;
+  using video::hdr_metadata::pq_to_u12;
+  using video::hdr_metadata::target_display_pq_u12;
+
+  // Matches the manual nits -> PQ -> 12-bit chain it replaces.
+  for (const float nits : { 1.0f, 400.0f, 1000.0f, 4000.0f, 10000.0f }) {
+    EXPECT_EQ(target_display_pq_u12(nits), pq_to_u12(nits_to_pq(nits))) << "nits=" << nits;
+  }
+
+  // Unreported / invalid peaks collapse to the documented 1000-nit default.
+  const auto fallback = pq_to_u12(nits_to_pq(1000.0f));
+  EXPECT_EQ(target_display_pq_u12(0.0f), fallback);
+  EXPECT_EQ(target_display_pq_u12(-1.0f), fallback);
+  EXPECT_EQ(target_display_pq_u12(-10000.0f), fallback);
+
+  // The denominator the codes are paired with is what FFmpeg parses them against.
+  EXPECT_EQ(video::hdr_metadata::pq_u12_den, 4095);
+  EXPECT_LE(target_display_pq_u12(10000.0f), video::hdr_metadata::pq_u12_den);
+}

--- a/tests/unit/test_video_hdr_metadata.cpp
+++ b/tests/unit/test_video_hdr_metadata.cpp
@@ -135,3 +135,39 @@ TEST(HdrDynamicMetadata, AppliesAnnexA9ThirtyTwoFrameMean) {
   filter.reset();
   EXPECT_EQ(filter.update(dark).average_maxrgb_pq, 100);
 }
+
+// Regression guard for the representation of
+// AVHDRVividColorToneMappingParams::targeted_system_display_maximum_luminance.
+//
+// FFmpeg parses that field as a 12-bit code with a fixed denominator of 4095
+// (libavcodec/dynamic_hdr_vivid.c: `(AVRational){get_bits(gb, 12), maximum_luminance_den}`)
+// and documents the value range as 0.0 to 1.0 inclusive. Writing raw nits with a
+// denominator of 1 — as this code did before — yields values like 1000/1, far outside
+// that range. Encode it as a PQ code value, consistently with the four maxrgb fields.
+TEST(HdrDynamicMetadata, TargetDisplayLuminanceIsPqCodeNotNits) {
+  for (const float nits : { 400.0f, 1000.0f, 4000.0f, 10000.0f }) {
+    const auto code = video::hdr_metadata::pq_to_u12(video::hdr_metadata::nits_to_pq(nits));
+
+    // Must land inside the 12-bit range the field is defined over.
+    EXPECT_LE(code, 4095u) << "nits=" << nits;
+
+    // A raw-nits encoding would exceed 4095 for every value above it, which is
+    // precisely the bug this guards against.
+    if (nits > 4095.0f) {
+      EXPECT_LT(static_cast<float>(code), nits) << "nits=" << nits;
+    }
+
+    // Round-trips back to the requested luminance within one code step.
+    const float decoded = video::hdr_metadata::pq_to_nits(static_cast<float>(code) / 4095.0f);
+    const float step = video::hdr_metadata::pq_to_nits(static_cast<float>(code + 1) / 4095.0f) -
+                       video::hdr_metadata::pq_to_nits(static_cast<float>(code) / 4095.0f);
+    EXPECT_NEAR(decoded, nits, std::max(step, 1.0f)) << "nits=" << nits;
+  }
+
+  // PQ is monotonic, so ordering of target luminances must be preserved.
+  EXPECT_LT(
+    video::hdr_metadata::pq_to_u12(video::hdr_metadata::nits_to_pq(400.0f)),
+    video::hdr_metadata::pq_to_u12(video::hdr_metadata::nits_to_pq(1000.0f)));
+  EXPECT_EQ(
+    video::hdr_metadata::pq_to_u12(video::hdr_metadata::nits_to_pq(10000.0f)), 4095u);
+}


### PR DESCRIPTION
Follow-up to #865, addressing the two review points I raised on it.

## ② first: #865 was right, and I've now verified it

I flagged `targeted_system_display_maximum_luminance` as an **unverified** semantic change during review. Confirmed against FFmpeg upstream — **#865's change was correct and the previous code was broken:**

- `libavcodec/dynamic_hdr_vivid.c` parses it as `(AVRational){get_bits(gb, 12), maximum_luminance_den}` with `maximum_luminance_den == 4095`
- `libavutil/hdr_dynamic_vivid_metadata.h` documents the range as **0.0 to 1.0 inclusive**

The old `av_make_q(nits, 1)` produced `1000/1` for a 1000-nit display — far outside that range. No code change needed; instead this PR adds a **regression test** pinning the representation so a future "fix" can't quietly revert it to nits.

Bonus confirmation for #865's syntax fix: the same parser hardcodes `s->num_windows = 1` for start codes 0x01–0x07 and **never reads it from the bitstream**. So the 3 spurious `num_windows` bits the old code wrote were misaligning every subsequent field — that fix was real, and all four maxrgb values were previously being read from the wrong bit positions.

## ① The gating inconsistency — but not for the reason I thought

While verifying, I found something that reframes it. **FFmpeg has no CUVA serializer at all:**

| | serializer | Sunshine impact |
|---|---|---|
| HDR10+ | `av_dynamic_hdr_plus_to_t35` ✓ | side data can reach the bitstream |
| HDR Vivid | **none** — only `ff_parse_itu_t_t35_to_dynamic_hdr_vivid` (decode-side) | side data is **inert** |

So my review concern ("avcodec emits placeholder metadata while NVENC emits nothing") was wrong in its consequence: the placeholders never reached the wire, because nothing serializes them. But the situation is arguably worse in a different way — **HDR Vivid only works on the native NVENC path.** QSV, AMF and software encoder users get nothing, silently, from code that reads as if it supports them.

### Changes

**1. Unified routing.** #865 introduced `formats_for()` as the single decision point but only wired it into NVENC; the avcodec path still called `colorspace_is_pq()` directly for HDR10+ and gated Vivid on *nothing at all*. Both now derive from `formats_for()`.

Behavior is unchanged today (PQ → `{hdr10plus, vivid}`, HLG → `{vivid}` is exactly what the old conditions computed) — but the paths can no longer drift, which was the point of the helper.

**2. Dropped fabricated placeholders.** The side data was attached at session setup with `average = 2047/4095` (0.5) and `maximum = 4095/4095` (1.0) — describing no real content — then overwritten per frame only once the 32-frame filter reports valid output. FFmpeg zero-initializes the struct, so not writing those fields is shorter *and* more honest. The explicitly-zeroed tone-mapping and three-spline members go for the same reason (−60 lines).

**3. Documented why the path is silent.** The comment and debug log now state that no FFmpeg encoder serializes this, naming the exact functions so it stays checkable. The side data is still attached and maintained, so it's correct the moment a serializer appears.

## Testing

`video_hdr_metadata.h` has no Windows or FFmpeg dependencies, so I extracted it into a native harness and ran under **ASan+UBSan — 15 checks pass**, including the existing ST 2084 reference points and the T.35 payload:

```
      400 nits -> code 2672 (0.6525)  round-trip    399.7  step 0.9
     1000 nits -> code 3078 (0.7516)  round-trip    998.4  step 2.2
     4000 nits -> code 3696 (0.9026)  round-trip   3999.7  step 9.1
    10000 nits -> code 4095 (1.0000)  round-trip  10000.0  step 0.0

PQ(100)=0.5080784  PQ(1000)=0.7518271        <- matches existing test constants
T.35: size=13 bytes, header=26 0004 0005 01  <- identifier intact
```

The new GoogleTest locks in the 12-bit range, monotonicity, the 10000-nit saturation point, and round-trip accuracy within one code step.

**Not compile-verified in tree** — `video.cpp` needs the full FFmpeg + Windows toolchain, which I don't have locally. Verified structurally: braces balanced, no remaining `colorspace_is_pq` users in this file, edited region reviewed line by line. CI covers the build.

### What a reviewer should check

1. **Build**, plus the 6 tests in `test_video_hdr_metadata.cpp`.
2. HDR streaming still works on the native NVENC path and the client still detects CUVA — this PR should not change NVENC behavior at all.
3. Whether keeping the inert avcodec side data is the call you want. The alternative is deleting it outright; I kept it because it's cheap, correct, and forward-compatible, but I don't feel strongly.

## Not addressed

- **This does not make HDR Vivid appear where it previously didn't.** The NVENC emission gate is untouched (`luminance_stats.valid && hdr_metadata && video_format ∈ {1,2}`), and the client scanner only matches the 5 identifier bytes, which were already correct. If Vivid still isn't detected, the cause is upstream of the metadata: either `hdr_metadata` is empty (desktop not actually in HDR, so `colorspace_is_hdr` is false) or the analyzer never produces valid stats. Neither node currently logs anything — I'd suggest adding that next.
- **AMF still has no dynamic Vivid**, as #865 noted.
- **`max_maxrgb` is still not the true frame maximum** (linear-sampled analysis grid misses peaks at non-integer downscale ratios). It only feeds scene-cut detection, not emitted metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)