### PR TITLE
fix(hdr): stabilize HLG Vivid stream startup

### DIFF
--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -560,6 +560,7 @@ namespace platf {
     init_encoder(const video::config_t &client_config, const video::sunshine_colorspace_t &colorspace, bool is_probe = false) = 0;
 
     nvenc::nvenc_encoder *nvenc = nullptr;
+    bool hdr_luminance_analysis_available = false;
   };
 
   struct amf_encode_device_t: encode_device_t {

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -487,6 +487,8 @@ namespace platf {
     float percentile_90_pq = 0.0f;  ///< 90th percentile in normalized PQ signal space
     float percentile_95 = 0.0f;     ///< 95th percentile of maxRGB (nits), for HDR10+
     float percentile_99 = 0.0f;     ///< 99th percentile of maxRGB (nits), for HDR10+
+    float analysis_max_nits = 0.0f; ///< Upper luminance bound used by the analyzer
+    uint64_t sample_sequence = 0;   ///< Increments only when a new GPU readback completes
     bool valid = false;         ///< Whether stats are available (false on first frame)
   };
 

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -362,6 +362,11 @@ namespace platf::dxgi {
       ::video::unregister_hdr_pipeline_status(runtime_status_id);
     }
 
+    bool
+    hdr_luminance_analysis_available() const {
+      return hdr_analysis_enabled;
+    }
+
     int
     convert(platf::img_t &img_base) {
       if (vram_timing_enabled) {
@@ -2604,10 +2609,16 @@ namespace platf::dxgi {
     init_encoder(const ::video::config_t &client_config, const ::video::sunshine_colorspace_t &colorspace, bool is_probe = false) override {
       if (!nvenc_d3d) return false;
 
+      hdr_luminance_analysis_available = false;
       if (!nvenc_d3d->create_encoder(config::video.nv, client_config, colorspace, buffer_format)) return false;
 
       base.apply_colorspace(colorspace);
-      return base.init_output(nvenc_d3d->get_input_texture(), client_config.width, client_config.height, colorspace, is_probe) == 0;
+      if (base.init_output(nvenc_d3d->get_input_texture(), client_config.width, client_config.height, colorspace, is_probe)) {
+        return false;
+      }
+
+      hdr_luminance_analysis_available = base.hdr_luminance_analysis_available();
+      return true;
     }
 
     int

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -678,6 +678,7 @@ namespace platf::dxgi {
       hdr_luminance_stats_out = {};
       hdr_analysis_pending = false;
       hdr_analysis_frame_index = 0;
+      hdr_analysis_sample_sequence = 0;
 
       // The underlying frame pool owns the texture, so we must reference it for ourselves
       frame_texture->AddRef();
@@ -1569,6 +1570,7 @@ namespace platf::dxgi {
     uint32_t hdr_analysis_height = 0;      // Analysis grid height (downsampled from source)
     uint32_t hdr_num_groups = 0;           // Number of thread groups dispatched in pass 1
     uint64_t hdr_analysis_frame_index = 0; // Used to downsample analysis frequency
+    uint64_t hdr_analysis_sample_sequence = 0; // Counts completed, independent GPU samples
     bool hdr_analysis_pending = false;     // Whether we have results ready to read
     bool hdr_analysis_enabled = false;     // Whether HDR analysis is initialized
     bool hdr_analysis_snapshot_enabled = false; // P010 converter fills the private analysis texture
@@ -1985,6 +1987,8 @@ namespace platf::dxgi {
           }
         }
 
+        hdr_luminance_stats_out.analysis_max_nits = hdr_analysis_max_nits;
+        hdr_luminance_stats_out.sample_sequence = ++hdr_analysis_sample_sequence;
         hdr_luminance_stats_out.valid = true;
       }
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -708,9 +708,12 @@ namespace video {
     nvenc_encode_session_t(std::unique_ptr<platf::nvenc_encode_device_t> encode_device):
         device(std::move(encode_device)) {
       const bool use_hlg = device && colorspace_is_hlg(device->colorspace);
-      vivid_preroll_active = use_hlg && config::video.hdr_luminance_analysis != "off";
-      dynamic_metadata_allowed = !use_hlg || vivid_preroll_active;
-      if (vivid_preroll_active) {
+      if (use_hlg) {
+        vivid_metadata_mode = config::video.hdr_luminance_analysis == "off" ?
+                                vivid_metadata_mode_e::disabled :
+                                vivid_metadata_mode_e::preroll;
+      }
+      if (vivid_metadata_mode == vivid_metadata_mode_e::preroll) {
         BOOST_LOG(info) << "NVENC: holding HLG startup for stable HDR Vivid metadata (3 independent samples, 500 ms timeout)";
       }
     }
@@ -807,16 +810,14 @@ namespace video {
     encode_frame(uint64_t frame_index) {
       if (!device || !device->nvenc) return {};
 
-      if (vivid_preroll_active) {
+      if (vivid_metadata_mode == vivid_metadata_mode_e::preroll) {
         const auto now = std::chrono::steady_clock::now();
         if (!vivid_preroll_started) {
           vivid_preroll_started = now;
         }
 
-        const auto state = vivid_startup_guard.observe(device->hdr_luminance_stats);
-        if (state == hdr_metadata::vivid_startup_guard_t::state_e::ready) {
-          vivid_preroll_active = false;
-          dynamic_metadata_allowed = true;
+        if (vivid_startup_guard.observe(device->hdr_luminance_stats)) {
+          vivid_metadata_mode = vivid_metadata_mode_e::enabled;
           force_idr = true;
           const auto &stats = device->hdr_luminance_stats;
           BOOST_LOG(info) << "NVENC: HDR Vivid startup guard ready after "
@@ -828,9 +829,7 @@ namespace video {
                           << ", P90=" << stats.percentile_90_pq << ')';
         }
         else if (now - *vivid_preroll_started >= VIVID_PREROLL_TIMEOUT) {
-          vivid_startup_guard.disable();
-          vivid_preroll_active = false;
-          dynamic_metadata_allowed = false;
+          vivid_metadata_mode = vivid_metadata_mode_e::disabled;
           force_idr = true;
           BOOST_LOG(warning) << "NVENC: HDR Vivid startup guard timed out after 500 ms; "
                                 "starting this session as pure HLG without dynamic metadata";
@@ -844,7 +843,7 @@ namespace video {
       }
 
       // Pass per-frame HDR luminance stats to NVENC for dynamic metadata injection
-      if (dynamic_metadata_allowed && device->hdr_luminance_stats.valid) {
+      if (vivid_metadata_mode != vivid_metadata_mode_e::disabled && device->hdr_luminance_stats.valid) {
         device->nvenc->set_luminance_stats(device->hdr_luminance_stats);
       }
 
@@ -874,12 +873,17 @@ namespace video {
   private:
     static constexpr auto VIVID_PREROLL_TIMEOUT = std::chrono::milliseconds { 500 };
 
+    enum class vivid_metadata_mode_e {
+      enabled,
+      preroll,
+      disabled,
+    };
+
     std::unique_ptr<platf::nvenc_encode_device_t> device;
     frame_timestamp_ring_t frame_timestamps;
     hdr_metadata::vivid_startup_guard_t vivid_startup_guard;
     std::optional<std::chrono::steady_clock::time_point> vivid_preroll_started;
-    bool vivid_preroll_active = false;
-    bool dynamic_metadata_allowed = true;
+    vivid_metadata_mode_e vivid_metadata_mode = vivid_metadata_mode_e::enabled;
     bool force_idr = false;
   };
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -707,6 +707,12 @@ namespace video {
   public:
     nvenc_encode_session_t(std::unique_ptr<platf::nvenc_encode_device_t> encode_device):
         device(std::move(encode_device)) {
+      const bool use_hlg = device && colorspace_is_hlg(device->colorspace);
+      vivid_preroll_active = use_hlg && config::video.hdr_luminance_analysis != "off";
+      dynamic_metadata_allowed = !use_hlg || vivid_preroll_active;
+      if (vivid_preroll_active) {
+        BOOST_LOG(info) << "NVENC: holding HLG startup for stable HDR Vivid metadata (3 independent samples, 500 ms timeout)";
+      }
     }
 
     int
@@ -801,8 +807,44 @@ namespace video {
     encode_frame(uint64_t frame_index) {
       if (!device || !device->nvenc) return {};
 
+      if (vivid_preroll_active) {
+        const auto now = std::chrono::steady_clock::now();
+        if (!vivid_preroll_started) {
+          vivid_preroll_started = now;
+        }
+
+        const auto state = vivid_startup_guard.observe(device->hdr_luminance_stats);
+        if (state == hdr_metadata::vivid_startup_guard_t::state_e::ready) {
+          vivid_preroll_active = false;
+          dynamic_metadata_allowed = true;
+          force_idr = true;
+          const auto &stats = device->hdr_luminance_stats;
+          BOOST_LOG(info) << "NVENC: HDR Vivid startup guard ready after "
+                          << vivid_startup_guard.consecutive_samples()
+                          << " independent samples; first encoded HLG frame will be IDR with Vivid"
+                          << " (avg=" << stats.avg_maxrgb
+                          << " nits, max=" << stats.max_maxrgb
+                          << " nits, P10=" << stats.percentile_10_pq
+                          << ", P90=" << stats.percentile_90_pq << ')';
+        }
+        else if (now - *vivid_preroll_started >= VIVID_PREROLL_TIMEOUT) {
+          vivid_startup_guard.disable();
+          vivid_preroll_active = false;
+          dynamic_metadata_allowed = false;
+          force_idr = true;
+          BOOST_LOG(warning) << "NVENC: HDR Vivid startup guard timed out after 500 ms; "
+                                "starting this session as pure HLG without dynamic metadata";
+        }
+        else {
+          // Keep converting capture frames so the asynchronous GPU analyzer can
+          // produce independent samples, but do not let the client see a plain-HLG
+          // IDR followed by a mid-stream transition into HDR Vivid.
+          return { {}, frame_index, false, false };
+        }
+      }
+
       // Pass per-frame HDR luminance stats to NVENC for dynamic metadata injection
-      if (device->hdr_luminance_stats.valid) {
+      if (dynamic_metadata_allowed && device->hdr_luminance_stats.valid) {
         device->nvenc->set_luminance_stats(device->hdr_luminance_stats);
       }
 
@@ -830,8 +872,14 @@ namespace video {
     }
 
   private:
+    static constexpr auto VIVID_PREROLL_TIMEOUT = std::chrono::milliseconds { 500 };
+
     std::unique_ptr<platf::nvenc_encode_device_t> device;
     frame_timestamp_ring_t frame_timestamps;
+    hdr_metadata::vivid_startup_guard_t vivid_startup_guard;
+    std::optional<std::chrono::steady_clock::time_point> vivid_preroll_started;
+    bool vivid_preroll_active = false;
+    bool dynamic_metadata_allowed = true;
     bool force_idr = false;
   };
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -709,9 +709,12 @@ namespace video {
         device(std::move(encode_device)) {
       const bool use_hlg = device && colorspace_is_hlg(device->colorspace);
       if (use_hlg) {
-        vivid_metadata_mode = config::video.hdr_luminance_analysis == "off" ?
-                                vivid_metadata_mode_e::disabled :
-                                vivid_metadata_mode_e::preroll;
+        const bool analysis_available =
+          config::video.hdr_luminance_analysis != "off" &&
+          device->hdr_luminance_analysis_available;
+        vivid_metadata_mode = analysis_available ?
+                                vivid_metadata_mode_e::preroll :
+                                vivid_metadata_mode_e::disabled;
       }
       if (vivid_metadata_mode == vivid_metadata_mode_e::preroll) {
         BOOST_LOG(info) << "NVENC: holding HLG startup for stable HDR Vivid metadata (3 independent samples, 500 ms timeout)";

--- a/src/video_hdr_metadata.h
+++ b/src/video_hdr_metadata.h
@@ -221,17 +221,11 @@ namespace video::hdr_metadata {
    */
   class vivid_startup_guard_t {
   public:
-    enum class state_e {
-      waiting,
-      ready,
-      disabled,
-    };
-
-    state_e
+    bool
     observe(const platf::hdr_frame_luminance_stats_t &stats) {
-      if (state_ != state_e::waiting || !stats.valid ||
+      if (ready_ || !stats.valid ||
           (have_sequence_ && stats.sample_sequence == last_sequence_)) {
-        return state_;
+        return ready_;
       }
 
       have_sequence_ = true;
@@ -240,7 +234,7 @@ namespace video::hdr_metadata {
       if (!is_sane(stats)) {
         consecutive_samples_ = 0;
         previous_ = {};
-        return state_;
+        return false;
       }
 
       if (previous_.valid && !is_stable(previous_, stats)) {
@@ -252,21 +246,9 @@ namespace video::hdr_metadata {
       previous_ = stats;
 
       if (consecutive_samples_ >= REQUIRED_SAMPLES) {
-        state_ = state_e::ready;
+        ready_ = true;
       }
-      return state_;
-    }
-
-    void
-    disable() {
-      if (state_ == state_e::waiting) {
-        state_ = state_e::disabled;
-      }
-    }
-
-    state_e
-    state() const {
-      return state_;
+      return ready_;
     }
 
     uint32_t
@@ -317,11 +299,11 @@ namespace video::hdr_metadata {
              std::abs(previous.percentile_90_pq - current.percentile_90_pq) <= 0.15f;
     }
 
-    state_e state_ = state_e::waiting;
     platf::hdr_frame_luminance_stats_t previous_ {};
     uint64_t last_sequence_ = 0;
     uint32_t consecutive_samples_ = 0;
     bool have_sequence_ = false;
+    bool ready_ = false;
   };
 
   namespace detail {

--- a/src/video_hdr_metadata.h
+++ b/src/video_hdr_metadata.h
@@ -214,6 +214,116 @@ namespace video::hdr_metadata {
     uint32_t maximum_sum_ = 0;
   };
 
+  /**
+   * Gates HDR Vivid at stream startup until several independent GPU readbacks
+   * describe a sane, stable HLG picture. The caller owns the wall-clock timeout
+   * because timeout policy is a streaming concern, not metadata validation.
+   */
+  class vivid_startup_guard_t {
+  public:
+    enum class state_e {
+      waiting,
+      ready,
+      disabled,
+    };
+
+    state_e
+    observe(const platf::hdr_frame_luminance_stats_t &stats) {
+      if (state_ != state_e::waiting || !stats.valid ||
+          (have_sequence_ && stats.sample_sequence == last_sequence_)) {
+        return state_;
+      }
+
+      have_sequence_ = true;
+      last_sequence_ = stats.sample_sequence;
+
+      if (!is_sane(stats)) {
+        consecutive_samples_ = 0;
+        previous_ = {};
+        return state_;
+      }
+
+      if (previous_.valid && !is_stable(previous_, stats)) {
+        consecutive_samples_ = 1;
+      }
+      else {
+        ++consecutive_samples_;
+      }
+      previous_ = stats;
+
+      if (consecutive_samples_ >= REQUIRED_SAMPLES) {
+        state_ = state_e::ready;
+      }
+      return state_;
+    }
+
+    void
+    disable() {
+      if (state_ == state_e::waiting) {
+        state_ = state_e::disabled;
+      }
+    }
+
+    state_e
+    state() const {
+      return state_;
+    }
+
+    uint32_t
+    consecutive_samples() const {
+      return consecutive_samples_;
+    }
+
+    static constexpr uint32_t REQUIRED_SAMPLES = 3;
+
+  private:
+    static bool
+    is_sane(const platf::hdr_frame_luminance_stats_t &stats) {
+      const bool finite =
+        std::isfinite(stats.min_maxrgb) &&
+        std::isfinite(stats.avg_maxrgb) &&
+        std::isfinite(stats.max_maxrgb) &&
+        std::isfinite(stats.percentile_10_pq) &&
+        std::isfinite(stats.percentile_90_pq) &&
+        std::isfinite(stats.analysis_max_nits);
+      if (!finite || stats.analysis_max_nits <= 0.0f) {
+        return false;
+      }
+
+      const float luminance_slack = std::max(1.0f, stats.analysis_max_nits * 0.01f);
+      return stats.min_maxrgb >= 0.0f &&
+             stats.max_maxrgb > 1.0f &&
+             stats.avg_maxrgb + luminance_slack >= stats.min_maxrgb &&
+             stats.max_maxrgb + luminance_slack >= stats.avg_maxrgb &&
+             stats.max_maxrgb <= stats.analysis_max_nits + luminance_slack &&
+             stats.percentile_10_pq >= 0.0f &&
+             stats.percentile_90_pq <= 1.0f &&
+             stats.percentile_10_pq <= stats.percentile_90_pq;
+    }
+
+    static bool
+    scalar_is_stable(float previous, float current, float absolute_floor) {
+      const float scale = std::max({ std::abs(previous), std::abs(current), absolute_floor });
+      return std::abs(previous - current) <= scale * 0.5f;
+    }
+
+    static bool
+    is_stable(
+      const platf::hdr_frame_luminance_stats_t &previous,
+      const platf::hdr_frame_luminance_stats_t &current) {
+      return scalar_is_stable(previous.avg_maxrgb, current.avg_maxrgb, 20.0f) &&
+             scalar_is_stable(previous.max_maxrgb, current.max_maxrgb, 50.0f) &&
+             std::abs(previous.percentile_10_pq - current.percentile_10_pq) <= 0.15f &&
+             std::abs(previous.percentile_90_pq - current.percentile_90_pq) <= 0.15f;
+    }
+
+    state_e state_ = state_e::waiting;
+    platf::hdr_frame_luminance_stats_t previous_ {};
+    uint64_t last_sequence_ = 0;
+    uint32_t consecutive_samples_ = 0;
+    bool have_sequence_ = false;
+  };
+
   namespace detail {
 
     class bit_writer_t {

--- a/src/video_hdr_metadata.h
+++ b/src/video_hdr_metadata.h
@@ -223,13 +223,11 @@ namespace video::hdr_metadata {
   public:
     bool
     observe(const platf::hdr_frame_luminance_stats_t &stats) {
+      const auto accepted_end = accepted_sequences_.begin() + consecutive_samples_;
       if (ready_ || !stats.valid ||
-          (have_sequence_ && stats.sample_sequence == last_sequence_)) {
+          std::find(accepted_sequences_.begin(), accepted_end, stats.sample_sequence) != accepted_end) {
         return ready_;
       }
-
-      have_sequence_ = true;
-      last_sequence_ = stats.sample_sequence;
 
       if (!is_sane(stats)) {
         consecutive_samples_ = 0;
@@ -239,8 +237,10 @@ namespace video::hdr_metadata {
 
       if (previous_.valid && !is_stable(previous_, stats)) {
         consecutive_samples_ = 1;
+        accepted_sequences_[0] = stats.sample_sequence;
       }
       else {
+        accepted_sequences_[consecutive_samples_] = stats.sample_sequence;
         ++consecutive_samples_;
       }
       previous_ = stats;
@@ -300,9 +300,8 @@ namespace video::hdr_metadata {
     }
 
     platf::hdr_frame_luminance_stats_t previous_ {};
-    uint64_t last_sequence_ = 0;
+    std::array<uint64_t, REQUIRED_SAMPLES> accepted_sequences_ {};
     uint32_t consecutive_samples_ = 0;
-    bool have_sequence_ = false;
     bool ready_ = false;
   };
 

--- a/tests/unit/test_video_hdr_metadata.cpp
+++ b/tests/unit/test_video_hdr_metadata.cpp
@@ -136,6 +136,78 @@ TEST(HdrDynamicMetadata, AppliesAnnexA9ThirtyTwoFrameMean) {
   EXPECT_EQ(filter.update(dark).average_maxrgb_pq, 100);
 }
 
+namespace {
+
+  platf::hdr_frame_luminance_stats_t
+  stable_hlg_stats(uint64_t sequence, float average = 120.0f, float maximum = 600.0f) {
+    return {
+      .min_maxrgb = 0.0f,
+      .max_maxrgb = maximum,
+      .avg_maxrgb = average,
+      .percentile_10_pq = 0.20f,
+      .percentile_90_pq = 0.70f,
+      .percentile_95 = 500.0f,
+      .percentile_99 = 580.0f,
+      .analysis_max_nits = 1000.0f,
+      .sample_sequence = sequence,
+      .valid = true,
+    };
+  }
+
+}  // namespace
+
+TEST(HdrDynamicMetadata, VividStartupGuardRequiresThreeIndependentSamples) {
+  using guard_t = video::hdr_metadata::vivid_startup_guard_t;
+  guard_t guard;
+
+  const auto first = stable_hlg_stats(1);
+  EXPECT_EQ(guard.observe(first), guard_t::state_e::waiting);
+  EXPECT_EQ(guard.consecutive_samples(), 1U);
+
+  // Reusing an analyzer result on intervening encoded frames must not satisfy
+  // the startup guard.
+  EXPECT_EQ(guard.observe(first), guard_t::state_e::waiting);
+  EXPECT_EQ(guard.consecutive_samples(), 1U);
+
+  EXPECT_EQ(guard.observe(stable_hlg_stats(2, 125.0f, 620.0f)), guard_t::state_e::waiting);
+  EXPECT_EQ(guard.observe(stable_hlg_stats(3, 130.0f, 610.0f)), guard_t::state_e::ready);
+}
+
+TEST(HdrDynamicMetadata, VividStartupGuardRejectsInvalidAndTransitionSamples) {
+  using guard_t = video::hdr_metadata::vivid_startup_guard_t;
+  guard_t guard;
+
+  EXPECT_EQ(guard.observe(stable_hlg_stats(1)), guard_t::state_e::waiting);
+
+  auto invalid = stable_hlg_stats(2);
+  invalid.max_maxrgb = 1500.0f;
+  EXPECT_EQ(guard.observe(invalid), guard_t::state_e::waiting);
+  EXPECT_EQ(guard.consecutive_samples(), 0U);
+
+  auto black = stable_hlg_stats(3, 0.0f, 0.0f);
+  black.percentile_10_pq = 0.0f;
+  black.percentile_90_pq = 0.0f;
+  EXPECT_EQ(guard.observe(black), guard_t::state_e::waiting);
+  EXPECT_EQ(guard.consecutive_samples(), 0U);
+
+  EXPECT_EQ(guard.observe(stable_hlg_stats(4)), guard_t::state_e::waiting);
+  // A large exposure transition restarts the consecutive run at the current sample.
+  EXPECT_EQ(guard.observe(stable_hlg_stats(5, 500.0f, 950.0f)), guard_t::state_e::waiting);
+  EXPECT_EQ(guard.consecutive_samples(), 1U);
+  EXPECT_EQ(guard.observe(stable_hlg_stats(6, 510.0f, 940.0f)), guard_t::state_e::waiting);
+  EXPECT_EQ(guard.observe(stable_hlg_stats(7, 500.0f, 930.0f)), guard_t::state_e::ready);
+}
+
+TEST(HdrDynamicMetadata, VividStartupGuardCanBePermanentlyDisabled) {
+  using guard_t = video::hdr_metadata::vivid_startup_guard_t;
+  guard_t guard;
+  guard.disable();
+
+  EXPECT_EQ(guard.observe(stable_hlg_stats(1)), guard_t::state_e::disabled);
+  EXPECT_EQ(guard.observe(stable_hlg_stats(2)), guard_t::state_e::disabled);
+  EXPECT_EQ(guard.observe(stable_hlg_stats(3)), guard_t::state_e::disabled);
+}
+
 // Regression guard for the representation of
 // AVHDRVividColorToneMappingParams::targeted_system_display_maximum_luminance.
 //

--- a/tests/unit/test_video_hdr_metadata.cpp
+++ b/tests/unit/test_video_hdr_metadata.cpp
@@ -169,6 +169,12 @@ TEST(HdrDynamicMetadata, VividStartupGuardRequiresThreeIndependentSamples) {
   EXPECT_EQ(guard.consecutive_samples(), 1U);
 
   EXPECT_FALSE(guard.observe(stable_hlg_stats(2, 125.0f, 620.0f)));
+  EXPECT_EQ(guard.consecutive_samples(), 2U);
+
+  // A non-adjacent replay is still the same GPU readback and must not count.
+  EXPECT_FALSE(guard.observe(first));
+  EXPECT_EQ(guard.consecutive_samples(), 2U);
+
   EXPECT_TRUE(guard.observe(stable_hlg_stats(3, 130.0f, 610.0f)));
 }
 

--- a/tests/unit/test_video_hdr_metadata.cpp
+++ b/tests/unit/test_video_hdr_metadata.cpp
@@ -184,22 +184,27 @@ TEST(HdrDynamicMetadata, VividStartupGuardRejectsInvalidAndTransitionSamples) {
   EXPECT_FALSE(guard.observe(stable_hlg_stats(1)));
 
   auto invalid = stable_hlg_stats(2);
+  invalid.avg_maxrgb = std::numeric_limits<float>::quiet_NaN();
+  EXPECT_FALSE(guard.observe(invalid));
+  EXPECT_EQ(guard.consecutive_samples(), 0U);
+
+  invalid = stable_hlg_stats(3);
   invalid.max_maxrgb = 1500.0f;
   EXPECT_FALSE(guard.observe(invalid));
   EXPECT_EQ(guard.consecutive_samples(), 0U);
 
-  auto black = stable_hlg_stats(3, 0.0f, 0.0f);
+  auto black = stable_hlg_stats(4, 0.0f, 0.0f);
   black.percentile_10_pq = 0.0f;
   black.percentile_90_pq = 0.0f;
   EXPECT_FALSE(guard.observe(black));
   EXPECT_EQ(guard.consecutive_samples(), 0U);
 
-  EXPECT_FALSE(guard.observe(stable_hlg_stats(4)));
+  EXPECT_FALSE(guard.observe(stable_hlg_stats(5)));
   // A large exposure transition restarts the consecutive run at the current sample.
-  EXPECT_FALSE(guard.observe(stable_hlg_stats(5, 500.0f, 950.0f)));
+  EXPECT_FALSE(guard.observe(stable_hlg_stats(6, 500.0f, 950.0f)));
   EXPECT_EQ(guard.consecutive_samples(), 1U);
-  EXPECT_FALSE(guard.observe(stable_hlg_stats(6, 510.0f, 940.0f)));
-  EXPECT_TRUE(guard.observe(stable_hlg_stats(7, 500.0f, 930.0f)));
+  EXPECT_FALSE(guard.observe(stable_hlg_stats(7, 510.0f, 940.0f)));
+  EXPECT_TRUE(guard.observe(stable_hlg_stats(8, 500.0f, 930.0f)));
 }
 
 // Regression guard for the representation of

--- a/tests/unit/test_video_hdr_metadata.cpp
+++ b/tests/unit/test_video_hdr_metadata.cpp
@@ -157,55 +157,43 @@ namespace {
 }  // namespace
 
 TEST(HdrDynamicMetadata, VividStartupGuardRequiresThreeIndependentSamples) {
-  using guard_t = video::hdr_metadata::vivid_startup_guard_t;
-  guard_t guard;
+  video::hdr_metadata::vivid_startup_guard_t guard;
 
   const auto first = stable_hlg_stats(1);
-  EXPECT_EQ(guard.observe(first), guard_t::state_e::waiting);
+  EXPECT_FALSE(guard.observe(first));
   EXPECT_EQ(guard.consecutive_samples(), 1U);
 
   // Reusing an analyzer result on intervening encoded frames must not satisfy
   // the startup guard.
-  EXPECT_EQ(guard.observe(first), guard_t::state_e::waiting);
+  EXPECT_FALSE(guard.observe(first));
   EXPECT_EQ(guard.consecutive_samples(), 1U);
 
-  EXPECT_EQ(guard.observe(stable_hlg_stats(2, 125.0f, 620.0f)), guard_t::state_e::waiting);
-  EXPECT_EQ(guard.observe(stable_hlg_stats(3, 130.0f, 610.0f)), guard_t::state_e::ready);
+  EXPECT_FALSE(guard.observe(stable_hlg_stats(2, 125.0f, 620.0f)));
+  EXPECT_TRUE(guard.observe(stable_hlg_stats(3, 130.0f, 610.0f)));
 }
 
 TEST(HdrDynamicMetadata, VividStartupGuardRejectsInvalidAndTransitionSamples) {
-  using guard_t = video::hdr_metadata::vivid_startup_guard_t;
-  guard_t guard;
+  video::hdr_metadata::vivid_startup_guard_t guard;
 
-  EXPECT_EQ(guard.observe(stable_hlg_stats(1)), guard_t::state_e::waiting);
+  EXPECT_FALSE(guard.observe(stable_hlg_stats(1)));
 
   auto invalid = stable_hlg_stats(2);
   invalid.max_maxrgb = 1500.0f;
-  EXPECT_EQ(guard.observe(invalid), guard_t::state_e::waiting);
+  EXPECT_FALSE(guard.observe(invalid));
   EXPECT_EQ(guard.consecutive_samples(), 0U);
 
   auto black = stable_hlg_stats(3, 0.0f, 0.0f);
   black.percentile_10_pq = 0.0f;
   black.percentile_90_pq = 0.0f;
-  EXPECT_EQ(guard.observe(black), guard_t::state_e::waiting);
+  EXPECT_FALSE(guard.observe(black));
   EXPECT_EQ(guard.consecutive_samples(), 0U);
 
-  EXPECT_EQ(guard.observe(stable_hlg_stats(4)), guard_t::state_e::waiting);
+  EXPECT_FALSE(guard.observe(stable_hlg_stats(4)));
   // A large exposure transition restarts the consecutive run at the current sample.
-  EXPECT_EQ(guard.observe(stable_hlg_stats(5, 500.0f, 950.0f)), guard_t::state_e::waiting);
+  EXPECT_FALSE(guard.observe(stable_hlg_stats(5, 500.0f, 950.0f)));
   EXPECT_EQ(guard.consecutive_samples(), 1U);
-  EXPECT_EQ(guard.observe(stable_hlg_stats(6, 510.0f, 940.0f)), guard_t::state_e::waiting);
-  EXPECT_EQ(guard.observe(stable_hlg_stats(7, 500.0f, 930.0f)), guard_t::state_e::ready);
-}
-
-TEST(HdrDynamicMetadata, VividStartupGuardCanBePermanentlyDisabled) {
-  using guard_t = video::hdr_metadata::vivid_startup_guard_t;
-  guard_t guard;
-  guard.disable();
-
-  EXPECT_EQ(guard.observe(stable_hlg_stats(1)), guard_t::state_e::disabled);
-  EXPECT_EQ(guard.observe(stable_hlg_stats(2)), guard_t::state_e::disabled);
-  EXPECT_EQ(guard.observe(stable_hlg_stats(3)), guard_t::state_e::disabled);
+  EXPECT_FALSE(guard.observe(stable_hlg_stats(6, 510.0f, 940.0f)));
+  EXPECT_TRUE(guard.observe(stable_hlg_stats(7, 500.0f, 930.0f)));
 }
 
 // Regression guard for the representation of


### PR DESCRIPTION
## 改了啥呀

- 给原生 NVENC 的 HLG / HDR Vivid 启动链路加了一道预热保护，先等 3 个独立且稳定的 GPU 亮度样本，再放出首帧。
- 给分析结果补上采样序号和分析亮度上限，避免同一份回读结果被重复计数，也会拒绝全黑、越界、非有限值和明显曝光跳变。
- 500 ms 内拿不到可信样本时，当前会话固定降级为纯 HLG，不允许中途再切入 Vivid；真正发出的第一帧会强制为 IDR。
- NVENC 会话用单一的 `enabled / preroll / disabled` 状态管理元数据，guard 只负责稳定性判定，清掉了重复布尔状态和无用接口。
- 补齐启动保护的单元测试，覆盖重复样本、异常数据和曝光跃迁。

## 为啥要改

鸿蒙端已经按 HEVC + HLG 解码，性能覆盖层也能显示 Vivid，但偶发首连过曝、重连恢复，更像是首个 GOP 与动态元数据准备时序不稳定。也就是说，客户端“识别成 Vivid”并不等于首批元数据一定可信呀，杂鱼 bug 还挺会伪装的。

这次保护把客户端能看到的起始状态收敛为两种：要么从首个 IDR 起就是带稳定元数据的 Vivid，要么整个会话保持纯 HLG，避免 plain HLG → Vivid 的中途跳变。

## 验证

- [x] `git diff --check`
- [x] 编译 `test_video_hdr_metadata.cpp`、`display_vram.cpp`、`video.cpp` 对应对象
- [x] `HdrDynamicMetadata.*`：9/9 通过
- [ ] 完整 `test_sunshine` 目标：被未改动的 `src/config.cpp` 与本机 AMF / Strawberry GCC `cinttypes` 头文件冲突阻塞

影响范围仅限原生 NVENC HLG 启动；SDR、HDR10 和其他编码后端不走这道预热保护。