### PR TITLE
fix(startup): bring the web UI up before probing encoders

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,10 +4,13 @@
  */
 // standard includes
 #include <atomic>
+#include <chrono>
 #include <codecvt>
 #include <csignal>
 #include <fstream>
+#include <future>
 #include <iostream>
+#include <thread>
 #include <utility>
 
 // lib includes
@@ -140,6 +143,53 @@ mainThreadLoop(const std::shared_ptr<safe::event_t<bool>> &shutdown_event) {
   shutdown_event->view();
 #endif
   BOOST_LOG(info) << "Main loop has exited"sv;
+}
+
+/**
+ * @brief Run the encoder probe, reporting progress so a stall is diagnosable.
+ *
+ * The probe talks to the graphics driver and cannot be safely interrupted from
+ * the outside — a hung driver call owns its thread until it returns. So the
+ * watchdog does not try to cancel anything; it only keeps writing to the log
+ * while the probe is outstanding. That turns "Sunshine started but streaming
+ * never works and nobody knows why" into a timestamped line naming the phase
+ * that is stuck.
+ */
+void
+probe_encoders_with_watchdog() {
+  constexpr auto report_interval = 30s;
+
+  std::promise<void> probe_finished;
+  auto probe_finished_future = probe_finished.get_future();
+
+  BOOST_LOG(info) << "Probing for supported encoders..."sv;
+  const auto probe_started_at = std::chrono::steady_clock::now();
+
+  std::thread watchdog([&probe_finished_future, report_interval, probe_started_at]() {
+    while (probe_finished_future.wait_for(report_interval) == std::future_status::timeout) {
+      const auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+        std::chrono::steady_clock::now() - probe_started_at);
+      BOOST_LOG(warning) << "Encoder probe has been running for "sv << elapsed.count()
+                         << "s and has not returned. This usually means a graphics driver call "
+                            "is stuck. Streaming will not work until it completes; the web UI is "
+                            "already available so the configuration can be changed."sv;
+    }
+  });
+
+  const bool probe_failed = video::probe_encoders();
+
+  probe_finished.set_value();
+  watchdog.join();
+
+  const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+    std::chrono::steady_clock::now() - probe_started_at);
+
+  if (probe_failed) {
+    BOOST_LOG(error) << "Video failed to find working encoder (probe took "sv << elapsed.count() << "ms)"sv;
+  }
+  else {
+    BOOST_LOG(info) << "Encoder probe completed in "sv << elapsed.count() << "ms"sv;
+  }
 }
 
 int
@@ -394,10 +444,6 @@ main(int argc, char *argv[]) {
     BOOST_LOG(warning) << "No gamepad input is available"sv;
   }
 
-  if (video::probe_encoders()) {
-    BOOST_LOG(error) << "Video failed to find working encoder"sv;
-  }
-
   if (http::init()) {
     BOOST_LOG(fatal) << "HTTP interface failed to initialize"sv;
 
@@ -461,8 +507,24 @@ main(int argc, char *argv[]) {
     BOOST_LOG(warning) << "Webhook runtime is unavailable; Sunshine will continue without Webhook delivery"sv;
   }
 
-  std::thread httpThread { nvhttp::start };
+  // Start the configuration web UI before probing encoders.
+  //
+  // probe_encoders() drives the graphics driver directly, and a bad driver or a
+  // bad encoder option can make it block for a very long time or forever. When
+  // the probe ran on the main thread ahead of every server, such a stall meant
+  // the web UI never bound its port: the service looked healthy, but the user
+  // had no way to read the logs or undo the option that caused the stall.
+  //
+  // confighttp does not consume probe results. It reads the active encoder name
+  // through an atomic (empty until the probe lands) and HDR pipeline status
+  // under its own mutex, so bringing it up early races with nothing. nvhttp and
+  // rtsp_stream do depend on the probe (codec support flags, YUV444 support),
+  // so they stay behind it.
   std::thread configThread { confighttp::start };
+
+  probe_encoders_with_watchdog();
+
+  std::thread httpThread { nvhttp::start };
   std::thread rtspThread { rtsp_stream::start };
 
 #if defined(_WIN32) && defined(SUNSHINE_GUI_TRAY) && SUNSHINE_GUI_TRAY >= 1


### PR DESCRIPTION
## 问题

`video::probe_encoders()` 在 `src/main.cpp` 里跑在主线程上，且排在所有 server 线程之前。探测会直接驱动显卡驱动，一个坏驱动或一个坏的编码器选项就能让驱动调用阻塞很久甚至永不返回。

一旦发生：

- Windows 服务报告 RUNNING
- `sunshine.exe` 进程活着
- Web UI 端口从未 bind

用户看到的就是"服务起来了但打不开网页"，既读不到日志，也没法把导致卡死的选项改回去 —— 只能手工编辑 `sunshine.conf`。这正是 #871 里 iseku 反复遇到的状态。

## 改动

**1. confighttp 提到探测前面。**

`confighttp` 不消费探测结果：它只通过原子量读 active encoder 名字（探测落地前就是空串），HDR pipeline 状态走自己的 mutex。提前启动不和任何东西竞争。

`nvhttp` 和 `rtsp_stream` 确实依赖探测结果（codec 支持位、YUV444 支持，而且都是无锁读），**保持在探测之后**。所以这里没有为了提前启动而引入新的数据竞争 —— 这也是没有把探测整体丢到后台线程的原因。

**2. 探测加日志和看门狗。**

开始时打一行，结束时打耗时，未返回时每 30s warn 一次。

看门狗**故意不做取消**：卡住的驱动调用会一直占着它那个线程直到返回，从外面强杀不安全。目的只是让下一次同类故障报告自带一行带时间戳的日志，指明卡在哪个阶段，而不是一片沉默。

## 与 #910 的关系

#910 修的是触发这次卡死的那个具体选项（10-bit 4:4:4 的 CUDA array 输入路径改为默认关闭）。这个 PR 修的是更根本的那一层：**任何**编码器探测卡死都不该让 Web UI 起不来。两者独立，互不依赖。

## 验证

`src/confighttp.cpp` 对 video 的全部引用已逐个核过：`video::active_encoder_name()`（原子）、`video::get_hdr_pipeline_statuses()`（mutex 保护）、`video::dynamic_param_t`（只在活跃会话上用，启动时没有会话）。没有读任何无保护的探测全局量。

未在本机构建（无 Windows/CUDA 工具链），依赖 CI。

🤖 Generated with [Claude Code](https://claude.com/claude-code)