### PR TITLE
fix(installer): 安装失败时保留已安装文件，并修掉 finish page 的 740 报错

### DIFF
--- a/cmake/packaging/FetchDriverDeps.cmake
+++ b/cmake/packaging/FetchDriverDeps.cmake
@@ -163,10 +163,8 @@ endfunction()
 # forwarded auth headers. We must use the GitHub REST API asset endpoint
 # with Accept: application/octet-stream.
 # ---------------------------------------------------------------------------
-function(_fetch_vmouse)
+function(_fetch_vmouse_impl _files)
   message(STATUS "Fetching ZakoVirtualMouse ${VMOUSE_DRIVER_VERSION} ...")
-
-  set(_files ZakoVirtualMouse.dll ZakoVirtualMouse.inf ZakoVirtualMouse.cat ZakoVirtualMouse.cer)
 
   # Check if all files already cached
   set(_all_cached TRUE)
@@ -280,6 +278,44 @@ function(_fetch_vmouse)
   endforeach()
 
   file(REMOVE "${_json}")
+endfunction()
+
+# The vmouse assets are downloaded as bare filenames with no version in them, so
+# a cache populated by an older VMOUSE_DRIVER_VERSION looks complete forever and
+# a pin bump silently ships the old driver on any tree that was configured
+# before. Stamp the tag next to the files and wipe the cache when it changes.
+function(_fetch_vmouse)
+  set(_files ZakoVirtualMouse.dll ZakoVirtualMouse.inf ZakoVirtualMouse.cat ZakoVirtualMouse.cer)
+  set(_marker "${VMOUSE_DRIVER_DIR}/.release-version")
+
+  set(_stamp_ok FALSE)
+  if(EXISTS "${_marker}")
+    file(READ "${_marker}" _current)
+    string(STRIP "${_current}" _current)
+    if("${_current}" STREQUAL "${VMOUSE_DRIVER_VERSION}")
+      set(_stamp_ok TRUE)
+    endif()
+  endif()
+
+  if(NOT _stamp_ok AND EXISTS "${VMOUSE_DRIVER_DIR}")
+    message(STATUS "  vmouse cache is not ${VMOUSE_DRIVER_VERSION}; clearing ${VMOUSE_DRIVER_DIR}")
+    file(REMOVE_RECURSE "${VMOUSE_DRIVER_DIR}")
+  endif()
+
+  _fetch_vmouse_impl("${_files}")
+
+  # Only stamp a complete set — a partial download must retry on the next
+  # configure instead of being treated as a good cache.
+  set(_all_ok TRUE)
+  foreach(_f ${_files})
+    if(NOT EXISTS "${VMOUSE_DRIVER_DIR}/${_f}")
+      set(_all_ok FALSE)
+      break()
+    endif()
+  endforeach()
+  if(_all_ok)
+    file(WRITE "${_marker}" "${VMOUSE_DRIVER_VERSION}\n")
+  endif()
 endfunction()
 
 # ---------------------------------------------------------------------------

--- a/cmake/packaging/FetchDriverDeps.cmake
+++ b/cmake/packaging/FetchDriverDeps.cmake
@@ -39,7 +39,7 @@ option(FETCH_DRIVER_DEPS "Download driver dependencies from GitHub Releases" ON)
 option(DRIVER_DEPS_REQUIRED "Treat missing driver dependencies as a fatal error" ON)
 
 # Version pins
-set(VMOUSE_DRIVER_VERSION "v1.2.0" CACHE STRING "ZakoVirtualMouse driver version tag")
+set(VMOUSE_DRIVER_VERSION "v1.3.2" CACHE STRING "ZakoVirtualMouse driver version tag")
 set(VDD_DRIVER_VERSION "v0.17.2" CACHE STRING "ZakoVDD driver version tag")
 set(VDD_WIN10_DRIVER_VERSION "v0.15.3" CACHE STRING "Win10-pinned ZakoVDD driver version tag")
 set(VDD_DRIVER_ASSET_NAME "zakovdd.zip" CACHE STRING "Latest ZakoVDD release asset name")

