### PR TITLE
fix(nvenc): make the 10-bit 4:4:4 CUDA array input opt-in and fix its pitch

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2524,7 +2524,12 @@ editing the `conf` file in a text editor. Use the examples as reference.
         <td colspan="2">
             Feed 10-bit 4:4:4 frames to NVENC through a block-linear CUDA array instead of the pitch-linear
             device pointer.
-            @warning{Experimental. Some drivers produce ghosted output or stall the encoder with this enabled.
+            @note{Windows only. Requires a driver exposing NVENC 13.1 or newer; on older drivers Sunshine
+            logs a message and keeps using the device pointer.}
+            @warning{Experimental. Some drivers produce ghosted output, and some stall while Sunshine probes
+            encoders at startup — which happens before the web UI binds, so the UI never becomes reachable and
+            you cannot turn this back off from there. Recover by stopping the Sunshine service, setting
+            `nvenc_cuda_array_input = disabled` in `sunshine.conf`, and starting the service again.
             Leave it disabled unless you are helping test the 4:4:4 path.}
         </td>
     </tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2516,6 +2516,32 @@ editing the `conf` file in a text editor. Use the examples as reference.
     </tr>
 </table>
 
+### [nvenc_cuda_array_input](https://localhost:47990/config/#nvenc_cuda_array_input)
+
+<table>
+    <tr>
+        <td>Description</td>
+        <td colspan="2">
+            Feed 10-bit 4:4:4 frames to NVENC through a block-linear CUDA array instead of the pitch-linear
+            device pointer.
+            @warning{Experimental. Some drivers produce ghosted output or stall the encoder with this enabled.
+            Leave it disabled unless you are helping test the 4:4:4 path.}
+        </td>
+    </tr>
+    <tr>
+        <td>Default</td>
+        <td colspan="2">@code{}
+            disabled
+            @endcode</td>
+    </tr>
+    <tr>
+        <td>Example</td>
+        <td colspan="2">@code{}
+            nvenc_cuda_array_input = disabled
+            @endcode</td>
+    </tr>
+</table>
+
 ## [Intel QuickSync Encoder](https://localhost:47990/config/#intel-quicksync-encoder)
 
 ### [qsv_preset](https://localhost:47990/config/#qsv_preset)

--- a/docs/source/about/advanced_usage.rst
+++ b/docs/source/about/advanced_usage.rst
@@ -1467,7 +1467,9 @@ min_fps_factor <https://localhost:47990/config/#min_fps_factor>`__
 **Description**
    Feed 10-bit 4:4:4 frames to NVENC through a block-linear CUDA array instead of the pitch-linear device pointer.
 
-   .. warning:: Experimental. Some drivers produce ghosted output or stall the encoder with this enabled. Leave it disabled unless you are helping test the 4:4:4 path.
+   .. note:: Windows only. Requires a driver exposing NVENC 13.1 or newer; on older drivers Sunshine logs a message and keeps using the device pointer.
+
+   .. warning:: Experimental. Some drivers produce ghosted output, and some stall while Sunshine probes encoders at startup — which happens before the web UI binds, so the UI never becomes reachable and you cannot turn this back off from there. Recover by stopping the Sunshine service, setting ``nvenc_cuda_array_input = disabled`` in ``sunshine.conf``, and starting the service again. Leave it disabled unless you are helping test the 4:4:4 path.
 
 **Choices**
 

--- a/docs/source/about/advanced_usage.rst
+++ b/docs/source/about/advanced_usage.rst
@@ -1461,6 +1461,34 @@ min_fps_factor <https://localhost:47990/config/#min_fps_factor>`__
 
       nvenc_h264_cavlc = disabled
 
+`nvenc_cuda_array_input <https://localhost:47990/config/#nvenc_cuda_array_input>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Description**
+   Feed 10-bit 4:4:4 frames to NVENC through a block-linear CUDA array instead of the pitch-linear device pointer.
+
+   .. warning:: Experimental. Some drivers produce ghosted output or stall the encoder with this enabled. Leave it disabled unless you are helping test the 4:4:4 path.
+
+**Choices**
+
+.. table::
+   :widths: auto
+
+   ========== ===========
+   Value      Description
+   ========== ===========
+   disabled   Pitch-linear CUDA device pointer
+   enabled    Block-linear CUDA array
+   ========== ===========
+
+**Default**
+   ``disabled``
+
+**Example**
+   .. code-block:: text
+
+      nvenc_cuda_array_input = disabled
+
 `Intel QuickSync Encoder <https://localhost:47990/config/#intel-quicksync-encoder>`__
 -------------------------------------------------------------------------------------
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1167,6 +1167,7 @@ namespace config {
     generic_f(vars, "nvenc_temporal_filter", video.nv.temporal_filter_level, nv::temporal_filter_level_from_view);
     generic_f(vars, "nvenc_rate_control", video.nv.rate_control_mode, nv::rate_control_mode_from_view);
     int_between_f(vars, "nvenc_target_quality", video.nv.target_quality, { 0, 63 });
+    bool_f(vars, "nvenc_cuda_array_input", video.nv.cuda_array_input);
     bool_f(vars, "nvenc_realtime_hags", video.nv_realtime_hags);
     bool_f(vars, "nvenc_opengl_vulkan_on_dxgi", video.nv_opengl_vulkan_on_dxgi);
     bool_f(vars, "nvenc_latency_over_power", video.nv_sunshine_high_power_mode);

--- a/src/nvenc/common_impl/nvenc_base.cpp
+++ b/src/nvenc/common_impl/nvenc_base.cpp
@@ -113,6 +113,7 @@ namespace nvenc {
     encoder_params.width = client_config.width;
     encoder_params.height = client_config.height;
     encoder_params.buffer_format = buffer_format;
+    encoder_params.cuda_array_input = config.cuda_array_input;
 
     // YUV 4:2:0 formats (NV12/P010) require even dimensions because
     // the chroma plane is half the size of the luma plane in both dimensions.

--- a/src/nvenc/common_impl/nvenc_base.h
+++ b/src/nvenc/common_impl/nvenc_base.h
@@ -106,6 +106,7 @@ namespace nvenc {
       NV_ENC_BUFFER_FORMAT buffer_format = NV_ENC_BUFFER_FORMAT_UNDEFINED;
       uint32_t ref_frames_in_dpb = 0;
       bool rfi = false;
+      bool cuda_array_input = false;  ///< Mirrors `nvenc_config::cuda_array_input` for `create_and_register_input_buffer()`.
     } encoder_params;
 
     std::string last_nvenc_error_string;

--- a/src/nvenc/nvenc_config.h
+++ b/src/nvenc/nvenc_config.h
@@ -124,6 +124,12 @@ namespace nvenc {
     // Target quality for VBR mode (0-51 for H.264/HEVC, 0-63 for AV1, 0=auto). Lower value = higher quality
     // Only used when rate_control_mode is VBR
     int target_quality = 0;  // 0 = automatic
+
+    // Feed 10-bit 4:4:4 to NVENC through a block-linear CUDA array instead of the
+    // pitch-linear device pointer. Off by default: the array path has produced
+    // ghosted/garbled output and stalls on some drivers, and the device-pointer
+    // path is the known-good fallback.
+    bool cuda_array_input = false;
   };
 
 }  // namespace nvenc

--- a/src/nvenc/win/impl/nvenc_d3d11_on_cuda.cpp
+++ b/src/nvenc/win/impl/nvenc_d3d11_on_cuda.cpp
@@ -206,6 +206,18 @@ namespace nvenc {
 
       BOOST_LOG(info) << "NvEnc: falling back to pitch-linear CUDA device pointer input";
     }
+
+    // synchronize_input_buffer() picks its copy destination by testing whether
+    // cuda_array_surface is set, and destroy_encoder() does not clear it. Today
+    // every session gets a fresh encoder object so it is always null here, but
+    // leaving a stale array behind while NVENC reads the device pointer would
+    // silently feed the encoder untouched memory. Drop it explicitly.
+    if (cuda_array_surface) {
+      auto autopop_context = push_context();
+      if (autopop_context) {
+        destroy_cuda_array_input();
+      }
+    }
 #endif
 
     return create_and_register_cuda_device_pointer_input();

--- a/src/nvenc/win/impl/nvenc_d3d11_on_cuda.cpp
+++ b/src/nvenc/win/impl/nvenc_d3d11_on_cuda.cpp
@@ -195,12 +195,17 @@ namespace nvenc {
     }
 
 #if NVENCAPI_MAJOR_VERSION * 100 + NVENCAPI_MINOR_VERSION >= 1301
-    if (create_and_register_cuda_array_input()) {
-      BOOST_LOG(info) << "NvEnc: using block-linear CUDA array input";
-      return true;
-    }
+    // Opt-in only. The array path has shipped ghosted output and has been seen to
+    // stall during encoder probing on some drivers, so the pitch-linear device
+    // pointer stays the default until it is confirmed good on real hardware.
+    if (encoder_params.cuda_array_input) {
+      if (create_and_register_cuda_array_input()) {
+        BOOST_LOG(info) << "NvEnc: using block-linear CUDA array input";
+        return true;
+      }
 
-    BOOST_LOG(info) << "NvEnc: falling back to pitch-linear CUDA device pointer input";
+      BOOST_LOG(info) << "NvEnc: falling back to pitch-linear CUDA device pointer input";
+    }
 #endif
 
     return create_and_register_cuda_device_pointer_input();
@@ -243,10 +248,14 @@ namespace nvenc {
       }
     }
 
+    // NVENC wants the byte width of the whole allocation. The header spells this
+    // as `CUDA_ARRAY3D_DESCRIPTOR::Width * NumChannels`, which only works out to
+    // bytes for 8-bit formats; UINT16_PLANAR_444 is 2 bytes per sample across 3
+    // planes, so the row stride is width * 3 * 2.
     if (!register_cuda_input(
           NV_ENC_INPUT_RESOURCE_TYPE_CUDAARRAY,
           cuda_array_surface,
-          encoder_params.width * planar_yuv_bytes_per_sample)) {
+          encoder_params.width * planar_yuv_plane_count * planar_yuv_bytes_per_sample)) {
       BOOST_LOG(warning) << "NvEnc: CUDA array registration failed: " << last_nvenc_error_string;
       destroy_cuda_array_input();
       return false;

--- a/src_assets/common/assets/web/composables/useConfig.js
+++ b/src_assets/common/assets/web/composables/useConfig.js
@@ -148,6 +148,7 @@ const DEFAULT_TABS = [
           nvenc_latency_over_power: 'enabled',
           nvenc_opengl_vulkan_on_dxgi: 'enabled',
           nvenc_h264_cavlc: 'disabled',
+          nvenc_cuda_array_input: 'disabled',
         },
       },
       {

--- a/src_assets/common/assets/web/configs/tabs/encoders/NvidiaNvencEncoder.vue
+++ b/src_assets/common/assets/web/configs/tabs/encoders/NvidiaNvencEncoder.vue
@@ -180,6 +180,16 @@ const config = ref(props.config)
               <div class="form-text">{{ $t('config.nvenc_opengl_vulkan_on_dxgi_desc') }}</div>
             </div>
 
+            <!-- 10-bit 4:4:4 CUDA array input -->
+            <div class="mb-3" v-if="platform === 'windows'">
+              <label for="nvenc_cuda_array_input" class="form-label">{{ $t('config.nvenc_cuda_array_input') }}</label>
+              <select id="nvenc_cuda_array_input" class="form-select" v-model="config.nvenc_cuda_array_input">
+                <option value="disabled">{{ $t('_common.disabled_def') }}</option>
+                <option value="enabled">{{ $t('_common.enabled') }}</option>
+              </select>
+              <div class="form-text">{{ $t('config.nvenc_cuda_array_input_desc') }}</div>
+            </div>
+
             <!-- NVENC H264 CAVLC -->
             <div>
               <label for="nvenc_h264_cavlc" class="form-label">{{ $t('config.nvenc_h264_cavlc') }}</label>

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -471,6 +471,8 @@
     "no_resolutions": "No resolutions added",
     "notify_pre_releases": "PreRelease Notifications",
     "notify_pre_releases_desc": "Whether to be notified of new pre-release versions of Sunshine",
+    "nvenc_cuda_array_input": "Use CUDA array input for 10-bit 4:4:4",
+    "nvenc_cuda_array_input_desc": "Feed 10-bit 4:4:4 frames to NVENC through a block-linear CUDA array instead of the pitch-linear device pointer. Experimental: some drivers produce ghosted output or stall the encoder with this enabled. Leave disabled unless you are testing it.",
     "nvenc_h264_cavlc": "Prefer CAVLC over CABAC in H.264",
     "nvenc_h264_cavlc_desc": "Simpler form of entropy coding. CAVLC needs around 10% more bitrate for same quality. Only relevant for really old decoding devices.",
     "nvenc_latency_over_power": "Prefer lower encoding latency over power savings",

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -472,7 +472,7 @@
     "notify_pre_releases": "PreRelease Notifications",
     "notify_pre_releases_desc": "Whether to be notified of new pre-release versions of Sunshine",
     "nvenc_cuda_array_input": "Use CUDA array input for 10-bit 4:4:4",
-    "nvenc_cuda_array_input_desc": "Feed 10-bit 4:4:4 frames to NVENC through a block-linear CUDA array instead of the pitch-linear device pointer. Experimental: some drivers produce ghosted output or stall the encoder with this enabled. Leave disabled unless you are testing it.",
+    "nvenc_cuda_array_input_desc": "Windows only. Feed 10-bit 4:4:4 frames to NVENC through a block-linear CUDA array instead of the pitch-linear device pointer. Requires a driver with NVENC 13.1 or newer; older drivers ignore this and keep using the device pointer. Experimental: some drivers produce ghosted output, and some stall while Sunshine probes encoders at startup, which prevents the web UI from becoming reachable. If that happens you cannot turn this back off from here — stop the Sunshine service, set nvenc_cuda_array_input = disabled in sunshine.conf, then start the service again. Leave disabled unless you are testing it.",
     "nvenc_h264_cavlc": "Prefer CAVLC over CABAC in H.264",
     "nvenc_h264_cavlc_desc": "Simpler form of entropy coding. CAVLC needs around 10% more bitrate for same quality. Only relevant for really old decoding devices.",
     "nvenc_latency_over_power": "Prefer lower encoding latency over power savings",

--- a/src_assets/common/assets/web/public/assets/locale/zh.json
+++ b/src_assets/common/assets/web/public/assets/locale/zh.json
@@ -471,6 +471,8 @@
     "no_resolutions": "未添加分辨率",
     "notify_pre_releases": "预发布版本通知",
     "notify_pre_releases_desc": "是否接收 Sunshine 新预发布版本的通知",
+    "nvenc_cuda_array_input": "10-bit 4:4:4 使用 CUDA array 输入",
+    "nvenc_cuda_array_input_desc": "将 10-bit 4:4:4 画面通过块线性（block-linear）CUDA array 送给 NVENC，而不是使用线性显存指针。实验功能：部分驱动开启后会出现重影或编码器卡死。除非你正在协助测试，否则请保持关闭。",
     "nvenc_h264_cavlc": "在 H.264 中优先使用 CAVLC 而非 CABAC",
     "nvenc_h264_cavlc_desc": "一种更简单的熵编码形式。相同质量下，CAVLC 需要增加约 10% 的比特率。仅适用于非常老旧的解码设备。",
     "nvenc_latency_over_power": "优先降低编码延迟而非省电",

--- a/src_assets/common/assets/web/public/assets/locale/zh.json
+++ b/src_assets/common/assets/web/public/assets/locale/zh.json
@@ -472,7 +472,7 @@
     "notify_pre_releases": "预发布版本通知",
     "notify_pre_releases_desc": "是否接收 Sunshine 新预发布版本的通知",
     "nvenc_cuda_array_input": "10-bit 4:4:4 使用 CUDA array 输入",
-    "nvenc_cuda_array_input_desc": "将 10-bit 4:4:4 画面通过块线性（block-linear）CUDA array 送给 NVENC，而不是使用线性显存指针。实验功能：部分驱动开启后会出现重影或编码器卡死。除非你正在协助测试，否则请保持关闭。",
+    "nvenc_cuda_array_input_desc": "仅 Windows。将 10-bit 4:4:4 画面通过块线性（block-linear）CUDA array 送给 NVENC，而不是使用线性显存指针。需要驱动支持 NVENC 13.1 及以上；旧驱动会忽略此项，继续走显存指针。实验功能：部分驱动开启后会出现重影，也有驱动会在 Sunshine 启动探测编码器时卡住，导致管理界面打不开。一旦出现这种情况就没法在这里关回去了 —— 请停止 Sunshine 服务，在 sunshine.conf 里写 nvenc_cuda_array_input = disabled，然后重新启动服务。除非你正在协助测试，否则请保持关闭。",
     "nvenc_h264_cavlc": "在 H.264 中优先使用 CAVLC 而非 CABAC",
     "nvenc_h264_cavlc_desc": "一种更简单的熵编码形式。相同质量下，CAVLC 需要增加约 10% 的比特率。仅适用于非常老旧的解码设备。",
     "nvenc_latency_over_power": "优先降低编码延迟而非省电",


### PR DESCRIPTION
## 背景

#861 把 block-linear CUDA array 变成了 10-bit 4:4:4 在 NVENC 上的**默认**输入路径。上线之后：

- #871 报告 4:4:4 画面重影；
- 该 issue 的报告者从 7/29 起就**根本进不去**测试包：服务 RUNNING 但 WebGUI 打不开。`probe_encoders()` 在启动时同步执行，且对任何带 `YUV444_SUPPORT` 的编码器**总是先测 HDR + 4:4:4**；而 `make_encode_device()`（CUDA array 注册就在这里）不在 `validate_config()` 那 5s 超时的保护范围内。卡在这里就意味着 web 服务器永远起不来。

## 改动

1. 新增 `nvenc_cuda_array_input`（默认 `disabled`），把 array 路径改成 opt-in。默认回到已知可用的 pitch-linear device pointer，所有人都不再受重影和启动卡死影响。
2. 顺手修掉 pitch：NVENC 头文件写的是 `Width * NumChannels`，那只在 8-bit 格式下等于字节宽度。`CU_AD_FORMAT_UINT16_PLANAR_444` 是 3 个 plane、每 sample 2 字节，所以行跨度是 `width * 3 * 2`，不是 `width * 2`。

这个 PR 取代 #874 —— #874 只把 `×2` 改成 `×3`，同样不是字节宽度，而且报告者装上之后依然起不来。

## 测试价值

出包之后报告者可以：
- 默认装上就能进 WebGUI（不管卡死的真实原因是不是 4:4:4 探测）；
- 在 NVENC 页面把 "Use CUDA array input for 10-bit 4:4:4" 打开，重启服务，单独验证修正后的 pitch 是否解决重影。

## 未做

启动流程加固（让编码器探测卡住也不影响 web UI 绑定）没有包含在这个 PR 里，值得单开一个。

🤖 Generated with [Claude Code](https://claude.com/claude-code)