### PR TITLE
fix(vdd): 避免旋转后恢复串流错误重建虚拟显示器

### DIFF
--- a/src/display_device/vdd_utils.cpp
+++ b/src/display_device/vdd_utils.cpp
@@ -55,6 +55,26 @@ namespace display_device {
       constexpr auto kModePublicationMaxPoll = 500ms;
       std::atomic_bool hardware_cursor_live_enable_confirmed { false };
 
+      bool
+      orientation_swaps_axes(DWORD orientation) {
+        return orientation == DMDO_90 || orientation == DMDO_270;
+      }
+
+      unsigned int
+      orientation_degrees(DWORD orientation) {
+        switch (orientation) {
+          case DMDO_90:
+            return 90;
+          case DMDO_180:
+            return 180;
+          case DMDO_270:
+            return 270;
+          case DMDO_DEFAULT:
+          default:
+            return 0;
+        }
+      }
+
       std::vector<std::string>
       collect_physical_devices_for_preservation() {
         const auto topology = get_current_topology();
@@ -794,6 +814,13 @@ namespace display_device {
 
       const auto &display_name = device_it->second.display_name;
       const std::wstring wide_display_name(display_name.begin(), display_name.end());
+      DEVMODEW current_mode {};
+      current_mode.dmSize = sizeof(current_mode);
+      const bool orientation_known =
+        EnumDisplaySettingsW(wide_display_name.c_str(), ENUM_CURRENT_SETTINGS, &current_mode) &&
+        (current_mode.dmFields & DM_DISPLAYORIENTATION) != 0;
+      const bool swaps_axes = orientation_known && orientation_swaps_axes(current_mode.dmDisplayOrientation);
+
       for (DWORD index = 0; index < 4096; ++index) {
         DEVMODEW mode {};
         mode.dmSize = sizeof(mode);
@@ -801,11 +828,20 @@ namespace display_device {
           break;
         }
 
-        if (advertised_mode_matches(
-              mode.dmPelsWidth,
-              mode.dmPelsHeight,
-              mode.dmDisplayFrequency,
-              requested_mode)) {
+        const auto match = classify_advertised_mode(
+          mode.dmPelsWidth,
+          mode.dmPelsHeight,
+          mode.dmDisplayFrequency,
+          requested_mode,
+          swaps_axes);
+        if (match == advertised_mode_match_e::rotation_equivalent) {
+          BOOST_LOG(info) << "VDD mode "
+                          << requested_mode.resolution.width << 'x' << requested_mode.resolution.height
+                          << " is available through the current "
+                          << orientation_degrees(current_mode.dmDisplayOrientation)
+                          << "-degree display orientation; reusing the existing monitor";
+        }
+        if (match != advertised_mode_match_e::none) {
           return true;
         }
       }

--- a/src/display_device/vdd_utils.h
+++ b/src/display_device/vdd_utils.h
@@ -51,15 +51,26 @@ namespace display_device::vdd_utils {
     std::vector<unsigned int> refresh_rates_hz;
   };
 
-  constexpr bool
-  advertised_mode_matches(unsigned int width,
+  enum class advertised_mode_match_e {
+    none,
+    exact,
+    rotation_equivalent,
+  };
+
+  /**
+   * @brief Classify a Windows-advertised mode against a client-requested mode.
+   * @details Windows exposes logical width and height after display rotation.
+   *          A swapped match is valid only when the current orientation swaps
+   *          the display axes (90 or 270 degrees).
+   */
+  constexpr advertised_mode_match_e
+  classify_advertised_mode(unsigned int width,
     unsigned int height,
     unsigned int refresh_hz,
-    const display_mode_t &requested_mode) {
-    if (requested_mode.refresh_rate.denominator == 0 ||
-        width != requested_mode.resolution.width ||
-        height != requested_mode.resolution.height) {
-      return false;
+    const display_mode_t &requested_mode,
+    bool orientation_swaps_axes) {
+    if (requested_mode.refresh_rate.denominator == 0) {
+      return advertised_mode_match_e::none;
     }
 
     const auto advertised_scaled =
@@ -69,7 +80,31 @@ namespace display_device::vdd_utils {
     const auto difference = advertised_scaled > requested_scaled ?
                               advertised_scaled - requested_scaled :
                               requested_scaled - advertised_scaled;
-    return difference <= requested_mode.refresh_rate.denominator;
+    if (difference > requested_mode.refresh_rate.denominator) {
+      return advertised_mode_match_e::none;
+    }
+
+    if (width == requested_mode.resolution.width &&
+        height == requested_mode.resolution.height) {
+      return advertised_mode_match_e::exact;
+    }
+
+    if (orientation_swaps_axes &&
+        width == requested_mode.resolution.height &&
+        height == requested_mode.resolution.width) {
+      return advertised_mode_match_e::rotation_equivalent;
+    }
+
+    return advertised_mode_match_e::none;
+  }
+
+  constexpr bool
+  advertised_mode_matches(unsigned int width,
+    unsigned int height,
+    unsigned int refresh_hz,
+    const display_mode_t &requested_mode) {
+    return classify_advertised_mode(width, height, refresh_hz, requested_mode, false) !=
+           advertised_mode_match_e::none;
   }
 
   /**

--- a/tests/unit/test_vdd_safety.cpp
+++ b/tests/unit/test_vdd_safety.cpp
@@ -215,6 +215,32 @@ TEST(VddModeRefreshSafety, MatchesAdvertisedModesWithRefreshTolerance) {
   EXPECT_FALSE(vdd_utils::advertised_mode_matches(2340, 1080, 120, invalid));
 }
 
+TEST(VddModeRefreshSafety, MatchesRotatedModesOnlyWhenOrientationSwapsAxes) {
+  using namespace display_device;
+  using match_e = vdd_utils::advertised_mode_match_e;
+
+  const display_mode_t requested {
+    {2720, 1260},
+    {120, 1},
+  };
+
+  EXPECT_EQ(
+    vdd_utils::classify_advertised_mode(2720, 1260, 120, requested, false),
+    match_e::exact);
+  EXPECT_EQ(
+    vdd_utils::classify_advertised_mode(2720, 1260, 120, requested, true),
+    match_e::exact);
+  EXPECT_EQ(
+    vdd_utils::classify_advertised_mode(1260, 2720, 120, requested, false),
+    match_e::none);
+  EXPECT_EQ(
+    vdd_utils::classify_advertised_mode(1260, 2720, 120, requested, true),
+    match_e::rotation_equivalent);
+  EXPECT_EQ(
+    vdd_utils::classify_advertised_mode(1260, 2720, 60, requested, true),
+    match_e::none);
+}
+
 TEST(VddFrameChannelSafety, SelectsExactOrSoleProducerWithoutAmbiguity) {
   using namespace platf::dxgi::vdd_frame_channel;
 


### PR DESCRIPTION
## 说明

客户端跟随屏幕旋转后，Windows 会根据当前显示方向交换 VDD 模式的逻辑宽高。恢复串流请求仍使用原始分辨率，原有的精确匹配会将旋转后的等价模式判定为缺失，触发无效重建，并可能导致恢复请求返回 503。

## 修改

- 读取 VDD 当前显示方向，仅在 90° 或 270° 时将宽高互换识别为旋转等价模式。
- 保留刷新率校验；精确匹配和旋转等价匹配均复用现有 VDD，只有模式确实缺失时才重建。
- 补充旋转等价匹配测试，覆盖未旋转、旋转和刷新率不匹配场景。

该修改不改变客户端协议，也不放宽未旋转状态下的模式匹配。