### PR TITLE
fix(build): 修复 Debug 构建链接失败（托盘守卫 + big-obj）

### DIFF
--- a/cmake/compile_definitions/windows.cmake
+++ b/cmake/compile_definitions/windows.cmake
@@ -14,6 +14,12 @@ list(APPEND SUNSHINE_COMPILE_OPTIONS -Wno-misleading-indentation)
 # can remove after https://gcc.gnu.org/bugzilla/show_bug.cgi?id=120495 is available in mingw-w64
 list(APPEND SUNSHINE_COMPILE_OPTIONS -Wno-template-body)
 
+# Template-heavy translation units (confighttp.cpp in particular) exceed the
+# 32767-section COFF limit. Without big-obj the assembler silently writes a
+# corrupt symbol table whose COMDAT entries (typeinfo, inline members) then
+# resolve as undefined at link time.
+list(APPEND SUNSHINE_COMPILE_OPTIONS -Wa,-mbig-obj)
+
 # see gcc bug 98723
 add_definitions(-DUSE_BOOST_REGEX)
 

--- a/cmake/compile_definitions/windows.cmake
+++ b/cmake/compile_definitions/windows.cmake
@@ -18,7 +18,17 @@ list(APPEND SUNSHINE_COMPILE_OPTIONS -Wno-template-body)
 # 32767-section COFF limit. Without big-obj the assembler silently writes a
 # corrupt symbol table whose COMDAT entries (typeinfo, inline members) then
 # resolve as undefined at link time.
-list(APPEND SUNSHINE_COMPILE_OPTIONS -Wa,-mbig-obj)
+#
+# Gated on GNU unlike the -Wno-* flags above: clang only warns about an unknown
+# -Wno-*, but rejects an unknown -Wa, argument outright, so an unconditional
+# flag here would hard-fail a clang-based MinGW build (e.g. MSYS2 CLANG64).
+# A plain if() rather than a COMPILE_LANG_AND_ID genex, because
+# cmake/targets/common.cmake wraps every SUNSHINE_COMPILE_OPTIONS entry as
+# --compiler-options=<flag> for CUDA, and a genex there would degrade to a bare
+# --compiler-options= for CUDA translation units.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    list(APPEND SUNSHINE_COMPILE_OPTIONS -Wa,-mbig-obj)
+endif()
 
 # see gcc bug 98723
 add_definitions(-DUSE_BOOST_REGEX)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -105,10 +105,12 @@ ConsoleCtrlHandler(DWORD type) {
 }
 #endif
 
+// Unused on Windows when the GUI agent owns the tray (SUNSHINE_TRAY=0): the
+// only remaining reader is the POSIX main-loop condition below.
 #if defined SUNSHINE_TRAY && SUNSHINE_TRAY >= 1
-constexpr bool tray_is_enabled = true;
+[[maybe_unused]] constexpr bool tray_is_enabled = true;
 #else
-constexpr bool tray_is_enabled = false;
+[[maybe_unused]] constexpr bool tray_is_enabled = false;
 #endif
 
 void
@@ -129,7 +131,14 @@ mainThreadLoop(const std::shared_ptr<safe::event_t<bool>> &shutdown_event) {
 
   // Main thread event loop
   BOOST_LOG(info) << "Starting main loop"sv;
+#if defined SUNSHINE_TRAY && SUNSHINE_TRAY >= 1
   while (system_tray::process_tray_events() == 0);
+#else
+  // Only the in-process tray sets run_loop, so this build cannot reach here.
+  // Block on shutdown anyway: falling through would return to main() and tear
+  // the host down immediately if another main-thread feature is ever added.
+  shutdown_event->view();
+#endif
   BOOST_LOG(info) << "Main loop has exited"sv;
 }
 
@@ -477,19 +486,21 @@ main(int argc, char *argv[]) {
   }
 #endif
 
+#if defined SUNSHINE_TRAY && SUNSHINE_TRAY >= 1
   if (tray_is_enabled && config::sunshine.system_tray) {
     BOOST_LOG(info) << "Starting system tray"sv;
-#ifdef _WIN32
+  #ifdef _WIN32
     // TODO: Windows has a weird bug where when running as a service and on the first Windows boot,
     // he tray icon would not appear even though Sunshine is running correctly otherwise.
     // Restarting the service would allow the icon to appear normally.
     // For now we will keep the Windows tray icon on a separate thread.
     // Ideally, we would run the system tray on the main thread for all platforms.
     system_tray::init_tray_threaded();
-#else
+  #else
     system_tray::init_tray();
-#endif
+  #endif
   }
