### PR TITLE
fix(build): skip asset-less GUI releases instead of failing configure

### DIFF
--- a/cmake/packaging/FetchGUI.cmake
+++ b/cmake/packaging/FetchGUI.cmake
@@ -50,9 +50,20 @@ if(NOT GITHUB_TOKEN AND DEFINED ENV{GITHUB_TOKEN})
   set(GITHUB_TOKEN "$ENV{GITHUB_TOKEN}")
 endif()
 
-# Resolve release URL
+# How many releases to look back through when GUI_VERSION is "latest".
+set(_gui_release_scan_count 20)
+
+# Resolve release URL.
+#
+# "latest" deliberately does not use /releases/latest. The GUI repo publishes
+# the release before its build uploads the binaries, so a failed or still
+# running build leaves an asset-less release sitting at /releases/latest. Since
+# a missing sunshine-gui.exe is a FATAL_ERROR for the GUI tray build, trusting
+# that endpoint blind means one upstream hiccup blocks every Windows package.
+# Ask for the release list instead and take the newest entry that actually
+# carries the binary.
 if(GUI_VERSION STREQUAL "latest")
-  set(_api_url "https://api.github.com/repos/${GUI_REPO}/releases/latest")
+  set(_api_url "https://api.github.com/repos/${GUI_REPO}/releases?per_page=${_gui_release_scan_count}")
 else()
   set(_api_url "https://api.github.com/repos/${GUI_REPO}/releases/tags/${GUI_VERSION}")
 endif()
@@ -84,6 +95,72 @@ endif()
 
 # Parse asset download URLs from JSON
 file(READ "${_json}" _json_content)
+file(REMOVE "${_json}")
+
+if(GUI_VERSION STREQUAL "latest")
+  # Narrow the release list down to a single release object, so everything
+  # downstream keeps working against one release exactly as before.
+  string(JSON _release_count ERROR_VARIABLE _json_error LENGTH "${_json_content}")
+  if(_json_error)
+    message(WARNING "Could not parse the GUI release list: ${_json_error}")
+    message(WARNING "GUI will not be available. Build it manually or set FETCH_GUI=OFF.")
+    return()
+  endif()
+
+  set(_selected_release "")
+  set(_selected_tag "")
+
+  if(_release_count GREATER 0)
+    math(EXPR _last_release_index "${_release_count} - 1")
+    foreach(_release_index RANGE 0 ${_last_release_index})
+      string(JSON _release GET "${_json_content}" ${_release_index})
+      string(JSON _release_tag GET "${_release}" tag_name)
+
+      # /releases/latest skips drafts and prereleases; match that so switching
+      # endpoints does not quietly start shipping prerelease GUIs.
+      string(JSON _is_draft GET "${_release}" draft)
+      string(JSON _is_prerelease GET "${_release}" prerelease)
+      if(_is_draft OR _is_prerelease)
+        continue()
+      endif()
+
+      string(JSON _asset_count ERROR_VARIABLE _assets_error LENGTH "${_release}" assets)
+      if(_assets_error)
+        set(_asset_count 0)
+      endif()
+
+      set(_release_has_gui FALSE)
+      if(_asset_count GREATER 0)
+        math(EXPR _last_asset_index "${_asset_count} - 1")
+        foreach(_asset_index RANGE 0 ${_last_asset_index})
+          string(JSON _asset_name GET "${_release}" assets ${_asset_index} name)
+          if(_asset_name STREQUAL "sunshine-gui.exe")
+            set(_release_has_gui TRUE)
+            break()
+          endif()
+        endforeach()
+      endif()
+
+      if(_release_has_gui)
+        set(_selected_release "${_release}")
+        set(_selected_tag "${_release_tag}")
+        break()
+      endif()
+
+      message(STATUS "  Skipping GUI release ${_release_tag}: no sunshine-gui.exe asset")
+    endforeach()
+  endif()
+
+  if(NOT _selected_release)
+    message(WARNING
+      "None of the newest ${_release_count} releases in ${GUI_REPO} carry sunshine-gui.exe")
+    message(WARNING "GUI will not be available. Build it manually or set FETCH_GUI=OFF.")
+    return()
+  endif()
+
+  message(STATUS "  Using GUI release ${_selected_tag}")
+  set(_json_content "${_selected_release}")
+endif()
 
 # Extract sunshine-gui.exe browser_download_url
 string(REGEX MATCH "\"browser_download_url\"[^\"]*\"(https://[^\"]*sunshine-gui\\.exe)\"" _m "${_json_content}")


### PR DESCRIPTION
## 问题

master 今天红了，而且**一行我们的代码都没编到** —— configure 阶段就死了：

```
CMake Warning at cmake/packaging/FetchGUI.cmake:98:
  Could not find sunshine-gui.exe in release assets
CMake Error at cmake/packaging/common.cmake:85:
  Sunshine GUI is required by the Windows GUI tray build, but
  sunshine-gui.exe is unavailable.
```

时间线：

| 时间 (UTC) | 事件 |
|---|---|
| 08:36 | #910 / #912 / #908 的 PR CI 全绿 |
| 11:06 | GUI 仓库发布 v0.4.16，其构建挂在 npm 镜像超时（`E504 Gateway Time-out`），**0 个 asset** |
| 12:57, 13:25 | master 的两次构建，全红 |

`qiin2333/sunshine-control-panel` 的 release workflow 是**先创建 release、后上传 asset**，所以一次瞬时的 npm 故障就留下一个空的 v0.4.16 挂在 `/releases/latest` 上。我们的 `FetchGUI.cmake` 无条件相信这个端点，拿到空 release 后 return，`common.cmake:85` 把它变成 `FATAL_ERROR`。

上游一次抖动 = 我们所有 Windows 出包全停，而且失败信息看起来像是自己的构建坏了。

## 改动

`GUI_VERSION` 为 `latest` 时，改查 `/releases?per_page=20`，取**最新那个真的带 `sunshine-gui.exe` 的 release**。

- **跳过 draft 和 prerelease** —— `/releases/latest` 本来就排除这两类，换端点不能悄悄开始发 prerelease 的 GUI。
- **跳过的 release 按 tag 打日志** —— 构建输出会明说越过了哪个、用了哪个，而不是无声地退回旧版 GUI。这点重要：降级本身是好事，降级而不说就是下一个难查的 bug。
- **显式 pin 的 `GUI_VERSION` 行为不变** —— 仍然走 `/releases/tags/<tag>`，那个 release 缺 asset 就仍然硬失败。要了具体版本却悄悄给你另一个，比失败更糟。

## 测试

选择逻辑拿真实 release 列表验证过（20 条），确认跳过 v0.4.16、落到 v0.4.15，`tag_name` / `draft` / `prerelease` / `assets[].name` 字段都在：

```
release_count = 20
  Skipping GUI release v0.4.16: no sunshine-gui.exe asset
=> Using GUI release v0.4.15
```

**CMake 本身没有本地验证** —— 这台机器上没有 cmake，`string(JSON ...)` 那段的语法要靠 CI。项目 `cmake_minimum_required(VERSION 3.20)`，`string(JSON)` 是 3.19 引入的，版本上没问题。

## 另一半

上游那次失败的 workflow 我已经重跑（纯 npm 瞬时故障），v0.4.16 的 asset 补上之后 master 自己也会恢复。这个 PR 修的是「下次再发生时不该阻断构建」。

更彻底的做法是让 GUI 仓库的 workflow 改成上传成功后再发布 release，那在另一个仓库，不在这个 PR 范围内。

🤖 Generated with [Claude Code](https://claude.com/claude-code)