### PR TITLE
fix(vdd): wake capture for cursor-only updates

### DIFF
--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -775,6 +775,7 @@ namespace platf::dxgi {
     unsigned int m_monitorIdx = 0;
     std::chrono::steady_clock::time_point m_nextCursorAttachAttempt {};
     UINT32 m_cursorAttachFailures = 0;
+    bool m_cursorUpdatePending = false;
     UINT32 m_lastSeenCursorShapeId = 0xFFFFFFFFu;
     UINT32 m_lastSeenCursorPositionId = 0xFFFFFFFFu;
 

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -625,9 +625,16 @@ namespace platf::dxgi {
      *                        The caller MUST call release_frame() before next_frame()
      *                        to release the keyed mutex.
      * @param out_frame_qpc   QPC value at producer-side push (for latency tracing).
+     * @param wait_for_cursor Include the optional cursor-ready event in the wait.
+     * @param out_cursor_only True when the wakeup contains cursor state but no
+     *                        newly-acquirable producer texture.
      */
     capture_e
-    next_frame(std::chrono::milliseconds timeout, ID3D11Texture2D **out, uint64_t &out_frame_qpc);
+    next_frame(std::chrono::milliseconds timeout,
+               ID3D11Texture2D **out,
+               uint64_t &out_frame_qpc,
+               bool wait_for_cursor,
+               bool &out_cursor_only);
 
     /**
      * @brief Hand the current keyed-mutex slot to a downstream D3D11 consumer.
@@ -665,6 +672,7 @@ namespace platf::dxgi {
       INT32    xhot = 0;
       INT32    yhot = 0;
       UINT32   sdr_white_level_x1000 = 0;
+      UINT64   update_qpc = 0;
       std::vector<uint8_t> shape_buffer;  ///< Empty if !shape_updated or shape is uninitialized.
     };
 
@@ -728,7 +736,9 @@ namespace platf::dxgi {
     };
 
     void close();
-    void attach_cursor_channel(unsigned int monitor_idx);
+    void detach_cursor_channel();
+    bool attach_cursor_channel();
+    bool ensure_cursor_channel_attached();
     void apply_metadata_snapshot(const vdd_frame_channel::shared_frame_metadata_t &meta);
     bool attach_texture_slot(ID3D11Device1 *device,
                              HANDLE shared_handle,
@@ -756,10 +766,14 @@ namespace platf::dxgi {
     bool m_holdsKey = false;
     UINT32 m_heldSlot = 0;
 
-    // Cursor SHM (optional; opened on a best-effort basis in init()).
+    // Cursor SHM is optional for compatibility with older driver builds. Newer
+    // drivers signal cursor-only updates through m_hCursorEvent.
     HANDLE m_hCursorMeta = nullptr;
     void  *m_pCursorMeta = nullptr;
-    HANDLE m_hCursorEvent = nullptr;  // For diagnostic use; poll_cursor() is event-free.
+    HANDLE m_hCursorEvent = nullptr;
+    unsigned int m_monitorIdx = 0;
+    std::chrono::steady_clock::time_point m_nextCursorAttachAttempt {};
+    UINT32 m_cursorAttachFailures = 0;
     UINT32 m_lastSeenCursorShapeId = 0xFFFFFFFFu;
     UINT32 m_lastSeenCursorPositionId = 0xFFFFFFFFu;
 
@@ -816,6 +830,8 @@ namespace platf::dxgi {
     UINT64 vdd_last_dropped_acquire_failures = 0;
     std::vector<std::shared_ptr<platf::img_t>> vdd_borrow_deferred_images;
     bool vdd_local_cursor_mode_active = false;
+    texture2d_t vdd_cursor_base_texture;
+    bool vdd_cursor_base_valid = false;
 
     void
     log_vdd_borrow_debug_telemetry();

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -627,7 +627,8 @@ namespace platf::dxgi {
      * @param out_frame_qpc   QPC value at producer-side push (for latency tracing).
      * @param wait_for_cursor Include the optional cursor-ready event in the wait.
      * @param out_cursor_only True when the wakeup contains cursor state but no
-     *                        newly-acquirable producer texture.
+     *                        new desktop frame. `out` then references the most
+     *                        recent producer texture reacquired as key 0.
      */
     capture_e
     next_frame(std::chrono::milliseconds timeout,
@@ -830,8 +831,6 @@ namespace platf::dxgi {
     UINT64 vdd_last_dropped_acquire_failures = 0;
     std::vector<std::shared_ptr<platf::img_t>> vdd_borrow_deferred_images;
     bool vdd_local_cursor_mode_active = false;
-    texture2d_t vdd_cursor_base_texture;
-    bool vdd_cursor_base_valid = false;
 
     void
     log_vdd_borrow_debug_telemetry();

--- a/src/platform/windows/display_vdd.cpp
+++ b/src/platform/windows/display_vdd.cpp
@@ -828,10 +828,38 @@ namespace platf::dxgi {
     };
 
     // An auto-reset cursor event was already consumed, but the texture slot
-    // was temporarily busy. Preserve and prioritize that update until the
-    // latest cursor-free desktop texture can be reacquired.
+    // was temporarily busy. Probe key 1 without consuming FrameReady first:
+    // a newly-published desktop frame must win over retrying key 0, otherwise
+    // a pending cursor update could starve the frame that advances key 1.
     if (m_cursorUpdatePending && wait_for_cursor) {
-      return acquire_cursor_frame();
+      bool desktop_frame_ready = false;
+      SharedFrameMetadata pending_meta {};
+      if (vdd_frame_channel::read_stable_metadata(meta, pending_meta) &&
+          pending_meta.SlotIndex < m_keyedMutex.size()) {
+        const UINT32 pending_slot = pending_meta.SlotIndex;
+        HRESULT probe_hr = m_keyedMutex[pending_slot]->AcquireSync(1, 0);
+        if (probe_hr == S_OK) {
+          probe_hr = m_keyedMutex[pending_slot]->ReleaseSync(1);
+          if (FAILED(probe_hr)) {
+            BOOST_LOG(error) << "[vdd_capture] ReleaseSync(1) failed after pending cursor probe for slot "sv
+                             << pending_slot << ": 0x"sv << util::hex(probe_hr).to_string_view();
+            return capture_e::error;
+          }
+          desktop_frame_ready = true;
+        }
+        else if (probe_hr != static_cast<HRESULT>(WAIT_TIMEOUT)) {
+          BOOST_LOG(error) << "[vdd_capture] AcquireSync(1) probe failed for pending cursor slot "sv
+                           << pending_slot << ": 0x"sv << util::hex(probe_hr).to_string_view();
+          return capture_e::error;
+        }
+      }
+
+      if (vdd_frame_channel::select_pending_cursor_action(
+            true,
+            desktop_frame_ready
+          ) == vdd_frame_channel::pending_cursor_action::retry_cursor_frame) {
+        return acquire_cursor_frame();
+      }
     }
 
     HANDLE events[] = {m_hEvent, m_hCursorEvent};
@@ -897,6 +925,7 @@ namespace platf::dxgi {
     }
     m_holdsKey = true;
     m_heldSlot = slot;
+    m_cursorUpdatePending = false;
 
     // Detect producer-side resize / format change: the metadata block can change
     // any time the swap chain is re-created. If so, signal reinit so the upper

--- a/src/platform/windows/display_vdd.cpp
+++ b/src/platform/windows/display_vdd.cpp
@@ -370,6 +370,7 @@ namespace platf::dxgi {
     }
     m_lastSeenCursorShapeId = 0xFFFFFFFFu;
     m_lastSeenCursorPositionId = 0xFFFFFFFFu;
+    m_cursorUpdatePending = false;
   }
 
   bool
@@ -793,13 +794,11 @@ namespace platf::dxgi {
     // CursorExporter uses an auto-reset event. Waiting on it alongside the
     // frame event lets pointer-only motion wake a static desktop capture.
     DWORD ms = static_cast<DWORD>(timeout.count() < 0 ? 0 : timeout.count());
-    HANDLE events[] = {m_hEvent, m_hCursorEvent};
-    const DWORD event_count = cursor_channel_ready ? 2 : 1;
-    DWORD wr = WaitForMultipleObjects(event_count, events, FALSE, ms);
-    if (wr == WAIT_TIMEOUT) {
-      return capture_e::timeout;
+    if (!wait_for_cursor) {
+      m_cursorUpdatePending = false;
     }
-    if (wr == WAIT_OBJECT_0 + 1) {
+
+    auto acquire_cursor_frame = [&]() -> capture_e {
       // The last consumed producer slot is available as key 0 while the
       // desktop is static. Reacquire it briefly so cursor-only updates retain
       // the normal single-copy/zero-copy cost on actual desktop frames.
@@ -823,8 +822,27 @@ namespace platf::dxgi {
         m_sharedTex[slot]->AddRef();
         *out = m_sharedTex[slot].get();
       }
+      m_cursorUpdatePending = false;
       out_cursor_only = true;
       return capture_e::ok;
+    };
+
+    // An auto-reset cursor event was already consumed, but the texture slot
+    // was temporarily busy. Preserve and prioritize that update until the
+    // latest cursor-free desktop texture can be reacquired.
+    if (m_cursorUpdatePending && wait_for_cursor) {
+      return acquire_cursor_frame();
+    }
+
+    HANDLE events[] = {m_hEvent, m_hCursorEvent};
+    const DWORD event_count = cursor_channel_ready ? 2 : 1;
+    DWORD wr = WaitForMultipleObjects(event_count, events, FALSE, ms);
+    if (wr == WAIT_TIMEOUT) {
+      return capture_e::timeout;
+    }
+    if (wr == WAIT_OBJECT_0 + 1) {
+      m_cursorUpdatePending = true;
+      return acquire_cursor_frame();
     }
     if (wr != WAIT_OBJECT_0) {
       BOOST_LOG(error) << "[vdd_capture] WaitForMultipleObjects: result="sv << wr

--- a/src/platform/windows/display_vdd.cpp
+++ b/src/platform/windows/display_vdd.cpp
@@ -800,6 +800,29 @@ namespace platf::dxgi {
       return capture_e::timeout;
     }
     if (wr == WAIT_OBJECT_0 + 1) {
+      // The last consumed producer slot is available as key 0 while the
+      // desktop is static. Reacquire it briefly so cursor-only updates retain
+      // the normal single-copy/zero-copy cost on actual desktop frames.
+      const UINT32 slot = m_slotIndex;
+      if (slot >= m_keyedMutex.size()) {
+        return capture_e::reinit;
+      }
+      const DWORD acquire_ms = vdd_frame_channel::bounded_consumer_acquire_timeout_ms(ms);
+      HRESULT hr = m_keyedMutex[slot]->AcquireSync(0, acquire_ms);
+      if (hr == static_cast<HRESULT>(WAIT_TIMEOUT)) {
+        return capture_e::timeout;
+      }
+      if (FAILED(hr)) {
+        BOOST_LOG(error) << "[vdd_capture] AcquireSync(0) failed for cursor-only slot "sv
+                         << slot << ": 0x"sv << util::hex(hr).to_string_view();
+        return capture_e::error;
+      }
+      m_holdsKey = true;
+      m_heldSlot = slot;
+      if (out) {
+        m_sharedTex[slot]->AddRef();
+        *out = m_sharedTex[slot].get();
+      }
       out_cursor_only = true;
       return capture_e::ok;
     }
@@ -1412,30 +1435,6 @@ namespace platf::dxgi {
         return -1;
       }
     }
-
-    // Keep one cursor-free desktop frame for cursor-only wakeups. The driver
-    // publishes cursor state separately, so reusing the last producer texture
-    // directly would require reacquiring a keyed mutex that has not been
-    // released by a new desktop frame.
-    D3D11_TEXTURE2D_DESC cursor_base_desc {};
-    cursor_base_desc.Width = dup.width();
-    cursor_base_desc.Height = dup.height();
-    cursor_base_desc.MipLevels = 1;
-    cursor_base_desc.ArraySize = 1;
-    cursor_base_desc.Format = capture_format;
-    cursor_base_desc.SampleDesc.Count = 1;
-    cursor_base_desc.Usage = D3D11_USAGE_DEFAULT;
-    auto cursor_base_status = device->CreateTexture2D(
-      &cursor_base_desc,
-      nullptr,
-      &vdd_cursor_base_texture
-    );
-    if (FAILED(cursor_base_status)) {
-      BOOST_LOG(error) << "[vdd] failed to create cursor redraw base texture [0x"sv
-                       << util::hex(cursor_base_status).to_string_view() << ']';
-      return -1;
-    }
-    vdd_cursor_base_valid = false;
 
     BOOST_LOG(info) << "[vdd] backend ready: monitor="sv << monitor_idx
                     << " "sv << dup.width() << "x"sv << dup.height()

--- a/src/platform/windows/display_vdd.cpp
+++ b/src/platform/windows/display_vdd.cpp
@@ -322,6 +322,7 @@ namespace platf::dxgi {
   static constexpr UINT32 VDD_CURSOR_MAGIC = 0x5A564355;  // 'ZVCU'
   static constexpr UINT32 VDD_CURSOR_VERSION = 1;
   static constexpr UINT32 VDD_CURSOR_MAX_BYTES = 256u * 256u * 4u;  // matches driver
+  static constexpr auto VDD_CURSOR_ATTACH_RETRY_DELAY = 250ms;
 
   vdd_capture_t::vdd_capture_t() = default;
 
@@ -350,6 +351,11 @@ namespace platf::dxgi {
       CloseHandle(m_hEvent);
       m_hEvent = nullptr;
     }
+    detach_cursor_channel();
+  }
+
+  void
+  vdd_capture_t::detach_cursor_channel() {
     if (m_pCursorMeta) {
       UnmapViewOfFile(m_pCursorMeta);
       m_pCursorMeta = nullptr;
@@ -366,35 +372,64 @@ namespace platf::dxgi {
     m_lastSeenCursorPositionId = 0xFFFFFFFFu;
   }
 
-  void
-  vdd_capture_t::attach_cursor_channel(unsigned int monitor_idx) {
+  bool
+  vdd_capture_t::attach_cursor_channel() {
     // Optional: old driver builds do not export cursor mappings. Capture must
     // remain usable in that case, with the cursor overlay simply disabled.
-    std::wstring cursor_meta_name = L"Global\\ZakoVDD_CursorMeta_" + std::to_wstring(monitor_idx);
-    std::wstring cursor_event_name = L"Global\\ZakoVDD_CursorReady_" + std::to_wstring(monitor_idx);
+    std::wstring cursor_meta_name = L"Global\\ZakoVDD_CursorMeta_" + std::to_wstring(m_monitorIdx);
+    std::wstring cursor_event_name = L"Global\\ZakoVDD_CursorReady_" + std::to_wstring(m_monitorIdx);
 
-    m_hCursorMeta = OpenFileMappingW(FILE_MAP_READ, FALSE, cursor_meta_name.c_str());
-    if (!m_hCursorMeta) {
-      BOOST_LOG(info) << "[vdd_capture] cursor SHM not present for monitor "sv
-                      << monitor_idx << " (driver may predate cursor export); "sv
-                      << "clients will see no overlay cursor for this output."sv;
-      return;
+    HANDLE cursor_meta = OpenFileMappingW(FILE_MAP_READ, FALSE, cursor_meta_name.c_str());
+    if (!cursor_meta) {
+      return false;
     }
 
     const SIZE_T map_size = sizeof(CursorSharedMetadata) + VDD_CURSOR_MAX_BYTES;
-    m_pCursorMeta = MapViewOfFile(m_hCursorMeta, FILE_MAP_READ, 0, 0, map_size);
-    if (!m_pCursorMeta) {
-      BOOST_LOG(warning) << "[vdd_capture] cursor MapViewOfFile failed: "sv << GetLastError()
-                         << "; cursor overlay disabled."sv;
-      CloseHandle(m_hCursorMeta);
-      m_hCursorMeta = nullptr;
-      return;
+    void *cursor_mapping = MapViewOfFile(cursor_meta, FILE_MAP_READ, 0, 0, map_size);
+    if (!cursor_mapping) {
+      CloseHandle(cursor_meta);
+      return false;
     }
 
-    // The event is diagnostic/future-facing; polling reads the mapping directly.
-    m_hCursorEvent = OpenEventW(SYNCHRONIZE, FALSE, cursor_event_name.c_str());
-    BOOST_LOG(info) << "[vdd_capture] cursor SHM attached (event="sv
-                    << (m_hCursorEvent ? "yes"sv : "no"sv) << ")"sv;
+    HANDLE cursor_event = OpenEventW(SYNCHRONIZE, FALSE, cursor_event_name.c_str());
+    if (!cursor_event) {
+      UnmapViewOfFile(cursor_mapping);
+      CloseHandle(cursor_meta);
+      return false;
+    }
+
+    m_hCursorMeta = cursor_meta;
+    m_pCursorMeta = cursor_mapping;
+    m_hCursorEvent = cursor_event;
+    return true;
+  }
+
+  bool
+  vdd_capture_t::ensure_cursor_channel_attached() {
+    if (m_pCursorMeta && m_hCursorEvent) {
+      return true;
+    }
+
+    const auto now = std::chrono::steady_clock::now();
+    if (now < m_nextCursorAttachAttempt) {
+      return false;
+    }
+    m_nextCursorAttachAttempt = now + VDD_CURSOR_ATTACH_RETRY_DELAY;
+    detach_cursor_channel();
+
+    if (attach_cursor_channel()) {
+      BOOST_LOG(info) << "[vdd_capture] cursor channel attached for monitor "sv << m_monitorIdx
+                      << (m_cursorAttachFailures ? " after retry" : "") << "."sv;
+      m_cursorAttachFailures = 0;
+      return true;
+    }
+
+    ++m_cursorAttachFailures;
+    if (m_cursorAttachFailures == 1 || (m_cursorAttachFailures % 40) == 0) {
+      BOOST_LOG(info) << "[vdd_capture] cursor channel not ready for monitor "sv << m_monitorIdx
+                      << "; capture will retry without restarting the backend."sv;
+    }
+    return false;
   }
 
   void
@@ -699,6 +734,10 @@ namespace platf::dxgi {
     }
     device1_t dev1 {dev1_p};
 
+    m_monitorIdx = monitor_idx;
+    m_nextCursorAttachAttempt = {};
+    m_cursorAttachFailures = 0;
+
     m_frameChannelMode = vdd_frame_channel_mode_env_override().value_or(vdd_frame_channel::channel_mode::auto_probe);
     m_frameChannelSelection = vdd_frame_channel::channel_selection::unknown;
     display_device::vdd_ioctl::frame_channel_caps sealed_caps {};
@@ -715,7 +754,7 @@ namespace platf::dxgi {
 
     switch (try_open_sealed_channel(dev1_p, monitor_idx, *device_luid, sealed_caps)) {
       case sealed_channel_attempt::opened:
-        attach_cursor_channel(monitor_idx);
+        ensure_cursor_channel_attached();
         return 0;
       case sealed_channel_attempt::required_failed:
         return -1;
@@ -729,14 +768,19 @@ namespace platf::dxgi {
     if (!attach_legacy_named_channel(dev1_p, monitor_idx, *device_luid)) {
       return -1;
     }
-    attach_cursor_channel(monitor_idx);
+    ensure_cursor_channel_attached();
     return 0;
   }
 
   capture_e
-  vdd_capture_t::next_frame(std::chrono::milliseconds timeout, ID3D11Texture2D **out, uint64_t &out_frame_qpc) {
+  vdd_capture_t::next_frame(std::chrono::milliseconds timeout,
+                            ID3D11Texture2D **out,
+                            uint64_t &out_frame_qpc,
+                            bool wait_for_cursor,
+                            bool &out_cursor_only) {
     if (out) *out = nullptr;
     out_frame_qpc = 0;
+    out_cursor_only = false;
 
     if (!m_hEvent || m_keyedMutex.empty() || m_sharedTex.empty() || !m_pMeta) {
       return capture_e::error;
@@ -744,15 +788,31 @@ namespace platf::dxgi {
 
     auto *meta = static_cast<const SharedFrameMetadata *>(m_pMeta);
 
-    // Wait for the next frame-ready signal from the producer.
+    const bool cursor_channel_ready = wait_for_cursor && ensure_cursor_channel_attached();
+
+    // CursorExporter uses an auto-reset event. Waiting on it alongside the
+    // frame event lets pointer-only motion wake a static desktop capture.
     DWORD ms = static_cast<DWORD>(timeout.count() < 0 ? 0 : timeout.count());
-    DWORD wr = WaitForSingleObject(m_hEvent, ms);
+    HANDLE events[] = {m_hEvent, m_hCursorEvent};
+    const DWORD event_count = cursor_channel_ready ? 2 : 1;
+    DWORD wr = WaitForMultipleObjects(event_count, events, FALSE, ms);
     if (wr == WAIT_TIMEOUT) {
       return capture_e::timeout;
     }
+    if (wr == WAIT_OBJECT_0 + 1) {
+      out_cursor_only = true;
+      return capture_e::ok;
+    }
     if (wr != WAIT_OBJECT_0) {
-      BOOST_LOG(error) << "[vdd_capture] WaitForSingleObject: gle="sv << GetLastError();
+      BOOST_LOG(error) << "[vdd_capture] WaitForMultipleObjects: result="sv << wr
+                       << " gle="sv << GetLastError();
       return capture_e::error;
+    }
+
+    // Coalesce a cursor signal that arrived with the new desktop frame. The
+    // caller will read the latest cursor state while processing this frame.
+    if (cursor_channel_ready) {
+      WaitForSingleObject(m_hCursorEvent, 0);
     }
 
     // Producer released the latest slot as key 1; consumer acquires that slot.
@@ -876,7 +936,7 @@ namespace platf::dxgi {
   bool
   vdd_capture_t::poll_cursor(cursor_snapshot &out) {
     out = {};
-    if (!m_pCursorMeta) {
+    if (!m_pCursorMeta && !ensure_cursor_channel_attached()) {
       return false;
     }
 
@@ -976,6 +1036,7 @@ namespace platf::dxgi {
       out.xhot = header.XHot;
       out.yhot = header.YHot;
       out.sdr_white_level_x1000 = header.SdrWhiteLevelX1000;
+      out.update_qpc = header.LastUpdateQpc;
       out.position_updated = header.PositionId != m_lastSeenCursorPositionId;
       out.shape_updated = shape_updated;
       out.shape_buffer = std::move(shape_buffer);
@@ -1351,6 +1412,30 @@ namespace platf::dxgi {
         return -1;
       }
     }
+
+    // Keep one cursor-free desktop frame for cursor-only wakeups. The driver
+    // publishes cursor state separately, so reusing the last producer texture
+    // directly would require reacquiring a keyed mutex that has not been
+    // released by a new desktop frame.
+    D3D11_TEXTURE2D_DESC cursor_base_desc {};
+    cursor_base_desc.Width = dup.width();
+    cursor_base_desc.Height = dup.height();
+    cursor_base_desc.MipLevels = 1;
+    cursor_base_desc.ArraySize = 1;
+    cursor_base_desc.Format = capture_format;
+    cursor_base_desc.SampleDesc.Count = 1;
+    cursor_base_desc.Usage = D3D11_USAGE_DEFAULT;
+    auto cursor_base_status = device->CreateTexture2D(
+      &cursor_base_desc,
+      nullptr,
+      &vdd_cursor_base_texture
+    );
+    if (FAILED(cursor_base_status)) {
+      BOOST_LOG(error) << "[vdd] failed to create cursor redraw base texture [0x"sv
+                       << util::hex(cursor_base_status).to_string_view() << ']';
+      return -1;
+    }
+    vdd_cursor_base_valid = false;
 
     BOOST_LOG(info) << "[vdd] backend ready: monitor="sv << monitor_idx
                     << " "sv << dup.width() << "x"sv << dup.height()

--- a/src/platform/windows/display_vdd_vram.cpp
+++ b/src/platform/windows/display_vdd_vram.cpp
@@ -72,8 +72,25 @@ namespace platf::dxgi {
       current_frame = nullptr;
     }
 
+    const bool use_local_cursor = local_cursor_mode_active();
+    if (use_local_cursor != vdd_local_cursor_mode_active) {
+      // poll_cursor() normally omits an acknowledged shape. Force a refresh
+      // whenever ownership moves between the video overlay and the client.
+      dup.invalidate_cursor_shape();
+      vdd_local_cursor_mode_active = use_local_cursor;
+      vdd_cursor_base_valid = false;
+    }
+
+    const bool should_poll_cursor = cursor_visible || use_local_cursor;
     std::uint64_t frame_qpc = 0;
-    auto status = dup.next_frame(timeout, &current_frame, frame_qpc);
+    bool cursor_only = false;
+    auto status = dup.next_frame(
+      timeout,
+      &current_frame,
+      frame_qpc,
+      should_poll_cursor,
+      cursor_only
+    );
     if (status != capture_e::ok) {
       return status;
     }
@@ -89,33 +106,7 @@ namespace platf::dxgi {
       }
     });
 
-    const auto now = std::chrono::steady_clock::now();
-    auto frame_timestamp = now - qpc_time_difference(qpc_counter(), frame_qpc);
-
-    D3D11_TEXTURE2D_DESC desc {};
-    current_frame->GetDesc(&desc);
-
-    if (desc.Width != static_cast<UINT>(width_before_rotation) ||
-        desc.Height != static_cast<UINT>(height_before_rotation) ||
-        desc.Format != capture_format) {
-      BOOST_LOG(info) << "[vdd] producer reconfigured: "sv
-                      << width_before_rotation << "x"sv << height_before_rotation
-                      << " " << dxgi_format_to_string(capture_format)
-                      << " -> "sv << desc.Width << "x"sv << desc.Height
-                      << " " << dxgi_format_to_string(desc.Format);
-      return capture_e::reinit;
-    }
-
-    const bool use_local_cursor = local_cursor_mode_active();
-    if (use_local_cursor != vdd_local_cursor_mode_active) {
-      // poll_cursor() normally omits an acknowledged shape. Force a refresh
-      // whenever ownership moves between the video overlay and the client.
-      dup.invalidate_cursor_shape();
-      vdd_local_cursor_mode_active = use_local_cursor;
-    }
-
     vdd_capture_t::cursor_snapshot cursor_state;
-    const bool should_poll_cursor = cursor_visible || use_local_cursor;
     const bool has_cursor_state = should_poll_cursor &&
                                   (cursor_pipeline_ready || use_local_cursor) &&
                                   dup.poll_cursor(cursor_state) &&
@@ -128,6 +119,42 @@ namespace platf::dxgi {
     if (has_cursor_state && use_local_cursor &&
         publish_local_cursor(cursor_state)) {
       dup.acknowledge_cursor_shape(cursor_state.shape_id);
+    }
+
+    if (cursor_only && use_local_cursor) {
+      // The control channel publication above is the output for local cursor
+      // mode; avoid encoding a duplicate desktop frame.
+      return capture_e::timeout;
+    }
+    if (cursor_only && (!has_cursor_state || !vdd_cursor_base_valid)) {
+      return capture_e::timeout;
+    }
+
+    const auto now = std::chrono::steady_clock::now();
+    const auto timestamp_qpc = cursor_only && cursor_state.update_qpc ?
+                                 cursor_state.update_qpc : frame_qpc;
+    auto frame_timestamp = timestamp_qpc ?
+                             now - qpc_time_difference(qpc_counter(), timestamp_qpc) :
+                             now;
+
+    D3D11_TEXTURE2D_DESC desc {};
+    if (!cursor_only) {
+      current_frame->GetDesc(&desc);
+      if (desc.Width != static_cast<UINT>(width_before_rotation) ||
+          desc.Height != static_cast<UINT>(height_before_rotation) ||
+          desc.Format != capture_format) {
+        BOOST_LOG(info) << "[vdd] producer reconfigured: "sv
+                        << width_before_rotation << "x"sv << height_before_rotation
+                        << " " << dxgi_format_to_string(capture_format)
+                        << " -> "sv << desc.Width << "x"sv << desc.Height
+                        << " " << dxgi_format_to_string(desc.Format);
+        return capture_e::reinit;
+      }
+
+      if (cursor_visible && !use_local_cursor) {
+        device_ctx->CopyResource(vdd_cursor_base_texture.get(), current_frame);
+        vdd_cursor_base_valid = true;
+      }
     }
 
     auto composite_cursor = [&](ID3D11RenderTargetView *capture_rt) {
@@ -201,8 +228,9 @@ namespace platf::dxgi {
       }
     };
 
-    auto copy_current_frame_to = [&](std::shared_ptr<platf::img_t> candidate_img,
-                                     std::shared_ptr<img_d3d_t> candidate_d3d) -> capture_e {
+    auto copy_frame_to = [&](ID3D11Texture2D *source,
+                             std::shared_ptr<platf::img_t> candidate_img,
+                             std::shared_ptr<img_d3d_t> candidate_d3d) -> capture_e {
       if (!candidate_img || !candidate_d3d) {
         return capture_e::error;
       }
@@ -217,7 +245,7 @@ namespace platf::dxgi {
         BOOST_LOG(error) << "[vdd] failed to lock capture texture"sv;
         return capture_e::error;
       }
-      device_ctx->CopyResource(candidate_d3d->capture_texture.get(), current_frame);
+      device_ctx->CopyResource(candidate_d3d->capture_texture.get(), source);
       composite_cursor(candidate_d3d->capture_rt.get());
 
       img_out = std::move(candidate_img);
@@ -226,7 +254,8 @@ namespace platf::dxgi {
       return capture_e::ok;
     };
 
-    if (!vdd_borrow_enabled &&
+    if (!cursor_only &&
+        !vdd_borrow_enabled &&
         vdd_borrow_deferred_images.empty() &&
         vdd_borrow_inflight_frames->load(std::memory_order_relaxed) == 0) {
       std::shared_ptr<platf::img_t> img;
@@ -234,7 +263,7 @@ namespace platf::dxgi {
         return capture_e::interrupted;
       }
       auto d3d_img = std::static_pointer_cast<img_d3d_t>(img);
-      return copy_current_frame_to(std::move(img), std::move(d3d_img));
+      return copy_frame_to(current_frame, std::move(img), std::move(d3d_img));
     }
 
     const auto producer_replaced_unread = dup.replaced_unread_frames();
@@ -330,6 +359,15 @@ namespace platf::dxgi {
     if (!pull_reusable_image()) {
       log_vdd_borrow_debug_telemetry();
       return pull_interrupted ? capture_e::interrupted : capture_e::timeout;
+    }
+
+    if (cursor_only) {
+      log_vdd_borrow_debug_telemetry();
+      return copy_frame_to(
+        vdd_cursor_base_texture.get(),
+        std::move(img),
+        std::move(d3d_img)
+      );
     }
 
     auto try_borrow_current_frame = [&]() -> bool {
@@ -450,7 +488,7 @@ namespace platf::dxgi {
       return pull_interrupted ? capture_e::interrupted : capture_e::timeout;
     }
 
-    return copy_current_frame_to(std::move(img), std::move(d3d_img));
+    return copy_frame_to(current_frame, std::move(img), std::move(d3d_img));
   }
 
   capture_e

--- a/src/platform/windows/display_vdd_vram.cpp
+++ b/src/platform/windows/display_vdd_vram.cpp
@@ -78,7 +78,6 @@ namespace platf::dxgi {
       // whenever ownership moves between the video overlay and the client.
       dup.invalidate_cursor_shape();
       vdd_local_cursor_mode_active = use_local_cursor;
-      vdd_cursor_base_valid = false;
     }
 
     const bool should_poll_cursor = cursor_visible || use_local_cursor;
@@ -126,7 +125,7 @@ namespace platf::dxgi {
       // mode; avoid encoding a duplicate desktop frame.
       return capture_e::timeout;
     }
-    if (cursor_only && (!has_cursor_state || !vdd_cursor_base_valid)) {
+    if (cursor_only && !has_cursor_state) {
       return capture_e::timeout;
     }
 
@@ -149,11 +148,6 @@ namespace platf::dxgi {
                         << " -> "sv << desc.Width << "x"sv << desc.Height
                         << " " << dxgi_format_to_string(desc.Format);
         return capture_e::reinit;
-      }
-
-      if (cursor_visible && !use_local_cursor) {
-        device_ctx->CopyResource(vdd_cursor_base_texture.get(), current_frame);
-        vdd_cursor_base_valid = true;
       }
     }
 
@@ -364,7 +358,7 @@ namespace platf::dxgi {
     if (cursor_only) {
       log_vdd_borrow_debug_telemetry();
       return copy_frame_to(
-        vdd_cursor_base_texture.get(),
+        current_frame,
         std::move(img),
         std::move(d3d_img)
       );

--- a/src/platform/windows/vdd_frame_channel.h
+++ b/src/platform/windows/vdd_frame_channel.h
@@ -122,6 +122,19 @@ namespace platf::dxgi::vdd_frame_channel {
     producer_match match = producer_match::unavailable;
   };
 
+  enum class pending_cursor_action {
+    wait_for_events,
+    retry_cursor_frame,
+  };
+
+  inline pending_cursor_action
+  select_pending_cursor_action(bool cursor_update_pending,
+                               bool desktop_frame_ready) {
+    return cursor_update_pending && !desktop_frame_ready ?
+             pending_cursor_action::retry_cursor_frame :
+             pending_cursor_action::wait_for_events;
+  }
+
   inline producer_selection
   select_producer(int exact_index, int only_valid_index, unsigned int valid_count) {
     if (exact_index >= 0) {

--- a/tests/unit/test_vdd_safety.cpp
+++ b/tests/unit/test_vdd_safety.cpp
@@ -197,6 +197,17 @@ TEST(VddFrameChannelSafety, BoundsPostEventAcquireWait) {
             consumer_acquire_wait_budget_ms);
 }
 
+TEST(VddFrameChannelSafety, PrioritizesDesktopFrameOverPendingCursorRetry) {
+  using namespace platf::dxgi::vdd_frame_channel;
+
+  EXPECT_EQ(select_pending_cursor_action(false, false),
+            pending_cursor_action::wait_for_events);
+  EXPECT_EQ(select_pending_cursor_action(true, false),
+            pending_cursor_action::retry_cursor_frame);
+  EXPECT_EQ(select_pending_cursor_action(true, true),
+            pending_cursor_action::wait_for_events);
+}
+
 TEST(VddModeRefreshSafety, MatchesAdvertisedModesWithRefreshTolerance) {
   using namespace display_device;
 


### PR DESCRIPTION
## Summary

杂鱼，这次把 ZakoVDD 光标“只在点击或桌面变化时才动”的根因端掉啦：

- 将 `CursorReady` 接入捕获等待，纯光标移动也会唤醒快照管线
- 纯光标事件短暂重取最近的 keyed-mutex 槽位再合成；正常桌面帧不增加额外全分辨率拷贝
- keyed-mutex 短暂繁忙时保留 pending 光标更新；若生产者已发布 `key 1`，桌面帧优先，避免光标重试把帧状态卡住
- 本地光标模式只发布控制通道更新，不额外编码重复桌面帧
- 光标 SHM/Event 初始化过早时每 250 ms 自动重连，不再依赖切换 DDAPI/VDD 自愈
- 使用驱动侧 cursor QPC 作为光标帧时间戳

## Root cause

VDD 桌面帧和硬件光标使用两套独立通道。此前 Sunshine 只等待桌面 `FrameReady`，虽然打开了 `CursorReady`，却没有等待它；静止桌面上光标移动因此无法推进视频管线。同时光标通道只在初始化时连接一次，如果驱动映射创建稍晚，本次捕获生命周期就永远没有光标更新。

## Verification

- MSYS2 UCRT64 完整 Windows 构建通过（`sunshine.exe`）
- `*Cursor*:*VddFrameChannelSafety*` 连续 100 轮：1900/1900 通过
- CTest：5/5 通过
- 双 D3D11 设备共享纹理实测：`key 0` 忙 → `key 1` 发布 → 非破坏性探测 → 正常帧消费 → 回到 `key 0` 全序列通过
- 核对 ZakoVDD 驱动事件与 Sunshine frame pacing：高频 `CursorReady` 由 auto-reset 事件合并，视频光标合成/编码仍受客户端目标帧率约束
- `git diff --check` 通过

仓库现有 `vmouse_unit_tests` 在本机仍有 `create_high_precision_timer()` / `adjust_thread_priority()` 未解析链接符号，与本次改动无关。

Related to #886（本 PR 仅修复 ZakoVDD 路径，等待报告者确认捕获后端与修复结果）
