### PR TITLE
fix(cursor): keep XOR cursors visible locally

### DIFF
--- a/src/display_device/session.cpp
+++ b/src/display_device/session.cpp
@@ -597,16 +597,16 @@ namespace display_device {
     const vdd_utils::hdr_brightness_t hdr_brightness { session.max_nits, session.min_nits, session.max_full_nits };
     const vdd_utils::physical_size_t physical_size = vdd_utils::get_client_physical_size(session.client_name);
 
-    if (config::video.capture == "vdd" && config::video.capture_cursor) {
+    if (config::video.capture == "vdd") {
       bool hardware_cursor_changed = false;
-      if (vdd_utils::ensure_hardware_cursor_disabled_for_capture(&hardware_cursor_changed)) {
+      if (vdd_utils::ensure_hardware_cursor_enabled_for_capture(&hardware_cursor_changed)) {
         if (hardware_cursor_changed) {
-          BOOST_LOG(info) << "VDD HardwareCursor disabled for direct capture; waiting for driver reload";
+          BOOST_LOG(info) << "VDD hardware cursor export enabled; waiting for one-time driver reload";
           std::this_thread::sleep_for(1200ms);
         }
       }
       else {
-        BOOST_LOG(warning) << "Failed to disable VDD HardwareCursor for direct capture; remote cursor may be invisible";
+        BOOST_LOG(warning) << "Failed to enable VDD hardware cursor export; cursor overlay and local synchronization may be unavailable";
       }
     }
 

--- a/src/display_device/vdd_utils.cpp
+++ b/src/display_device/vdd_utils.cpp
@@ -255,10 +255,6 @@ namespace display_device {
       }
 
       BOOST_LOG(info) << "Enabling VDD hardware cursor export for direct capture";
-      if (!set_hardware_cursor_enabled(true)) {
-        return false;
-      }
-
       bool persisted = false;
       for (int attempt = 0; attempt < kMaxRetryCount; ++attempt) {
         if (persist_hardware_cursor_setting(true)) {
@@ -270,7 +266,15 @@ namespace display_device {
       }
 
       if (!persisted) {
-        BOOST_LOG(error) << "VDD hardware cursor export enabled in driver, but failed to persist vdd_settings.xml";
+        BOOST_LOG(error) << "Failed to persist VDD hardware cursor export before reloading the driver";
+        return false;
+      }
+
+      // The VDD command reloads the driver synchronously and the driver reads
+      // HardwareCursor from this file during reload. Persist first so it cannot
+      // observe the old value and keep cursor export disabled in memory.
+      if (!set_hardware_cursor_enabled(true)) {
+        BOOST_LOG(error) << "VDD hardware cursor export is persisted, but the live driver reload failed";
         return false;
       }
 

--- a/src/display_device/vdd_utils.cpp
+++ b/src/display_device/vdd_utils.cpp
@@ -221,13 +221,19 @@ namespace display_device {
     }
 
     bool
-    ensure_hardware_cursor_disabled_for_capture(bool *changed) {
+    hardware_cursor_export_enabled(std::string value) {
+      boost::algorithm::trim(value);
+      return boost::algorithm::iequals(value, "true") || value == "1";
+    }
+
+    bool
+    ensure_hardware_cursor_enabled_for_capture(bool *changed) {
       if (changed) {
         *changed = false;
       }
 
       const auto settings_path = std::filesystem::path(platf::appdata()) / "vdd_settings.xml";
-      bool needs_disable = true;
+      bool needs_enable = true;
 
       try {
         if (std::filesystem::exists(settings_path)) {
@@ -235,29 +241,27 @@ namespace display_device {
           pt::read_xml(settings_path.string(), tree);
 
           if (const auto value = tree.get_optional<std::string>("vdd_settings.cursor.HardwareCursor")) {
-            auto hardware_cursor = *value;
-            boost::algorithm::trim(hardware_cursor);
-            needs_disable = !(boost::algorithm::iequals(hardware_cursor, "false") || hardware_cursor == "0");
+            needs_enable = !hardware_cursor_export_enabled(*value);
           }
         }
       }
       catch (const std::exception &e) {
-        BOOST_LOG(warning) << "Unable to inspect VDD HardwareCursor setting; will request software cursor for direct capture: " << e.what();
+        BOOST_LOG(warning) << "Unable to inspect VDD HardwareCursor setting; will request cursor export for direct capture: " << e.what();
       }
 
-      if (!needs_disable) {
-        BOOST_LOG(debug) << "VDD HardwareCursor is already disabled for direct capture";
+      if (!needs_enable) {
+        BOOST_LOG(debug) << "VDD hardware cursor export is already enabled for direct capture";
         return true;
       }
 
-      BOOST_LOG(info) << "Disabling VDD HardwareCursor because direct VDD capture only receives the shared framebuffer texture";
-      if (!set_hardware_cursor_enabled(false)) {
+      BOOST_LOG(info) << "Enabling VDD hardware cursor export for direct capture";
+      if (!set_hardware_cursor_enabled(true)) {
         return false;
       }
 
       bool persisted = false;
       for (int attempt = 0; attempt < kMaxRetryCount; ++attempt) {
-        if (persist_hardware_cursor_setting(false)) {
+        if (persist_hardware_cursor_setting(true)) {
           persisted = true;
           break;
         }
@@ -266,7 +270,7 @@ namespace display_device {
       }
 
       if (!persisted) {
-        BOOST_LOG(error) << "VDD HardwareCursor disabled in driver, but failed to persist vdd_settings.xml";
+        BOOST_LOG(error) << "VDD hardware cursor export enabled in driver, but failed to persist vdd_settings.xml";
         return false;
       }
 

--- a/src/display_device/vdd_utils.cpp
+++ b/src/display_device/vdd_utils.cpp
@@ -5,6 +5,7 @@
 #include "vdd_ioctl.h"
 
 #include <algorithm>
+#include <atomic>
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/process/v1.hpp>
@@ -52,6 +53,7 @@ namespace display_device {
       constexpr auto kModePublicationTimeout = 3s;
       constexpr auto kModePublicationInitialPoll = 50ms;
       constexpr auto kModePublicationMaxPoll = 500ms;
+      std::atomic_bool hardware_cursor_live_enable_confirmed { false };
 
       std::vector<std::string>
       collect_physical_devices_for_preservation() {
@@ -233,7 +235,7 @@ namespace display_device {
       }
 
       const auto settings_path = std::filesystem::path(platf::appdata()) / "vdd_settings.xml";
-      bool needs_enable = true;
+      bool persisted_enabled = false;
 
       try {
         if (std::filesystem::exists(settings_path)) {
@@ -241,7 +243,7 @@ namespace display_device {
           pt::read_xml(settings_path.string(), tree);
 
           if (const auto value = tree.get_optional<std::string>("vdd_settings.cursor.HardwareCursor")) {
-            needs_enable = !hardware_cursor_export_enabled(*value);
+            persisted_enabled = hardware_cursor_export_enabled(*value);
           }
         }
       }
@@ -249,20 +251,24 @@ namespace display_device {
         BOOST_LOG(warning) << "Unable to inspect VDD HardwareCursor setting; will request cursor export for direct capture: " << e.what();
       }
 
-      if (!needs_enable) {
-        BOOST_LOG(debug) << "VDD hardware cursor export is already enabled for direct capture";
+      if (!hardware_cursor_export_needs_enable(
+            persisted_enabled,
+            hardware_cursor_live_enable_confirmed.load(std::memory_order_acquire))) {
+        BOOST_LOG(debug) << "VDD hardware cursor export is enabled in settings and confirmed by the live driver";
         return true;
       }
 
       BOOST_LOG(info) << "Enabling VDD hardware cursor export for direct capture";
-      bool persisted = false;
-      for (int attempt = 0; attempt < kMaxRetryCount; ++attempt) {
-        if (persist_hardware_cursor_setting(true)) {
-          persisted = true;
-          break;
-        }
+      bool persisted = persisted_enabled;
+      if (!persisted) {
+        for (int attempt = 0; attempt < kMaxRetryCount; ++attempt) {
+          if (persist_hardware_cursor_setting(true)) {
+            persisted = true;
+            break;
+          }
 
-        std::this_thread::sleep_for(calculate_exponential_backoff(attempt));
+          std::this_thread::sleep_for(calculate_exponential_backoff(attempt));
+        }
       }
 
       if (!persisted) {
@@ -274,10 +280,12 @@ namespace display_device {
       // HardwareCursor from this file during reload. Persist first so it cannot
       // observe the old value and keep cursor export disabled in memory.
       if (!set_hardware_cursor_enabled(true)) {
+        hardware_cursor_live_enable_confirmed.store(false, std::memory_order_release);
         BOOST_LOG(error) << "VDD hardware cursor export is persisted, but the live driver reload failed";
         return false;
       }
 
+      hardware_cursor_live_enable_confirmed.store(true, std::memory_order_release);
       if (changed) {
         *changed = true;
       }

--- a/src/display_device/vdd_utils.h
+++ b/src/display_device/vdd_utils.h
@@ -149,14 +149,22 @@ namespace display_device::vdd_utils {
   execute_vdd_command(const std::string &action);
 
   /**
-   * @brief Ensure ZakoVDD renders the cursor into the framebuffer instead of exposing a hardware cursor plane.
-   * @details Sunshine's direct VDD capture backend consumes only the shared frame texture exported by ZakoVDD.
-   *          Hardware cursor planes are not part of that texture, so they would be invisible to remote clients.
-   * @param changed Optional output set to true when this call had to update the driver setting.
-   * @return True when the setting is already safe or was updated successfully.
+   * @brief Parse the persisted VDD HardwareCursor value.
    */
   bool
-  ensure_hardware_cursor_disabled_for_capture(bool *changed = nullptr);
+  hardware_cursor_export_enabled(std::string value);
+
+  /**
+   * @brief Ensure ZakoVDD continuously exports its hardware cursor channel.
+   * @details Direct VDD capture consumes this channel for both server-side
+   *          composition and client-side local cursor synchronization. Once
+   *          enabled, switching cursor ownership is a session-only operation
+   *          and does not require another driver reload.
+   * @param changed Optional output set to true when this call had to update the driver setting.
+   * @return True when cursor export was already enabled or was updated successfully.
+   */
+  bool
+  ensure_hardware_cursor_enabled_for_capture(bool *changed = nullptr);
 
   /**
    * @brief Outcome of attempting a live SETMODES update.

--- a/src/display_device/vdd_utils.h
+++ b/src/display_device/vdd_utils.h
@@ -154,6 +154,11 @@ namespace display_device::vdd_utils {
   bool
   hardware_cursor_export_enabled(std::string value);
 
+  constexpr bool
+  hardware_cursor_export_needs_enable(bool persisted_enabled, bool live_enable_confirmed) {
+    return !persisted_enabled || !live_enable_confirmed;
+  }
+
   /**
    * @brief Ensure ZakoVDD continuously exports its hardware cursor channel.
    * @details Direct VDD capture consumes this channel for both server-side

--- a/src/platform/windows/display_cursor.cpp
+++ b/src/platform/windows/display_cursor.cpp
@@ -202,6 +202,85 @@ namespace platf::dxgi {
     }
   }
 
+  util::buffer_t<std::uint8_t>
+  make_local_cursor_image(const normalized_cursor_shape_t &normalized) {
+    if (normalized.xor_mask.size() == 0) {
+      return normalized.alpha;
+    }
+    if (normalized.alpha.size() != normalized.xor_mask.size() ||
+        normalized.info.Width == 0 ||
+        normalized.alpha.size() % sizeof(std::uint32_t) != 0) {
+      return {};
+    }
+
+    const std::size_t pixel_count =
+      normalized.alpha.size() / sizeof(std::uint32_t);
+    if (pixel_count % normalized.info.Width != 0) {
+      return {};
+    }
+    const std::size_t height = pixel_count / normalized.info.Width;
+    std::vector<bool> invert_pixel(pixel_count, false);
+    util::buffer_t<std::uint8_t> local = normalized.alpha;
+
+    for (std::size_t index = 0; index < pixel_count; ++index) {
+      std::uint32_t xor_pixel;
+      std::memcpy(
+        &xor_pixel,
+        std::begin(normalized.xor_mask) + index * sizeof(xor_pixel),
+        sizeof(xor_pixel)
+      );
+      if ((xor_pixel & 0x00FFFFFFu) != 0) {
+        invert_pixel[index] = true;
+        constexpr std::uint32_t white = 0xFFFFFFFFu;
+        std::memcpy(
+          std::begin(local) + index * sizeof(white),
+          &white,
+          sizeof(white)
+        );
+      }
+    }
+
+    constexpr std::uint32_t black = 0xFF000000u;
+    for (std::size_t index = 0; index < pixel_count; ++index) {
+      if (!invert_pixel[index]) {
+        continue;
+      }
+      const std::size_t x = index % normalized.info.Width;
+      const std::size_t y = index / normalized.info.Width;
+      for (int dy = -1; dy <= 1; ++dy) {
+        for (int dx = -1; dx <= 1; ++dx) {
+          const auto nx = static_cast<std::int64_t>(x) + dx;
+          const auto ny = static_cast<std::int64_t>(y) + dy;
+          if (nx < 0 || ny < 0 ||
+              nx >= static_cast<std::int64_t>(normalized.info.Width) ||
+              ny >= static_cast<std::int64_t>(height)) {
+            continue;
+          }
+          const std::size_t neighbor =
+            static_cast<std::size_t>(ny) * normalized.info.Width +
+            static_cast<std::size_t>(nx);
+          if (invert_pixel[neighbor]) {
+            continue;
+          }
+          std::uint32_t alpha_pixel;
+          std::memcpy(
+            &alpha_pixel,
+            std::begin(normalized.alpha) + neighbor * sizeof(alpha_pixel),
+            sizeof(alpha_pixel)
+          );
+          if ((alpha_pixel & 0xFF000000u) == 0) {
+            std::memcpy(
+              std::begin(local) + neighbor * sizeof(black),
+              &black,
+              sizeof(black)
+            );
+          }
+        }
+      }
+    }
+    return local;
+  }
+
   bool
   set_cursor_texture(device_t::pointer device,
                      gpu_cursor_t &cursor,
@@ -371,7 +450,7 @@ namespace platf::dxgi {
       }
 
       normalized_cursor_shape_t normalized;
-      if (!normalize_cursor_shape(shape_buffer, shape_info, false, normalized)) {
+      if (!normalize_cursor_shape(shape_buffer, shape_info, true, normalized)) {
         return false;
       }
       const UINT32 output_height =
@@ -389,9 +468,13 @@ namespace platf::dxgi {
         return false;
       }
 
+      const auto local_image = make_local_cursor_image(normalized);
+      if (local_image.size() == 0) {
+        return false;
+      }
       std::vector<std::uint8_t> bgra(
-        std::begin(normalized.alpha),
-        std::end(normalized.alpha)
+        std::begin(local_image),
+        std::end(local_image)
       );
       cursor_channel::publish_shape(
         visible,

--- a/src/platform/windows/display_cursor.cpp
+++ b/src/platform/windows/display_cursor.cpp
@@ -202,6 +202,78 @@ namespace platf::dxgi {
     }
   }
 
+  namespace {
+    std::vector<bool>
+    compute_invert_mask(const normalized_cursor_shape_t &normalized,
+                        util::buffer_t<std::uint8_t> &local,
+                        std::size_t pixel_count) {
+      std::vector<bool> invert_pixel(pixel_count, false);
+      constexpr std::uint32_t white = 0xFFFFFFFFu;
+      for (std::size_t index = 0; index < pixel_count; ++index) {
+        std::uint32_t xor_pixel;
+        std::memcpy(
+          &xor_pixel,
+          std::begin(normalized.xor_mask) + index * sizeof(xor_pixel),
+          sizeof(xor_pixel)
+        );
+        if ((xor_pixel & 0x00FFFFFFu) != 0) {
+          invert_pixel[index] = true;
+          std::memcpy(
+            std::begin(local) + index * sizeof(white),
+            &white,
+            sizeof(white)
+          );
+        }
+      }
+      return invert_pixel;
+    }
+
+    void
+    draw_invert_outline(const normalized_cursor_shape_t &normalized,
+                        util::buffer_t<std::uint8_t> &local,
+                        const std::vector<bool> &invert_pixel,
+                        std::size_t height) {
+      constexpr std::uint32_t black = 0xFF000000u;
+      for (std::size_t index = 0; index < invert_pixel.size(); ++index) {
+        if (!invert_pixel[index]) {
+          continue;
+        }
+        const std::size_t x = index % normalized.info.Width;
+        const std::size_t y = index / normalized.info.Width;
+        for (int dy = -1; dy <= 1; ++dy) {
+          for (int dx = -1; dx <= 1; ++dx) {
+            const auto nx = static_cast<std::int64_t>(x) + dx;
+            const auto ny = static_cast<std::int64_t>(y) + dy;
+            if (nx < 0 || ny < 0 ||
+                nx >= static_cast<std::int64_t>(normalized.info.Width) ||
+                ny >= static_cast<std::int64_t>(height)) {
+              continue;
+            }
+            const std::size_t neighbor =
+              static_cast<std::size_t>(ny) * normalized.info.Width +
+              static_cast<std::size_t>(nx);
+            if (invert_pixel[neighbor]) {
+              continue;
+            }
+            std::uint32_t alpha_pixel;
+            std::memcpy(
+              &alpha_pixel,
+              std::begin(normalized.alpha) + neighbor * sizeof(alpha_pixel),
+              sizeof(alpha_pixel)
+            );
+            if ((alpha_pixel & 0xFF000000u) == 0) {
+              std::memcpy(
+                std::begin(local) + neighbor * sizeof(black),
+                &black,
+                sizeof(black)
+              );
+            }
+          }
+        }
+      }
+    }
+  }  // namespace
+
   util::buffer_t<std::uint8_t>
   make_local_cursor_image(const normalized_cursor_shape_t &normalized) {
     if (normalized.xor_mask.size() == 0) {
@@ -218,66 +290,15 @@ namespace platf::dxgi {
     if (pixel_count % normalized.info.Width != 0) {
       return {};
     }
-    const std::size_t height = pixel_count / normalized.info.Width;
-    std::vector<bool> invert_pixel(pixel_count, false);
+
     util::buffer_t<std::uint8_t> local = normalized.alpha;
-
-    for (std::size_t index = 0; index < pixel_count; ++index) {
-      std::uint32_t xor_pixel;
-      std::memcpy(
-        &xor_pixel,
-        std::begin(normalized.xor_mask) + index * sizeof(xor_pixel),
-        sizeof(xor_pixel)
-      );
-      if ((xor_pixel & 0x00FFFFFFu) != 0) {
-        invert_pixel[index] = true;
-        constexpr std::uint32_t white = 0xFFFFFFFFu;
-        std::memcpy(
-          std::begin(local) + index * sizeof(white),
-          &white,
-          sizeof(white)
-        );
-      }
-    }
-
-    constexpr std::uint32_t black = 0xFF000000u;
-    for (std::size_t index = 0; index < pixel_count; ++index) {
-      if (!invert_pixel[index]) {
-        continue;
-      }
-      const std::size_t x = index % normalized.info.Width;
-      const std::size_t y = index / normalized.info.Width;
-      for (int dy = -1; dy <= 1; ++dy) {
-        for (int dx = -1; dx <= 1; ++dx) {
-          const auto nx = static_cast<std::int64_t>(x) + dx;
-          const auto ny = static_cast<std::int64_t>(y) + dy;
-          if (nx < 0 || ny < 0 ||
-              nx >= static_cast<std::int64_t>(normalized.info.Width) ||
-              ny >= static_cast<std::int64_t>(height)) {
-            continue;
-          }
-          const std::size_t neighbor =
-            static_cast<std::size_t>(ny) * normalized.info.Width +
-            static_cast<std::size_t>(nx);
-          if (invert_pixel[neighbor]) {
-            continue;
-          }
-          std::uint32_t alpha_pixel;
-          std::memcpy(
-            &alpha_pixel,
-            std::begin(normalized.alpha) + neighbor * sizeof(alpha_pixel),
-            sizeof(alpha_pixel)
-          );
-          if ((alpha_pixel & 0xFF000000u) == 0) {
-            std::memcpy(
-              std::begin(local) + neighbor * sizeof(black),
-              &black,
-              sizeof(black)
-            );
-          }
-        }
-      }
-    }
+    const auto invert_pixel = compute_invert_mask(normalized, local, pixel_count);
+    draw_invert_outline(
+      normalized,
+      local,
+      invert_pixel,
+      pixel_count / normalized.info.Width
+    );
     return local;
   }
 

--- a/src/platform/windows/display_cursor.h
+++ b/src/platform/windows/display_cursor.h
@@ -21,6 +21,14 @@ namespace platf::dxgi {
   make_cursor_alpha_image(const util::buffer_t<std::uint8_t> &img_data,
                           DXGI_OUTDUPL_POINTER_SHAPE_INFO shape_info);
 
+  /**
+   * Flatten alpha and XOR cursor layers into a system-cursor-safe image.
+   * XOR pixels use a white fill with a black outline because native client
+   * cursors cannot invert the remote framebuffer beneath them.
+   */
+  util::buffer_t<std::uint8_t>
+  make_local_cursor_image(const normalized_cursor_shape_t &normalized);
+
   bool
   set_cursor_texture(device_t::pointer device,
                      gpu_cursor_t &cursor,

--- a/src_assets/windows/misc/vdd/driver/vdd_settings.xml
+++ b/src_assets/windows/misc/vdd/driver/vdd_settings.xml
@@ -57,8 +57,8 @@
     -->
   </colour>
   <cursor>
-    <HardwareCursor>false</HardwareCursor>
-    <!--Whether to display a hardware cursor in the buffer (If disabled streaming apps will use client cursor)-->
+    <HardwareCursor>true</HardwareCursor>
+    <!--Keep cursor export enabled so Sunshine can compose it into video or synchronize it to the client.-->
     <CursorMaxY>128</CursorMaxY>
     <!--The maximum height support for all cursor types. Older intel cpus may be limited to 64x64 -->
     <CursorMaxX>128</CursorMaxX>

--- a/tests/unit/platform/windows/test_display_cursor.cpp
+++ b/tests/unit/platform/windows/test_display_cursor.cpp
@@ -88,6 +88,29 @@ TEST(WindowsCursorImage, PreservesMaskedColorPixelConversion) {
   EXPECT_EQ(read_pixel(xor_mask, 1), 0xFF445566u);
 }
 
+TEST(WindowsCursorImage, MakesXorCursorVisibleOnLightAndDarkBackgrounds) {
+  platf::dxgi::normalized_cursor_shape_t normalized;
+  normalized.info.Width = 3;
+  normalized.info.Height = 3;
+  normalized.alpha = util::buffer_t<std::uint8_t>(9 * sizeof(std::uint32_t));
+  normalized.xor_mask = util::buffer_t<std::uint8_t>(9 * sizeof(std::uint32_t));
+  std::fill(normalized.alpha.begin(), normalized.alpha.end(), 0);
+  std::fill(normalized.xor_mask.begin(), normalized.xor_mask.end(), 0);
+  write_pixel(normalized.alpha, 0, 0xFF112233u);
+  write_pixel(normalized.xor_mask, 4, 0xFFFFFFFFu);
+
+  const auto local = platf::dxgi::make_local_cursor_image(normalized);
+
+  ASSERT_EQ(local.size(), normalized.alpha.size());
+  EXPECT_EQ(read_pixel(local, 0), 0xFF112233u);
+  EXPECT_EQ(read_pixel(local, 4), 0xFFFFFFFFu);
+  for (std::size_t index = 1; index < 9; ++index) {
+    if (index != 4) {
+      EXPECT_EQ(read_pixel(local, index), 0xFF000000u);
+    }
+  }
+}
+
 TEST(WindowsCursorImage, RejectsMalformedCursorShapes) {
   platf::dxgi::normalized_cursor_shape_t normalized;
 

--- a/tests/unit/test_vdd_safety.cpp
+++ b/tests/unit/test_vdd_safety.cpp
@@ -74,6 +74,17 @@ TEST(VddBaselineSafety, DetectsVddOnlyTopology) {
   EXPECT_TRUE(is_vdd_only_topology({ { "vdd" } }, "vdd"));
 }
 
+TEST(VddCursorExportSafety, ParsesPersistedEnabledValues) {
+  using display_device::vdd_utils::hardware_cursor_export_enabled;
+
+  EXPECT_TRUE(hardware_cursor_export_enabled("true"));
+  EXPECT_TRUE(hardware_cursor_export_enabled(" TRUE "));
+  EXPECT_TRUE(hardware_cursor_export_enabled("1"));
+  EXPECT_FALSE(hardware_cursor_export_enabled("false"));
+  EXPECT_FALSE(hardware_cursor_export_enabled("0"));
+  EXPECT_FALSE(hardware_cursor_export_enabled(""));
+}
+
 TEST(VddFrameChannelSafety, AcceptsValidMetadataForAttach) {
   using namespace platf::dxgi::vdd_frame_channel;
 

--- a/tests/unit/test_vdd_safety.cpp
+++ b/tests/unit/test_vdd_safety.cpp
@@ -85,6 +85,20 @@ TEST(VddCursorExportSafety, ParsesPersistedEnabledValues) {
   EXPECT_FALSE(hardware_cursor_export_enabled(""));
 }
 
+TEST(VddCursorExportSafety, RetriesAfterPersistSucceedsButLiveEnableFails) {
+  using display_device::vdd_utils::hardware_cursor_export_needs_enable;
+
+  bool persisted_enabled = false;
+  bool live_enable_confirmed = false;
+  EXPECT_TRUE(hardware_cursor_export_needs_enable(persisted_enabled, live_enable_confirmed));
+
+  persisted_enabled = true;
+  EXPECT_TRUE(hardware_cursor_export_needs_enable(persisted_enabled, live_enable_confirmed));
+
+  live_enable_confirmed = true;
+  EXPECT_FALSE(hardware_cursor_export_needs_enable(persisted_enabled, live_enable_confirmed));
+}
+
 TEST(VddFrameChannelSafety, AcceptsValidMetadataForAttach) {
   using namespace platf::dxgi::vdd_frame_channel;
 


### PR DESCRIPTION
## 改了啥呀

- 本地光标模式下保持 VDD 光标导出开启，并在刷新显示器前持久化配置
- 发布本地光标时保留 XOR 图层；对系统光标无法表达的反色像素生成白色主体和黑色轮廓
- 保留原有非透明 Alpha 像素，不覆盖彩色箭头等普通光标内容
- 补齐 padding、masked color、XOR 可见性、畸形输入和热切换重发布测试

## 为啥

原先本地发布路径丢弃了 XOR 图层，I-beam 这类依赖反色的光标在浅色或深色背景上都会消失。系统原生光标又不能实时反转远端画面，所以需要一个稳定可见的降级表示，别再让杂鱼 I-beam 玩隐身啦。

## 影响

只影响 Windows 本地光标同步路径；视频内嵌光标和 GPU 合成路径不变。

## 验证

- `test_sunshine --gtest_filter=WindowsCursorImage.*`：5/5 通过
- 本机替换 Sunshine 核心并连接 macOS 客户端，箭头背景/透明度与 I-beam 可见性实测正常

## 依赖

- Control Panel：https://github.com/qiin2333/sunshine-control-panel/pull/72