--- a/cmake/packaging/sunshine.iss.in
+++ b/cmake/packaging/sunshine.iss.in
@@ -110,7 +110,7 @@ english.MsgOldNSISDetected=Detected a previous NSIS installation of Sunshine.%nI
 english.MsgOldNSISFailed=The previous installation could not be fully removed.%nPlease uninstall it manually and try again.
 english.MsgOldNSISStaleRegistry=The previous installation files appear to be gone, but registry entries remain.%nClean up the leftover registry and continue installing?
 english.MsgOldNSISCleanupFailed=Failed to clean up the previous installation registry entries.%nPlease remove HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Sunshine manually and try again.
-english.MsgServiceInstallFailed=Sunshine service could not be installed or verified.%n%nThe files were installed and are kept. Reboot and run scripts\install-service.bat as administrator, or use the repair action in the Sunshine GUI. The installer log in your TEMP folder has the details.
+english.MsgServiceInstallFailed=Sunshine service could not be installed or verified.%n%nThe files were installed and are kept. Reboot and run "{app}\scripts\install-service.bat" as administrator, or use the repair action in the Sunshine GUI. The installer log in your TEMP folder has the details.
 english.MsgUninstallGamepad=Do you want to remove Virtual Gamepad?
 english.MsgUninstallData=Do you want to remove all data in %1?%n(This includes configuration, cover images, and settings)
 english.StatusStoppingService=Stopping Sunshine service...
@@ -151,7 +151,7 @@ chinesesimplified.MsgOldNSISDetected=检测到旧版 NSIS 安装的 Sunshine。%
 chinesesimplified.MsgOldNSISFailed=无法完全移除旧版安装。%n请手动卸载后重试。
 chinesesimplified.MsgOldNSISStaleRegistry=旧版本的文件已经不存在，但注册表中仍残留旧版的卸载信息。%n是否清理残留的注册表项并继续安装？
 chinesesimplified.MsgOldNSISCleanupFailed=清理旧版注册表项失败。%n请手动删除 HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Sunshine 后重试。
-chinesesimplified.MsgServiceInstallFailed=无法安装或验证 Sunshine 服务。%n%n程序文件已经装好并会保留。请重启后以管理员身份运行 scripts\install-service.bat，或在 Sunshine 管理界面里使用修复功能。详细信息见 TEMP 目录下的安装日志。
+chinesesimplified.MsgServiceInstallFailed=无法安装或验证 Sunshine 服务。%n%n程序文件已经装好并会保留。请重启后以管理员身份运行 "{app}\scripts\install-service.bat"，或在 Sunshine 管理界面里使用修复功能。详细信息见 TEMP 目录下的安装日志。
 chinesesimplified.MsgUninstallGamepad=是否移除虚拟手柄（ViGEmBus）？
 chinesesimplified.MsgUninstallData=是否删除 %1 中的所有数据？%n（包括配置文件、封面图片和设置）
 chinesesimplified.StatusStoppingService=正在停止 Sunshine 服务...
@@ -305,7 +305,9 @@ Filename: "https://docs.qq.com/aio/DSGdQc3htbFJjSFdO?p=DXpTjzl2kZwBjN7jlRMkRJ"; 
 ; "无法执行文件 ... 错误代码 740" box on the finish page, which reads like the
 ; whole install failed. cmd.exe never requires elevation, and `start` uses
 ; ShellExecute, so a layered GUI just gets a normal UAC prompt instead.
-Filename: "{cmd}"; Parameters: "/c start """" ""{app}\assets\gui\{#MyAppGUIExeName}"""; Description: "{cm:FinishLaunchGUI}"; Flags: postinstall nowait runhidden skipifsilent runasoriginaluser; Components: gui
+; WorkingDir has to be spelled out now: Inno derives it from Filename when it
+; is blank, which would hand the GUI {sys} instead of its own directory.
+Filename: "{cmd}"; Parameters: "/c start """" ""{app}\assets\gui\{#MyAppGUIExeName}"""; WorkingDir: "{app}\assets\gui"; Description: "{cm:FinishLaunchGUI}"; Flags: postinstall nowait runhidden skipifsilent runasoriginaluser; Components: gui
 
 [UninstallRun]
 ; Remove the per-user GUI startup entry before terminating the agent.
