### PR TITLE
fix(tests): update vmouse test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -188,6 +188,7 @@ endif ()
 if (WIN32)
     add_executable(vmouse_unit_tests
             ${CMAKE_SOURCE_DIR}/tests/unit/platform/windows/test_virtual_mouse.cpp
+            ${CMAKE_SOURCE_DIR}/tests/tools/vmouse_platform_support.cpp
             ${CMAKE_SOURCE_DIR}/src/platform/windows/virtual_mouse.cpp)
     target_include_directories(vmouse_unit_tests PRIVATE "${CMAKE_SOURCE_DIR}")
     target_link_libraries(vmouse_unit_tests
@@ -208,6 +209,7 @@ if (WIN32)
 
     add_executable(vmouse_probe
             ${CMAKE_SOURCE_DIR}/tests/tools/vmouse_probe.cpp
+            ${CMAKE_SOURCE_DIR}/tests/tools/vmouse_platform_support.cpp
             ${CMAKE_SOURCE_DIR}/src/platform/windows/virtual_mouse.cpp)
     target_include_directories(vmouse_probe PRIVATE "${CMAKE_SOURCE_DIR}")
     target_link_libraries(vmouse_probe

--- a/tests/tools/vmouse_platform_support.cpp
+++ b/tests/tools/vmouse_platform_support.cpp
@@ -1,0 +1,83 @@
+/**
+ * @file tests/tools/vmouse_platform_support.cpp
+ * @brief Minimal Windows platform support for standalone virtual mouse targets.
+ */
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+
+#include <chrono>
+#include <memory>
+
+#include "src/platform/common.h"
+
+using namespace std::chrono_literals;
+
+namespace platf {
+  namespace {
+    class standalone_high_precision_timer final: public high_precision_timer {
+    public:
+      standalone_high_precision_timer() {
+        timer_ = CreateWaitableTimerEx(nullptr, nullptr, CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, TIMER_ALL_ACCESS);
+        if (!timer_) {
+          timer_ = CreateWaitableTimerEx(nullptr, nullptr, 0, TIMER_ALL_ACCESS);
+        }
+      }
+
+      ~standalone_high_precision_timer() override {
+        if (timer_) {
+          CloseHandle(timer_);
+        }
+      }
+
+      void
+      sleep_for(const std::chrono::nanoseconds &duration) override {
+        if (!timer_ || duration < 0s || duration > 5s) {
+          return;
+        }
+
+        LARGE_INTEGER due_time {};
+        due_time.QuadPart = duration.count() / -100;
+        if (SetWaitableTimer(timer_, &due_time, 0, nullptr, nullptr, false)) {
+          WaitForSingleObject(timer_, INFINITE);
+        }
+      }
+
+      operator bool() override {
+        return timer_ != nullptr;
+      }
+
+    private:
+      HANDLE timer_ = nullptr;
+    };
+  }  // namespace
+
+  void
+  adjust_thread_priority(thread_priority_e priority) {
+    int win32_priority;
+
+    switch (priority) {
+      case thread_priority_e::low:
+        win32_priority = THREAD_PRIORITY_BELOW_NORMAL;
+        break;
+      case thread_priority_e::normal:
+        win32_priority = THREAD_PRIORITY_NORMAL;
+        break;
+      case thread_priority_e::high:
+        win32_priority = THREAD_PRIORITY_ABOVE_NORMAL;
+        break;
+      case thread_priority_e::critical:
+        win32_priority = THREAD_PRIORITY_HIGHEST;
+        break;
+      default:
+        return;
+    }
+
+    SetThreadPriority(GetCurrentThread(), win32_priority);
+  }
+
+  std::unique_ptr<high_precision_timer>
+  create_high_precision_timer() {
+    return std::make_unique<standalone_high_precision_timer>();
+  }
+}  // namespace platf


### PR DESCRIPTION
## 说明

虚拟鼠标发送线程使用通用 Windows 平台的高精度定时器和线程优先级接口。独立构建 vmouse_unit_tests 和 vmouse_probe 时未链接这些接口的实现，导致链接失败。

## 修改

- 为两个独立目标增加轻量的 Windows 平台支撑，提供 Waitable Timer 和线程优先级实现。
- 保持独立目标不依赖完整的 Windows misc.cpp，避免引入无关平台模块。