### PR TITLE
fix(windows): correct nested shader include path

### DIFF
--- a/src_assets/windows/assets/shaders/directx/include/convert_yuv420_nv12p010_cs_base.hlsl
+++ b/src_assets/windows/assets/shaders/directx/include/convert_yuv420_nv12p010_cs_base.hlsl
@@ -36,7 +36,7 @@ cbuffer cs_layout_cbuffer : register(b1) {
     int2  cs_layout_pad;
 };
 
-#include "hdr_analysis_snapshot.hlsl"
+#include "include/hdr_analysis_snapshot.hlsl"
 
 groupshared float3 s_rgb[16][16];
 

--- a/src_assets/windows/assets/shaders/directx/include/convert_yuv420_nv12p010_cs_scaled_base.hlsl
+++ b/src_assets/windows/assets/shaders/directx/include/convert_yuv420_nv12p010_cs_scaled_base.hlsl
@@ -38,7 +38,7 @@ cbuffer cs_layout_cbuffer : register(b1) {
     int2  cs_layout_pad;
 };
 
-#include "hdr_analysis_snapshot.hlsl"
+#include "include/hdr_analysis_snapshot.hlsl"
 
 #define CS_TILE 16
 


### PR DESCRIPTION
## 改了啥呀

- 修正 NV12/P010 基础 shader 对 `hdr_analysis_snapshot.hlsl` 的嵌套 include 路径
- 同步覆盖原尺寸与缩放版本，免得其中一只杂鱼漏网呀

## 为啥会坏

Sunshine 通过 `D3DCompileFromFile(..., D3D_COMPILE_STANDARD_FILE_INCLUDE)` 编译入口 shader。基础文件虽然位于 `include/`，但嵌套 include 会按入口文件根目录解析，因此原来的裸文件名触发 `X1507: failed to open source file`。

改成从 shader 根目录可解析的 `include/hdr_analysis_snapshot.hlsl` 后，两条包含链都能正常编译。

## 验证

- `git diff --check`
- 使用与 Sunshine 相同的 `D3DCompileFromFile` 调用编译 8 个受影响的 NV12/P010 shader 变体，全部成功