@@ -357,6 +359,11 @@ var
   BrandSubtitle: TNewStaticText;
   AccentBar: TBevel;
   ExistingInnoInstall: Boolean;
+  // Set when VerifyServiceInstalled() could not confirm the SunshineService
+  // registration. Surfaced through GetCustomSetupExitCode() so unattended
+  // callers still see a failure — the GUI updater runs us with /VERYSILENT
+  // and treats exit code 0 as "update installed successfully".
+  ServiceVerifyFailed: Boolean;
 
 procedure InitializeWizard();
 var
@@ -734,7 +741,29 @@ begin
   // The files are fine; only the service registration needs another attempt,
   // which scripts\install-service.bat, the GUI's repair action, or a reboot
   // can all do. Keep the install and tell the user how to retry.
-  MsgBox(CustomMessage('MsgServiceInstallFailed') + #13#10 + #13#10 + Detail, mbError, MB_OK);
+  //
+  // The exit code still reports the failure — see GetCustomSetupExitCode().
+  ServiceVerifyFailed := True;
+  Log('Service verification failed. ' + Detail);
+  // MsgBox() ignores /SILENT (only /SUPPRESSMSGBOXES auto-answers it), so an
+  // unattended install without that switch would sit here forever now that we
+  // no longer abort. The log line above carries the same information.
+  // CustomMessage() returns the string verbatim, so {app} needs ExpandConstant.
+  if not WizardSilent then
+    MsgBox(ExpandConstant(CustomMessage('MsgServiceInstallFailed')) + #13#10 + #13#10 + Detail, mbError, MB_OK);
+end;
+
+// Report a nonzero exit code when the service could not be verified. Inno
+// returns 0 on a completed install, and callers such as the GUI's auto-updater
+// (`/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-`, success := code = 0) would
+// otherwise report a broken install as a successful update. 100 is outside the
+// range Inno itself uses (1-8).
+function GetCustomSetupExitCode(): Integer;
+begin
+  if ServiceVerifyFailed then
+    Result := 100
+  else
+    Result := 0;
 end;
 
 // Initialization: handle old NSIS upgrade

--- a/cmake/packaging/sunshine.iss.in
+++ b/cmake/packaging/sunshine.iss.in
@@ -65,6 +65,10 @@ RestartApplications=yes
 ; Driver/helper installers may return a reboot-required exit code. Do not show
 ; Inno's final reboot prompt; users can reboot later if a driver needs it.
 RestartIfNeededByRun=no
+; Always write %TEMP%\Setup Log*.txt. Support reports for "service did not
+; install" / "files disappeared" are unanswerable without the per-file and
+; per-[Run] results, and users cannot be expected to re-run with /LOG.
+SetupLogging=yes
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
@@ -106,7 +110,7 @@ english.MsgOldNSISDetected=Detected a previous NSIS installation of Sunshine.%nI
 english.MsgOldNSISFailed=The previous installation could not be fully removed.%nPlease uninstall it manually and try again.
 english.MsgOldNSISStaleRegistry=The previous installation files appear to be gone, but registry entries remain.%nClean up the leftover registry and continue installing?
 english.MsgOldNSISCleanupFailed=Failed to clean up the previous installation registry entries.%nPlease remove HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Sunshine manually and try again.
-english.MsgServiceInstallFailed=Sunshine service could not be installed or verified.%nPlease check the installer log and run the installer as administrator.
+english.MsgServiceInstallFailed=Sunshine service could not be installed or verified.%n%nThe files were installed and are kept. Reboot and run scripts\install-service.bat as administrator, or use the repair action in the Sunshine GUI. The installer log in your TEMP folder has the details.
 english.MsgUninstallGamepad=Do you want to remove Virtual Gamepad?
 english.MsgUninstallData=Do you want to remove all data in %1?%n(This includes configuration, cover images, and settings)
 english.StatusStoppingService=Stopping Sunshine service...
@@ -147,7 +151,7 @@ chinesesimplified.MsgOldNSISDetected=检测到旧版 NSIS 安装的 Sunshine。%
 chinesesimplified.MsgOldNSISFailed=无法完全移除旧版安装。%n请手动卸载后重试。
 chinesesimplified.MsgOldNSISStaleRegistry=旧版本的文件已经不存在，但注册表中仍残留旧版的卸载信息。%n是否清理残留的注册表项并继续安装？
 chinesesimplified.MsgOldNSISCleanupFailed=清理旧版注册表项失败。%n请手动删除 HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Sunshine 后重试。
-chinesesimplified.MsgServiceInstallFailed=无法安装或验证 Sunshine 服务。%n请检查安装日志，并确认以管理员身份运行安装程序。
+chinesesimplified.MsgServiceInstallFailed=无法安装或验证 Sunshine 服务。%n%n程序文件已经装好并会保留。请重启后以管理员身份运行 scripts\install-service.bat，或在 Sunshine 管理界面里使用修复功能。详细信息见 TEMP 目录下的安装日志。
 chinesesimplified.MsgUninstallGamepad=是否移除虚拟手柄（ViGEmBus）？
 chinesesimplified.MsgUninstallData=是否删除 %1 中的所有数据？%n（包括配置文件、封面图片和设置）
 chinesesimplified.StatusStoppingService=正在停止 Sunshine 服务...
@@ -292,7 +296,16 @@ Filename: "{app}\scripts\autostart-service.bat"; StatusMsg: "{cm:StatusAutostart
 Filename: "https://docs.qq.com/aio/DSGdQc3htbFJjSFdO?p=DXpTjzl2kZwBjN7jlRMkRJ"; Description: "{cm:FinishOpenDocs}"; Flags: postinstall shellexec runasoriginaluser unchecked nowait skipifsilent
 ; Launch the user-session agent with the original desktop token. The GUI then
 ; owns and reconciles its HKCU autostart entry from the correct user context.
-Filename: "{app}\assets\gui\{#MyAppGUIExeName}"; Description: "{cm:FinishLaunchGUI}"; Flags: postinstall nowait skipifsilent runasoriginaluser; Components: gui
+;
+; Go through `cmd /c start` instead of pointing Filename at the GUI directly:
+; sunshine-gui.exe carries no requestedExecutionLevel manifest, so Windows
+; treats it as a legacy app and the Program Compatibility Assistant may stamp
+; a RUNASADMIN layer on its path after an earlier crash. CreateProcessAsUser
+; then fails with 740 (ERROR_ELEVATION_REQUIRED) and Inno shows a red
+; "无法执行文件 ... 错误代码 740" box on the finish page, which reads like the
+; whole install failed. cmd.exe never requires elevation, and `start` uses
+; ShellExecute, so a layered GUI just gets a normal UAC prompt instead.
+Filename: "{cmd}"; Parameters: "/c start """" ""{app}\assets\gui\{#MyAppGUIExeName}"""; Description: "{cm:FinishLaunchGUI}"; Flags: postinstall nowait runhidden skipifsilent runasoriginaluser; Components: gui
 
 [UninstallRun]
 ; Remove the per-user GUI startup entry before terminating the agent.
@@ -713,8 +726,15 @@ begin
     Detail := 'ImagePath: ' + ImagePath;
   Detail := Detail + #13#10 + 'Expected: ' + ExpectedPath;
   Detail := Detail + #13#10 + 'sc qc exit: ' + IntToStr(ResultCode);
+  // Warn, but do NOT Abort(). Aborting here rolls the whole installation back
+  // and leaves {app} holding nothing but the preserved `config` directory —
+  // a total loss for what is usually a recoverable condition (SunshineService
+  // still "marked for deletion" from the previous uninstall, a stale binPath
+  // pointing at an old install drive, SCM being slow to publish ImagePath).
+  // The files are fine; only the service registration needs another attempt,
+  // which scripts\install-service.bat, the GUI's repair action, or a reboot
+  // can all do. Keep the install and tell the user how to retry.
   MsgBox(CustomMessage('MsgServiceInstallFailed') + #13#10 + #13#10 + Detail, mbError, MB_OK);
-  Abort();
 end;
 
 // Initialization: handle old NSIS upgrade


### PR DESCRIPTION
## 背景

起因是 #871 的排查：测试者装完之后 `C:\Program Files\Sunshine` 里只剩下 `config`，同时 finish page 弹了一个红色的 `CreateProcess 失败；错误代码 740`。

**后续更正**：那次「只剩 config」查明是测试者自己手动卸载留下的，不是安装回滚 —— 拿到安装日志后确认所有步骤 exit code 都是 0，`install-service.bat` 也是 0，日志里写的是 `Installation process succeeded`。#871 的真正根因在 `sunshine.exe`（NVENC 10-bit 4:4:4 的 CUDA array 输入路径），已由 #910 / #912 解决。

所以本 PR **不再是**修一个已复现的事故。它修的是排查过程中顺带发现的三个独立问题，其中一个（740）确实被真实观测到过，另两个是潜在缺陷和可观测性缺口。

排查中另外确认的事实（与本 PR 的改动无关，记录备查）：

- 测试者装成功的正式版 v2026.806 和我们给他的测试包是同一条流水线（main.yml）出的，同为 gcc 16.1.0、同样未签名，安装包大小 35,724,259 / 35,727,944 字节；
- 两个包里的 `assets/gui/sunshine-gui.exe` 是同一个二进制（39,782,400 字节，GUI release v0.4.15）；
- `sign-and-repackage.yml` 最近 5 次运行全部 skipped，线上产物实际从来没有签过名。

## 改动

**1. `VerifyServiceInstalled()` 不再 `Abort()`。**（潜在缺陷，未复现）

从 `[Run]` 的 `AfterInstall` 里 `Abort()` 会让 Inno 回滚整个安装。服务注册失败通常是可恢复的 —— 上次卸载后 SunshineService 还处于 marked for deletion、binPath 指向旧盘、SCM 迟迟没写出 ImagePath —— 用一整套好文件去赔一个能重试的状况不划算，而且回滚后留下的 `config`（不在安装清单里）会让现场看起来像是别的毛病。现在改为只告警，并告诉用户怎么重试：`scripts\install-service.bat`、GUI 里的修复功能，或者重启。

**2. finish page 启动 GUI 改走 `cmd /c start`。**（真实观测到过）

`sunshine-gui.exe` 没有 `requestedExecutionLevel` manifest，Windows 按 legacy 程序对待，PCA 在它崩过一次之后可能给这个路径打上 RUNASADMIN 兼容性层；此时 `runasoriginaluser` 的 `CreateProcessAsUser` 直接返回 740，Inno 弹出的红框看起来像整个安装失败了。`cmd.exe` 永远不需要提权，`start` 走 ShellExecute，被打了兼容性层的 GUI 会正常弹 UAC 而不是报错。

**3. `SetupLogging=yes`。**（可观测性）

上面两个问题都没法从用户的反馈里直接判断，因为不手动带 `/LOG` 重跑就没有日志。这一条在 #871 的排查里已经自证价值 —— 上面那句「所有步骤 exit code 都是 0、没有回滚」的结论，完全来自事后补拿到的安装日志。默认开着，下次不用再让用户重跑一遍。

**4. 顺带**把 ZakoVirtualMouse 的 pin 从 `v1.2.0` 提到 `v1.3.2` —— 公共镜像 `AlkaidLab/zako-vmouse-release` 上 v1.3.2 的四个文件（dll/inf/cat/cer）齐全，匿名 CI 不需要回退到私库 token 路径。这条与 #871 无关。

## 测试

- CI 出包即可验证 Inno 脚本能编译、`[Run]` 的引号转义正确（`/c start "" "<path>"`）。
- 服务验证失败的分支需要人工构造（例如安装前 `sc create SunshineService binPath= C:\nonexistent`），确认弹框之后文件仍然保留。**这一条没有实机验证过。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)