### PR TITLE
fix(ai): protect persisted llm api keys

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -119,6 +119,8 @@ set(SUNSHINE_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/main.h"
         "${CMAKE_SOURCE_DIR}/src/crypto.cpp"
         "${CMAKE_SOURCE_DIR}/src/crypto.h"
+        "${CMAKE_SOURCE_DIR}/src/ai/credential_store.cpp"
+        "${CMAKE_SOURCE_DIR}/src/ai/credential_store.h"
         "${CMAKE_SOURCE_DIR}/src/webhook/webhook_auth.cpp"
         "${CMAKE_SOURCE_DIR}/src/webhook/webhook_auth.h"
         "${CMAKE_SOURCE_DIR}/src/webhook/webhook_api.cpp"

--- a/cmake/compile_definitions/windows.cmake
+++ b/cmake/compile_definitions/windows.cmake
@@ -196,6 +196,7 @@ set(OPENSSL_LIBRARIES
 
 list(PREPEND PLATFORM_LIBRARIES
         ${CURL_STATIC_LIBRARIES}
+        advapi32
         avrt
         crypt32
         d3d11

--- a/src/ai/credential_store.cpp
+++ b/src/ai/credential_store.cpp
@@ -29,25 +29,26 @@ namespace credential_store {
     }
 
     std::string
-    windows_error(const char *operation) {
-      return std::string { operation } + " failed (Windows error " + std::to_string(GetLastError()) + ")";
+    windows_error(const char *operation, DWORD error) {
+      return std::string { operation } + " failed (Windows error " + std::to_string(error) + ")";
     }
 
-    bool
+    DWORD
     restrict_file_acl(const std::filesystem::path &path) {
       PSECURITY_DESCRIPTOR descriptor = nullptr;
       constexpr auto sddl = L"D:P(A;;FA;;;SY)(A;;FA;;;BA)(A;;FA;;;OW)";
       if (!ConvertStringSecurityDescriptorToSecurityDescriptorW(
             sddl, SDDL_REVISION_1, &descriptor, nullptr)) {
-        return false;
+        return GetLastError();
       }
 
       const BOOL ok = SetFileSecurityW(
         path.c_str(),
         DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
         descriptor);
+      const DWORD error = ok ? ERROR_SUCCESS : GetLastError();
       LocalFree(descriptor);
-      return ok != FALSE;
+      return error;
     }
 
     mutation_result_t
@@ -69,15 +70,16 @@ namespace credential_store {
         }
       }
 
-      if (!restrict_file_acl(temp)) {
+      if (const DWORD error = restrict_file_acl(temp); error != ERROR_SUCCESS) {
         std::error_code ignored;
         std::filesystem::remove(temp, ignored);
-        return { false, windows_error("Restricting credential file access") };
+        return { false, windows_error("Restricting credential file access", error) };
       }
       if (!MoveFileExW(temp.c_str(), path.c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+        const DWORD error = GetLastError();
         std::error_code ignored;
         std::filesystem::remove(temp, ignored);
-        return { false, windows_error("Replacing credential file") };
+        return { false, windows_error("Replacing credential file", error) };
       }
       return { true, {} };
     }
@@ -109,7 +111,7 @@ namespace credential_store {
     DATA_BLOB output {};
     auto entropy = entropy_blob();
     if (!CryptUnprotectData(&input, nullptr, &entropy, nullptr, nullptr, CRYPTPROTECT_UI_FORBIDDEN, &output)) {
-      return { read_status_e::error, {}, windows_error("Decrypting LLM credential") };
+      return { read_status_e::error, {}, windows_error("Decrypting LLM credential", GetLastError()) };
     }
     std::string secret(reinterpret_cast<const char *>(output.pbData), output.cbData);
     SecureZeroMemory(output.pbData, output.cbData);
@@ -138,7 +140,7 @@ namespace credential_store {
           &input, L"Sunshine LLM API key", &entropy, nullptr, nullptr,
           CRYPTPROTECT_LOCAL_MACHINE | CRYPTPROTECT_UI_FORBIDDEN,
           &output)) {
-      return { false, windows_error("Encrypting LLM credential") };
+      return { false, windows_error("Encrypting LLM credential", GetLastError()) };
     }
     auto result = write_blob_atomically(path, output.pbData, output.cbData);
     SecureZeroMemory(output.pbData, output.cbData);

--- a/src/ai/credential_store.cpp
+++ b/src/ai/credential_store.cpp
@@ -1,0 +1,179 @@
+/**
+ * @file src/ai/credential_store.cpp
+ * @brief DPAPI storage on Windows and environment-only credentials elsewhere.
+ */
+
+#include "credential_store.h"
+
+#include <cstdlib>
+#include <fstream>
+#include <system_error>
+#include <vector>
+
+#if defined(_WIN32)
+  #include <windows.h>
+  #include <sddl.h>
+  #include <wincrypt.h>
+#endif
+
+namespace credential_store {
+  namespace {
+#if defined(_WIN32)
+    DATA_BLOB
+    entropy_blob() {
+      static constexpr char entropy[] = "Sunshine/LLM/APIKey/v1";
+      return {
+        static_cast<DWORD>(sizeof(entropy) - 1),
+        reinterpret_cast<BYTE *>(const_cast<char *>(entropy))
+      };
+    }
+
+    std::string
+    windows_error(const char *operation) {
+      return std::string { operation } + " failed (Windows error " + std::to_string(GetLastError()) + ")";
+    }
+
+    bool
+    restrict_file_acl(const std::filesystem::path &path) {
+      PSECURITY_DESCRIPTOR descriptor = nullptr;
+      constexpr auto sddl = L"D:P(A;;FA;;;SY)(A;;FA;;;BA)(A;;FA;;;OW)";
+      if (!ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            sddl, SDDL_REVISION_1, &descriptor, nullptr)) {
+        return false;
+      }
+
+      const BOOL ok = SetFileSecurityW(
+        path.c_str(),
+        DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+        descriptor);
+      LocalFree(descriptor);
+      return ok != FALSE;
+    }
+
+    mutation_result_t
+    write_blob_atomically(const std::filesystem::path &path, const BYTE *data, DWORD size) {
+      auto temp = path;
+      temp += L".tmp";
+      {
+        std::ofstream file(temp, std::ios::binary | std::ios::trunc);
+        if (!file.is_open()) {
+          return { false, "Could not open the protected credential file" };
+        }
+        file.write(reinterpret_cast<const char *>(data), static_cast<std::streamsize>(size));
+        file.flush();
+        if (!file.good()) {
+          file.close();
+          std::error_code ignored;
+          std::filesystem::remove(temp, ignored);
+          return { false, "Could not write the protected credential file" };
+        }
+      }
+
+      if (!restrict_file_acl(temp)) {
+        std::error_code ignored;
+        std::filesystem::remove(temp, ignored);
+        return { false, windows_error("Restricting credential file access") };
+      }
+      if (!MoveFileExW(temp.c_str(), path.c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+        std::error_code ignored;
+        std::filesystem::remove(temp, ignored);
+        return { false, windows_error("Replacing credential file") };
+      }
+      return { true, {} };
+    }
+#endif
+  }  // namespace
+
+  read_result_t
+  read_llm_api_key(const std::filesystem::path &path) {
+#if defined(_WIN32)
+    std::ifstream file(path, std::ios::binary | std::ios::ate);
+    if (!file.is_open()) {
+      std::error_code ec;
+      return std::filesystem::exists(path, ec)
+               ? read_result_t { read_status_e::error, {}, "Could not open the protected credential file" }
+               : read_result_t { read_status_e::not_found, {}, {} };
+    }
+    const auto length = file.tellg();
+    if (length <= 0 || length > 64 * 1024) {
+      return { read_status_e::error, {}, "Protected credential file has an invalid size" };
+    }
+    std::vector<BYTE> protected_data(static_cast<std::size_t>(length));
+    file.seekg(0);
+    file.read(reinterpret_cast<char *>(protected_data.data()), length);
+    if (!file.good()) {
+      return { read_status_e::error, {}, "Could not read the protected credential file" };
+    }
+
+    DATA_BLOB input { static_cast<DWORD>(protected_data.size()), protected_data.data() };
+    DATA_BLOB output {};
+    auto entropy = entropy_blob();
+    if (!CryptUnprotectData(&input, nullptr, &entropy, nullptr, nullptr, CRYPTPROTECT_UI_FORBIDDEN, &output)) {
+      return { read_status_e::error, {}, windows_error("Decrypting LLM credential") };
+    }
+    std::string secret(reinterpret_cast<const char *>(output.pbData), output.cbData);
+    SecureZeroMemory(output.pbData, output.cbData);
+    LocalFree(output.pbData);
+    return { read_status_e::success, std::move(secret), {} };
+#else
+    (void) path;
+    const char *value = std::getenv("SUNSHINE_LLM_API_KEY");
+    if (!value || !*value) return { read_status_e::not_found, {}, {} };
+    return { read_status_e::success, value, {} };
+#endif
+  }
+
+  mutation_result_t
+  write_llm_api_key(const std::filesystem::path &path, const std::string &secret) {
+    if (secret.empty()) return erase_llm_api_key(path);
+    if (secret.size() > 16 * 1024) return { false, "The LLM API key is too large" };
+#if defined(_WIN32)
+    DATA_BLOB input {
+      static_cast<DWORD>(secret.size()),
+      reinterpret_cast<BYTE *>(const_cast<char *>(secret.data()))
+    };
+    DATA_BLOB output {};
+    auto entropy = entropy_blob();
+    if (!CryptProtectData(
+          &input, L"Sunshine LLM API key", &entropy, nullptr, nullptr,
+          CRYPTPROTECT_LOCAL_MACHINE | CRYPTPROTECT_UI_FORBIDDEN,
+          &output)) {
+      return { false, windows_error("Encrypting LLM credential") };
+    }
+    auto result = write_blob_atomically(path, output.pbData, output.cbData);
+    SecureZeroMemory(output.pbData, output.cbData);
+    LocalFree(output.pbData);
+    return result;
+#else
+    (void) path;
+    const char *configured = std::getenv("SUNSHINE_LLM_API_KEY");
+    if (configured && secret == configured) {
+      // Allows a matching legacy plaintext value to be removed safely.
+      return { true, {} };
+    }
+    return {
+      false,
+      "Secure API key persistence is only supported on Windows; set SUNSHINE_LLM_API_KEY in the service environment"
+    };
+#endif
+  }
+
+  mutation_result_t
+  erase_llm_api_key(const std::filesystem::path &path) {
+#if defined(_WIN32)
+    std::error_code ec;
+    const bool removed = std::filesystem::remove(path, ec);
+    if (ec) return { false, "Could not remove the protected credential file: " + ec.message() };
+    (void) removed;
+    return { true, {} };
+#else
+    (void) path;
+    const char *configured = std::getenv("SUNSHINE_LLM_API_KEY");
+    if (configured && *configured) {
+      return { false, "Remove SUNSHINE_LLM_API_KEY from the service environment to clear the API key" };
+    }
+    return { true, {} };
+#endif
+  }
+
+}  // namespace credential_store

--- a/src/ai/credential_store.h
+++ b/src/ai/credential_store.h
@@ -1,0 +1,42 @@
+/**
+ * @file src/ai/credential_store.h
+ * @brief Platform-backed storage for the LLM API credential.
+ */
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+namespace credential_store {
+
+  enum class read_status_e {
+    success,
+    not_found,
+    error
+  };
+
+  struct read_result_t {
+    read_status_e status = read_status_e::error;
+    std::string secret;
+    std::string error;
+  };
+
+  struct mutation_result_t {
+    bool success = false;
+    std::string error;
+  };
+
+  /**
+   * The path is used for the DPAPI-protected blob on Windows. Other platforms
+   * read SUNSHINE_LLM_API_KEY and do not persist credentials.
+   */
+  read_result_t
+  read_llm_api_key(const std::filesystem::path &path);
+
+  mutation_result_t
+  write_llm_api_key(const std::filesystem::path &path, const std::string &secret);
+
+  mutation_result_t
+  erase_llm_api_key(const std::filesystem::path &path);
+
+}  // namespace credential_store

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -42,6 +42,7 @@
 #include "config.h"
 #include "confighttp.h"
 #include "clipboard_http.h"
+#include "ai/credential_store.h"
 #include "crypto.h"
 #include "display_device/session.h"
 #include "file_mapping/file_mapping_store.h"
@@ -2381,6 +2382,48 @@ namespace confighttp {
     return (config_dir / "ai_config.json").string();
   }
 
+  static fs::path
+  getAiCredentialPath() {
+    auto config_dir = fs::path(config::sunshine.config_file).parent_path();
+    return config_dir / "ai_llm_credential.bin";
+  }
+
+  static bool
+  writeAiConfigFile(const nlohmann::json &cfg) {
+    const fs::path path = getAiConfigPath();
+    auto temp = path;
+    temp += ".tmp";
+    try {
+      {
+        std::ofstream file(temp, std::ios::trunc);
+        if (!file.is_open()) return false;
+        file << cfg.dump(2);
+        file.flush();
+        if (!file.good()) throw std::runtime_error("Failed to flush AI config");
+      }
+#ifdef _WIN32
+      if (!MoveFileExW(temp.c_str(), path.c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+        std::error_code ignored;
+        fs::remove(temp, ignored);
+        return false;
+      }
+#else
+      std::error_code ec;
+      fs::rename(temp, path, ec);
+      if (ec) {
+        fs::remove(temp, ec);
+        return false;
+      }
+#endif
+      return true;
+    } catch (const std::exception &e) {
+      std::error_code ignored;
+      fs::remove(temp, ignored);
+      BOOST_LOG(error) << "Failed to save AI config: " << e.what();
+      return false;
+    }
+  }
+
   /**
    * @brief 从文件或缓存读取 AI 配置（调用方需持有 ai_config_mutex）
    */
@@ -2394,7 +2437,40 @@ namespace confighttp {
     try {
       std::string content = file_handler::read_file(path.c_str());
       if (!content.empty()) {
-        ai_config_cache = nlohmann::json::parse(content);
+        auto persisted = nlohmann::json::parse(content);
+        ai_config_cache = persisted;
+
+        // Migrate legacy plaintext credentials before exposing the runtime
+        // configuration. Never remove the old value until both secure storage
+        // and the sanitized config rewrite have succeeded.
+        const std::string legacy_key = persisted.value("apiKey", "");
+        if (!legacy_key.empty()) {
+          auto migration = credential_store::write_llm_api_key(getAiCredentialPath(), legacy_key);
+          if (migration.success) {
+            auto sanitized = persisted;
+            sanitized.erase("apiKey");
+            if (writeAiConfigFile(sanitized)) {
+              ai_config_cache = std::move(sanitized);
+              BOOST_LOG(info) << "Migrated the LLM API key out of ai_config.json";
+            } else {
+              BOOST_LOG(error) << "The LLM API key was secured, but ai_config.json could not be sanitized; migration will retry";
+            }
+          } else {
+            BOOST_LOG(error) << "Could not migrate the plaintext LLM API key: " << migration.error;
+          }
+          ai_config_cache["apiKey"] = legacy_key;
+        } else {
+          auto credential = credential_store::read_llm_api_key(getAiCredentialPath());
+          if (credential.status == credential_store::read_status_e::success) {
+            ai_config_cache["apiKey"] = std::move(credential.secret);
+          } else {
+            ai_config_cache["apiKey"] = "";
+            if (credential.status == credential_store::read_status_e::error) {
+              BOOST_LOG(error) << "Could not load the LLM API key from secure storage: " << credential.error;
+            }
+          }
+        }
+        ai_config_cache["apiKeyConfigured"] = !ai_config_cache.value("apiKey", "").empty();
         ai_config_loaded = true;
         return ai_config_cache;
       }
@@ -2405,11 +2481,19 @@ namespace confighttp {
       {"provider", "openai"},
       {"apiBase", "https://api.openai.com/v1"},
       {"apiKey", ""},
+      {"apiKeyConfigured", false},
       {"model", "gpt-4.1-mini"},
       {"compatibility", "openai-chat"},
       {"temperature", 0.3},
       {"max_tokens", 2048}
     };
+    auto credential = credential_store::read_llm_api_key(getAiCredentialPath());
+    if (credential.status == credential_store::read_status_e::success) {
+      ai_config_cache["apiKey"] = std::move(credential.secret);
+      ai_config_cache["apiKeyConfigured"] = true;
+    } else if (credential.status == credential_store::read_status_e::error) {
+      BOOST_LOG(error) << "Could not load the LLM API key from secure storage: " << credential.error;
+    }
     ai_config_loaded = true;
     return ai_config_cache;
   }
@@ -2428,19 +2512,14 @@ namespace confighttp {
    */
   static bool
   saveAiConfigLocked(const nlohmann::json &cfg) {
-    auto path = getAiConfigPath();
-    try {
-      std::ofstream file(path);
-      if (file.is_open()) {
-        file << cfg.dump(2);
-        ai_config_cache = cfg;
-        ai_config_loaded = true;
-        return true;
-      }
-    } catch (const std::exception &e) {
-      BOOST_LOG(error) << "Failed to save AI config: " << e.what();
-    }
-    return false;
+    auto persisted = cfg;
+    persisted.erase("apiKey");
+    persisted.erase("apiKeyConfigured");
+    persisted.erase("apiKeyHint");
+    if (!writeAiConfigFile(persisted)) return false;
+    ai_config_cache = cfg;
+    ai_config_loaded = true;
+    return true;
   }
 
   /**
@@ -2740,14 +2819,9 @@ namespace confighttp {
     auto cfg = loadAiConfig();
 
     // 掩码 API key：仅显示前4+后4字符
-    if (cfg.contains("apiKey") && cfg["apiKey"].is_string()) {
-      std::string key = cfg["apiKey"].get<std::string>();
-      if (key.length() > 8) {
-        cfg["apiKey"] = key.substr(0, 4) + "****" + key.substr(key.length() - 4);
-      } else if (!key.empty()) {
-        cfg["apiKey"] = "****";
-      }
-    }
+    const std::string key = cfg.value("apiKey", "");
+    cfg.erase("apiKey");
+    cfg["apiKeyConfigured"] = !key.empty();
 
     SimpleWeb::CaseInsensitiveMultimap headers;
     headers.emplace("Content-Type", "application/json");
@@ -2780,28 +2854,95 @@ namespace confighttp {
       if (input.contains("system_prompt")) current["system_prompt"] = input["system_prompt"].get<std::string>();
       if (input.contains("temperature")) current["temperature"] = input["temperature"].get<double>();
       if (input.contains("max_tokens")) current["max_tokens"] = input["max_tokens"].get<int>();
-      if (input.contains("apiKey")) {
-        std::string key = input["apiKey"].get<std::string>();
-        // 如果前端发来的是掩码（包含****），不覆盖
-        if (key.find("****") == std::string::npos) {
-          current["apiKey"] = key;
+      std::string key_action = input.value("apiKeyAction", "keep");
+      // Backward compatibility for older clients that only send apiKey.
+      if (input.contains("apiKey") && key_action == "keep") {
+        const std::string candidate = input["apiKey"].get<std::string>();
+        if (candidate.find("****") == std::string::npos) {
+          key_action = candidate.empty() ? "clear" : "replace";
         }
       }
 
+      if (key_action == "replace") {
+        if (!input.contains("apiKey") || !input["apiKey"].is_string() || input["apiKey"].get_ref<const std::string &>().empty()) {
+          throw std::invalid_argument("apiKeyAction=replace requires a non-empty apiKey");
+        }
+        const std::string key = input["apiKey"].get<std::string>();
+        auto stored = credential_store::write_llm_api_key(getAiCredentialPath(), key);
+        if (!stored.success) throw std::runtime_error("Failed to secure API key: " + stored.error);
+        current["apiKey"] = key;
+      } else if (key_action == "clear") {
+        auto erased = credential_store::erase_llm_api_key(getAiCredentialPath());
+        if (!erased.success) throw std::runtime_error("Failed to clear API key: " + erased.error);
+        current["apiKey"] = "";
+      } else if (key_action != "keep") {
+        throw std::invalid_argument("apiKeyAction must be keep, replace, or clear");
+      }
+      current["apiKeyConfigured"] = !current.value("apiKey", "").empty();
+
       if (saveAiConfigLocked(current)) {
         output["status"] = "ok";
+        output["apiKeyConfigured"] = current["apiKeyConfigured"];
       } else {
         output["status"] = "error";
         output["error"] = "Failed to write config file";
+        // Credential mutations have already completed. Keep runtime behavior
+        // consistent with secure storage even if the non-secret JSON write
+        // failed; the caller still receives an error and can retry.
+        ai_config_cache = current;
+        ai_config_loaded = true;
       }
     } catch (const std::exception &e) {
       output["status"] = "error";
-      output["error"] = std::string("Invalid JSON: ") + e.what();
+      output["error"] = e.what();
     }
 
     SimpleWeb::CaseInsensitiveMultimap headers;
     headers.emplace("Content-Type", "application/json");
     response->write(SimpleWeb::StatusCode::success_ok, output.dump(), headers);
+  }
+
+  void
+  proxyAiModels(resp_https_t response, req_https_t request) {
+    if (!authenticate(response, request)) return;
+    print_req(request);
+
+    const auto cfg = loadAiConfig();
+    const std::string api_key = cfg.value("apiKey", "");
+    std::string api_base = cfg.value("apiBase", "");
+    if (api_base.empty() || (api_key.empty() && isApiKeyRequired(cfg))) {
+      response->write(
+        SimpleWeb::StatusCode::client_error_bad_request,
+        R"({"error":{"message":"AI proxy not configured","type":"invalid_request_error"}})",
+        json_headers());
+      return;
+    }
+    if (isAnthropicProvider(cfg)) {
+      response->write(SimpleWeb::StatusCode::success_ok, R"({"data":[]})", json_headers());
+      return;
+    }
+
+    while (!api_base.empty() && api_base.back() == '/') api_base.pop_back();
+    if (hasSuffix(api_base, "/chat/completions")) {
+      api_base.resize(api_base.size() - std::string_view { "/chat/completions" }.size());
+    }
+    const std::string target_url = api_base + "/models";
+    std::map<std::string, std::string> headers;
+    if (!api_key.empty()) headers["Authorization"] = "Bearer " + api_key;
+
+    std::string body;
+    long http_code = 0;
+    if (!http::get_json(target_url, headers, body, http_code)) {
+      response->write(
+        SimpleWeb::StatusCode::server_error_bad_gateway,
+        R"({"error":{"message":"Failed to connect to upstream LLM API","type":"upstream_error"}})",
+        json_headers());
+      return;
+    }
+    const auto status = http_code >= 200 && http_code < 300
+                          ? SimpleWeb::StatusCode::success_ok
+                          : SimpleWeb::StatusCode::server_error_bad_gateway;
+    response->write(status, body, json_headers());
   }
 
   /**
@@ -3338,6 +3479,7 @@ namespace confighttp {
     server.resource["^/steam-store/.+$"]["GET"] = proxySteamStore;
     server.resource["^/api/ai/config$"]["GET"] = getAiConfig;
     server.resource["^/api/ai/config$"]["POST"] = saveAiConfigEndpoint;
+    server.resource["^/api/ai/models$"]["GET"] = proxyAiModels;
     server.resource["^/api/ai/chat/completions$"]["POST"] = proxyAiChat;
     server.resource["^/api/ai/chat/completions$"]["OPTIONS"] = handleAiCors;
     server.resource["^/api/v1/file-mapping/mappings$"]["GET"] = listFileMappings;

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -2388,6 +2388,20 @@ namespace confighttp {
     return config_dir / "ai_llm_credential.bin";
   }
 
+  static void
+  applyStoredCredentialLocked(nlohmann::json &cfg) {
+    auto credential = credential_store::read_llm_api_key(getAiCredentialPath());
+    if (credential.status == credential_store::read_status_e::success) {
+      cfg["apiKey"] = std::move(credential.secret);
+    } else {
+      cfg["apiKey"] = "";
+      if (credential.status == credential_store::read_status_e::error) {
+        BOOST_LOG(error) << "Could not load the LLM API key from secure storage: " << credential.error;
+      }
+    }
+    cfg["apiKeyConfigured"] = !cfg.value("apiKey", "").empty();
+  }
+
   static bool
   writeAiConfigFile(const nlohmann::json &cfg) {
     const fs::path path = getAiConfigPath();
@@ -2460,15 +2474,7 @@ namespace confighttp {
           }
           ai_config_cache["apiKey"] = legacy_key;
         } else {
-          auto credential = credential_store::read_llm_api_key(getAiCredentialPath());
-          if (credential.status == credential_store::read_status_e::success) {
-            ai_config_cache["apiKey"] = std::move(credential.secret);
-          } else {
-            ai_config_cache["apiKey"] = "";
-            if (credential.status == credential_store::read_status_e::error) {
-              BOOST_LOG(error) << "Could not load the LLM API key from secure storage: " << credential.error;
-            }
-          }
+          applyStoredCredentialLocked(ai_config_cache);
         }
         ai_config_cache["apiKeyConfigured"] = !ai_config_cache.value("apiKey", "").empty();
         ai_config_loaded = true;
@@ -2487,13 +2493,7 @@ namespace confighttp {
       {"temperature", 0.3},
       {"max_tokens", 2048}
     };
-    auto credential = credential_store::read_llm_api_key(getAiCredentialPath());
-    if (credential.status == credential_store::read_status_e::success) {
-      ai_config_cache["apiKey"] = std::move(credential.secret);
-      ai_config_cache["apiKeyConfigured"] = true;
-    } else if (credential.status == credential_store::read_status_e::error) {
-      BOOST_LOG(error) << "Could not load the LLM API key from secure storage: " << credential.error;
-    }
+    applyStoredCredentialLocked(ai_config_cache);
     ai_config_loaded = true;
     return ai_config_cache;
   }
@@ -2818,7 +2818,7 @@ namespace confighttp {
 
     auto cfg = loadAiConfig();
 
-    // 掩码 API key：仅显示前4+后4字符
+    // Never expose the key; only report whether one is configured.
     const std::string key = cfg.value("apiKey", "");
     cfg.erase("apiKey");
     cfg["apiKeyConfigured"] = !key.empty();
@@ -2833,6 +2833,7 @@ namespace confighttp {
    */
   void
   saveAiConfigEndpoint(resp_https_t response, req_https_t request) {
+    if (!check_content_type(response, request, "application/json")) return;
     if (!authenticate(response, request)) return;
     print_req(request);
 
@@ -2858,8 +2859,8 @@ namespace confighttp {
       // Backward compatibility for older clients that only send apiKey.
       if (input.contains("apiKey") && key_action == "keep") {
         const std::string candidate = input["apiKey"].get<std::string>();
-        if (candidate.find("****") == std::string::npos) {
-          key_action = candidate.empty() ? "clear" : "replace";
+        if (!candidate.empty() && candidate.find("****") == std::string::npos) {
+          key_action = "replace";
         }
       }
 
@@ -2908,6 +2909,13 @@ namespace confighttp {
     print_req(request);
 
     const auto cfg = loadAiConfig();
+    if (!cfg.value("enabled", false)) {
+      response->write(
+        SimpleWeb::StatusCode::client_error_forbidden,
+        R"({"error":{"message":"AI proxy is not enabled","type":"invalid_request_error"}})",
+        json_headers());
+      return;
+    }
     const std::string api_key = cfg.value("apiKey", "");
     std::string api_base = cfg.value("apiBase", "");
     if (api_base.empty() || (api_key.empty() && isApiKeyRequired(cfg))) {

--- a/src/httpcommon.cpp
+++ b/src/httpcommon.cpp
@@ -316,6 +316,38 @@ namespace http {
     return true;
   }
 
+  bool get_json(const std::string &url, const std::map<std::string, std::string> &headers, std::string &response_body, long &http_code, long timeout_seconds) {
+    BOOST_LOG(info) << "GET JSON from: " << url;
+    CURL *curl = curl_easy_init();
+    if (!curl) return false;
+
+    response_body.clear();
+    response_body.reserve(4096);
+    struct curl_slist *header_list = nullptr;
+    header_list = curl_slist_append(header_list, "Accept: application/json");
+    for (const auto &[key, value] : headers) {
+      const std::string header_line = key + ": " + value;
+      header_list = curl_slist_append(header_list, header_line.c_str());
+    }
+
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header_list);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, string_write_callback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_body);
+    curl_easy_setopt(curl, CURLOPT_MAXFILESIZE_LARGE, static_cast<curl_off_t>(10 * 1024 * 1024));
+    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10L);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds);
+    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 0L);
+    curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
+
+    const CURLcode result = curl_easy_perform(curl);
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+    curl_slist_free_all(header_list);
+    curl_easy_cleanup(curl);
+    return result == CURLE_OK;
+  }
+
   bool post_json(const std::string &url, const std::string &body, const std::map<std::string, std::string> &headers, std::string &response_body, long &http_code, long timeout_seconds) {
     BOOST_LOG(info) << "POST JSON to: " << url;
     CURL *curl = curl_easy_init();

--- a/src/httpcommon.cpp
+++ b/src/httpcommon.cpp
@@ -331,6 +331,11 @@ namespace http {
     }
 
     curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+#if LIBCURL_VERSION_NUM >= 0x075500
+    curl_easy_setopt(curl, CURLOPT_PROTOCOLS_STR, "http,https");
+#else
+    curl_easy_setopt(curl, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+#endif
     curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header_list);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, string_write_callback);

--- a/src/httpcommon.h
+++ b/src/httpcommon.h
@@ -29,6 +29,7 @@ namespace http {
   int reload_user_creds(const std::string &file);
   bool download_file(const std::string &url, const std::string &file, long ssl_version = CURL_SSLVERSION_TLSv1_2);
   bool fetch_url(const std::string &url, std::string &content, long ssl_version = CURL_SSLVERSION_TLSv1_2);
+  bool get_json(const std::string &url, const std::map<std::string, std::string> &headers, std::string &response_body, long &http_code, long timeout_seconds = 30);
   bool post_json(const std::string &url, const std::string &body, const std::map<std::string, std::string> &headers, std::string &response_body, long &http_code, long timeout_seconds = 120);
   bool download_image_with_magic_check(const std::string &url, const std::string &file, long ssl_version = CURL_SSLVERSION_TLSv1_2);
   bool download_public_cover_image(const std::string &url, const std::string &file, long ssl_version = CURL_SSLVERSION_TLSv1_2);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,6 +55,20 @@ if (WIN32)
             CXX_STANDARD 23
             LINK_SEARCH_START_STATIC 1)
     add_test(NAME vdd_prerequisite_unit_tests COMMAND vdd_prerequisite_unit_tests)
+
+    add_executable(credential_store_unit_tests
+            ${CMAKE_SOURCE_DIR}/src/ai/credential_store.cpp
+            ${CMAKE_SOURCE_DIR}/tests/unit/test_credential_store.cpp)
+    target_include_directories(credential_store_unit_tests PRIVATE "${CMAKE_SOURCE_DIR}")
+    target_link_libraries(credential_store_unit_tests
+            advapi32
+            crypt32
+            gtest_main)
+    target_compile_options(credential_store_unit_tests PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${SUNSHINE_COMPILE_OPTIONS}>)
+    set_target_properties(credential_store_unit_tests PROPERTIES
+            CXX_STANDARD 23
+            LINK_SEARCH_START_STATIC 1)
+    add_test(NAME credential_store_unit_tests COMMAND credential_store_unit_tests)
 endif ()
 
 if (NOT BUILD_TESTS)

--- a/tests/unit/test_credential_store.cpp
+++ b/tests/unit/test_credential_store.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <fstream>
+#include <utility>
 
 #include <gtest/gtest.h>
 
@@ -11,10 +12,26 @@
 
 #if defined(_WIN32)
 
+namespace {
+  struct scoped_credential_file_t {
+    explicit scoped_credential_file_t(std::string name):
+        path(std::filesystem::temp_directory_path() / std::move(name)) {
+      std::error_code ignored;
+      std::filesystem::remove(path, ignored);
+    }
+
+    ~scoped_credential_file_t() {
+      std::error_code ignored;
+      std::filesystem::remove(path, ignored);
+    }
+
+    std::filesystem::path path;
+  };
+}  // namespace
+
 TEST(CredentialStoreTest, RoundTripsWithoutWritingPlaintext) {
-  const auto path = std::filesystem::temp_directory_path() / "sunshine-credential-store-test.bin";
-  std::error_code ignored;
-  std::filesystem::remove(path, ignored);
+  const scoped_credential_file_t file_guard("sunshine-credential-store-test.bin");
+  const auto &path = file_guard.path;
 
   const std::string secret = "sk-test-value-that-must-not-appear-on-disk";
   const auto written = credential_store::write_llm_api_key(path, secret);
@@ -36,6 +53,44 @@ TEST(CredentialStoreTest, RoundTripsWithoutWritingPlaintext) {
   const auto erased = credential_store::erase_llm_api_key(path);
   ASSERT_TRUE(erased.success) << erased.error;
   EXPECT_FALSE(std::filesystem::exists(path));
+}
+
+TEST(CredentialStoreTest, ReportsNotFoundForMissingFile) {
+  const scoped_credential_file_t file_guard("sunshine-credential-store-missing.bin");
+  const auto loaded = credential_store::read_llm_api_key(file_guard.path);
+  EXPECT_EQ(loaded.status, credential_store::read_status_e::not_found);
+  EXPECT_TRUE(loaded.secret.empty());
+}
+
+TEST(CredentialStoreTest, RejectsInvalidBlobSizes) {
+  const scoped_credential_file_t file_guard("sunshine-credential-store-invalid.bin");
+  std::ofstream(file_guard.path, std::ios::binary);
+  EXPECT_EQ(
+    credential_store::read_llm_api_key(file_guard.path).status,
+    credential_store::read_status_e::error);
+
+  std::ofstream oversized(file_guard.path, std::ios::binary | std::ios::trunc);
+  oversized.seekp(64 * 1024);
+  oversized.put('\0');
+  oversized.close();
+  EXPECT_EQ(
+    credential_store::read_llm_api_key(file_guard.path).status,
+    credential_store::read_status_e::error);
+}
+
+TEST(CredentialStoreTest, RejectsOversizedSecret) {
+  const scoped_credential_file_t file_guard("sunshine-credential-store-oversized.bin");
+  const auto written = credential_store::write_llm_api_key(file_guard.path, std::string(16 * 1024 + 1, 'a'));
+  EXPECT_FALSE(written.success);
+  EXPECT_FALSE(std::filesystem::exists(file_guard.path));
+}
+
+TEST(CredentialStoreTest, EmptySecretErasesAndEraseIsIdempotent) {
+  const scoped_credential_file_t file_guard("sunshine-credential-store-empty.bin");
+  ASSERT_TRUE(credential_store::write_llm_api_key(file_guard.path, "sk-value").success);
+  EXPECT_TRUE(credential_store::write_llm_api_key(file_guard.path, "").success);
+  EXPECT_FALSE(std::filesystem::exists(file_guard.path));
+  EXPECT_TRUE(credential_store::erase_llm_api_key(file_guard.path).success);
 }
 
 #endif

--- a/tests/unit/test_credential_store.cpp
+++ b/tests/unit/test_credential_store.cpp
@@ -1,0 +1,41 @@
+/**
+ * @file tests/unit/test_credential_store.cpp
+ * @brief Tests for native LLM credential storage.
+ */
+
+#include <fstream>
+
+#include <gtest/gtest.h>
+
+#include "src/ai/credential_store.h"
+
+#if defined(_WIN32)
+
+TEST(CredentialStoreTest, RoundTripsWithoutWritingPlaintext) {
+  const auto path = std::filesystem::temp_directory_path() / "sunshine-credential-store-test.bin";
+  std::error_code ignored;
+  std::filesystem::remove(path, ignored);
+
+  const std::string secret = "sk-test-value-that-must-not-appear-on-disk";
+  const auto written = credential_store::write_llm_api_key(path, secret);
+  ASSERT_TRUE(written.success) << written.error;
+
+  {
+    std::ifstream file(path, std::ios::binary);
+    ASSERT_TRUE(file.is_open());
+    const std::string on_disk(
+      (std::istreambuf_iterator<char>(file)),
+      std::istreambuf_iterator<char>());
+    EXPECT_EQ(on_disk.find(secret), std::string::npos);
+  }
+
+  const auto loaded = credential_store::read_llm_api_key(path);
+  ASSERT_EQ(loaded.status, credential_store::read_status_e::success) << loaded.error;
+  EXPECT_EQ(loaded.secret, secret);
+
+  const auto erased = credential_store::erase_llm_api_key(path);
+  ASSERT_TRUE(erased.success) << erased.error;
+  EXPECT_FALSE(std::filesystem::exists(path));
+}
+
+#endif


### PR DESCRIPTION
## 改了啥呀

- 将 Windows LLM API Key 从 `ai_config.json` 迁移到 DPAPI 机器级加密文件，并限制文件 ACL
- macOS / Linux 仅从 `SUNSHINE_LLM_API_KEY` 读取，不新增明文持久化回退
- 配置 API 不再返回完整或部分密钥，支持 keep / replace / clear
- 模型列表通过后端代理，控制面板不再持有已保存的完整 Key
- 自动迁移旧 `ai_config.json` 和旧 WebView 存储
- 控制面板配套：[qiin2333/sunshine-control-panel#76](https://github.com/qiin2333/sunshine-control-panel/pull/76)

## 为啥要改

之前用户配置的 LLM Key 会明文写入 JSON 和 WebView localStorage。密钥这种小秘密可不能大摇大摆躺在磁盘上呀，杂鱼明文状态退散。

## 验证

- `npm run build:renderer`
- `cmake --build build --target credential_store_unit_tests -j 2`
- 单独编译 `credential_store.cpp`、`confighttp.cpp`、`httpcommon.cpp`
- Windows DPAPI smoke test：写入、磁盘无明文、解密读取、删除均通过
- `git diff --check`

## 已知限制

- 当前工作区全量构建被既有 Strawberry / MSYS2 编译器混用卡在未修改的 `src/config.cpp`；本 PR 涉及的 C++ 对象均已单独编译通过。