### PR TITLE
fix(webui): 修复新手引导资源加载和完成页布局

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -394,6 +394,18 @@ namespace confighttp {
     getStaticResource(response, request, WEB_DIR "images/logo-sunshine-256.png", "image/png");
   }
 
+  void
+  getAlkaidLabLogoImage(resp_https_t response, req_https_t request) {
+    if (!authenticate(response, request)) return;
+    getStaticResource(response, request, WEB_DIR "images/logo-alkaidlab.png", "image/png");
+  }
+
+  void
+  getNatPierceLogoImage(resp_https_t response, req_https_t request) {
+    if (!authenticate(response, request)) return;
+    getStaticResource(response, request, WEB_DIR "images/logo-natpierce.png", "image/png");
+  }
+
   /**
    * @brief 检查 child 是否是 parent 目录的子路径（防止路径穿越）
    */
@@ -3280,6 +3292,8 @@ namespace confighttp {
     server.resource["^/api/v1/file-mapping/mappings/([A-Za-z0-9_\\-]{1,64})$"]["DELETE"] = deleteFileMapping;
     server.resource["^/images/sunshine.ico$"]["GET"] = getFaviconImage;
     server.resource["^/images/logo-sunshine-256.png$"]["GET"] = getSunshineLogoImage;
+    server.resource["^/images/logo-alkaidlab.png$"]["GET"] = getAlkaidLabLogoImage;
+    server.resource["^/images/logo-natpierce.png$"]["GET"] = getNatPierceLogoImage;
     server.resource["^/boxart/.+$"]["GET"] = getBoxArt;
 
     // Clipboard sync routes are registered in a sibling module so the

--- a/src_assets/common/assets/web/components/SetupWizard.vue
+++ b/src_assets/common/assets/web/components/SetupWizard.vue
@@ -297,7 +297,7 @@
                         <img :src="androidQrCode" alt="Android QR Code" class="qr-code-image">
                       </div>
                       <div class="qr-code-label">
-                        <i class="fab fa-android"></i>
+                        <i class="fas fa-mobile-alt"></i>
                         {{ $t('setup.android_client') }}
                       </div>
                     </div>
@@ -306,7 +306,7 @@
                         <img :src="iosQrCode" alt="iOS QR Code" class="qr-code-image">
                       </div>
                       <div class="qr-code-label">
-                        <i class="fab fa-apple"></i>
+                        <i class="fas fa-tablet-alt"></i>
                         {{ $t('setup.ios_client') }}
                       </div>
                     </div>
@@ -439,6 +439,12 @@ const SETUP_CLIENT_RESOURCE_ORDER = [
   'moonlight-macos',
   'moonlight-desktop',
 ]
+
+const SETUP_CLIENT_ICON_OVERRIDES = Object.freeze({
+  'android-vplus': 'fas fa-mobile-alt',
+  voidlink: 'fas fa-tablet-alt',
+  'moonlight-macos': 'fas fa-laptop',
+})
 
 const COMPLETION_NOTICES = Object.freeze([
   {
@@ -601,7 +607,13 @@ export default {
     },
     setupClientResources() {
       const resourcesById = new Map(CLIENT_RESOURCES.map((resource) => [resource.id, resource]))
-      return SETUP_CLIENT_RESOURCE_ORDER.map((id) => resourcesById.get(id)).filter(Boolean)
+      return SETUP_CLIENT_RESOURCE_ORDER
+        .map((id) => resourcesById.get(id))
+        .filter(Boolean)
+        .map((resource) => ({
+          ...resource,
+          icon: SETUP_CLIENT_ICON_OVERRIDES[resource.id] || resource.icon,
+        }))
     }
   },
   methods: {

--- a/src_assets/common/assets/web/components/SetupWizard.vue
+++ b/src_assets/common/assets/web/components/SetupWizard.vue
@@ -1,5 +1,37 @@
 <template>
   <div class="setup-container">
+    <Teleport to="body">
+      <TransitionGroup
+        v-if="visibleCompletionNotices.length"
+        name="setup-toast"
+        tag="div"
+        class="setup-completion-toasts"
+        aria-live="polite"
+        aria-atomic="false"
+      >
+        <div
+          v-for="notice in visibleCompletionNotices"
+          :key="notice.id"
+          class="setup-completion-toast"
+          :class="`setup-completion-toast-${notice.tone}`"
+          role="status"
+        >
+          <i :class="notice.icon" aria-hidden="true"></i>
+          <span :class="{ 'setup-completion-toast-title': notice.emphasis }">
+            {{ $t(notice.messageKey) }}
+          </span>
+          <button
+            type="button"
+            class="setup-completion-toast-close"
+            :aria-label="$t('_common.close')"
+            @click="dismissCompletionNotice(notice.id)"
+          >
+            <i class="fas fa-times" aria-hidden="true"></i>
+          </button>
+        </div>
+      </TransitionGroup>
+    </Teleport>
+
     <div class="setup-card">
       <div class="setup-header">
         <img src="/images/logo-sunshine-256.png" height="60" alt="Sunshine">
@@ -211,19 +243,6 @@
           <!-- 步骤 5: 完成 -->
           <div v-else-if="currentStep === 5">
             <div>
-              <div class="text-center mb-3">
-                <h3 class="mb-1">
-                  <i class="fas fa-check-circle setup-complete-icon"></i>
-                  {{ $t('setup.setup_complete') }}
-                </h3>
-                <p class="mb-0">{{ $t('setup.setup_complete_desc') }}</p>
-              </div>
-              
-              <div class="alert alert-info text-center" v-if="saveSuccess">
-                <i class="fas fa-info-circle"></i>
-                {{ $t('setup.config_saved') }}
-              </div>
-              
               <div class="alert alert-danger" v-if="saveError">
                 <i class="fas fa-exclamation-triangle"></i>
                 {{ saveError }}
@@ -267,6 +286,7 @@
                       :description="resourceDescription(resource)"
                       :icon="resource.icon"
                       :variant="resource.variant"
+                      compact
                       @activate="handleResourceActivate(resource, $event)"
                     />
                   </div>
@@ -420,6 +440,30 @@ const SETUP_CLIENT_RESOURCE_ORDER = [
   'moonlight-desktop',
 ]
 
+const COMPLETION_NOTICES = Object.freeze([
+  {
+    id: 'complete',
+    messageKey: 'setup.setup_complete',
+    icon: 'fas fa-check-circle',
+    tone: 'success',
+    emphasis: true,
+  },
+  {
+    id: 'ready',
+    messageKey: 'setup.setup_complete_desc',
+    icon: 'fas fa-moon',
+    tone: 'info',
+  },
+  {
+    id: 'saved',
+    messageKey: 'setup.config_saved',
+    icon: 'fas fa-save',
+    tone: 'success',
+  },
+])
+
+const COMPLETION_NOTICE_DURATION_MS = 5000
+
 // 向导第一步只暴露 简体中文(zh) / English(en) 两个选项，
 // 因此把系统语言探测结果折叠到这两者之一即可
 function detectInitialWizardLocale() {
@@ -429,10 +473,6 @@ function detectInitialWizardLocale() {
 
 function isPhysicalDisplay(device) {
   return !/^FRIENDLY NAME:\s*Zako HDR\s*$/im.test(device?.data || '')
-}
-
-function firstPhysicalDisplayId(devices) {
-  return (devices || []).find(isPhysicalDisplay)?.device_id ?? null
 }
 
 function markLanguageSavedForReload() {
@@ -467,10 +507,9 @@ export default {
       // 已有 locale 时向导会跳过第一步，不预置，避免 saveConfiguration() 覆盖已有设置（如 de / ja）
       // 首次进入向导时依然按系统 / 浏览器语言预选 zh / en
       selectedLocale: this.hasLocale ? null : detectInitialWizardLocale(),
-      selectedDisplay: firstPhysicalDisplayId(this.displayDevices),
+      selectedDisplay: 'ZakoHDR', // 默认选择基地显示器
       selectedAdapter: '',
       displayDevicePrep: 'ensure_only_display', // 默认选择：确保唯一显示器（VDD 和普通模式通用）
-      saveSuccess: false,
       saveError: null,
       saving: false,
       showSkipModal: false, // 跳过向导确认弹窗
@@ -478,6 +517,8 @@ export default {
       showRestartModal: false, // 重启倒计时弹窗
       restartCountdown: 8, // 倒计时秒数
       restartTimer: null, // 倒计时定时器
+      visibleCompletionNoticeIds: [],
+      completionNoticeTimer: null,
       // 客户端下载链接
       androidQrCode: 'https://assets.alkaidlab.com/androidQrCode.png',
       iosQrCode: 'https://assets.alkaidlab.com/iosQrCode.png',
@@ -513,8 +554,14 @@ export default {
       clearInterval(this.restartTimer)
       this.restartTimer = null
     }
+    this.clearCompletionNoticeTimer()
   },
   computed: {
+    visibleCompletionNotices() {
+      return COMPLETION_NOTICES.filter((notice) =>
+        this.visibleCompletionNoticeIds.includes(notice.id)
+      )
+    },
     canProceed() {
       if (this.currentStep === 1) {
         return this.selectedLocale !== null
@@ -659,8 +706,8 @@ export default {
         })
 
         if (response.ok) {
-          this.saveSuccess = true
           this.currentStep = 5
+          this.showCompletionNotices()
           
           // 记录设置完成
           trackEvents.userAction('setup_wizard_completed', {
@@ -706,6 +753,28 @@ export default {
     },
     closeHarmonyModal() {
       this.showHarmonyModal = false
+    },
+    clearCompletionNoticeTimer() {
+      if (this.completionNoticeTimer) {
+        clearTimeout(this.completionNoticeTimer)
+        this.completionNoticeTimer = null
+      }
+    },
+    showCompletionNotices() {
+      this.clearCompletionNoticeTimer()
+      this.visibleCompletionNoticeIds = COMPLETION_NOTICES.map((notice) => notice.id)
+      this.completionNoticeTimer = setTimeout(() => {
+        this.visibleCompletionNoticeIds = []
+        this.completionNoticeTimer = null
+      }, COMPLETION_NOTICE_DURATION_MS)
+    },
+    dismissCompletionNotice(noticeId) {
+      this.visibleCompletionNoticeIds = this.visibleCompletionNoticeIds.filter(
+        (id) => id !== noticeId
+      )
+      if (this.visibleCompletionNoticeIds.length === 0) {
+        this.clearCompletionNoticeTimer()
+      }
     },
     async confirmHarmonyLink() {
       this.closeHarmonyModal()
@@ -979,9 +1048,12 @@ export default {
 
 .step-content {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
   overflow-x: hidden;
   padding-right: 0.5em;
+  padding-bottom: 1em;
+  scrollbar-gutter: stable;
 }
 
 .step-content h3 {
@@ -1243,14 +1315,6 @@ export default {
   background: var(--ui-accent);
 }
 
-/* 完成页面标题 */
-.setup-complete-icon {
-  font-size: 1.2em;
-  color: var(--ui-success);
-  margin-right: 0.3em;
-  vertical-align: middle;
-}
-
 /* 完成页资源区样式 */
 .client-download-section,
 .promo-service-section {
@@ -1274,25 +1338,24 @@ export default {
 }
 
 .client-download-layout {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: 1.5em;
   align-items: flex-start;
 }
 
 .client-links {
-  flex: 0 0 auto;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.5em;
-  min-width: 240px;
+  min-width: 0;
 }
 
 .client-qrcodes {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: repeat(2, 168px);
   gap: 1em;
   align-items: flex-start;
-  flex: 1;
   min-width: 0;
 }
 
@@ -1301,7 +1364,6 @@ export default {
   flex-direction: column;
   align-items: center;
   gap: 0.3em;
-  flex: 1;
 }
 
 .qr-code-box {
@@ -1326,6 +1388,92 @@ export default {
 
 .qr-code-label i {
   margin-right: 0.3em;
+}
+
+.setup-completion-toasts {
+  position: fixed;
+  top: max(1rem, env(safe-area-inset-top));
+  left: 50%;
+  z-index: 1080;
+  display: grid;
+  width: min(480px, calc(100vw - 2rem));
+  gap: 0.6rem;
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+
+.setup-completion-toast {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  min-height: 48px;
+  gap: 0.75rem;
+  padding: 0.75rem 0.9rem;
+  border: 1px solid var(--ui-border);
+  border-radius: var(--ui-radius-md);
+  color: var(--ui-text-primary);
+  background: var(--ui-surface-strong);
+  box-shadow: var(--ui-shadow-lg);
+  pointer-events: auto;
+}
+
+.setup-completion-toast-success {
+  border-color: color-mix(in srgb, var(--ui-success) 40%, var(--ui-border));
+  background: color-mix(in srgb, var(--ui-success) 10%, var(--ui-surface-strong));
+}
+
+.setup-completion-toast-success > i {
+  color: var(--ui-success);
+}
+
+.setup-completion-toast-info {
+  border-color: color-mix(in srgb, var(--ui-accent) 40%, var(--ui-border));
+  background: color-mix(in srgb, var(--ui-accent) 10%, var(--ui-surface-strong));
+}
+
+.setup-completion-toast-info > i {
+  color: var(--ui-accent);
+}
+
+.setup-completion-toast-title {
+  font-weight: 700;
+}
+
+.setup-completion-toast-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--ui-radius-sm);
+  color: var(--ui-text-secondary);
+  background: transparent;
+  cursor: pointer;
+}
+
+.setup-completion-toast-close:hover,
+.setup-completion-toast-close:focus-visible {
+  color: var(--ui-text-primary);
+  background: var(--ui-surface-hover);
+}
+
+.setup-toast-enter-active,
+.setup-toast-leave-active {
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease;
+}
+
+.setup-toast-enter-from,
+.setup-toast-leave-to {
+  opacity: 0;
+  transform: translateY(-0.75rem);
+}
+
+.setup-toast-move {
+  transition: transform 0.2s ease;
 }
 
 /* 小图标样式 */
@@ -1435,17 +1583,21 @@ export default {
   }
 
   .client-download-layout {
-    flex-direction: column;
+    grid-template-columns: 1fr;
     gap: 1rem;
   }
 
   .client-links {
     width: 100%;
     min-width: 0;
+    grid-template-columns: 1fr;
   }
 
   .client-qrcodes {
     width: 100%;
+    max-width: 360px;
+    margin: 0 auto;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .promo-service-links {


### PR DESCRIPTION
## 说明

新手引导完成页引用的 AlkaidLab 和皎月连 PNG 未注册到 Config HTTP 的静态资源路由，打包运行时无法加载。完成页内容在较小窗口下也可能被底部操作栏遮挡。

## 修改

- 为两个 PNG 添加经过现有 WebUI 鉴权的静态资源路由。
- 调整完成页资源卡片、二维码区域和滚动布局，避免底部内容不可见。
- 将完成状态改为短暂置顶提示，并默认选择基地显示器 ZakoHDR。