### PR TITLE
fix(vdd): 修复 RDP、锁屏和恢复串流时的基地显示器失败问题

### DIFF
--- a/cmake/dependencies/Boost_Sunshine.cmake
+++ b/cmake/dependencies/Boost_Sunshine.cmake
@@ -6,6 +6,7 @@ include_guard(GLOBAL)
 set(BOOST_VERSION "1.91.0")
 set(BOOST_RELEASE_VERSION "1.91.0-1")
 set(BOOST_COMPONENTS
+        atomic
         beast
         filesystem
         locale

--- a/src/display_device/session.cpp
+++ b/src/display_device/session.cpp
@@ -3,6 +3,7 @@
 #include <boost/process/v1.hpp>
 #include <future>
 #include <thread>
+#include <utility>
 
 // local includes
 #include "parsed_config.h"
@@ -173,6 +174,7 @@ namespace display_device {
     current_device_prep.reset();
     current_vdd_prep.reset();
     current_use_vdd.reset();
+    pending_vdd_.reset();
     // 恢复原始的 output_name，避免下一个会话使用已销毁的 VDD 设备 ID
     if (!original_output_name.empty()) {
       config::video.output_name = original_output_name;
@@ -196,6 +198,11 @@ namespace display_device {
      */
     std::string
     get_client_id_from_session(const rtsp_stream::launch_session_t &session) {
+      if (!session.client_cert_uuid.empty()) {
+        return session.client_cert_uuid;
+      }
+
+      // 兼容尚未通过独立字段传递 client_cert_uuid、只写入启动环境的内部调用方。
       if (auto cert_uuid_it = session.env.find("SUNSHINE_CLIENT_CERT_UUID");
         cert_uuid_it != session.env.end()) {
         if (std::string cert_uuid = cert_uuid_it->to_string(); !cert_uuid.empty()) {
@@ -339,7 +346,38 @@ namespace display_device {
 
       return { result, apply_result.get_error_message(), hint };
     }
+
   }  // namespace
+
+  session_t::vdd_stage_result_e
+  session_t::apply_vdd_display_stage(const parsed_config_t &config,
+    const boost::optional<device_info_map_t> &pre_vdd_devices) {
+    if (config.vdd_prep != parsed_config_t::vdd_prep_e::no_operation &&
+        !vdd_utils::apply_vdd_prep(config.device_id, config.vdd_prep, pre_vdd_devices)) {
+      return vdd_stage_result_e::topology_failed;
+    }
+
+    // 仅在 VDD 预期已经激活后检查 Windows 是否已发布目标模式。
+    // 锁屏场景会在解锁后执行本阶段；SYSTEM+RDP 不进入本阶段。
+    if (config.resolution && config.refresh_rate) {
+      const display_mode_t requested_mode {*config.resolution, *config.refresh_rate};
+      if (!vdd_utils::wait_for_mode_publication(config.device_id, requested_mode)) {
+        BOOST_LOG(error) << "VDD monitor did not publish "
+                         << to_string(*config.resolution) << "@" << to_string(*config.refresh_rate);
+        return vdd_stage_result_e::modes_failed;
+      }
+    }
+
+    // 在 settings_t 应用目标 HDR 状态前先重置新准备的显示器。
+    // 此处失败不作为最终错误，实际 HDR 操作及结果仍以 settings_t 为准。
+    if (config.change_hdr_state && !vdd_utils::set_hdr_state(false)) {
+      BOOST_LOG(debug) << "首次设置HDR状态失败，等待设备稳定后重试";
+      std::this_thread::sleep_for(500ms);
+      vdd_utils::set_hdr_state(false);
+    }
+
+    return vdd_stage_result_e::ready;
+  }
 
   session_t::configure_result_t
   session_t::configure_display(const config::video_t &config,
@@ -347,16 +385,16 @@ namespace display_device {
     bool is_reconfigure) {
     std::lock_guard lock { mutex };
 
-    // Clean up VDD state if this is a new session with a different client
+    // 恢复运行中的应用时可能换成另一个客户端。取消旧的延迟恢复任务，
+    // 但在完成模式兼容性判断前保留当前 VDD；仅客户端身份变化不要求重建。
     if (!is_reconfigure) {
       if (const std::string new_client_id = get_client_id_from_session(session);
         !current_vdd_client_id.empty() && !new_client_id.empty() &&
         current_vdd_client_id != new_client_id) {
-        BOOST_LOG(info) << "New session detected with different client ID, cleaning up VDD state";
-        // Cancel any pending restore from the old session before it can interfere
+        BOOST_LOG(info) << "New client is resuming the app; preserving the current VDD while checking the requested mode";
         pending_restore_ = false;
         SessionEventListener::clear_unlock_task();
-        stop_timer_and_clear_vdd_state();
+        timer->setup_timer(nullptr);
       }
     }
 
@@ -373,9 +411,11 @@ namespace display_device {
 
     // Parsing is side-effect free. From this point on, parsed_config is the
     // single source of truth for whether this session needs VDD preparation.
-    const bool is_rdp_blocking_vdd = !is_running_as_system_user && display_device::w_utils::is_any_rdp_session_active();
+    const bool rdp_session_active = display_device::w_utils::is_any_rdp_session_active();
+    const bool is_rdp_blocking_vdd = !is_running_as_system_user && rdp_session_active;
     const bool use_vdd = parsed_config->use_vdd.value_or(false);
     const bool should_prepare_vdd = use_vdd && !is_rdp_blocking_vdd;
+    const bool is_system_rdp_vdd_session = should_prepare_vdd && is_running_as_system_user && rdp_session_active;
     if (use_vdd && is_rdp_blocking_vdd) {
       BOOST_LOG(info) << "[Display] RDP环境：强制使用RDP虚拟显示器，跳过VDD准备";
     }
@@ -396,13 +436,13 @@ namespace display_device {
     }
 
     const bool vulkan_hdr_bridge_requested =
-      should_prepare_vdd && session.enable_hdr && config.vdd_vulkan_hdr_bridge;
+      should_prepare_vdd && !is_system_rdp_vdd_session && session.enable_hdr && config.vdd_vulkan_hdr_bridge;
     const bool will_disable_physical_displays =
-      should_prepare_vdd && parsed_config->vdd_prep == parsed_config_t::vdd_prep_e::display_off;
+      should_prepare_vdd && !is_system_rdp_vdd_session &&
+      parsed_config->vdd_prep == parsed_config_t::vdd_prep_e::display_off;
 
-    // Preserve the pre-VDD topology before prepare_vdd can create a monitor
-    // and switch Windows into extended mode.
-    boost::optional<active_topology_t> pre_saved_initial_topology;
+    // 在创建 VDD 可能使 Windows 自动激活显示器、Sunshine 应用目标布局之前保存拓扑。
+    boost::optional<active_topology_t> pre_saved_initial_topology = pending_vdd_.initial_topology;
     if (should_prepare_vdd) {
       const bool vdd_already_exists = !display_device::find_device_by_friendlyname(ZAKO_NAME).empty();
       if (will_disable_physical_displays) {
@@ -420,24 +460,40 @@ namespace display_device {
       else if (vdd_already_exists) {
         BOOST_LOG(debug) << "VDD already exists, skipping initial topology save (topology may be corrupted)";
       }
-      else {
-        pre_saved_initial_topology = get_current_topology();
+      else if (!is_system_rdp_vdd_session) {
+        pending_vdd_.initial_topology = get_current_topology();
+        pre_saved_initial_topology = pending_vdd_.initial_topology;
         BOOST_LOG(debug) << "Pre-saved initial topology before VDD creation: " << to_string(*pre_saved_initial_topology);
       }
 
-      if (!prepare_vdd(*parsed_config, session)) {
+      boost::optional<device_info_map_t> captured_pre_vdd_devices;
+      const auto prepare_result = prepare_vdd(*parsed_config, session, captured_pre_vdd_devices);
+      if (captured_pre_vdd_devices) {
+        pending_vdd_.pre_vdd_devices = std::move(*captured_pre_vdd_devices);
+      }
+
+      if (prepare_result != vdd_stage_result_e::ready) {
         if (will_disable_physical_displays) {
           settings.release_audio_sink();
         }
 
-        BOOST_LOG(error) << "Failed to prepare the VDD device";
+        const bool modes_failed = prepare_result == vdd_stage_result_e::modes_failed;
+        BOOST_LOG(error) << (modes_failed ?
+                              "Failed to update the VDD mode list" :
+                              "Failed to prepare the VDD device");
         restore_state_impl(revert_reason_e::config_cleanup);
         return {
-          configure_result_t::result_e::vdd_create_failed,
-          "Sunshine could not create the virtual display.",
-          "Repair the virtual display driver in Sunshine settings, then try again."
+          modes_failed ? configure_result_t::result_e::modes_fail : configure_result_t::result_e::vdd_create_failed,
+          modes_failed ? "Sunshine could not configure the requested virtual display mode." : "Sunshine could not create the virtual display.",
+          modes_failed ?
+            "Choose a resolution and refresh rate supported by the virtual display, or set resolution and FPS to Auto." :
+            "Repair the virtual display driver in Sunshine settings, then try again."
         };
       }
+
+      // NVHTTP 的短间隔重试可能在 VDD 已创建后再次进入 configure_display。
+      // 在 settings_t 持久化状态或会话完成清理前，始终保留第一次创建前的快照。
+      pre_saved_initial_topology = pending_vdd_.initial_topology;
     }
 
     // 保存当前会话的配置模式（可能包含客户端的override）
@@ -445,12 +501,42 @@ namespace display_device {
     current_vdd_prep = parsed_config->vdd_prep;
     current_use_vdd = parsed_config->use_vdd;
 
-    if (settings.is_changing_settings_going_to_fail()) {
+    if (is_system_rdp_vdd_session) {
+      // SYSTEM 服务可以在 RDP 会话中创建 VDD，但此时 Windows 无法提供
+      // 可靠的交互式 CCD 拓扑。因此这里不修改拓扑和显示设置，最终由编码器探测
+      // 确认 VDD 是否可捕获，避免在持有会话锁时等待一个不会改变处理结果的条件。
+      BOOST_LOG(info) << "[Display] SYSTEM RDP session: VDD is ready; skipping topology and display-setting changes";
+      pending_vdd_.reset();
+      timer->setup_timer(nullptr);
+      return {
+        configure_result_t::result_e::success,
+        {},
+        {}
+      };
+    }
+
+    const bool should_defer_display_settings = settings.is_changing_settings_going_to_fail();
+    if (should_defer_display_settings) {
       timer->setup_timer([this, config_copy = *parsed_config, client_name = session.client_name,
-                           pre_saved_initial_topology, vulkan_hdr_bridge_requested]() {
+                           pre_saved_initial_topology,
+                           pre_vdd_devices = pending_vdd_.pre_vdd_devices,
+                           should_prepare_vdd,
+                           vulkan_hdr_bridge_requested]() {
         if (settings.is_changing_settings_going_to_fail()) {
           BOOST_LOG(warning) << "Applying display settings will fail - retrying later...";
           return false;
+        }
+
+        if (should_prepare_vdd) {
+          const auto vdd_stage_result = apply_vdd_display_stage(config_copy, pre_vdd_devices);
+          if (vdd_stage_result == vdd_stage_result_e::modes_failed) {
+            BOOST_LOG(warning) << "The rebuilt VDD has not published the requested mode yet; retrying the deferred display configuration";
+            return false;
+          }
+          if (vdd_stage_result == vdd_stage_result_e::topology_failed) {
+            BOOST_LOG(warning) << "The deferred VDD topology change is still unavailable; retrying without tearing down the active monitor";
+            return false;
+          }
         }
 
         auto retry_session = rtsp_stream::launch_session_t {};
@@ -460,6 +546,7 @@ namespace display_device {
           // WARNING! After call to the method below, this lambda function is no longer valid!
           // DO NOT access anything from the capture list!
           restore_state_impl(revert_reason_e::config_cleanup);
+          return true;
         }
 #ifdef _WIN32
         else if (vulkan_hdr_bridge_requested) {
@@ -471,6 +558,7 @@ namespace display_device {
           platf::vulkan_hdr_bridge::disable();
         }
 #endif
+        pending_vdd_.reset();
         return true;
       });
 
@@ -482,9 +570,35 @@ namespace display_device {
       };
     }
 
+    // 延迟任务尚未执行时可能收到新的重配置。本次调用已经接管立即应用，
+    // 因此必须取消旧回调，避免它随后使用过期配置再次修改显示状态。
+    timer->setup_timer(nullptr);
+
+    if (should_prepare_vdd) {
+      const auto vdd_stage_result = apply_vdd_display_stage(*parsed_config, pending_vdd_.pre_vdd_devices);
+      if (vdd_stage_result == vdd_stage_result_e::topology_failed) {
+        restore_state_impl(revert_reason_e::config_cleanup);
+        return {
+          configure_result_t::result_e::topology_fail,
+          "Sunshine could not apply the requested virtual display topology.",
+          "Unlock the desktop, make sure Windows display settings are available, and try again."
+        };
+      }
+      if (vdd_stage_result == vdd_stage_result_e::modes_failed) {
+        BOOST_LOG(warning) << "VDD mode publication failed; cleaning up the prepared VDD state";
+        restore_state_impl(revert_reason_e::config_cleanup);
+        return {
+          configure_result_t::result_e::modes_fail,
+          "The virtual display did not publish the requested mode.",
+          "Choose a resolution and refresh rate supported by the virtual display, or set resolution and FPS to Auto."
+        };
+      }
+    }
+
     const auto apply_result = settings.apply_config(*parsed_config, session, pre_saved_initial_topology);
     if (apply_result) {
       timer->setup_timer(nullptr);
+      pending_vdd_.reset();
 #ifdef _WIN32
       if (vulkan_hdr_bridge_requested) {
         if (!platf::vulkan_hdr_bridge::enable_for_vdd_hdr_session()) {
@@ -591,8 +705,10 @@ namespace display_device {
     return vdd_mode_update_e::failed;
   }
 
-  bool
-  session_t::prepare_vdd(parsed_config_t &config, const rtsp_stream::launch_session_t &session) {
+  session_t::vdd_stage_result_e
+  session_t::prepare_vdd(parsed_config_t &config, const rtsp_stream::launch_session_t &session, boost::optional<device_info_map_t> &pre_vdd_devices) {
+    pre_vdd_devices.reset();
+
     const std::string current_client_id = get_client_id_from_session(session);
     const vdd_utils::hdr_brightness_t hdr_brightness { session.max_nits, session.min_nits, session.max_full_nits };
     const vdd_utils::physical_size_t physical_size = vdd_utils::get_client_physical_size(session.client_name);
@@ -612,62 +728,20 @@ namespace display_device {
 
     auto device_zako = display_device::find_device_by_friendlyname(ZAKO_NAME);
 
-    // pre_vdd_devices: 在 VDD 创建前一刻保存的物理显示器快照
-    // 延迟到 VDD 创建前才捕获，确保无论是新建还是重建都能拿到正确状态
-    device_info_map_t pre_vdd_devices;
-
-    // Rebuild VDD device on client switch
-    if (!device_zako.empty() && !current_vdd_client_id.empty() &&
-        !current_client_id.empty() && current_vdd_client_id != current_client_id) {
-      
-      // 是否复用VDD（由独立配置项控制）
-      const bool reuse_vdd = config::video.vdd_reuse;
-
-      if (reuse_vdd) {
-        // 复用VDD：所有客户端共享同一VDD，只更新客户端ID
-        BOOST_LOG(info) << "共享VDD模式，复用现有VDD（客户端: " << current_vdd_client_id << " -> " << current_client_id << "）";
-        current_vdd_client_id = current_client_id;
-      }
-      else {
-        // 不复用：销毁并重建VDD（每个客户端独立VDD）
-        BOOST_LOG(info) << "独立VDD模式，重建VDD设备（客户端: " << current_vdd_client_id << " -> " << current_client_id << "）";
-        
-        const auto old_vdd_id = device_zako;
-        destroy_vdd_monitor();
-        clear_vdd_state();
-        device_zako.clear();
-        
-        // Handle VDD ID in persistent_data
-        if (config::video.vdd_keep_enabled) {
-          // 常驻模式：需要替换ID（保留VDD在persistent_data中）
-          should_replace_vdd_id_ = true;
-          old_vdd_id_ = old_vdd_id;
-          BOOST_LOG(debug) << "标记需要替换VDD ID: " << old_vdd_id;
-        }
-        else {
-          // 非常驻模式：从initial中移除VDD
-          BOOST_LOG(debug) << "从initial拓扑中移除VDD: " << old_vdd_id;
-          settings.remove_vdd_from_initial_topology(old_vdd_id);
-        }
-        
-        std::this_thread::sleep_for(500ms);
-      }
-    }
-
     std::string mode_rebuild_old_vdd_id;
     // Update VDD resolution configuration
     if (auto vdd_settings = vdd_utils::prepare_vdd_settings(config);
       config.resolution && config.refresh_rate) {
       const auto mode_update = update_vdd_resolution(config, vdd_settings, device_zako);
       if (mode_update == vdd_mode_update_e::failed) {
-        return false;
+        return vdd_stage_result_e::modes_failed;
       }
 
       if (mode_update == vdd_mode_update_e::recreate_monitor) {
         mode_rebuild_old_vdd_id = device_zako;
         if (!vdd_utils::destroy_vdd_monitor()) {
           BOOST_LOG(error) << "Failed to destroy the VDD monitor for an IOCTL mode-list rebuild";
-          return false;
+          return vdd_stage_result_e::create_failed;
         }
         if (!wait_for_vdd_device_departure(5, 100ms, 1000ms)) {
           // The driver has already removed its monitor object synchronously.
@@ -684,16 +758,14 @@ namespace display_device {
       // 在创建 VDD 之前捕获物理显示器快照
       // 此时无 VDD 存在（新建 or 重建后已销毁），物理屏应处于正常状态
       pre_vdd_devices = display_device::enum_available_devices();
-      BOOST_LOG(info) << "已保存pre-VDD设备列表: " << display_device::to_string(pre_vdd_devices);
+      BOOST_LOG(info) << "已保存pre-VDD设备列表: " << display_device::to_string(*pre_vdd_devices);
 
       BOOST_LOG(info) << "创建虚拟显示器...";
-      // 复用模式使用固定标识符，否则使用客户端ID生成唯一GUID
-      const std::string vdd_identifier = config::video.vdd_reuse
-        ? "shared_vdd"  // 固定标识符，所有客户端共用同一GUID
-        : current_client_id;  // 为每个客户端生成不同GUID
+      // 共享模式使用固定标识符；独立模式则使用当前客户端标识符创建显示器。
+      const std::string vdd_identifier = config::video.vdd_reuse ? "shared_vdd" : current_client_id;
       if (!vdd_utils::create_vdd_monitor(vdd_identifier, hdr_brightness, physical_size)) {
         BOOST_LOG(error) << "VDD monitor creation command failed";
-        return false;
+        return vdd_stage_result_e::create_failed;
       }
       std::this_thread::sleep_for(200ms);
     }
@@ -722,51 +794,12 @@ namespace display_device {
         else {
           BOOST_LOG(warning) << "VDD IOCTL 仍可用，跳过 disable/enable，避免制造 phantom monitor";
         }
-        return false;
+        return vdd_stage_result_e::create_failed;
       }
     }
 
     if (device_zako.empty()) {
-      return false;
-    }
-
-    // Apply topology before mode verification so a cold-created monitor
-    // receives the GDI display name consumed by EnumDisplaySettingsW.
-    if (config.vdd_prep != parsed_config_t::vdd_prep_e::no_operation) {
-      if (!vdd_utils::apply_vdd_prep(device_zako, config.vdd_prep, pre_vdd_devices)) {
-        BOOST_LOG(error) << "Failed to apply the requested VDD topology";
-        return false;
-      }
-      BOOST_LOG(info) << "已应用VDD屏幕布局设置";
-    }
-    else {
-      std::vector<std::string> physical_devices_to_preserve;
-      const auto append_physical_devices = [&](device_state_e state) {
-        for (const auto &[device_id, info] : pre_vdd_devices) {
-          if (info.friendly_name != ZAKO_NAME && info.device_state == state) {
-            physical_devices_to_preserve.push_back(device_id);
-          }
-        }
-      };
-      append_physical_devices(device_state_e::primary);
-      append_physical_devices(device_state_e::active);
-
-      if (!vdd_utils::ensure_vdd_extended_mode(device_zako, physical_devices_to_preserve)) {
-        BOOST_LOG(error) << "Failed to ensure the default VDD extended topology";
-        return false;
-      }
-      BOOST_LOG(info) << "VDD extended topology is ready";
-    }
-
-    // Wait for the OS-facing mode contract using the utility's bounded
-    // deadline policy rather than driver-specific timing assumptions.
-    if (config.resolution && config.refresh_rate) {
-      const display_mode_t requested_mode {*config.resolution, *config.refresh_rate};
-      if (!vdd_utils::wait_for_mode_publication(device_zako, requested_mode)) {
-        BOOST_LOG(error) << "VDD monitor did not publish "
-                         << to_string(*config.resolution) << "@" << to_string(*config.refresh_rate);
-        return false;
-      }
+      return vdd_stage_result_e::create_failed;
     }
 
     if (!mode_rebuild_old_vdd_id.empty() && mode_rebuild_old_vdd_id != device_zako) {
@@ -780,27 +813,13 @@ namespace display_device {
       BOOST_LOG(debug) << "保存原始 output_name: " << original_output_name;
     }
 
-    // Replace VDD ID if needed (after client switch in keep_enabled mode)
-    if (should_replace_vdd_id_ && !old_vdd_id_.empty()) {
-      BOOST_LOG(info) << "替换persistent_data中的VDD ID: " << old_vdd_id_ << " -> " << device_zako;
-      settings.replace_vdd_id(old_vdd_id_, device_zako);
-      should_replace_vdd_id_ = false;
-      old_vdd_id_.clear();
-    }
-    
     // Update configuration and state
     config.device_id = device_zako;
     config::video.output_name = device_zako;
     current_vdd_client_id = current_client_id;
     BOOST_LOG(info) << "成功配置VDD设备: " << device_zako;
 
-    // Set HDR state with retry
-    if (!vdd_utils::set_hdr_state(false)) {
-      BOOST_LOG(debug) << "首次设置HDR状态失败，等待设备稳定后重试";
-      std::this_thread::sleep_for(500ms);
-      vdd_utils::set_hdr_state(false);
-    }
-    return true;
+    return vdd_stage_result_e::ready;
   }
 
   void

--- a/src/display_device/session.cpp
+++ b/src/display_device/session.cpp
@@ -184,8 +184,15 @@ namespace display_device {
   }
 
   void
-  session_t::stop_timer_and_clear_vdd_state() {
+  session_t::cancel_pending_display_retry() {
+    pending_restore_ = false;
+    SessionEventListener::clear_unlock_task();
     timer->setup_timer(nullptr);
+  }
+
+  void
+  session_t::stop_timer_and_clear_vdd_state() {
+    cancel_pending_display_retry();
     clear_vdd_state();
   }
 
@@ -392,9 +399,7 @@ namespace display_device {
         !current_vdd_client_id.empty() && !new_client_id.empty() &&
         current_vdd_client_id != new_client_id) {
         BOOST_LOG(info) << "New client is resuming the app; preserving the current VDD while checking the requested mode";
-        pending_restore_ = false;
-        SessionEventListener::clear_unlock_task();
-        timer->setup_timer(nullptr);
+        cancel_pending_display_retry();
       }
     }
 
@@ -453,9 +458,7 @@ namespace display_device {
         BOOST_LOG(info) << (vdd_already_exists ?
                               "有待恢复的设置且 VDD 仍存在，保留原有初始拓扑" :
                               "有待恢复的设置，保留原有初始拓扑");
-        pending_restore_ = false;
-        SessionEventListener::clear_unlock_task();
-        timer->setup_timer(nullptr);
+        cancel_pending_display_retry();
       }
       else if (vdd_already_exists) {
         BOOST_LOG(debug) << "VDD already exists, skipping initial topology save (topology may be corrupted)";
@@ -572,7 +575,7 @@ namespace display_device {
 
     // 延迟任务尚未执行时可能收到新的重配置。本次调用已经接管立即应用，
     // 因此必须取消旧回调，避免它随后使用过期配置再次修改显示状态。
-    timer->setup_timer(nullptr);
+    cancel_pending_display_retry();
 
     if (should_prepare_vdd) {
       const auto vdd_stage_result = apply_vdd_display_stage(*parsed_config, pending_vdd_.pre_vdd_devices);
@@ -832,8 +835,6 @@ namespace display_device {
   session_t::reset_persistence() {
     std::lock_guard lock { mutex };
     settings.reset_persistence();
-    pending_restore_ = false;
-    SessionEventListener::clear_unlock_task();
     stop_timer_and_clear_vdd_state();
     current_vdd_client_id.clear();
   }

--- a/src/display_device/session.h
+++ b/src/display_device/session.h
@@ -321,6 +321,13 @@ namespace display_device {
     clear_vdd_state();
 
     /**
+     * @brief 取消旧的延迟配置或恢复任务，并清除对应的待处理状态。
+     * @note 调用方必须已经持有 mutex。
+     */
+    void
+    cancel_pending_display_retry();
+
+    /**
      * @brief Stop timer and clear VDD state
      * @note This method does NOT acquire the mutex! It is intended to be used from places
      *       where the mutex has already been locked.

--- a/src/display_device/session.h
+++ b/src/display_device/session.h
@@ -190,24 +190,6 @@ namespace display_device {
     destroy_vdd_monitor();
 
     /**
-     * @brief Enable VDD driver
-     */
-    void
-    enable_vdd();
-
-    /**
-     * @brief Disable VDD driver
-     */
-    void
-    disable_vdd();
-
-    /**
-     * @brief Disable and enable VDD driver
-     */
-    void
-    disable_enable_vdd();
-
-    /**
      * @brief Toggle display power
      */
     bool
@@ -218,12 +200,6 @@ namespace display_device {
      */
     bool
     is_display_on();
-
-    /**
-     * @brief Prepares VDD for use
-     */
-    bool
-    prepare_vdd(parsed_config_t &config, const rtsp_stream::launch_session_t &session);
 
     /**
      * @brief A deleted copy constructor for singleton pattern.
@@ -251,6 +227,30 @@ namespace display_device {
      */
     class StateRetryTimer;
 
+    enum class vdd_mode_update_e {
+      ready,
+      recreate_monitor,
+      failed,
+    };
+
+    enum class vdd_stage_result_e {
+      ready,
+      create_failed,
+      topology_failed,
+      modes_failed,
+    };
+
+    struct pending_vdd_context_t {
+      boost::optional<active_topology_t> initial_topology;
+      boost::optional<device_info_map_t> pre_vdd_devices;
+
+      void
+      reset() {
+        initial_topology.reset();
+        pre_vdd_devices.reset();
+      }
+    };
+
     /**
      * @brief A private constructor to ensure the singleton pattern.
      * @note Cannot be defaulted in declaration because of forward declared StateRetryTimer.
@@ -272,6 +272,12 @@ namespace display_device {
     void
     start_polling_restore(revert_reason_e reason);
 
+    /**
+     * @brief 执行依赖可访问交互式 Windows 会话的 VDD 显示操作。
+     */
+    static vdd_stage_result_e
+    apply_vdd_display_stage(const parsed_config_t &config, const boost::optional<device_info_map_t> &pre_vdd_devices);
+
     settings_t settings; /**< A class for managing display device settings. */
     std::mutex mutex; /**< A mutex for ensuring thread-safety. */
     std::string current_vdd_client_id; /**< Current client ID associated with VDD monitor. */
@@ -279,9 +285,8 @@ namespace display_device {
     boost::optional<parsed_config_t::device_prep_e> current_device_prep; /**< Current device preparation mode, respecting client overrides. */
     boost::optional<parsed_config_t::vdd_prep_e> current_vdd_prep; /**< Current VDD preparation mode for VDD mode sessions. */
     boost::optional<bool> current_use_vdd; /**< Whether current session is using VDD mode. */
+    pending_vdd_context_t pending_vdd_; /**< 在显示配置成功或清理前保留的 VDD 创建基线。 */
     bool pending_restore_ = false; /**< Flag indicating if there is a pending restore settings operation waiting for unlock. */
-    bool should_replace_vdd_id_ = false; /**< Flag indicating if VDD ID needs to be replaced after client switch. */
-    std::string old_vdd_id_; /**< Old VDD ID that needs to be replaced. */
     boost::atomic<int> polling_retry_count_ {0}; /**< Retry counter for polling restore mechanism. */
 
     /**
@@ -290,11 +295,17 @@ namespace display_device {
      */
     std::unique_ptr<StateRetryTimer> timer;
 
-    enum class vdd_mode_update_e {
-      ready,
-      recreate_monitor,
-      failed,
-    };
+    /**
+     * @brief 准备 VDD 驱动和显示器，不修改 Windows 显示拓扑。
+     * @param config 已解析的会话配置；成功时写回 VDD 设备 ID。
+     * @param session 用于标识和配置显示器的启动会话。
+     * @param pre_vdd_devices 接收新建显示器前捕获的物理显示器快照；
+     *        有值但为空表示主机确实无头。
+     */
+    vdd_stage_result_e
+    prepare_vdd(parsed_config_t &config,
+      const rtsp_stream::launch_session_t &session,
+      boost::optional<device_info_map_t> &pre_vdd_devices);
 
     vdd_mode_update_e
     update_vdd_resolution(const parsed_config_t &config,

--- a/src/display_device/vdd_utils.cpp
+++ b/src/display_device/vdd_utils.cpp
@@ -143,62 +143,35 @@ namespace display_device {
       return std::min(delay, kMaxRetryDelay);
     }
 
-    /**
-     * @brief Allowed DevManView actions for VDD driver management.
-     */
-    enum class vdd_action_e {
-      enable,
-      disable,
-      disable_enable
-    };
-
-    /**
-     * @brief Get the command-line argument string for a VDD action.
-     */
-    const char *
-    vdd_action_to_string(vdd_action_e action) {
-      switch (action) {
-        case vdd_action_e::enable: return "enable";
-        case vdd_action_e::disable: return "disable";
-        case vdd_action_e::disable_enable: return "disable_enable";
-        default: return nullptr;
-      }
-    }
-
     bool
-    execute_vdd_command(vdd_action_e action) {
+    execute_vdd_disable_enable_command() {
       static const std::string kDevManPath = (std::filesystem::path(SUNSHINE_ASSETS_DIR).parent_path() / "tools" / "DevManView.exe").string();
       static const std::string kDriverName = "Zako Display Adapter";
-
-      const char *action_str = vdd_action_to_string(action);
-      if (!action_str) {
-        BOOST_LOG(error) << "未知的VDD命令操作";
-        return false;
-      }
+      static constexpr auto kAction = "disable_enable";
 
       boost::process::v1::environment _env = boost::this_process::environment();
       auto working_dir = boost::filesystem::path();
       std::error_code ec;
 
-      std::string cmd = kDevManPath + " /" + action_str + " \"" + kDriverName + "\"";
+      std::string cmd = kDevManPath + " /" + kAction + " \"" + kDriverName + "\"";
 
       for (int attempt = 0; attempt < kMaxRetryCount; ++attempt) {
         auto child = platf::run_command(true, true, cmd, working_dir, _env, nullptr, ec, nullptr);
         if (!ec) {
-          BOOST_LOG(info) << "成功执行VDD " << action_str << " 命令";
+          BOOST_LOG(info) << "成功执行VDD " << kAction << " 命令";
           child.detach();
           return true;
         }
 
         auto delay = calculate_exponential_backoff(attempt);
-        BOOST_LOG(warning) << "执行VDD " << action_str << " 命令失败 (尝试 "
+        BOOST_LOG(warning) << "执行VDD " << kAction << " 命令失败 (尝试 "
                            << (attempt + 1) << "/" << kMaxRetryCount
                            << "): " << ec.message() << ". 将在 "
                            << delay.count() << "ms 后重试";
         std::this_thread::sleep_for(delay);
       }
 
-      BOOST_LOG(error) << "执行VDD " << action_str << " 命令失败，已达到最大重试次数";
+      BOOST_LOG(error) << "执行VDD " << kAction << " 命令失败，已达到最大重试次数";
       return false;
     }
 
@@ -636,18 +609,8 @@ namespace display_device {
     }
 
     void
-    enable_vdd() {
-      execute_vdd_command(vdd_action_e::enable);
-    }
-
-    void
-    disable_vdd() {
-      execute_vdd_command(vdd_action_e::disable);
-    }
-
-    void
     disable_enable_vdd() {
-      execute_vdd_command(vdd_action_e::disable_enable);
+      execute_vdd_disable_enable_command();
     }
 
     bool
@@ -1005,7 +968,7 @@ namespace display_device {
 
     bool
     apply_vdd_prep(const std::string &vdd_device_id, parsed_config_t::vdd_prep_e vdd_prep,
-      const device_info_map_t &pre_vdd_devices) {
+      const boost::optional<device_info_map_t> &pre_vdd_devices) {
       if (vdd_device_id.empty()) {
         BOOST_LOG(info) << "VDD设备ID为空，跳过vdd_prep处理";
         return true;
@@ -1026,9 +989,9 @@ namespace display_device {
                 info.device_state == device_state_e::primary);
       };
 
-      if (!pre_vdd_devices.empty()) {
+      if (pre_vdd_devices) {
         // 使用 VDD 创建前保存的设备信息（可靠）
-        for (const auto &[device_id, info] : pre_vdd_devices) {
+        for (const auto &[device_id, info] : *pre_vdd_devices) {
           if (is_active_physical_display(info)) {
             physical_devices.push_back(device_id);
             if (info.device_state == device_state_e::primary) {
@@ -1111,12 +1074,16 @@ namespace display_device {
         return false;
       }
 
-      if (!set_topology(new_topology)) {
+      BOOST_LOG(info) << "vdd_prep 目标拓扑: " << to_string(new_topology);
+
+      const bool topology_applied = set_topology(new_topology);
+      if (!topology_applied) {
         BOOST_LOG(error) << "设置拓扑失败";
         return false;
       }
 
       BOOST_LOG(info) << "成功应用vdd_prep设置";
+      BOOST_LOG(debug) << "vdd_prep 执行后显示设备: " << to_string(enum_available_devices());
       return true;
     }
   }  // namespace vdd_utils

--- a/src/display_device/vdd_utils.h
+++ b/src/display_device/vdd_utils.h
@@ -11,6 +11,8 @@
 #include <vector>
 #include <windows.h>
 
+#include <boost/optional.hpp>
+
 #include "parsed_config.h"
 
 namespace display_device::vdd_utils {
@@ -175,14 +177,6 @@ namespace display_device::vdd_utils {
   vdd_status_t
   get_vdd_status();
 
-  // 指数退避计算
-  std::chrono::milliseconds
-  calculate_exponential_backoff(int attempt);
-
-  // VDD命令执行
-  bool
-  execute_vdd_command(const std::string &action);
-
   /**
    * @brief Parse the persisted VDD HardwareCursor value.
    */
@@ -274,12 +268,6 @@ namespace display_device::vdd_utils {
   destroy_vdd_monitor_nolog();
 
   void
-  enable_vdd();
-
-  void
-  disable_vdd();
-
-  void
   disable_enable_vdd();
 
   bool
@@ -298,16 +286,16 @@ namespace display_device::vdd_utils {
    * @brief Apply VDD prep settings to handle physical displays.
    * @param vdd_device_id The VDD device ID.
    * @param vdd_prep The vdd_prep_e value specifying how to handle physical displays.
-   * @param pre_vdd_devices Physical device info captured BEFORE VDD creation.
-   *        Used to reliably identify physical displays even if VDD creation
-   *        caused them to become inactive. If empty, falls back to current device enumeration.
+   * @param pre_vdd_devices Physical device info captured before VDD creation.
+   *        An engaged empty map represents a headless host. An unengaged value
+   *        falls back to current device enumeration.
    * @returns True if the operation succeeded.
    * @note This operation modifies topology without saving/restoring state,
    *       as Windows automatically handles topology memory when displays change.
    */
   bool
   apply_vdd_prep(const std::string &vdd_device_id, parsed_config_t::vdd_prep_e vdd_prep,
-    const device_info_map_t &pre_vdd_devices = {});
+    const boost::optional<device_info_map_t> &pre_vdd_devices);
 
   VddSettings
   prepare_vdd_settings(const parsed_config_t &config);

--- a/src/globals.h
+++ b/src/globals.h
@@ -61,6 +61,7 @@ namespace mail {
   MAIL(video_packets);
   MAIL(audio_packets);
   MAIL(switch_display);
+  MAIL(active_display);
 
   // Local mail
   MAIL(touch_port);

--- a/src/platform/windows/display_device/settings.cpp
+++ b/src/platform/windows/display_device/settings.cpp
@@ -895,9 +895,9 @@ namespace display_device {
       bool failed_while_reverting_settings { false };
 
       if (is_vdd_mode) {
-        // VDD模式：拓扑由 vdd_prep 控制（在 prepare_vdd 中已处理），这里只获取 metadata
+        // VDD模式：拓扑由 session_t 的 VDD 显示阶段控制，这里只获取 metadata
         // 这里不修改拓扑，分辨率、刷新率、HDR 等设置仍然会应用
-        BOOST_LOG(info) << "VDD mode: topology controlled by vdd_prep in prepare_vdd, only getting current topology metadata";
+        BOOST_LOG(info) << "VDD mode: topology controlled by the session VDD display stage, only getting current topology metadata";
         topology_result = get_current_topology_metadata(config.device_id);
 
         // 如果有预保存的初始拓扑（在 VDD 创建前保存的物理显示器拓扑），

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -5,11 +5,13 @@
 #include "process.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <future>
 #include <iomanip>
 #include <optional>
 #include <queue>
 #include <unordered_map>
+#include <utility>
 
 #include <fstream>
 #include <openssl/err.h>
@@ -20,8 +22,8 @@
 #include <boost/endian/arithmetic.hpp>
 #include <boost/make_shared.hpp>
 #include <boost/shared_ptr.hpp>
-#include <boost/thread/mutex.hpp>
 #include <boost/thread/lock_guard.hpp>
+#include <boost/thread/mutex.hpp>
 
 #include "abr.h"
 
@@ -37,6 +39,7 @@ extern "C" {
 
 #include "client_fingerprint.h"
 #include "config.h"
+#include "display_device/display_device.h"
 #include "display_device/session.h"
 #include "globals.h"
 #include "rtsp.h"
@@ -539,6 +542,8 @@ namespace stream {
     // 添加客户端名称字段
     std::string client_name;
     std::string client_cert_uuid;
+    bool use_vdd {false};
+    int custom_screen_mode {-1};
     bool highly_suspected_unknown_client {false};
     std::string app_name;
     int app_id = 0;
@@ -629,6 +634,101 @@ namespace stream {
     // 标识这是仅控制流会话（只作为输入设备，不传输视频/音频）
     bool control_only { false };
   };
+
+  namespace session {
+    // 高位表示显示设备正在重配置，低 31 位记录已登记的视频会话数。
+    // 两者共用一个原子状态，确保“确认单会话”和“取得重配置权”由同一次 CAS 完成。
+    constexpr std::uint32_t VIDEO_SESSION_RECONFIGURING = std::uint32_t {1} << 31;
+    constexpr std::uint32_t VIDEO_SESSION_COUNT_MASK = ~VIDEO_SESSION_RECONFIGURING;
+
+    std::atomic_uint running_sessions;
+    boost::atomic<std::uint32_t> video_session_state {0};
+
+    // 在创建音视频线程前登记会话。显示设备重配置期间，新会话在此等待占用位释放，
+    // 避免会话启动和 VDD 重建同时进行。返回值表示它是否是首个视频会话。
+    std::optional<bool>
+    register_video_session() {
+      auto state = video_session_state.load(boost::memory_order_acquire);
+      for (;;) {
+        if ((state & VIDEO_SESSION_RECONFIGURING) != 0) {
+          state = video_session_state.wait(state, boost::memory_order_acquire);
+          continue;
+        }
+
+        const auto count = state & VIDEO_SESSION_COUNT_MASK;
+        if (count == VIDEO_SESSION_COUNT_MASK) {
+          BOOST_LOG(error) << "Cannot register another video session because the session counter is exhausted"sv;
+          return std::nullopt;
+        }
+
+        if (video_session_state.compare_exchange_weak(
+              state,
+              state + 1,
+              boost::memory_order_acq_rel,
+              boost::memory_order_acquire)) {
+          return count == 0;
+        }
+      }
+    }
+
+    // 只递减低位的会话计数，保留可能并发存在的重配置占用位。
+    // 返回注销后的会话数，由最后一个会话负责执行平台停止和显示恢复逻辑。
+    std::uint32_t
+    unregister_video_session() {
+      auto state = video_session_state.load(boost::memory_order_acquire);
+      for (;;) {
+        const auto count = state & VIDEO_SESSION_COUNT_MASK;
+        if (count == 0) {
+          BOOST_LOG(error) << "Cannot unregister a video session because the session counter is already zero"sv;
+          return 0;
+        }
+
+        const auto desired = (state & VIDEO_SESSION_RECONFIGURING) | (count - 1);
+        if (video_session_state.compare_exchange_weak(
+              state,
+              desired,
+              boost::memory_order_acq_rel,
+              boost::memory_order_acquire)) {
+          return count - 1;
+        }
+      }
+    }
+
+    std::uint32_t
+    video_session_count() {
+      return video_session_state.load(boost::memory_order_acquire) & VIDEO_SESSION_COUNT_MASK;
+    }
+
+    template <class F>
+    bool
+    run_display_reconfiguration_if_single_video_session(F &&operation) {
+      // 只有恰好一个视频会话时才允许重配置。CAS 成功设置占用位后，
+      // 后续视频会话会在 register_video_session() 中等待，不会进入重建窗口。
+      auto state = video_session_state.load(boost::memory_order_acquire);
+      for (;;) {
+        if ((state & VIDEO_SESSION_RECONFIGURING) != 0 ||
+            (state & VIDEO_SESSION_COUNT_MASK) != 1) {
+          return false;
+        }
+
+        if (video_session_state.compare_exchange_weak(
+              state,
+              state | VIDEO_SESSION_RECONFIGURING,
+              boost::memory_order_acq_rel,
+              boost::memory_order_acquire)) {
+          break;
+        }
+      }
+
+      // 无论重配置正常返回还是抛出异常，都必须清除占用位并唤醒等待的新会话。
+      auto reconfiguration_guard = util::fail_guard([]() {
+        video_session_state.fetch_and(VIDEO_SESSION_COUNT_MASK, boost::memory_order_release);
+        video_session_state.notify_all();
+      });
+      std::forward<F>(operation)();
+      return true;
+    }
+  }  // namespace session
 
   /**
    * First part of cipher must be struct of type control_encrypted_t
@@ -1586,15 +1686,46 @@ namespace stream {
       // 注意：必须按照结构体声明顺序初始化字段
       rtsp_stream::launch_session_t temp_launch_session {};
       temp_launch_session.id = session->launch_session_id;
+      temp_launch_session.client_cert_uuid = session->client_cert_uuid;
       temp_launch_session.client_name = session->client_name;
       temp_launch_session.width = new_width;
       temp_launch_session.height = new_height;
       temp_launch_session.fps = session->config.monitor.framerate;
       temp_launch_session.enable_hdr = session->enable_hdr;
       temp_launch_session.enable_sops = session->enable_sops;
+      temp_launch_session.use_vdd = session->use_vdd;
+      temp_launch_session.custom_screen_mode = session->custom_screen_mode;
       temp_launch_session.max_nits = session->max_nits;
       temp_launch_session.min_nits = session->min_nits;
       temp_launch_session.max_full_nits = session->max_full_nits;
+
+      bool active_display_resolved = true;
+      const auto active_display_event = mail::man->event<std::string>(mail::active_display);
+      const auto active_display = active_display_event->view(std::chrono::milliseconds {0});
+      const bool has_active_display = active_display && !active_display->empty();
+      const std::string target_display = has_active_display ?
+                                           *active_display :
+                                           session->config.monitor.display_name;
+      if (!target_display.empty()) {
+        const auto devices = display_device::enum_available_devices();
+        const auto device_it = std::find_if(devices.begin(), devices.end(), [&](const auto &entry) {
+          return entry.first == target_display ||
+                 entry.second.display_name == target_display ||
+                 entry.second.friendly_name == target_display;
+        });
+        if (device_it != devices.end()) {
+          temp_launch_session.env["SUNSHINE_CLIENT_DISPLAY_NAME"] = device_it->first;
+          temp_launch_session.use_vdd = device_it->second.friendly_name == ZAKO_NAME;
+        }
+        else if (has_active_display) {
+          active_display_resolved = false;
+          BOOST_LOG(warning) << "Current capture display [" << target_display
+                             << "] is no longer available; skipping display device reconfiguration";
+        }
+        else {
+          temp_launch_session.env["SUNSHINE_CLIENT_DISPLAY_NAME"] = target_display;
+        }
+      }
 
       // 更新显示设备配置（重新配置模式）
       // 注意：这也会触发捕获端和编码器的重新初始化，以适配新的分辨率
@@ -1607,7 +1738,17 @@ namespace stream {
                         << " -> " << new_width << "x" << new_height;
       }
       
-      display_device::session_t::get().configure_display(config::video, temp_launch_session, true);
+      if (active_display_resolved) {
+        const bool display_reconfigured = stream::session::run_display_reconfiguration_if_single_video_session([&]() {
+          display_device::session_t::get().configure_display(config::video, temp_launch_session, true);
+        });
+        if (!display_reconfigured) {
+          BOOST_LOG(info) << "Skipping display device reconfiguration for the dynamic resolution request because other streaming sessions are active";
+        }
+      }
+      else {
+        BOOST_LOG(info) << "Dynamic stream resolution updated without changing the unavailable capture display";
+      }
 
       // 请求 IDR 帧以确保客户端能正确显示新分辨率
       // 这对于旋转场景特别重要，因为宽高互换需要新的关键帧
@@ -3258,9 +3399,6 @@ namespace stream {
   }
 
   namespace session {
-    std::atomic_uint running_sessions;
-    std::atomic_uint running_non_control_only_sessions;  // 跟踪非仅控制流会话的数量
-
     const char *
     stop_reason_name(stop_reason_e reason) {
       switch (reason) {
@@ -3290,7 +3428,7 @@ namespace stream {
 
     bool
     has_active_video_sessions() {
-      return running_non_control_only_sessions.load(std::memory_order_relaxed) > 0;
+      return video_session_count() > 0;
     }
 
     void
@@ -3361,7 +3499,7 @@ namespace stream {
         // 非仅控制流会话：减少两个计数器
         --running_sessions;
         // If this is the last non-control-only session, invoke the platform callbacks
-        if (--running_non_control_only_sessions == 0) {
+        if (unregister_video_session() == 0) {
           // 最后一个会话结束时，确保麦克风socket已关闭
           if (session.broadcast_ref->mic_socket_enabled.load()) {
             session.broadcast_ref->mic_socket_enabled.store(false);
@@ -3464,7 +3602,38 @@ namespace stream {
         return -1;
       }
 
+      bool first_video_session {false};
+      bool video_session_registered {false};
+      if (!session.control_only) {
+        const auto registration = register_video_session();
+        if (!registration) {
+          return -1;
+        }
+
+        first_video_session = *registration;
+        video_session_registered = true;
+      }
+      // 登记后的启动失败由 guard 回退计数；正常进入 RUNNING 后转交 join() 注销。
+      auto video_session_registration_guard = util::fail_guard([&]() {
+        if (video_session_registered) {
+          unregister_video_session();
+        }
+      });
+
       session.control.expected_peer_address = addr_string;
+      auto addr = boost::asio::ip::make_address(addr_string);
+      session.video.peer.address(addr);
+      session.video.peer.port(0);
+      session.audio.peer.address(addr);
+      session.audio.peer.port(0);
+
+      // 会话加入 _sessions 后，控制线程可能立即读取它。因此必须先初始化
+      // 控制线程依赖的所有字段，否则默认构造的超时时间会被误判为已经过期。
+      session.pingTimeout = std::chrono::steady_clock::now() + config::stream.ping_timeout;
+      session.lifecycle.set_state(state_e::STARTING);
+      auto starting_guard = util::fail_guard([&]() {
+        session.lifecycle.set_state(state_e::RUNNING);
+      });
       if (session.control_only) {
         BOOST_LOG(info) << "Starting control-only session from ["sv << addr_string << "] - will only handle input control"sv;
       }
@@ -3472,25 +3641,12 @@ namespace stream {
         BOOST_LOG(debug) << "Expecting incoming session connections from "sv << addr_string;
       }
 
-      // Insert this session into the session list
+      // 将完成初始化的会话加入共享列表。
       {
         auto lg = session.broadcast_ref->control_server._sessions.lock();
         session.broadcast_ref->control_server._sessions->push_back(&session);
       }
       clipboard_bridge::bridge_t::instance().session_started(session.launch_session_id);
-
-      auto addr = boost::asio::ip::make_address(addr_string);
-      session.video.peer.address(addr);
-      session.video.peer.port(0);
-
-      session.audio.peer.address(addr);
-      session.audio.peer.port(0);
-
-      session.pingTimeout = std::chrono::steady_clock::now() + config::stream.ping_timeout;
-      session.lifecycle.set_state(state_e::STARTING);
-      auto starting_guard = util::fail_guard([&]() {
-        session.lifecycle.set_state(state_e::RUNNING);
-      });
 
       // 仅控制流会话不启动视频/音频线程
       if (!session.control_only) {
@@ -3503,6 +3659,10 @@ namespace stream {
 
       session.lifecycle.set_state(state_e::RUNNING);
       starting_guard.disable();
+
+      ++running_sessions;
+      video_session_registration_guard.disable();
+
       perf::begin_session({
         session.launch_session_id,
         session.client_name,
@@ -3523,15 +3683,11 @@ namespace stream {
       // 仅控制流会话不触发 streaming_will_start 回调，因为它们不传输视频/音频
       // 但它们仍然需要被计入 running_sessions，以便正确管理会话
       if (session.control_only) {
-        // 仅控制流会话：只增加总会话计数，不调用平台回调
-        ++running_sessions;
         BOOST_LOG(debug) << "Control-only session started (total sessions: "sv << running_sessions.load() << ")"sv;
       }
       else {
-        // 非仅控制流会话：增加两个计数器
-        ++running_sessions;
         // If this is the first non-control-only session, invoke the platform callbacks
-        if (++running_non_control_only_sessions == 1) {
+        if (first_video_session) {
           // 根据会话的麦克风启用标志管理麦克风socket
           if (session.audio.enable_mic) {
             setup_mic_for_session(session);
@@ -3599,6 +3755,8 @@ namespace stream {
       // 设置客户端名称
       session->client_name = launch_session.client_name;
       session->client_cert_uuid = launch_session.client_cert_uuid;
+      session->use_vdd = launch_session.use_vdd;
+      session->custom_screen_mode = launch_session.custom_screen_mode;
       session->highly_suspected_unknown_client = launch_session.highly_suspected_unknown_client;
       session->app_id = launch_session.appid;
       session->app_name = proc::proc.get_app_name(launch_session.appid);

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -1740,7 +1740,10 @@ namespace stream {
       
       if (active_display_resolved) {
         const bool display_reconfigured = stream::session::run_display_reconfiguration_if_single_video_session([&]() {
-          display_device::session_t::get().configure_display(config::video, temp_launch_session, true);
+          const auto result = display_device::session_t::get().configure_display(config::video, temp_launch_session, true);
+          if (!result) {
+            BOOST_LOG(warning) << "Dynamic display reconfiguration failed: " << result.message;
+          }
         });
         if (!display_reconfigured) {
           BOOST_LOG(info) << "Skipping display device reconfiguration for the dynamic resolution request because other streaming sessions are active";
@@ -1757,7 +1760,7 @@ namespace stream {
       // 注意：编码器和触摸端口的更新会在捕获端重新初始化时自动处理
       // - 编码器会在重新初始化时使用新的宽高（通过 config.monitor.width/height）
       // - 触摸端口会在视频捕获循环中通过 make_port() 自动更新
-      BOOST_LOG(info) << "Resolution change completed: " << new_width << "x" << new_height 
+      BOOST_LOG(info) << "Dynamic stream resolution updated: " << new_width << "x" << new_height
                       << (is_rotation ? " (rotation detected)" : "");
     };
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1769,6 +1769,22 @@ namespace video {
     constexpr auto capture_buffer_size = 12;
     std::list<std::shared_ptr<platf::img_t>> imgs(capture_buffer_size);
 
+    auto append_pending_capture_contexts = [&]() -> bool {
+      while (capture_ctx_queue->peek()) {
+        auto capture_ctx = capture_ctx_queue->pop();
+        if (!capture_ctx) {
+          return false;
+        }
+
+        // 同一个捕获线程中的会话共享当前显示器。手动切换显示器后加入的会话
+        // 必须继承当前目标，避免后续重新初始化跳回它启动时选择的显示器。
+        capture_ctx->config.display_name = target_display_name;
+        capture_ctxs.emplace_back(std::move(*capture_ctx));
+      }
+
+      return true;
+    };
+
     std::vector<std::optional<std::chrono::steady_clock::time_point>> imgs_used_timestamps;
     const std::chrono::seconds trim_timeot = 3s;
     auto trim_imgs = [&]() {
@@ -1888,18 +1904,8 @@ namespace video {
           return false;
         }
 
-        while (capture_ctx_queue->peek()) {
-          auto capture_ctx = capture_ctx_queue->pop();
-          if (!capture_ctx) {
-            return false;
-          }
-
-          // All sessions in this capture thread share one display. A session
-          // joining after a manual switch must inherit the active target so a
-          // later capture reinitialization cannot jump back to its launch-time
-          // display selection.
-          capture_ctx->config.display_name = target_display_name;
-          capture_ctxs.emplace_back(std::move(*capture_ctx));
+        if (!append_pending_capture_contexts()) {
+          return false;
         }
 
         if (switch_display_event->peek()) {
@@ -1949,6 +1955,12 @@ namespace video {
             });
 
             std::this_thread::sleep_for(20ms);
+          }
+
+          // 等待旧显示器释放期间，最后一个旧会话可能退出，同时新会话已经加入队列。
+          // 先接入新上下文；若仍无会话则安全结束捕获线程，不能访问空容器的 front()。
+          if (!append_pending_capture_contexts() || capture_ctxs.empty()) {
+            return;
           }
 
           while (capture_ctx_queue->running()) {

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1712,6 +1712,7 @@ namespace video {
     });
 
     auto switch_display_event = mail::man->event<int>(mail::switch_display);
+    auto active_display_event = mail::man->event<std::string>(mail::active_display);
 
     // Wait for the initial capture context or a request to stop the queue
     auto initial_capture_ctx = capture_ctx_queue->pop();
@@ -1762,6 +1763,7 @@ namespace video {
     if (!disp) {
       return;
     }
+    active_display_event->raise(target_display_name);
     display_wp = disp;
 
     constexpr auto capture_buffer_size = 12;
@@ -1887,7 +1889,17 @@ namespace video {
         }
 
         while (capture_ctx_queue->peek()) {
-          capture_ctxs.emplace_back(std::move(*capture_ctx_queue->pop()));
+          auto capture_ctx = capture_ctx_queue->pop();
+          if (!capture_ctx) {
+            return false;
+          }
+
+          // All sessions in this capture thread share one display. A session
+          // joining after a manual switch must inherit the active target so a
+          // later capture reinitialization cannot jump back to its launch-time
+          // display selection.
+          capture_ctx->config.display_name = target_display_name;
+          capture_ctxs.emplace_back(std::move(*capture_ctx));
         }
 
         if (switch_display_event->peek()) {
@@ -1955,8 +1967,8 @@ namespace video {
             }
 
             // Use client-specified display_name if provided (only for auto-reinit, not manual switch)
-            const auto &config = capture_ctxs.front().config;
-            std::string target_display_name = display_names[display_p];
+            auto &config = capture_ctxs.front().config;
+            target_display_name = display_names[display_p];
             if (!user_switched && !config.display_name.empty()) {
               // config.display_name may be a device ID - convert to display name
               std::string resolved_display_name = display_device::get_display_name(config.display_name);
@@ -1979,9 +1991,16 @@ namespace video {
               }
             }
 
+            if (user_switched) {
+              for (auto &capture_ctx : capture_ctxs) {
+                capture_ctx.config.display_name = target_display_name;
+              }
+            }
+
             // reset_display() will sleep between retries
             reset_display(disp, encoder.platform_formats->dev_type, target_display_name, config);
             if (disp) {
+              active_display_event->raise(target_display_name);
               break;
             }
           }
@@ -3351,6 +3370,8 @@ namespace video {
     std::shared_ptr<platf::display_t> disp;
 
     auto switch_display_event = mail::man->event<int>(mail::switch_display);
+    auto active_display_event = mail::man->event<std::string>(mail::active_display);
+    std::string active_display_name;
 
     if (synced_session_ctxs.empty()) {
       auto ctx = encode_session_ctx_queue.pop();
@@ -3373,7 +3394,7 @@ namespace video {
       }
 
       // Use client-specified display_name if provided (only for auto-reinit, not manual switch)
-      const auto &config = synced_session_ctxs.front()->config;
+      auto &config = synced_session_ctxs.front()->config;
       std::string target_display_name = display_names[display_p];
       if (!user_switched && !config.display_name.empty()) {
         // config.display_name may be a device ID - convert to display name
@@ -3397,9 +3418,17 @@ namespace video {
         }
       }
 
+      if (user_switched) {
+        for (auto &ctx : synced_session_ctxs) {
+          ctx->config.display_name = target_display_name;
+        }
+      }
+
       // reset_display() will sleep between retries
       reset_display(disp, encoder.platform_formats->dev_type, target_display_name, config);
       if (disp) {
+        active_display_name = target_display_name;
+        active_display_event->raise(target_display_name);
         break;
       }
     }
@@ -3432,6 +3461,10 @@ namespace video {
             return false;
           }
 
+          // Synchronous sessions share the display opened above. Keep the
+          // active target in newly joined contexts so the next reinit does not
+          // restore their stale launch-time display selection.
+          encode_session_ctx->config.display_name = active_display_name;
           synced_session_ctxs.emplace_back(std::make_unique<sync_session_ctx_t>(std::move(*encode_session_ctx)));
 
           auto encode_session = make_synced_session(disp.get(), encoder, *img, *synced_session_ctxs.back());


### PR DESCRIPTION
## 说明

Windows 锁屏或 SYSTEM RDP 会话中可以创建 VDD，但交互式 CCD 拓扑和显示设置可能暂时不可用。原流程会继续同步修改拓扑，导致启动或恢复串流返回 503。Resume 和动态分辨率重配置还可能使用启动时记录的屏幕，或者仅因客户端变化重建仍兼容的 VDD。

## 修改

- 将 VDD 驱动与显示器准备从拓扑、模式确认和 HDR 设置中拆分；锁屏时延迟交互式显示操作，SYSTEM RDP 会话只准备 VDD，不修改拓扑。
- 在配置完成前保留 VDD 创建前的拓扑和物理显示器快照，并区分未捕获快照与无头主机。
- Resume 时先检查现有 VDD 是否已经发布请求模式，仅在模式不兼容时重建，不再仅因客户端标识变化重建。
- 动态分辨率重配置使用当前实际捕获的显示器，并在单视频会话条件下取得原子重配置权，避免新会话与 VDD 重建并发。
- 手动切换捕获显示器后同步更新会话上下文，避免后续捕获重初始化跳回启动时的显示器。