### PR TITLE
fix(nvenc): correct CUDA array registration pitch

### DIFF
--- a/src/nvenc/win/impl/nvenc_d3d11_on_cuda.cpp
+++ b/src/nvenc/win/impl/nvenc_d3d11_on_cuda.cpp
@@ -246,7 +246,9 @@ namespace nvenc {
     if (!register_cuda_input(
           NV_ENC_INPUT_RESOURCE_TYPE_CUDAARRAY,
           cuda_array_surface,
-          encoder_params.width * planar_yuv_bytes_per_sample)) {
+          // NVENC SDK 13.1 requires CUDA array pitch to be the allocation
+          // width multiplied by CUDA_ARRAY3D_DESCRIPTOR::NumChannels.
+          encoder_params.width * planar_yuv_plane_count)) {
       BOOST_LOG(warning) << "NvEnc: CUDA array registration failed: " << last_nvenc_error_string;
       destroy_cuda_array_input();
       return false;


### PR DESCRIPTION
## 改了啥呀

- 修正 NVENC SDK 13.1 block-linear CUDA array 输入的注册 pitch。
- CUDA array 现在按 `Width × NumChannels` 传给 `NvEncRegisterResource()`。
- 保留现有 CUDA device pointer 回退路径不变。

## 为啥要改

YUV444 10-bit CUDA array 的 `NumChannels` 是 3，但原实现按每采样 2 字节计算成了 `width × 2`。这只杂鱼 pitch 少算了一个通道，NVENC 会以错误布局读取图像，表现为四等分虚影和色彩异常。

Closes #871

## 验证

- `ninja -C build sunshine -j4 -v`
- `build/tests/test_sunshine.exe --gtest_filter=NvencVersionTest.*:NvencDynamicFactoryTest.*`（9/9 通过）
- Windows Inno Setup 安装包生成成功
- Windows CPack ZIP 生成及完整性检查通过

> 画面修复仍需要 issue 用户在 NVIDIA RTX 2060、HEVC 10-bit、YUV 4:4:4 环境实测，测试包已附在 #871。