### PR TITLE
fix(input): boost pointer feedback cadence

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1817,11 +1817,20 @@ namespace input {
       payload = (PNV_INPUT_HEADER) entry.data();
       input->input_queue.pop_front();
 
+      if (!input->activity_tracker.evaluate(payload, entry.size()).has_value()) {
+        return;
+      }
+
       // Try to batch with remaining items on the queue
       auto i = input->input_queue.begin();
       while (i != input->input_queue.end()) {
         auto batchable_entry = *i;
         auto batchable_payload = (PNV_INPUT_HEADER) batchable_entry.data();
+
+        if (!input->activity_tracker.evaluate(batchable_payload, batchable_entry.size()).has_value()) {
+          i = input->input_queue.erase(i);
+          continue;
+        }
 
         auto batch_result = batch(payload, batchable_payload);
         if (batch_result == batch_result_e::terminate_batch) {
@@ -1842,9 +1851,9 @@ namespace input {
     // Print the final input packet
     input::print((void *) payload);
 
+    const auto activity = input->activity_tracker.evaluate(payload, entry.size());
     const bool should_raise_input_activity =
-      config::video.input_activity_boost &&
-      input->activity_tracker.evaluate(payload);
+      config::video.input_activity_boost && activity.value_or(false);
 
     // Send the batched input to the OS
     switch (util::endian::little(payload->magic)) {

--- a/src/input_activity.cpp
+++ b/src/input_activity.cpp
@@ -14,11 +14,18 @@
 
 namespace input::activity {
 
-  bool
-  tracker_t::evaluate(_NV_INPUT_HEADER *payload) {
+  std::optional<bool>
+  tracker_t::evaluate(const _NV_INPUT_HEADER *payload, std::size_t payload_size) {
+    if (payload_size < sizeof(*payload)) {
+      return std::nullopt;
+    }
+
     switch (util::endian::little(payload->magic)) {
       case MOUSE_MOVE_REL_MAGIC_GEN5: {
-        const auto *mouse = reinterpret_cast<PNV_REL_MOUSE_MOVE_PACKET>(payload);
+        if (payload_size < sizeof(NV_REL_MOUSE_MOVE_PACKET)) {
+          return std::nullopt;
+        }
+        const auto *mouse = reinterpret_cast<const NV_REL_MOUSE_MOVE_PACKET *>(payload);
         return config::input.mouse &&
                cursor_channel::local_mode_active() &&
                (util::endian::big(mouse->deltaX) != 0 ||
@@ -30,14 +37,20 @@ namespace input::activity {
       case MOUSE_BUTTON_UP_EVENT_MAGIC_GEN5:
         return config::input.mouse;
       case SCROLL_MAGIC_GEN5: {
-        const auto *scroll = reinterpret_cast<PNV_SCROLL_PACKET>(payload);
+        if (payload_size < sizeof(NV_SCROLL_PACKET)) {
+          return std::nullopt;
+        }
+        const auto *scroll = reinterpret_cast<const NV_SCROLL_PACKET *>(payload);
         return config::input.mouse &&
                (util::endian::big(scroll->scrollAmt1) != 0 ||
                 util::endian::big(scroll->scrollAmt2) != 0);
       }
       case SS_HSCROLL_MAGIC:
+        if (payload_size < sizeof(SS_HSCROLL_PACKET)) {
+          return std::nullopt;
+        }
         return config::input.mouse &&
-               util::endian::big(reinterpret_cast<PSS_HSCROLL_PACKET>(payload)->scrollAmount) != 0;
+               util::endian::big(reinterpret_cast<const SS_HSCROLL_PACKET *>(payload)->scrollAmount) != 0;
       case KEY_DOWN_EVENT_MAGIC:
       case KEY_UP_EVENT_MAGIC:
       case UTF8_TEXT_EVENT_MAGIC:

--- a/src/input_activity.cpp
+++ b/src/input_activity.cpp
@@ -8,6 +8,7 @@
 
 // local includes
 #include "config.h"
+#include "cursor_channel.h"
 #include "input_activity.h"
 #include "utility.h"
 
@@ -16,6 +17,27 @@ namespace input::activity {
   bool
   tracker_t::evaluate(_NV_INPUT_HEADER *payload) {
     switch (util::endian::little(payload->magic)) {
+      case MOUSE_MOVE_REL_MAGIC_GEN5: {
+        const auto *mouse = reinterpret_cast<PNV_REL_MOUSE_MOVE_PACKET>(payload);
+        return config::input.mouse &&
+               cursor_channel::local_mode_active() &&
+               (util::endian::big(mouse->deltaX) != 0 ||
+                util::endian::big(mouse->deltaY) != 0);
+      }
+      case MOUSE_MOVE_ABS_MAGIC:
+        return config::input.mouse && cursor_channel::local_mode_active();
+      case MOUSE_BUTTON_DOWN_EVENT_MAGIC_GEN5:
+      case MOUSE_BUTTON_UP_EVENT_MAGIC_GEN5:
+        return config::input.mouse;
+      case SCROLL_MAGIC_GEN5: {
+        const auto *scroll = reinterpret_cast<PNV_SCROLL_PACKET>(payload);
+        return config::input.mouse &&
+               (util::endian::big(scroll->scrollAmt1) != 0 ||
+                util::endian::big(scroll->scrollAmt2) != 0);
+      }
+      case SS_HSCROLL_MAGIC:
+        return config::input.mouse &&
+               util::endian::big(reinterpret_cast<PSS_HSCROLL_PACKET>(payload)->scrollAmount) != 0;
       case KEY_DOWN_EVENT_MAGIC:
       case KEY_UP_EVENT_MAGIC:
       case UTF8_TEXT_EVENT_MAGIC:

--- a/src/input_activity.h
+++ b/src/input_activity.h
@@ -4,6 +4,9 @@
  */
 #pragma once
 
+#include <cstddef>
+#include <optional>
+
 struct _NV_INPUT_HEADER;
 
 namespace input::activity {
@@ -13,17 +16,20 @@ namespace input::activity {
    * @details Tracks keyboard input, mouse buttons and scrolling. Pointer motion
    *          only counts while local cursor rendering is active, because video
    *          cursor motion already produces capture updates. Zero-delta motion
-   *          and scrolling packets are ignored.
+   *          and zero-delta scrolling packets are ignored; non-zero vertical or
+   *          horizontal scrolling counts as activity.
    */
   class tracker_t {
   public:
     /**
      * @brief Evaluate an input packet.
      * @param payload The raw input packet header.
-     * @return true if the packet should count as user activity.
+     * @param payload_size The number of bytes available at payload.
+     * @return No value if the packet is truncated; otherwise whether it should
+     *         count as user activity.
      */
-    bool
-    evaluate(_NV_INPUT_HEADER *payload);
+    std::optional<bool>
+    evaluate(const _NV_INPUT_HEADER *payload, std::size_t payload_size);
   };
 
 }  // namespace input::activity

--- a/src/input_activity.h
+++ b/src/input_activity.h
@@ -10,9 +10,10 @@ namespace input::activity {
 
   /**
    * @brief Decides whether an incoming input packet represents meaningful user activity.
-   * @details Filters device management/telemetry packets, zero-delta no-ops and analog
-   *          jitter/drift so the video pipeline only boosts encode cadence for input
-   *          that can plausibly produce visible feedback.
+   * @details Tracks keyboard input, mouse buttons and scrolling. Pointer motion
+   *          only counts while local cursor rendering is active, because video
+   *          cursor motion already produces capture updates. Zero-delta motion
+   *          and scrolling packets are ignored.
    */
   class tracker_t {
   public:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -125,6 +125,20 @@ foreach(dep ${SUNSHINE_TARGET_DEPENDENCIES})
 endforeach()
 add_test(NAME abr_unit_tests COMMAND abr_unit_tests)
 
+add_executable(input_activity_unit_tests
+        ${CMAKE_SOURCE_DIR}/tests/unit/test_input_activity.cpp
+        ${CMAKE_SOURCE_DIR}/src/input_activity.cpp
+        ${CMAKE_SOURCE_DIR}/src/cursor_channel.cpp)
+target_include_directories(input_activity_unit_tests PRIVATE
+        "${CMAKE_SOURCE_DIR}"
+        "${CMAKE_SOURCE_DIR}/third-party")
+target_link_libraries(input_activity_unit_tests
+        gtest_main)
+target_compile_definitions(input_activity_unit_tests PRIVATE INPUT_ACTIVITY_STANDALONE_TEST)
+target_compile_options(input_activity_unit_tests PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${SUNSHINE_COMPILE_OPTIONS}>)
+set_target_properties(input_activity_unit_tests PROPERTIES CXX_STANDARD 23)
+add_test(NAME input_activity_unit_tests COMMAND input_activity_unit_tests)
+
 add_executable(launch_session_manager_unit_tests
         ${CMAKE_SOURCE_DIR}/tests/unit/test_rtsp.cpp
         ${CMAKE_SOURCE_DIR}/src/launch_session_manager.cpp

--- a/tests/unit/test_input_activity.cpp
+++ b/tests/unit/test_input_activity.cpp
@@ -1,0 +1,150 @@
+/**
+ * @file tests/unit/test_input_activity.cpp
+ * @brief Tests for VRR input activity classification.
+ */
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <moonlight-common-c/src/Input.h>
+
+#include <src/config.h>
+#include <src/cursor_channel.h>
+#include <src/input_activity.h>
+#include <src/utility.h>
+
+#ifdef INPUT_ACTIVITY_STANDALONE_TEST
+namespace config {
+  input_t input;
+}
+#endif
+
+namespace {
+  constexpr std::uint32_t session_id = 0xFFFFFFFEu;
+
+  template <typename Packet>
+  Packet
+  make_packet(std::uint32_t magic) {
+    Packet packet {};
+    packet.header.size = util::endian::big<std::uint32_t>(sizeof(Packet) - sizeof(packet.header.size));
+    packet.header.magic = util::endian::little(magic);
+    return packet;
+  }
+
+  template <typename Packet>
+  std::vector<std::uint8_t>
+  packet_bytes(const Packet &packet) {
+    std::vector<std::uint8_t> bytes(sizeof(packet));
+    std::memcpy(bytes.data(), &packet, sizeof(packet));
+    return bytes;
+  }
+
+  struct activity_case_t {
+    std::string name;
+    std::vector<std::uint8_t> packet;
+    bool local_cursor;
+    bool mouse_enabled;
+    bool keyboard_enabled;
+    bool expected;
+  };
+
+  class InputActivityTest: public ::testing::Test {
+  protected:
+    void
+    SetUp() override {
+      original_mouse = config::input.mouse;
+      original_keyboard = config::input.keyboard;
+      cursor_channel::set_session_enabled(session_id, false);
+    }
+
+    void
+    TearDown() override {
+      cursor_channel::set_session_enabled(session_id, false);
+      config::input.mouse = original_mouse;
+      config::input.keyboard = original_keyboard;
+    }
+
+    bool original_mouse {};
+    bool original_keyboard {};
+  };
+}  // namespace
+
+TEST_F(InputActivityTest, ClassifiesPointerMouseAndKeyboardPackets) {
+  auto relative_zero = make_packet<NV_REL_MOUSE_MOVE_PACKET>(MOUSE_MOVE_REL_MAGIC_GEN5);
+  auto relative_move = make_packet<NV_REL_MOUSE_MOVE_PACKET>(MOUSE_MOVE_REL_MAGIC_GEN5);
+  relative_move.deltaX = util::endian::big<std::int16_t>(0x0102);
+  relative_move.deltaY = util::endian::big<std::int16_t>(-3);
+
+  const auto absolute_move = make_packet<NV_ABS_MOUSE_MOVE_PACKET>(MOUSE_MOVE_ABS_MAGIC);
+  const auto button_down = make_packet<NV_MOUSE_BUTTON_PACKET>(MOUSE_BUTTON_DOWN_EVENT_MAGIC_GEN5);
+  const auto button_up = make_packet<NV_MOUSE_BUTTON_PACKET>(MOUSE_BUTTON_UP_EVENT_MAGIC_GEN5);
+
+  auto vertical_zero = make_packet<NV_SCROLL_PACKET>(SCROLL_MAGIC_GEN5);
+  auto vertical_scroll = make_packet<NV_SCROLL_PACKET>(SCROLL_MAGIC_GEN5);
+  vertical_scroll.scrollAmt1 = util::endian::big<std::int16_t>(0x0102);
+
+  auto horizontal_zero = make_packet<SS_HSCROLL_PACKET>(SS_HSCROLL_MAGIC);
+  auto horizontal_scroll = make_packet<SS_HSCROLL_PACKET>(SS_HSCROLL_MAGIC);
+  horizontal_scroll.scrollAmount = util::endian::big<std::int16_t>(-0x0102);
+
+  const auto key_down = make_packet<NV_KEYBOARD_PACKET>(KEY_DOWN_EVENT_MAGIC);
+  const auto key_up = make_packet<NV_KEYBOARD_PACKET>(KEY_UP_EVENT_MAGIC);
+  const auto text = make_packet<NV_UNICODE_PACKET>(UTF8_TEXT_EVENT_MAGIC);
+
+  const std::vector<activity_case_t> cases {
+    {"relative zero in local mode", packet_bytes(relative_zero), true, true, true, false},
+    {"relative move outside local mode", packet_bytes(relative_move), false, true, true, false},
+    {"relative move in local mode", packet_bytes(relative_move), true, true, true, true},
+    {"absolute move outside local mode", packet_bytes(absolute_move), false, true, true, false},
+    {"absolute move in local mode", packet_bytes(absolute_move), true, true, true, true},
+    {"button down", packet_bytes(button_down), false, true, true, true},
+    {"button up", packet_bytes(button_up), false, true, true, true},
+    {"vertical scroll zero", packet_bytes(vertical_zero), false, true, true, false},
+    {"vertical scroll non-zero", packet_bytes(vertical_scroll), false, true, true, true},
+    {"horizontal scroll zero", packet_bytes(horizontal_zero), false, true, true, false},
+    {"horizontal scroll non-zero", packet_bytes(horizontal_scroll), false, true, true, true},
+    {"mouse disabled", packet_bytes(button_down), false, false, true, false},
+    {"key down", packet_bytes(key_down), false, true, true, true},
+    {"key up", packet_bytes(key_up), false, true, true, true},
+    {"text", packet_bytes(text), false, true, true, true},
+    {"keyboard disabled", packet_bytes(key_down), false, true, false, false},
+  };
+
+  input::activity::tracker_t tracker;
+  for (const auto &test : cases) {
+    SCOPED_TRACE(test.name);
+    cursor_channel::set_session_enabled(session_id, test.local_cursor);
+    config::input.mouse = test.mouse_enabled;
+    config::input.keyboard = test.keyboard_enabled;
+    const auto *payload = reinterpret_cast<const NV_INPUT_HEADER *>(test.packet.data());
+    EXPECT_EQ(tracker.evaluate(payload, test.packet.size()), test.expected);
+  }
+}
+
+TEST_F(InputActivityTest, RejectsTruncatedPacketsBeforeReadingEventFields) {
+  const std::vector<std::pair<std::uint32_t, std::size_t>> cases {
+    {MOUSE_MOVE_REL_MAGIC_GEN5, sizeof(NV_REL_MOUSE_MOVE_PACKET)},
+    {SCROLL_MAGIC_GEN5, sizeof(NV_SCROLL_PACKET)},
+    {SS_HSCROLL_MAGIC, sizeof(SS_HSCROLL_PACKET)},
+  };
+
+  input::activity::tracker_t tracker;
+  config::input.mouse = true;
+  cursor_channel::set_session_enabled(session_id, true);
+
+  for (const auto &[magic, full_size] : cases) {
+    SCOPED_TRACE(magic);
+    std::vector<std::uint8_t> bytes(full_size - 1);
+    auto *payload = reinterpret_cast<PNV_INPUT_HEADER>(bytes.data());
+    payload->size = util::endian::big<std::uint32_t>(static_cast<std::uint32_t>(full_size - sizeof(payload->size)));
+    payload->magic = util::endian::little(magic);
+    EXPECT_FALSE(tracker.evaluate(payload, bytes.size()));
+  }
+
+  NV_INPUT_HEADER header {};
+  auto bytes = packet_bytes(header);
+  bytes.resize(sizeof(header) - 1);
+  EXPECT_FALSE(tracker.evaluate(reinterpret_cast<PNV_INPUT_HEADER>(bytes.data()), bytes.size()));
+}


### PR DESCRIPTION
## 改了啥呢

- 把鼠标按键、滚轮事件接入现有 VRR input activity boost
- 本地指针模式下，让真实的相对/绝对鼠标移动也触发 boost
- 过滤零位移和零滚动包，普通视频内光标移动继续保持原行为
- 更新 activity tracker 注释，说明新的触发边界

## 为啥要改

本地指针模式由客户端即时绘制光标，鼠标本身很流畅，但主机侧 hover、点击和滚动反馈仍受低 VRR 编码 cadence 限制。现有 boost 只认键盘，导致这些鼠标交互要等较慢的下一帧，杂鱼低帧率就会显得黏糊糊的。

这次直接复用已有 boost 和编码等待抢占机制，同时把移动事件限定在本地指针模式，避免视频内光标场景重复抬高编码负载。

## 验证

- `git diff --cached --check`
- MSYS2 UCRT64 GCC 15.2：`ninja -C build-local-pointer-test sunshine`
- 将构建结果安装到本机，Sunshine、GUI 正常启动
- 本地 HTTPS 管理端返回 200
