### PR TITLE
fix(shaders): correct chroma siting and filtering in the compute-shader converters

### DIFF
--- a/src_assets/windows/assets/shaders/directx/include/convert_yuv420_nv12p010_cs_base.hlsl
+++ b/src_assets/windows/assets/shaders/directx/include/convert_yuv420_nv12p010_cs_base.hlsl
@@ -2,7 +2,8 @@
 //
 // Each threadgroup writes a 16x16 block of Y plane + 8x8 block of UV plane.
 // One source RGB sample per thread is cached in groupshared memory, then reused
-// for both Y (per pixel) and UV (2x2 box filter, matching LEFT_SUBSAMPLING PS).
+// for both Y (per pixel) and UV (type-0 sited chroma tent, matching the
+// LEFT_SUBSAMPLING PS).
 //
 // Includer must `#define CONVERT_FUNCTION fn` before including this file.
 //
@@ -38,9 +39,12 @@ cbuffer cs_layout_cbuffer : register(b1) {
 
 #include "include/hdr_analysis_snapshot.hlsl"
 
-groupshared float3 s_rgb[16][16];
-
 #define CS_TILE 16
+
+// Column 0 is a left halo: s_rgb[y][k] holds the pixel at tile column (k - 1).
+// The type-0 chroma tent reaches one pixel to the left of each 2x2 block, which
+// for GTid.x == 0 lives in the previous threadgroup.
+groupshared float3 s_rgb[CS_TILE][CS_TILE + 1];
 
 [numthreads(CS_TILE, CS_TILE, 1)]
 void main_cs(uint3 DTid : SV_DispatchThreadID,
@@ -58,7 +62,19 @@ void main_cs(uint3 DTid : SV_DispatchThreadID,
     if (inside_rect && src_pos.x < src_size.x && src_pos.y < src_size.y) {
         src_rgb = source_image.Load(int3(src_pos, 0)).rgb;
     }
-    s_rgb[GTid.y][GTid.x] = src_rgb;
+    s_rgb[GTid.y][GTid.x + 1] = src_rgb;
+
+    // Left halo column, needed by the chroma tent of the leftmost 2x2 block.
+    // At the rect's left edge we replicate the first column, which is exactly what
+    // the pixel shader's CLAMP sampler does.
+    if (GTid.x == 0u) {
+        float3 halo_rgb = src_rgb;
+        int halo_x = rect_pos.x - 1;
+        if (halo_x >= 0 && halo_x < src_size.x && inside_rect && src_pos.y < src_size.y) {
+            halo_rgb = source_image.Load(int3(halo_x, src_pos.y, 0)).rgb;
+        }
+        s_rgb[GTid.y][0] = halo_rgb;
+    }
 
     GroupMemoryBarrierWithGroupSync();
 
@@ -112,25 +128,26 @@ void main_cs(uint3 DTid : SV_DispatchThreadID,
     // ---- UV plane (one thread per 2x2 block) ----
     // Only threads at even (gx, gy) within the tile emit a UV pixel.
     if ((GTid.x & 1u) == 0u && (GTid.y & 1u) == 0u) {
-        // Bounds check on the UV pixel: we need 2x2 source coverage.
-        bool uv_inside = (rect_pos.x + 1 < out_rect_size.x) && (rect_pos.y + 1 < out_rect_size.y);
-        // Allow edge UV pixels even when the second column/row is out-of-rect: just clamp the average.
-        // Initialize to silence fxc X4000 (the else-branch returns, so the read is safe at runtime,
-        // but the compiler's flow analysis cannot prove it through the early `return`).
-        float3 rgb_avg = float3(0, 0, 0);
-        if (uv_inside) {
-            rgb_avg = (s_rgb[GTid.y    ][GTid.x    ] +
-                       s_rgb[GTid.y    ][GTid.x + 1] +
-                       s_rgb[GTid.y + 1][GTid.x    ] +
-                       s_rgb[GTid.y + 1][GTid.x + 1]) * 0.25;
-        }
-        else if (rect_pos.x < out_rect_size.x && rect_pos.y < out_rect_size.y) {
-            // Edge: fall back to a single sample.
-            rgb_avg = s_rgb[GTid.y][GTid.x];
-        }
-        else {
+        if (rect_pos.x >= out_rect_size.x || rect_pos.y >= out_rect_size.y) {
             return;
         }
+
+        // Type-0 chroma siting (the H.264/HEVC default when chroma_sample_loc is
+        // unspecified): horizontally co-sited with the left luma column, vertically
+        // centred between the two luma rows. That is a [1/4, 1/2, 1/4] horizontal
+        // tent times a [1/2, 1/2] vertical average -- the same effective filter the
+        // LEFT_SUBSAMPLING pixel shader gets from its two bilinear taps. A plain 2x2
+        // box would instead sit half a luma pixel to the right.
+        uint lx = GTid.x;       // pixel at rect_pos.x - 1 (halo column when GTid.x == 0)
+        uint cx = GTid.x + 1u;  // pixel at rect_pos.x
+        // Replicate at the right/bottom edges, matching the clamped sampler.
+        uint rx = (rect_pos.x + 1 < out_rect_size.x) ? (GTid.x + 2u) : cx;
+        uint ty = GTid.y;
+        uint by = (rect_pos.y + 1 < out_rect_size.y) ? (GTid.y + 1u) : ty;
+
+        float3 rgb_avg = (s_rgb[ty][lx] + s_rgb[by][lx]) * 0.125 +
+                         (s_rgb[ty][cx] + s_rgb[by][cx]) * 0.25 +
+                         (s_rgb[ty][rx] + s_rgb[by][rx]) * 0.125;
 
         float3 rgb_uv = CONVERT_FUNCTION(rgb_avg);
         float u = dot(color_vec_u.xyz, rgb_uv) + color_vec_u.w;

--- a/src_assets/windows/assets/shaders/directx/include/convert_yuv420_nv12p010_cs_scaled_base.hlsl
+++ b/src_assets/windows/assets/shaders/directx/include/convert_yuv420_nv12p010_cs_scaled_base.hlsl
@@ -5,7 +5,9 @@
 // using:
 //   - Y plane: 5-tap Catmull-Rom via bilinear samples (matches PS bicubic
 //     quality with ~5 SampleLevel taps vs PS's 16 raw taps).
-//   - UV plane: hardware bilinear box filter at the 2x2 chroma center.
+//   - UV plane: 6 bilinear taps forming the type-0 sited chroma filter
+//     ([1,2,1]/4 horizontal x [1,1]/2 vertical), matching the
+//     LEFT_SUBSAMPLING_SCALE PS.
 //
 // Includer must `#define CONVERT_FUNCTION fn` before including this file.
 //
@@ -150,18 +152,32 @@ void main_cs(uint3 DTid : SV_DispatchThreadID,
 
     // ---- UV plane (one thread per 2x2 block) ----
     if ((GTid.x & 1u) == 0u && (GTid.y & 1u) == 0u) {
-        bool uv_inside_pair = (rect_pos.x + 1 < out_rect_size.x) && (rect_pos.y + 1 < out_rect_size.y);
-        if (!uv_inside_pair && !inside_rect) {
+        if (!inside_rect) {
             return;
         }
-        // Hardware bilinear box: sample at the center of the 2x2 output pixel
-        // group, mapped into source UV space. For non-edge UV pixels this is
-        // equivalent to averaging the 4 surrounding source taps weighted by
-        // the inverse-scale; cheaper than 4x Catmull-Rom and visually fine for
-        // chroma (already half-resolution).
-        float2 uv_pair_center_out = float2(rect_pos + 1);  // center of (rect_pos, rect_pos+1) box
-        float2 uv_norm = uv_pair_center_out / float2(out_rect_size);
-        float3 rgb_avg = source_image.SampleLevel(linear_sampler, uv_norm, 0).rgb;
+        // Type-0 chroma siting: horizontally co-sited with the left luma column,
+        // vertically centred between the two luma rows. Six bilinear taps at output
+        // pixel centres, weighted [1, 2, 1] / 8 per row across both rows -- the same
+        // tap layout and weights as the LEFT_SUBSAMPLING_SCALE pixel shader.
+        //
+        // A single tap at the 2x2 centre (what this used to do) is both mis-sited by
+        // half a luma pixel and far too narrow when downscaling: at 2x it reads one
+        // 2x2 source neighbourhood where the chroma pixel actually spans 4x4.
+        // The CLAMP sampler supplies edge replication at the rect borders.
+        float2 inv_out = 1.0 / float2(out_rect_size);
+        float xl = (float(rect_pos.x) - 0.5) * inv_out.x;
+        float xc = (float(rect_pos.x) + 0.5) * inv_out.x;
+        float xr = (float(rect_pos.x) + 1.5) * inv_out.x;
+        float yt = (float(rect_pos.y) + 0.5) * inv_out.y;
+        float yb = (float(rect_pos.y) + 1.5) * inv_out.y;
+
+        float3 rgb_avg =
+            (source_image.SampleLevel(linear_sampler, float2(xl, yt), 0).rgb +
+             source_image.SampleLevel(linear_sampler, float2(xl, yb), 0).rgb) * 0.125 +
+            (source_image.SampleLevel(linear_sampler, float2(xc, yt), 0).rgb +
+             source_image.SampleLevel(linear_sampler, float2(xc, yb), 0).rgb) * 0.25 +
+            (source_image.SampleLevel(linear_sampler, float2(xr, yt), 0).rgb +
+             source_image.SampleLevel(linear_sampler, float2(xr, yb), 0).rgb) * 0.125;
 
         float3 rgb_uv = CONVERT_FUNCTION(rgb_avg);
         float u = dot(color_vec_u.xyz, rgb_uv) + color_vec_u.w;


### PR DESCRIPTION
## 问题

RGB → NV12/P010 的 **compute shader** 路径产生的色度与编码器实际信令的 **type-0 siting** 不一致，缩放变体的色度滤波还严重欠采样。

type-0（`chroma_sample_loc` 未指定时 H.264/HEVC 的默认值）要求色度采样点**水平与左侧亮度列同位**、垂直位于两行亮度之间。

Pixel shader 路径本来就是对的：`LEFT_SUBSAMPLING` 的两个 clamp 双线性抽头展开后等价于水平 `[1/4, 1/2, 1/4]` tent × 垂直 `[1/2, 1/2]`，水平重心正好落在左侧亮度列上。

### 1. `convert_yuv420_nv12p010_cs_base.hlsl` — 色度位置偏移

用的是普通 2×2 box。水平重心落在两列亮度**中间**，比解码器重建的位置**右偏半个亮度像素**。

在色彩边界上表现为轻微的色度横向位移／色边不对齐，静态画面尤其容易看出来。

### 2. `convert_yuv420_nv12p010_cs_scaled_base.hlsl` — 色度只有 1 个抽头

在 2×2 中心取**一个**双线性抽头。除了同样的半像素偏移之外，2× 缩小时它只读到一个 2×2 的源邻域，而这个色度像素实际覆盖 4×4 —— **16 个源像素里只有 4 个参与**，其余直接丢弃。高频区域的色度会出现明显的锯齿／闪烁。

## 改动

**base（非缩放）**：换成同样的 tent。它需要左侧一个像素的上下文，因此 groupshared tile 增加一列 halo（`s_rgb[y][k]` 现在存 tile 第 `k-1` 列）。在 rect 左边界 halo 复制第 0 列，精确复现 PS 路径 CLAMP sampler 的结果（`0.75*c0 + 0.25*c1`）。右／下边界同样 clamp，替换掉原来"退化成单点采样"的边缘分支。

**scaled**：换成 6 个抽头，落在输出像素中心，两行各按 `[1,2,1]/4` 加权 —— 与 PS 路径的 `LEFT_SUBSAMPLING_SCALE` 抽头布局和权重完全一致。

两个文件的头部注释原本都声称 box filter "matching LEFT_SUBSAMPLING PS"，一并订正。

## 影响范围

CS 路径的启用条件是 `is_scaled || (is_p010 && hdr_analysis)`（`display_vram.cpp` 的 `capture_compute_shader=auto`），所以受影响的是：

- **所有分辨率不匹配的串流**（客户端分辨率 ≠ 显示器分辨率）
- **默认配置下的 HDR 串流**（P010 + HDR analysis）

SDR 且分辨率一致的场景走 PS 路径，本来就是正确的，不受影响。

## 验证情况

### Shader 编译

- ✅ 作者原有验证：8 个 CS 入口 shader（NV12/P010 × linear/passthrough/PQ/HLG × scaled/非 scaled）全部通过 `glslangValidator -D`；同时覆盖 `HDR_ANALYSIS_SNAPSHOT` 定义与否。
- ✅ Windows SDK `fxc.exe` 本机验证：使用与运行时 `D3DCompileFromFile` 相同的入口和目标（`main_cs / cs_5_0`），8 个普通入口 + 4 个 P010 `HDR_ANALYSIS_SNAPSHOT` 组合共 **12/12 通过**。
- ✅ 同一批 12 个组合在 Release 优化配置和 Debug `/Od /Zi` 配置下均为 **12/12 通过**，未出现 groupshared 动态索引或 shader model 兼容问题。
- ℹ️ DXC（`cs_6_0`）可编译两个 passthrough 变体；其余变体会在项目既有的 `include/common.hlsl` 向量三元表达式处失败。基线 commit `7bfc643e5` 同样失败，因此不是本 PR 引入的问题；当前运行时使用 FXC，不影响本 PR。

### PS/CS 数值等价验证

使用随机图像覆盖缩小、放大、奇偶 active 尺寸，共检查 1814 个 UV 输出点：

- 非缩放 CS 与 `LEFT_SUBSAMPLING` PS 的最大绝对误差：`1.11e-16`
- scaled CS 与 `LEFT_SUBSAMPLING_SCALE` PS 的最大绝对误差：`2.22e-16`

误差仅为浮点舍入量，采样坐标、CLAMP 边界行为和权重可以认为与 PS 路径完全等价。另已确认 groupshared 最大索引均在新的 `16×17` tile 范围内，`git diff --check` 通过。

### 尚未覆盖

- ⚠️ 尚未在真实缩放/HDR 串流中抓帧，对比 `capture_compute_shader=off` 与 CS 输出。
- ⚠️ 尚未对实际 GPU 帧时间进行 profiling。静态指令检查显示 scaled 路径平均纹理采样约从 `5.25` 增至 `6.5` 次/线程（约 +24%），最终性能影响应以 GPU 实测为准。
- 建议继续主观检查红/蓝文字边缘和高饱和度细节，并确认日志没有 `cs_fallback_reason` 相关的 shader 编译失败。

## 性能

- base：每组多 16 次 `Load`（halo 列），LDS 从 `16×16` 变成 `16×17` float3（3 KB → 3.2 KB），不影响 occupancy。UV 线程从 4 次 LDS 读变成 6 次。可以忽略。
- scaled：UV 从 1 次 `SampleLevel` 变成 6 次，但只有 1/4 的线程执行这段。相对整个 dispatch（每线程 5 次 Catmull-Rom 抽头）增量很小。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
