### PR TITLE
fix(video): enforce bitrate cap at encoder startup

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -164,13 +164,23 @@ namespace video {
   }
 
   int
-  cap_encoder_bitrate(int encoder_bitrate_kbps, int max_total_bitrate_kbps, int fec_percentage) {
+  encoder_bitrate_for_total_request(int requested_total_bitrate_kbps, int max_total_bitrate_kbps, int fec_percentage) {
+    auto capped_total_bitrate_kbps = requested_total_bitrate_kbps;
+    if (max_total_bitrate_kbps > 0) {
+      capped_total_bitrate_kbps = std::min(capped_total_bitrate_kbps, max_total_bitrate_kbps);
+    }
+
+    return encoder_bitrate_from_total_bitrate(capped_total_bitrate_kbps, fec_percentage);
+  }
+
+  int
+  cap_initial_encoder_bitrate(int initial_encoder_bitrate_kbps, int max_total_bitrate_kbps, int fec_percentage) {
     if (max_total_bitrate_kbps <= 0) {
-      return encoder_bitrate_kbps;
+      return initial_encoder_bitrate_kbps;
     }
 
     return std::min(
-      encoder_bitrate_kbps,
+      initial_encoder_bitrate_kbps,
       encoder_bitrate_from_total_bitrate(max_total_bitrate_kbps, fec_percentage)
     );
   }
@@ -639,7 +649,7 @@ namespace video {
     set_bitrate(int bitrate_kbps) override {
       if (!avcodec_ctx) return;
 
-      const auto adjusted_bitrate_kbps = cap_encoder_bitrate(
+      const auto adjusted_bitrate_kbps = encoder_bitrate_for_total_request(
         bitrate_kbps,
         config::video.max_bitrate,
         config::stream.fec_percentage
@@ -771,7 +781,7 @@ namespace video {
       if (device && device->nvenc) {
         // 考虑FEC影响，调整编码码率
         // 当FEC百分比为X%时，实际编码码率需要调整为原始码率的(100-X)%
-        const auto adjusted_bitrate_kbps = cap_encoder_bitrate(
+        const auto adjusted_bitrate_kbps = encoder_bitrate_for_total_request(
           bitrate_kbps,
           config::video.max_bitrate,
           config::stream.fec_percentage
@@ -945,7 +955,7 @@ namespace video {
     void
     set_bitrate(int bitrate_kbps) override {
       if (device && device->amf) {
-        const auto adjusted_bitrate_kbps = cap_encoder_bitrate(
+        const auto adjusted_bitrate_kbps = encoder_bitrate_for_total_request(
           bitrate_kbps,
           config::video.max_bitrate,
           config::stream.fec_percentage
@@ -2855,7 +2865,7 @@ namespace video {
   std::unique_ptr<encode_session_t>
   make_encode_session(platf::display_t *disp, const encoder_t &encoder, const config_t &config, int width, int height, std::unique_ptr<platf::encode_device_t> encode_device, bool is_probe = false) {
     auto effective_config = config;
-    effective_config.bitrate = cap_encoder_bitrate(
+    effective_config.bitrate = cap_initial_encoder_bitrate(
       config.bitrate,
       config::video.max_bitrate,
       config::stream.fec_percentage

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -639,8 +639,9 @@ namespace video {
     set_bitrate(int bitrate_kbps) override {
       if (!avcodec_ctx) return;
 
-      const auto adjusted_bitrate_kbps = encoder_bitrate_from_total_bitrate(
+      const auto adjusted_bitrate_kbps = cap_encoder_bitrate(
         bitrate_kbps,
+        config::video.max_bitrate,
         config::stream.fec_percentage
       );
 
@@ -770,8 +771,9 @@ namespace video {
       if (device && device->nvenc) {
         // 考虑FEC影响，调整编码码率
         // 当FEC百分比为X%时，实际编码码率需要调整为原始码率的(100-X)%
-        const auto adjusted_bitrate_kbps = encoder_bitrate_from_total_bitrate(
+        const auto adjusted_bitrate_kbps = cap_encoder_bitrate(
           bitrate_kbps,
+          config::video.max_bitrate,
           config::stream.fec_percentage
         );
 
@@ -943,8 +945,9 @@ namespace video {
     void
     set_bitrate(int bitrate_kbps) override {
       if (device && device->amf) {
-        const auto adjusted_bitrate_kbps = encoder_bitrate_from_total_bitrate(
+        const auto adjusted_bitrate_kbps = cap_encoder_bitrate(
           bitrate_kbps,
+          config::video.max_bitrate,
           config::stream.fec_percentage
         );
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -154,6 +154,27 @@ namespace video {
     return statuses;
   }
 
+  int
+  encoder_bitrate_from_total_bitrate(int total_bitrate_kbps, int fec_percentage) {
+    if (fec_percentage > 0 && fec_percentage <= 80) {
+      return total_bitrate_kbps * (100 - fec_percentage) / 100;
+    }
+
+    return total_bitrate_kbps;
+  }
+
+  int
+  cap_encoder_bitrate(int encoder_bitrate_kbps, int max_total_bitrate_kbps, int fec_percentage) {
+    if (max_total_bitrate_kbps <= 0) {
+      return encoder_bitrate_kbps;
+    }
+
+    return std::min(
+      encoder_bitrate_kbps,
+      encoder_bitrate_from_total_bitrate(max_total_bitrate_kbps, fec_percentage)
+    );
+  }
+
   std::chrono::duration<double, std::milli>
   minimum_frame_time_for_vrr(int stream_fps, int minimum_fps_target) {
     if (minimum_fps_target > 0) {
@@ -618,12 +639,10 @@ namespace video {
     set_bitrate(int bitrate_kbps) override {
       if (!avcodec_ctx) return;
 
-      // Adjust encoding bitrate considering FEC overhead
-      // When FEC percentage is X%, actual encoding bitrate should be (100-X)% of requested
-      auto adjusted_bitrate_kbps = bitrate_kbps;
-      if (config::stream.fec_percentage > 0 && config::stream.fec_percentage <= 80) {
-        adjusted_bitrate_kbps = bitrate_kbps * (100 - config::stream.fec_percentage) / 100;
-      }
+      const auto adjusted_bitrate_kbps = encoder_bitrate_from_total_bitrate(
+        bitrate_kbps,
+        config::stream.fec_percentage
+      );
 
       auto bitrate = static_cast<int64_t>(adjusted_bitrate_kbps) * 1000;  // Convert to bps
 
@@ -751,10 +770,10 @@ namespace video {
       if (device && device->nvenc) {
         // 考虑FEC影响，调整编码码率
         // 当FEC百分比为X%时，实际编码码率需要调整为原始码率的(100-X)%
-        auto adjusted_bitrate_kbps = bitrate_kbps;
-        if (config::stream.fec_percentage <= 80) {
-          adjusted_bitrate_kbps = (int) (bitrate_kbps * (100 - config::stream.fec_percentage) / 100.0f);
-        }
+        const auto adjusted_bitrate_kbps = encoder_bitrate_from_total_bitrate(
+          bitrate_kbps,
+          config::stream.fec_percentage
+        );
 
         device->nvenc->set_bitrate(adjusted_bitrate_kbps);
         BOOST_LOG(info) << "NVENC encoder bitrate changed to: " << adjusted_bitrate_kbps
@@ -924,10 +943,10 @@ namespace video {
     void
     set_bitrate(int bitrate_kbps) override {
       if (device && device->amf) {
-        auto adjusted_bitrate_kbps = bitrate_kbps;
-        if (config::stream.fec_percentage <= 80) {
-          adjusted_bitrate_kbps = (int) (bitrate_kbps * (100 - config::stream.fec_percentage) / 100.0f);
-        }
+        const auto adjusted_bitrate_kbps = encoder_bitrate_from_total_bitrate(
+          bitrate_kbps,
+          config::stream.fec_percentage
+        );
 
         device->amf->set_bitrate(adjusted_bitrate_kbps);
         BOOST_LOG(info) << "AMF standalone encoder bitrate changed to: " << adjusted_bitrate_kbps
@@ -2513,7 +2532,7 @@ namespace video {
         }
       }
 
-      auto bitrate = ((config::video.max_bitrate > 0) ? std::min(config.bitrate, config::video.max_bitrate) : config.bitrate) * 1000;
+      auto bitrate = config.bitrate * 1000;
       BOOST_LOG(info) << "Streaming bitrate is " << bitrate;
       ctx->rc_max_rate = bitrate;
       ctx->bit_rate = bitrate;
@@ -2832,17 +2851,30 @@ namespace video {
 
   std::unique_ptr<encode_session_t>
   make_encode_session(platf::display_t *disp, const encoder_t &encoder, const config_t &config, int width, int height, std::unique_ptr<platf::encode_device_t> encode_device, bool is_probe = false) {
+    auto effective_config = config;
+    effective_config.bitrate = cap_encoder_bitrate(
+      config.bitrate,
+      config::video.max_bitrate,
+      config::stream.fec_percentage
+    );
+    if (!is_probe && effective_config.bitrate != config.bitrate) {
+      BOOST_LOG(info) << "Capping initial encoder bitrate from " << config.bitrate
+                      << " Kbps to " << effective_config.bitrate
+                      << " Kbps (host maximum total bitrate: " << config::video.max_bitrate
+                      << " Kbps, FEC: " << config::stream.fec_percentage << "%)";
+    }
+
     if (dynamic_cast<platf::avcodec_encode_device_t *>(encode_device.get())) {
       auto avcodec_encode_device = boost::dynamic_pointer_cast<platf::avcodec_encode_device_t>(std::move(encode_device));
-      return make_avcodec_encode_session(disp, encoder, config, width, height, std::move(avcodec_encode_device));
+      return make_avcodec_encode_session(disp, encoder, effective_config, width, height, std::move(avcodec_encode_device));
     }
     else if (dynamic_cast<platf::nvenc_encode_device_t *>(encode_device.get())) {
       auto nvenc_encode_device = boost::dynamic_pointer_cast<platf::nvenc_encode_device_t>(std::move(encode_device));
-      return make_nvenc_encode_session(disp, config, std::move(nvenc_encode_device), is_probe);
+      return make_nvenc_encode_session(disp, effective_config, std::move(nvenc_encode_device), is_probe);
     }
     else if (dynamic_cast<platf::amf_encode_device_t *>(encode_device.get())) {
       auto amf_encode_device = boost::dynamic_pointer_cast<platf::amf_encode_device_t>(std::move(encode_device));
-      return make_amf_encode_session(disp, config, std::move(amf_encode_device), is_probe);
+      return make_amf_encode_session(disp, effective_config, std::move(amf_encode_device), is_probe);
     }
 
     return nullptr;

--- a/src/video.h
+++ b/src/video.h
@@ -135,6 +135,12 @@ namespace video {
     }
   };
 
+  int
+  encoder_bitrate_from_total_bitrate(int total_bitrate_kbps, int fec_percentage);
+
+  int
+  cap_encoder_bitrate(int encoder_bitrate_kbps, int max_total_bitrate_kbps, int fec_percentage);
+
   struct input_activity_boost_policy_t {
     bool configured {};
     bool useful {};

--- a/src/video.h
+++ b/src/video.h
@@ -135,11 +135,17 @@ namespace video {
     }
   };
 
+  // Convert a total video transport budget (including FEC) to encoder bitrate.
   int
   encoder_bitrate_from_total_bitrate(int total_bitrate_kbps, int fec_percentage);
 
+  // Cap a dynamic total-bitrate request, then convert it to encoder bitrate.
   int
-  cap_encoder_bitrate(int encoder_bitrate_kbps, int max_total_bitrate_kbps, int fec_percentage);
+  encoder_bitrate_for_total_request(int requested_total_bitrate_kbps, int max_total_bitrate_kbps, int fec_percentage);
+
+  // Cap an initial bitrate that has already been converted to an encoder budget.
+  int
+  cap_initial_encoder_bitrate(int initial_encoder_bitrate_kbps, int max_total_bitrate_kbps, int fec_percentage);
 
   struct input_activity_boost_policy_t {
     bool configured {};

--- a/tests/unit/test_video.cpp
+++ b/tests/unit/test_video.cpp
@@ -120,6 +120,18 @@ TEST(HlgSystemGamma, FallsBackToReferencePeakForInvalidValues) {
   EXPECT_NEAR(video::hlg_system_gamma(std::numeric_limits<float>::quiet_NaN()), 1.2f, 0.00001f);
 }
 
+TEST(VideoBitrate, ConvertsTotalBitrateToEncoderBitrate) {
+  EXPECT_EQ(video::encoder_bitrate_from_total_bitrate(50000, 10), 45000);
+  EXPECT_EQ(video::encoder_bitrate_from_total_bitrate(50000, 0), 50000);
+  EXPECT_EQ(video::encoder_bitrate_from_total_bitrate(50000, 81), 50000);
+}
+
+TEST(VideoBitrate, CapsEncoderBitrateUsingTotalBitrateLimit) {
+  EXPECT_EQ(video::cap_encoder_bitrate(90000, 0, 10), 90000);
+  EXPECT_EQ(video::cap_encoder_bitrate(90000, 50000, 10), 45000);
+  EXPECT_EQ(video::cap_encoder_bitrate(40000, 50000, 10), 40000);
+}
+
 TEST(HdrPipelineStatus, RegistersUpdatesAndRemovesPipelineState) {
   video::hdr_pipeline_status_t status {
     .hdr_mode = "hlg",

--- a/tests/unit/test_video.cpp
+++ b/tests/unit/test_video.cpp
@@ -122,7 +122,9 @@ TEST(HlgSystemGamma, FallsBackToReferencePeakForInvalidValues) {
 
 TEST(VideoBitrate, ConvertsTotalBitrateToEncoderBitrate) {
   EXPECT_EQ(video::encoder_bitrate_from_total_bitrate(50000, 10), 45000);
+  EXPECT_EQ(video::encoder_bitrate_from_total_bitrate(50000, 80), 10000);
   EXPECT_EQ(video::encoder_bitrate_from_total_bitrate(50000, 0), 50000);
+  EXPECT_EQ(video::encoder_bitrate_from_total_bitrate(50000, -1), 50000);
   EXPECT_EQ(video::encoder_bitrate_from_total_bitrate(50000, 81), 50000);
 }
 

--- a/tests/unit/test_video.cpp
+++ b/tests/unit/test_video.cpp
@@ -128,10 +128,16 @@ TEST(VideoBitrate, ConvertsTotalBitrateToEncoderBitrate) {
   EXPECT_EQ(video::encoder_bitrate_from_total_bitrate(50000, 81), 50000);
 }
 
-TEST(VideoBitrate, CapsEncoderBitrateUsingTotalBitrateLimit) {
-  EXPECT_EQ(video::cap_encoder_bitrate(90000, 0, 10), 90000);
-  EXPECT_EQ(video::cap_encoder_bitrate(90000, 50000, 10), 45000);
-  EXPECT_EQ(video::cap_encoder_bitrate(40000, 50000, 10), 40000);
+TEST(VideoBitrate, ConvertsCappedTotalRequestToEncoderBitrate) {
+  EXPECT_EQ(video::encoder_bitrate_for_total_request(90000, 0, 10), 81000);
+  EXPECT_EQ(video::encoder_bitrate_for_total_request(90000, 50000, 10), 45000);
+  EXPECT_EQ(video::encoder_bitrate_for_total_request(40000, 50000, 10), 36000);
+}
+
+TEST(VideoBitrate, CapsInitialEncoderBitrateUsingTotalBitrateLimit) {
+  EXPECT_EQ(video::cap_initial_encoder_bitrate(90000, 0, 10), 90000);
+  EXPECT_EQ(video::cap_initial_encoder_bitrate(90000, 50000, 10), 45000);
+  EXPECT_EQ(video::cap_initial_encoder_bitrate(40000, 50000, 10), 40000);
 }
 
 TEST(HdrPipelineStatus, RegistersUpdatesAndRemovesPipelineState) {


### PR DESCRIPTION
## What

- apply the host `max_bitrate` limit before creating AVCodec, native NVENC, or native AMF sessions
- convert the configured total-bitrate ceiling to an encoder bitrate after FEC overhead
- reuse the same total-to-encoder conversion for runtime bitrate updates
- add regression coverage for capped, uncapped, and invalid-FEC cases

## Why

启动码率和串流中动态调码走了两套语义：通用 AVCodec 路径会在启动时看 `max_bitrate`，native NVENC/AMF 却直接使用客户端码率；动态调码又先按总码率上限截断，再扣除 FEC。于是同一条流在启动时可以超过 host 上限，调高码率后反而被压回去——这只杂鱼 bug 看起来就像动态调码失效了。

## Root cause

`config_t::bitrate` is already the video encoder budget after FEC, while `config::video.max_bitrate` is a total stream bitrate. The startup AVCodec clamp compared those values directly, native encoder startup skipped the clamp entirely, and runtime updates performed the correct total-bitrate clamp before the encoder-specific FEC adjustment.

## Impact

For `max_bitrate = 50000` and `fec_percentage = 10`, every encoder path now starts with at most `45000 Kbps` of video bitrate and runtime updates obey the same ceiling. A disabled maximum (`0`) keeps the requested encoder bitrate unchanged.

## Checks

- `git diff --cached --check`
- syntax-compiled `src/video.cpp` with the existing Windows build command
- syntax-compiled `tests/unit/test_video.cpp` with the existing Windows test build command
- full test executable was not rebuilt because isolated-worktree submodule initialization stalled