### PR TITLE
fix(hdr): align HLG encoding with display luminance

### DIFF
--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -611,6 +611,25 @@ namespace platf::dxgi {
   }
 
   class d3d_base_encode_device final {
+    struct alignas(16) HlgDisplayParams {
+      float peakNits;
+      float systemGamma;
+      float pad[2];
+    };
+    static_assert(sizeof(HlgDisplayParams) == 16);
+
+    // Must match the AnalysisParams constant buffer in both HDR analysis shaders.
+    struct AnalysisParams {
+      uint32_t analysisWidth;
+      uint32_t analysisHeight;
+      uint32_t sourceWidth;
+      uint32_t sourceHeight;
+      uint32_t inputHasCellStatistics;
+      float maxAnalysisNits;
+      uint32_t pad[2];
+    };
+    static_assert(sizeof(AnalysisParams) == 32);
+
     struct gpu_timing_sample_t {
       query_t disjoint;
       query_t start;
@@ -893,6 +912,76 @@ namespace platf::dxgi {
     }
 
     int
+    configure_hlg_display(bool use_hlg_shader, bool is_probe) {
+      hlg_display_cbuf.reset();
+      ID3D11Buffer *null_cbuf = nullptr;
+      device_ctx->PSSetConstantBuffers(3, 1, &null_cbuf);
+
+      float analysis_max_nits = 10000.0f;
+      if (use_hlg_shader) {
+        SS_HDR_METADATA metadata {};
+        // Use the effective capture-display metadata as the single source of
+        // truth. VDD reports the client-mapped capabilities here; a physical
+        // output reports the values after Windows applies its HDR color profile.
+        const bool has_display_peak =
+          display->get_hdr_metadata(metadata) && metadata.maxDisplayLuminance > 0;
+        const float peak_nits = has_display_peak
+                                  ? static_cast<float>(metadata.maxDisplayLuminance)
+                                  : 1000.0f;
+        const float system_gamma = ::video::hlg_system_gamma(peak_nits);
+        const HlgDisplayParams params {
+          peak_nits,
+          system_gamma,
+          {},
+        };
+
+        auto hlg_params = make_buffer(device.get(), params);
+        if (!hlg_params) {
+          BOOST_LOG(error) << "Failed to create HLG display parameter buffer";
+          return -1;
+        }
+
+        ID3D11Buffer *hlg_params_p = hlg_params.get();
+        device_ctx->PSSetConstantBuffers(3, 1, &hlg_params_p);
+        hlg_display_cbuf = std::move(hlg_params);
+        // Vivid statistics must describe the encoded HLG range, not scRGB
+        // headroom that cannot be represented by the nominal HLG signal.
+        analysis_max_nits = std::min(peak_nits, 10000.0f);
+
+        BOOST_LOG(is_probe ? debug : info)
+          << "HLG conversion: BT.2100 inverse OOTF, nominal display peak "
+          << peak_nits << " nits, system gamma " << system_gamma
+          << (has_display_peak
+                ? " (capture display metadata)"
+                : " (1000-nit fallback)");
+      }
+
+      hdr_analysis_max_nits = analysis_max_nits;
+      if (hdr_analysis_enabled) {
+        const AnalysisParams analysis_params {
+          hdr_analysis_width,
+          hdr_analysis_height,
+          static_cast<uint32_t>(display->width),
+          static_cast<uint32_t>(display->height),
+          0,
+          hdr_analysis_max_nits,
+          {},
+        };
+        auto analysis_cbuf = make_buffer(device.get(), analysis_params);
+        if (!analysis_cbuf) {
+          BOOST_LOG(warning)
+            << "Failed to update HDR analysis luminance limit; disabling dynamic metadata";
+          hdr_analysis_enabled = false;
+        }
+        else {
+          hdr_analysis_cbuf = std::move(analysis_cbuf);
+        }
+      }
+
+      return 0;
+    }
+
+    int
     init_output(ID3D11Texture2D *frame_texture, int width, int height, const ::video::sunshine_colorspace_t &colorspace, bool is_probe = false) {
       // The underlying frame pool owns the texture, so we must reference it for ourselves
       frame_texture->AddRef();
@@ -914,6 +1003,10 @@ namespace platf::dxgi {
       // Determine which HDR shader to use based on colorspace
       const bool use_pq_shader = ::video::colorspace_is_pq(colorspace);
       const bool use_hlg_shader = ::video::colorspace_is_hlg(colorspace);
+
+      if (configure_hlg_display(use_hlg_shader, is_probe) != 0) {
+        return -1;
+      }
 
       const bool downscaling = display->width > width || display->height > height;
       // Determine downscaling quality based on config
@@ -1653,6 +1746,7 @@ namespace platf::dxgi {
 
     buf_t subsample_offset;
     buf_t color_matrix;
+    buf_t hlg_display_cbuf;
 
     blend_t blend_disable;
     sampler_state_t sampler_linear;
@@ -1727,6 +1821,7 @@ namespace platf::dxgi {
     bool hdr_analysis_pending = false;     // Whether we have results ready to read
     bool hdr_analysis_enabled = false;     // Whether HDR analysis is initialized
     bool hdr_analysis_snapshot_enabled = false; // P010 converter fills the private analysis texture
+    float hdr_analysis_max_nits = 10000.0f; // Clamp metadata to the encoded transfer-function range
 
     // ===== Compute-shader RGB->P010/NV12 fast path =====
     // Phase 1: HDR PQ/HLG -> P010. Phase 2A: SDR sRGB/scRGB -> NV12.
@@ -1771,17 +1866,6 @@ namespace platf::dxgi {
       float sumMaxRGB;
       uint32_t pixelCount;
     };
-
-    // Must match HLSL AnalysisParams layout exactly.
-    struct AnalysisParams {
-      uint32_t analysisWidth;
-      uint32_t analysisHeight;
-      uint32_t sourceWidth;
-      uint32_t sourceHeight;
-      uint32_t inputHasCellStatistics;
-      uint32_t pad[3];
-    };
-    static_assert(sizeof(AnalysisParams) == 32);
 
     // Must match HLSL FinalResult layout exactly. This one keeps the histogram because
     // it is what the CPU reads back.
@@ -1879,6 +1963,7 @@ namespace platf::dxgi {
         width,
         height,
         0,
+        hdr_analysis_max_nits,
         {},
       };
       hdr_analysis_cbuf = make_buffer(device.get(), analysis_cb_data);
@@ -2441,6 +2526,7 @@ namespace platf::dxgi {
           static_cast<uint32_t>(active_w),
           static_cast<uint32_t>(active_h),
           1,
+          hdr_analysis_max_nits,
           {},
         };
         if (SUCCEEDED(snapshot_status)) {
@@ -2549,6 +2635,10 @@ namespace platf::dxgi {
       };
       const UINT cbuf_count = write_hdr_analysis_snapshot ? 3 : 2;
       device_ctx->CSSetConstantBuffers(0, cbuf_count, cbufs);
+      if (hlg_display_cbuf) {
+        ID3D11Buffer *hlg_cbuf = hlg_display_cbuf.get();
+        device_ctx->CSSetConstantBuffers(3, 1, &hlg_cbuf);
+      }
 
       // Dispatch covers only the active rect (precomputed in init_compute_path).
       device_ctx->Dispatch((UINT) cs_dispatch_groups_x, (UINT) cs_dispatch_groups_y, 1);
@@ -2565,6 +2655,8 @@ namespace platf::dxgi {
       device_ctx->CSSetUnorderedAccessViews(0, uav_count, null_uavs, nullptr);
       ID3D11Buffer *null_cb[3] = { nullptr, nullptr, nullptr };
       device_ctx->CSSetConstantBuffers(0, cbuf_count, null_cb);
+      ID3D11Buffer *null_hlg_cbuf = nullptr;
+      device_ctx->CSSetConstantBuffers(3, 1, &null_hlg_cbuf);
       device_ctx->CSSetShader(nullptr, nullptr, 0);
       if (timing) {
         device_ctx->End(timing->before_copy.get());

--- a/src/video_colorspace.cpp
+++ b/src/video_colorspace.cpp
@@ -9,6 +9,8 @@
 #include "logging.h"
 #include "video.h"
 
+#include <cmath>
+
 extern "C" {
 #include <libswscale/swscale.h>
 }
@@ -29,6 +31,21 @@ namespace video {
   bool
   colorspace_is_pq(const sunshine_colorspace_t &colorspace) {
     return colorspace.colorspace == colorspace_e::bt2020;
+  }
+
+  float
+  hlg_system_gamma(float peak_luminance_nits) {
+    if (!std::isfinite(peak_luminance_nits) || peak_luminance_nits <= 0.0f) {
+      peak_luminance_nits = 1000.0f;
+    }
+
+    if (peak_luminance_nits >= 400.0f && peak_luminance_nits <= 2000.0f) {
+      return 1.2f + 0.42f * std::log10(peak_luminance_nits / 1000.0f);
+    }
+
+    // BT.2100-3 Note 5f extended-range formula:
+    // gamma = 1.2 * 1.111 ^ log2(Lw / 1000).
+    return 1.2f * std::pow(1.111f, std::log2(peak_luminance_nits / 1000.0f));
   }
 
   sunshine_colorspace_t

--- a/src/video_colorspace.h
+++ b/src/video_colorspace.h
@@ -33,6 +33,18 @@ namespace video {
   bool
   colorspace_is_pq(const sunshine_colorspace_t &colorspace);
 
+  /**
+   * @brief Calculate the BT.2100 HLG system gamma for a nominal display peak.
+   *
+   * Uses the normal production-monitor formula from 400 to 2000 nits and the
+   * BT.2100-3 extended-range formula outside that interval.
+   *
+   * @param peak_luminance_nits Nominal display peak luminance in cd/m2.
+   * @return HLG system gamma. Invalid peaks fall back to the 1000-nit value (1.2).
+   */
+  float
+  hlg_system_gamma(float peak_luminance_nits);
+
   // Declared in video.h
   struct config_t;
 

--- a/src_assets/windows/assets/shaders/directx/hdr_luminance_analysis_cs.hlsl
+++ b/src_assets/windows/assets/shaders/directx/hdr_luminance_analysis_cs.hlsl
@@ -41,7 +41,8 @@ cbuffer AnalysisParams : register(b0) {
     uint sourceWidth;
     uint sourceHeight;
     uint inputHasCellStatistics;
-    uint3 _pad;
+    float maxAnalysisNits;
+    uint2 _pad;
 };
 
 // Per-group reduction results (scalars only — the histogram goes straight to the
@@ -70,7 +71,7 @@ groupshared uint  gs_histogram[HISTOGRAM_BINS];
 float HdrAnalysisMaxRgbNits(float3 sc_rgb)
 {
     float3 rec2020_nits = max(Rec709toRec2020(sc_rgb) * SCRGB_NITS_PER_UNIT, 0.0);
-    return min(max(max(rec2020_nits.r, rec2020_nits.g), rec2020_nits.b), 10000.0);
+    return min(max(max(rec2020_nits.r, rec2020_nits.g), rec2020_nits.b), maxAnalysisNits);
 }
 
 [numthreads(16, 16, 1)]

--- a/src_assets/windows/assets/shaders/directx/include/common.hlsl
+++ b/src_assets/windows/assets/shaders/directx/include/common.hlsl
@@ -40,12 +40,7 @@ float3 scRGBTo2100PQ(float3 rgb)
     return NitsToPQ(rgb);
 }
 
-// HLG (Hybrid Log-Gamma) OETF as defined in ARIB STD-B67 / ITU-R BT.2100
-// Optimized: branchless vectorized implementation
-//
-// Note: HLG OETF is mathematically valid for L > 1, but output > 1 will be
-// clipped by the encoder (10-bit can only represent [0, 1]). We don't clip
-// in the shader to preserve precision; the encoder handles clipping.
+// HLG (Hybrid Log-Gamma) OETF as defined in ARIB STD-B67 / ITU-R BT.2100.
 float3 LinearToHLG(float3 L)
 {
     // HLG constants from ARIB STD-B67
@@ -54,7 +49,7 @@ float3 LinearToHLG(float3 L)
     static const float c = 0.55991073;  // 0.5 - a * ln(4 * a)
     static const float threshold = 1.0 / 12.0;
 
-    // Clamp negative values only (out of gamut), allow > 1 for HDR headroom
+    // Clamp negative values only. Production signals may retain headroom above 1.
     L = max(L, 0.0);
 
     // Compute both branches for all channels (branchless)
@@ -62,45 +57,46 @@ float3 LinearToHLG(float3 L)
     float3 lowRange = sqrt(3.0 * L);
 
     // High range: a * log(12 * L - b) + c
-    // For L > 1, this produces output > 1 which is fine (encoder clips later)
     float3 highRange = a * log(max(12.0 * L - b, 1e-6)) + c;
 
     // Branchless select using step function
     float3 selector = step(threshold, L);
 
-    // Return unclamped result - let encoder handle clipping
     return lerp(lowRange, highRange, selector);
 }
 
-float3 scRGBTo2100HLG(float3 rgb)
+// Convert display-linear Rec. 2020 light to scene-linear HLG light using the
+// inverse of the BT.2100 reference OOTF (Table 5, Note 5i).
+float3 DisplayLinearToHLGScene(float3 display_rgb_nits, float peak_nits, float system_gamma)
 {
-    // Convert from Rec 709 primaries (used by scRGB) to Rec 2020 primaries (used by Rec 2100)
-    rgb = Rec709toRec2020(rgb);
+    float3 normalized_rgb = max(display_rgb_nits, 0.0) / peak_nits;
+    float normalized_luminance = dot(
+        normalized_rgb,
+        float3(0.2627, 0.6780, 0.0593)
+    );
 
-    // scRGB luminance mapping to HLG:
-    // - scRGB 1.0 = 80 nits (SDR reference white)
-    // - HLG is scene-referred, OETF expects normalized scene light [0, 1]
-    // - For a 1000 nits peak display, HLG signal 1.0 maps to ~1000 nits
-    // - HLG reference white (75% signal) is ~203 nits
-    //
-    // Mapping strategy:
-    // - scRGB 1.0 (80 nits) should map to HLG ~0.5 (SDR-compatible level)
-    // - scRGB 12.5 (1000 nits) should map to HLG 1.0 (peak white)
-    //
-    // Scale factor: 80 nits / 1000 nits = 0.08
-    // This maps the full HDR range [0, 1000 nits] to HLG input [0, 1]
-    
-    static const float HDR_PEAK_NITS = 1000.0;
-    static const float SCRGB_NITS_PER_UNIT = 80.0;
-    static const float scaleToHLG = SCRGB_NITS_PER_UNIT / HDR_PEAK_NITS;  // 0.08
-    
-    // Convert scRGB to normalized scene light for HLG
-    // Negative values are clamped (out of gamut), but > 1.0 is preserved
-    // This allows content > 1000 nits to pass through (soft rolloff)
-    rgb = max(rgb, 0.0) * scaleToHLG;
+    // Avoid the 0 * infinity form when gamma > 1 and luminance is black.
+    if (normalized_luminance <= 0.0) {
+        return 0.0;
+    }
 
-    // Apply the HLG OETF
-    // For input > 1.0, output will exceed 1.0 and be clipped by encoder
-    // This provides a natural "soft knee" rolloff for super-bright content
-    return LinearToHLG(rgb);
+    float ootf_scale = pow(
+        max(normalized_luminance, 1e-6),
+        (1.0 - system_gamma) / system_gamma
+    );
+    return normalized_rgb * ootf_scale;
+}
+
+float3 scRGBTo2100HLG(float3 rgb, float peak_nits, float system_gamma)
+{
+    // Windows capture supplies display-linear scRGB: Rec. 709 primaries and
+    // 1.0 = 80 cd/m2. Convert primaries before applying the luminance-dependent
+    // inverse OOTF so its Y calculation is in Rec. 2020.
+    float3 display_rgb_nits = Rec709toRec2020(rgb) * 80.0;
+    float3 scene_rgb = DisplayLinearToHLGScene(
+        display_rgb_nits,
+        peak_nits,
+        system_gamma
+    );
+    return LinearToHLG(scene_rgb);
 }

--- a/src_assets/windows/assets/shaders/directx/include/convert_hybrid_log_gamma_base.hlsl
+++ b/src_assets/windows/assets/shaders/directx/include/convert_hybrid_log_gamma_base.hlsl
@@ -1,3 +1,14 @@
 #include "include/common.hlsl"
 
-#define CONVERT_FUNCTION scRGBTo2100HLG
+cbuffer hlg_display_cbuffer : register(b3) {
+    float hlg_peak_nits;
+    float hlg_system_gamma;
+    float2 hlg_display_pad;
+};
+
+float3 ConvertScRGBTo2100HLG(float3 rgb)
+{
+    return scRGBTo2100HLG(rgb, hlg_peak_nits, hlg_system_gamma);
+}
+
+#define CONVERT_FUNCTION ConvertScRGBTo2100HLG

--- a/src_assets/windows/assets/shaders/directx/include/hdr_analysis_snapshot.hlsl
+++ b/src_assets/windows/assets/shaders/directx/include/hdr_analysis_snapshot.hlsl
@@ -17,13 +17,17 @@ cbuffer hdr_analysis_snapshot_cbuffer : register(b2) {
     uint2 hdr_analysis_snapshot_size;
     uint2 hdr_analysis_snapshot_source_size;
     uint hdr_analysis_snapshot_has_cell_statistics;
-    uint3 hdr_analysis_snapshot_pad;
+    float hdr_analysis_snapshot_max_nits;
+    uint2 hdr_analysis_snapshot_pad;
 };
 
 float HdrAnalysisMaxRgbNits(float3 sc_rgb)
 {
     float3 rec2020_nits = max(Rec709toRec2020(sc_rgb) * 80.0, 0.0);
-    return min(max(max(rec2020_nits.r, rec2020_nits.g), rec2020_nits.b), 10000.0);
+    return min(
+        max(max(rec2020_nits.r, rec2020_nits.g), rec2020_nits.b),
+        hdr_analysis_snapshot_max_nits
+    );
 }
 
 bool GetHdrAnalysisCell(

--- a/tests/unit/test_video.cpp
+++ b/tests/unit/test_video.cpp
@@ -6,6 +6,8 @@
 
 #include "../tests_common.h"
 
+#include <limits>
+
 namespace {
 
   double
@@ -97,6 +99,24 @@ TEST(VideoInputActivityBoostPolicy, CapsBoostAtStreamFps) {
   ASSERT_TRUE(policy.useful);
   EXPECT_EQ(policy.fps, 120);
   EXPECT_NEAR(millis(policy.frame_time), 1000.0 / 120.0, 0.001);
+}
+
+TEST(HlgSystemGamma, UsesBt2100ProductionMonitorFormula) {
+  EXPECT_NEAR(video::hlg_system_gamma(400.0f), 1.0328653f, 0.00001f);
+  EXPECT_NEAR(video::hlg_system_gamma(678.0f), 1.12912f, 0.00001f);
+  EXPECT_NEAR(video::hlg_system_gamma(1000.0f), 1.2f, 0.00001f);
+  EXPECT_NEAR(video::hlg_system_gamma(2000.0f), 1.32643f, 0.00001f);
+}
+
+TEST(HlgSystemGamma, UsesBt2100ExtendedRangeFormula) {
+  EXPECT_NEAR(video::hlg_system_gamma(300.0f), 0.99949f, 0.00001f);
+  EXPECT_NEAR(video::hlg_system_gamma(4000.0f), 1.48119f, 0.00001f);
+}
+
+TEST(HlgSystemGamma, FallsBackToReferencePeakForInvalidValues) {
+  EXPECT_NEAR(video::hlg_system_gamma(0.0f), 1.2f, 0.00001f);
+  EXPECT_NEAR(video::hlg_system_gamma(-1.0f), 1.2f, 0.00001f);
+  EXPECT_NEAR(video::hlg_system_gamma(std::numeric_limits<float>::quiet_NaN()), 1.2f, 0.00001f);
 }
 
 struct EncoderTest: PlatformTestSuite, testing::WithParamInterface<video::encoder_t *> {


### PR DESCRIPTION
## 改了啥呀

- 按 ITU-R BT.2100-3 为 scRGB → HLG 增加基于显示峰值和 system gamma 的 inverse OOTF
- 把捕获显示器的有效 HDR 元数据作为唯一亮度来源：VDD 使用客户端映射值，物理屏使用 Windows HDR color profile 生效后的 DXGI 值
- 让像素着色器与计算着色器共用同一组 HLG 参数
- 将 Vivid 帧分析上限绑定到实际可编码的 HLG 峰值，避免动态元数据继续描述会被编码范围裁掉的 scRGB headroom
- 补充 BT.2100 正常范围、扩展范围和非法输入回退测试

## 为啥要改

原链路直接把 display-linear scRGB 按固定 1000 nit 缩放后送进 HLG OETF，等于把显示光误当成场景光。客户端再执行 HLG OOTF 时，这只杂鱼转换就会额外拉高对比度，表现为暗部死黑、亮部过冲；客户端峰值不是 1000 nit 时偏差更明显。

现在图像转换和 Vivid 元数据使用相同的有效显示峰值。物理屏 HDR profile 异步生效后，现有 HDR 元数据变更检测会触发捕获重建并刷新参数。

## 影响范围

- 仅影响 Windows scRGB → HLG 的 D3D11 PS/CS 路径及对应 Vivid 分析上限
- PQ、SDR 和不启用 HLG 的路径保持原行为
- 不新增设置项，也不按 VDD/物理显示器拆分实现

## 验证

- `ninja -C build -j8 sunshine test_sunshine`
- Windows SDK `fxc /Ges /WX` 编译 9 个 HLG shader、2 个 snapshot 变体和 HDR analyzer
- `test_sunshine.exe --gtest_filter=HlgSystemGamma.*`：3/3 通过
- 排除两个因 httpbin.org 返回 HTTP 503 的外部联网用例后：253 通过，11 个按本机硬件/平台条件跳过，无失败