### PR TITLE
fix(windows): 修复恢复串流时保留HDR状态

### DIFF
--- a/src/platform/windows/display_device/settings.cpp
+++ b/src/platform/windows/display_device/settings.cpp
@@ -505,7 +505,16 @@ namespace display_device {
       const std::unordered_set<std::string> valid_ids_set(valid_device_ids.begin(), valid_device_ids.end());
 
       if (change_hdr_state) {
-        const auto original_hdr_states { previous_hdr_states.empty() ? get_current_hdr_states(valid_device_ids) : previous_hdr_states };
+        const auto current_hdr_states { get_current_hdr_states(valid_device_ids) };
+        if (current_hdr_states.empty()) {
+          return boost::none;
+        }
+
+        auto original_hdr_states { previous_hdr_states };
+        for (const auto &[device_id, state] : current_hdr_states) {
+          original_hdr_states.try_emplace(device_id, state);
+        }
+
         auto new_hdr_states { determine_new_hdr_states(change_hdr_state, original_hdr_states, metadata) };
         filter_stale_devices(new_hdr_states, valid_ids_set, "HDR states");
 


### PR DESCRIPTION
## 背景

首次启动 HDR 虚拟显示器串流时，Sunshine 会记录当前显示器的 HDR 状态，以便串流结束后恢复。由于虚拟显示器的设备 ID 可能在销毁和重建后发生变化，VDD 状态不会写入持久化数据，这一设计可以避免后续使用失效的设备 ID。

恢复串流时，旧逻辑只要发现已经存在持久化的 HDR 状态，就会直接复用该状态表，不再读取当前拓扑。此时状态表只包含物理显示器，没有正在复用的 VDD。后续计算目标 HDR 状态时，缺失的 VDD 会被当作 `UNKNOWN`，而 `UNKNOWN` 会被安全地跳过。由于 VDD 在准备阶段已经暂时关闭 HDR，恢复后的串流最终会停留在 SDR。

## 修改

需要切换 HDR 时，现在会先读取当前活动拓扑的实际 HDR 状态，再将其中缺失的设备补入原有状态表。已经保存的物理显示器状态不会被覆盖，因此串流结束后的恢复基线保持不变；VDD 则会以当前实际状态补入，使客户端请求的 HDR 目标能够正常应用。

如果当前 HDR 状态无法读取，配置流程会返回失败，而不是使用不完整的状态表继续执行。VDD 仍然不会进入持久化数据，也不会对状态为 `UNKNOWN` 的显示器强制开启 HDR。

修改后，首次串流和恢复串流使用相同的判断方式：以显示器实际状态为基础，再应用客户端和服务端配置要求的目标 HDR 状态。