### PR TITLE
fix(tray): align GUI tray with Core lifecycle

### DIFF
--- a/docs/tray-protocol.md
+++ b/docs/tray-protocol.md
@@ -63,6 +63,11 @@ signed-in user's session after Core starts. Failed launches are retried while
 Core remains alive, and the GUI's single-instance guard absorbs duplicate
 logon and service-start attempts.
 
+The GUI keeps its tray during a short Core restart window. If Core remains
+unreachable for 15 seconds, the GUI removes the native tray icon so the tray
+does not imply that Sunshine is still running. The background GUI agent stays
+alive and recreates the tray when the local Core becomes available again.
+
 ## Actions and operations
 
 `POST /api/tray/action` accepts:


### PR DESCRIPTION
## Summary

- Align the packaged GUI tray with the user-facing Sunshine Core lifecycle.
- Keep the tray during a short Core restart window, then remove it after 15 seconds of persistent Core unavailability.
- Recreate the tray automatically when Core recovers.
- Document the tray lifecycle contract.

The GUI implementation is in qiin2333/sunshine-control-panel PR #75 and is pinned here at `1a6be45a`.

## Validation

- GUI PR #75: `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- GUI PR #75: `cargo test --manifest-path src-tauri/Cargo.toml tray::events`
- Parent documentation diff checked with `git diff --check`