+#endif
 
   mainThreadLoop(shutdown_event);
 


### PR DESCRIPTION
## 概述

从 #845 摘出两处独立的构建修复。#845 的主体（VDD 模式 XML 缓存）在当前 SETMODES 架构下已无收益且有回归风险，建议单独关掉，本 PR 不含那部分。

两处问题都只在 Release CI 矩阵之外触发，所以 CI 一直是绿的。

## 变更内容

### 1. `main.cpp` 托盘守卫

`main.cpp` 的 3 处 `system_tray::` 引用是全仓库**仅剩的未加守卫**的调用点——`vdd_utils`、`stream`、`process`、`pairing`、`audio`、`tray_state`，以及 `main.cpp` 自己的 `end_tray()` 两处，全都有 `#if defined SUNSHINE_TRAY && SUNSHINE_TRAY >= 1`。

托盘统一到 GUI agent 之后，Windows 默认配置是 `SUNSHINE_ENABLE_TRAY=ON` + `SUNSHINE_ENABLE_LEGACY_TRAY=OFF`（见 `cmake/prep/options.cmake`），推导出 `SUNSHINE_TRAY=0` / `SUNSHINE_GUI_TRAY=1`。此时 `src/tray/system_tray.cpp` 整个文件体被 `#if SUNSHINE_TRAY >= 1` 包住，是个**空编译单元，不产生任何符号**。

Release 能链接过只是因为 `constexpr bool tray_is_enabled = false` 让优化器在链接器看到之前就删掉了分支；`-O0` 不删，于是**默认配置的 Debug 构建链接失败**。

### 2. `-Wa,-mbig-obj`

`confighttp.cpp` 等模板密集编译单元超过 COFF 32767 段上限，汇编器静默写坏 COMDAT 符号表，Debug 链接报大量 typeinfo/内联符号未定义。

## 设计取舍

**为什么加守卫而不是删掉这几行。** 托盘统一到 GUI agent 是 **Windows-only** 的。Linux 上 `cmake/compile_definitions/linux.cmake` 在 appindicator + libnotify 存在时仍设 `SUNSHINE_TRAY=1`，`mainThreadLoop` 里的 `process_tray_events()` 就是 Linux 托盘的事件泵，`init_tray()` 也是活代码。删掉会直接破坏 Linux。`tray_state.cpp` 的 `tray_owner()` 返回 `core` / `gui` / `disabled` 三态，也印证三种配置都还在支持范围内。

**`mainThreadLoop` 的 `#else` 分支为什么阻塞而不是留空。** `run_loop` 目前只由托盘条件置位，所以 `SUNSHINE_TRAY=0` 时那段不可达。但如果只写 `#if`/`#endif`，将来一旦有别的 main-thread 特性把 `run_loop` 置真，函数会直接返回到 `main()` 并立刻走完整个关闭流程。`#else` 里 `shutdown_event->view()` 保持了阻塞语义。

**`[[maybe_unused]]`。** 加守卫后 `tray_is_enabled` 在 Windows + `SUNSHINE_TRAY=0` 下失去唯一读者（`mainThreadLoop` 里那处在 `#ifndef _WIN32` 内）。GCC 的 `-Wunused-const-variable` 在 C++ 下不随 `-Wall` 开启，所以现网 msys2 GCC 不会报；但 clang 会，`BUILD_WERROR=ON` 时是 error。加 `[[maybe_unused]]` 以免依赖编译器特定的告警行为。

## 测试

**未做完整构建验证**——本地无 cmake/ninja 环境，且 CI 只跑 Release（问题本身不在 Release 中出现）。已验证的部分：

- 把 `mainThreadLoop` / 托盘初始化两段连同预处理条件抽成独立编译单元，在 `SUNSHINE_TRAY` × `_WIN32` 四种组合下用 `-Wall -Wno-sign-compare -Werror`（项目实际告警配置）全部通过
- 复核全仓库 `system_tray::` 引用，确认改后无遗漏的未守卫调用点
- `-Wa,-mbig-obj` 经 `cmake/targets/common.cmake` 只作用于 `COMPILE_LANGUAGE:CXX`；`windows.cmake` 无 MSVC/clang-cl 分支，CI 用 msys2 ucrt64 GCC，与文件内既有的 GCC 专用 flag 一致

**需要 reviewer 补的验证**：Windows Debug（MSYS2 UCRT64）默认配置全量重编译 + 链接，以及一次 Linux 构建确认托盘仍正常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
