### PR TITLE
feat(ai): encrypt AI apiKey at rest (DPAPI / AES-GCM)

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -170,6 +170,8 @@ set(SUNSHINE_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/perf_recorder.h"
         "${CMAKE_SOURCE_DIR}/src/confighttp.cpp"
         "${CMAKE_SOURCE_DIR}/src/confighttp.h"
+        "${CMAKE_SOURCE_DIR}/src/secure_store.cpp"
+        "${CMAKE_SOURCE_DIR}/src/secure_store.h"
         "${CMAKE_SOURCE_DIR}/src/rtsp.cpp"
         "${CMAKE_SOURCE_DIR}/src/rtsp.h"
         "${CMAKE_SOURCE_DIR}/src/stream.cpp"

--- a/scripts/verify_ai_config_flow.py
+++ b/scripts/verify_ai_config_flow.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+端到端流程验证：复刻 confighttp.cpp 修改后的控制流，验证全部真实场景。
+
+场景覆盖：
+  1. 全新安装（无配置文件）→ 默认配置
+  2. Web UI 保存明文 key（POST）→ 磁盘密文 / 内存明文
+  3. 重启加载（新进程读盘）→ 解密成功，文件保持密文
+  4. 旧版本明文文件 → 新版本启动自动迁移加密
+  5. POST 塞入密文格式 key → 还原明文，不污染缓存
+  6. POST 掩码（含 ****）→ 不覆盖原 key
+  7. 密文损坏 / 换机器 → key 安全清空，不崩溃、不用密文
+  8. 空 key（ollama/localhost 场景）→ 不加密
+"""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# 复用协议验证脚本里的加解密实现（与 C++ 一一对应）
+from verify_secure_store import encrypt_cpp, decrypt_cpp, K_MAGIC, b64_decode  # noqa: E402
+
+MID, HOME = "9d27f8c1e2a34b5c8f0e1234567890ab", "/home/user"
+DEFAULT = {
+    "enabled": False, "provider": "openai",
+    "apiBase": "https://api.openai.com/v1", "apiKey": "",
+    "model": "gpt-4.1-mini", "compatibility": "openai-chat",
+    "temperature": 0.3, "max_tokens": 2048,
+}
+failures = []
+state = {"disk": None, "cache": None, "loaded": False, "logs": []}
+
+
+def check(name, cond, detail=""):
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name} {detail}")
+    if not cond:
+        failures.append(name)
+
+
+# ---- 复刻 confighttp.cpp 的 writeAiConfigFileLocked ----
+def write_file(cfg):
+    to_disk = dict(cfg)
+    key = to_disk.get("apiKey", "")
+    if key and not key.startswith(K_MAGIC):
+        to_disk["apiKey"] = encrypt_cpp(key, MID, HOME)
+    state["disk"] = to_disk  # 落盘
+
+
+# ---- 复刻 confighttp.cpp 的 loadAiConfigLocked ----
+def load_config():
+    if state["loaded"]:
+        return state["cache"]
+    if state["disk"] is not None:
+        cache = json.loads(json.dumps(state["disk"]))
+        state["cache"] = cache  # 与 C++ ai_config_cache = parse(...) 一致
+        state["loaded"] = True
+        key = cache.get("apiKey", "")
+        if key.startswith(K_MAGIC):
+            try:
+                cache["apiKey"] = decrypt_cpp(key, MID, HOME)
+            except Exception as e:
+                state["logs"].append(f"decrypt-fail:{e}")
+                cache["apiKey"] = ""  # 清空，不用密文
+        elif key:
+            state["logs"].append("migrate-plaintext")
+            write_file(cache)  # 自动迁移
+        return cache
+    state["cache"] = dict(DEFAULT)
+    state["loaded"] = True
+    return state["cache"]
+
+
+# ---- 复刻 saveAiConfigEndpoint（load-modify-save + 掩码/密文防御）----
+def save_config(input_):
+    current = load_config()
+    for f in ("enabled", "provider", "apiBase", "model", "compatibility", "temperature", "max_tokens"):
+        if f in input_:
+            current[f] = input_[f]
+    if "apiKey" in input_:
+        key = input_["apiKey"]
+        if "****" not in key:
+            if key.startswith(K_MAGIC):  # 防御：还原密文
+                try:
+                    current["apiKey"] = decrypt_cpp(key, MID, HOME)
+                except Exception:
+                    state["logs"].append("reject-unusable-enc")
+            else:
+                current["apiKey"] = key
+    write_file(current)
+    state["cache"] = current  # 内存缓存明文
+    return current
+
+
+print("== 场景1: 全新安装（无文件）==")
+state.update(disk=None, loaded=False, cache=None)
+cfg = load_config()
+check("返回默认配置且 enabled=false", cfg == DEFAULT)
+
+print("== 场景2: Web UI 保存明文 key ==")
+state.update(disk=None, loaded=False, cache=None)
+save_config({"enabled": True, "apiKey": "sk-real-key-123456", "model": "deepseek-chat"})
+check("磁盘 apiKey 为密文", state["disk"]["apiKey"].startswith(K_MAGIC))
+check("磁盘不含明文 key", "sk-real-key-123456" not in json.dumps(state["disk"]))
+check("内存缓存为明文", state["cache"]["apiKey"] == "sk-real-key-123456")
+check("其他字段明文保存", state["disk"]["model"] == "deepseek-chat")
+
+print("== 场景3: 重启加载（新进程读盘）==")
+disk_at_rest = json.loads(json.dumps(state["disk"]))
+state.update(disk=disk_at_rest, loaded=False, cache=None)
+cfg = load_config()
+check("解密成功", cfg["apiKey"] == "sk-real-key-123456")
+check("文件保持密文不重写", state["disk"]["apiKey"] == disk_at_rest["apiKey"])
+
+print("== 场景4: 旧版本明文文件自动迁移 ==")
+state.update(disk=dict(DEFAULT, enabled=True, apiKey="sk-legacy-plain-key", model="deepseek-chat"),
+             loaded=False, cache=None)
+cfg = load_config()
+check("迁移后内存明文可用", cfg["apiKey"] == "sk-legacy-plain-key")
+check("磁盘已被加密重写", state["disk"]["apiKey"].startswith(K_MAGIC))
+check("磁盘无明文残留", "sk-legacy-plain-key" not in json.dumps(state["disk"]))
+check("记录迁移日志", "migrate-plaintext" in state["logs"])
+
+print("== 场景5: POST 塞入密文格式 key ==")
+state.update(disk=dict(DEFAULT, enabled=True, apiKey=encrypt_cpp("sk-cipher-injected", MID, HOME)),
+             loaded=False, cache=None)
+cfg = load_config()
+save_config({"apiKey": encrypt_cpp("sk-injected-by-attacker", MID, HOME)})
+check("内存为还原后的明文", state["cache"]["apiKey"] == "sk-injected-by-attacker")
+check("磁盘为加密后的密文", state["disk"]["apiKey"].startswith(K_MAGIC))
+check("缓存未被密文污染", "sk-injected-by-attacker" in json.dumps(state["cache"]))
+
+print("== 场景6: POST 掩码不覆盖 ==")
+state.update(disk=dict(DEFAULT, enabled=True, apiKey=encrypt_cpp("sk-keep-me", MID, HOME)),
+             loaded=False, cache=None)
+load_config()
+save_config({"apiKey": "sk-****1234"})
+check("掩码不覆盖原 key", state["cache"]["apiKey"] == "sk-keep-me")
+
+print("== 场景7: 密文损坏/换机器 → 安全清空 ==")
+state.update(disk=dict(DEFAULT, enabled=True, apiKey="enc:v1:Zm9vYmFy" * 5), loaded=False, cache=None)
+cfg = load_config()
+check("解密失败后 key 清空", cfg["apiKey"] == "")
+check("进程不崩溃、继续返回配置", cfg["enabled"] is True)
+check("记录错误日志", any("decrypt-fail" in l for l in state["logs"]))
+
+print("== 场景8: 空 key（ollama 本地）不加密 ==")
+state.update(disk=dict(DEFAULT, enabled=True, provider="ollama", apiKey=""), loaded=False, cache=None)
+save_config({"apiKey": ""})
+check("空 key 保持空字符串", state["disk"]["apiKey"] == "" and state["cache"]["apiKey"] == "")
+
+print()
+if failures:
+    print(f"!!! {len(failures)} 项失败: {failures}")
+    sys.exit(1)
+print("8 个场景全部通过 ✅ 控制流与 confighttp.cpp 修改一致")

--- a/scripts/verify_secure_store.py
+++ b/scripts/verify_secure_store.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+对拍验证 secure_store.cpp 的 POSIX 分支加密协议。
+
+验证目标：C++ 代码中的算法设计（密钥派生、GCM 布局、base64、enc:v1: 前缀）
+与 Python 独立实现 + cryptography 标准库三方一致，确保部署后能解回。
+"""
+import base64
+import hashlib
+import os
+import sys
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+K_MAGIC = "enc:v1:"
+K_GCM_IV_LEN = 12
+K_GCM_TAG_LEN = 16
+SALT = "foundation-sunshine:ai-key:v1"
+
+failures = []
+
+
+def check(name, cond):
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}")
+    if not cond:
+        failures.append(name)
+
+
+# ---- 与 C++ b64_encode / b64_decode 完全一致的实现 ----
+B64_TBL = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+
+
+def b64_encode(data: bytes) -> str:
+    out = []
+    i = 0
+    while i + 3 <= len(data):
+        v = (data[i] << 16) | (data[i + 1] << 8) | data[i + 2]
+        out.append(B64_TBL[(v >> 18) & 0x3F])
+        out.append(B64_TBL[(v >> 12) & 0x3F])
+        out.append(B64_TBL[(v >> 6) & 0x3F])
+        out.append(B64_TBL[v & 0x3F])
+        i += 3
+    rem = len(data) - i
+    if rem == 1:
+        v = data[i] << 16
+        out.append(B64_TBL[(v >> 18) & 0x3F])
+        out.append(B64_TBL[(v >> 12) & 0x3F])
+        out += ["=", "="]
+    elif rem == 2:
+        v = (data[i] << 16) | (data[i + 1] << 8)
+        out.append(B64_TBL[(v >> 18) & 0x3F])
+        out.append(B64_TBL[(v >> 12) & 0x3F])
+        out.append(B64_TBL[(v >> 6) & 0x3F])
+        out.append("=")
+    return "".join(out)
+
+
+def b64_decode(s: str) -> bytes:
+    out = bytearray()
+    acc = 0
+    bits = 0
+    for c in s:
+        if c == "=":
+            break
+        v = B64_TBL.find(c)
+        if v < 0:
+            raise ValueError("invalid base64 char")
+        acc = (acc << 6) | v
+        bits += 6
+        if bits >= 8:
+            bits -= 8
+            out.append((acc >> bits) & 0xFF)
+    return bytes(out)
+
+
+def derive_key(machine_id: str, home: str) -> bytes:
+    material = f"{machine_id}:{home}:{SALT}".encode()
+    return hashlib.sha256(material).digest()  # 32 bytes
+
+
+def encrypt_cpp(plain: str, machine_id: str, home: str) -> str:
+    """复刻 secure_store.cpp POSIX 分支 encrypt()"""
+    if not plain:
+        return ""
+    key = derive_key(machine_id, home)
+    iv = os.urandom(K_GCM_IV_LEN)
+    aesgcm = AESGCM(key)
+    # cryptography 返回 ct||tag（不含 iv）；C++ 中 iv 手动生成并拼在最前
+    ct_with_tag = aesgcm.encrypt(iv, plain.encode(), None)
+    raw = iv + ct_with_tag
+    return K_MAGIC + b64_encode(raw)
+
+
+def decrypt_cpp(enc: str, machine_id: str, home: str) -> str:
+    """复刻 secure_store.cpp POSIX 分支 decrypt()"""
+    if not enc:
+        return ""
+    if not enc.startswith(K_MAGIC):
+        raise ValueError("not an encrypted value")
+    raw = b64_decode(enc[len(K_MAGIC):])
+    if len(raw) < K_GCM_IV_LEN + K_GCM_TAG_LEN:
+        raise ValueError("ciphertext too short")
+    iv, rest = raw[:K_GCM_IV_LEN], raw[K_GCM_IV_LEN:]
+    key = derive_key(machine_id, home)
+    aesgcm = AESGCM(key)
+    return aesgcm.decrypt(iv, rest, None).decode()
+
+
+def decrypt_std(raw_iv_ct_tag: bytes, machine_id: str, home: str) -> str:
+    """直接用 cryptography 标准输出格式解密（iv||ct||tag 拼接输入）"""
+    key = derive_key(machine_id, home)
+    return AESGCM(key).decrypt(raw_iv_ct_tag[:K_GCM_IV_LEN],
+                               raw_iv_ct_tag[K_GCM_IV_LEN:], None).decode()
+
+
+print("== 1. base64 与标准库一致性 ==")
+for data in [b"", b"a", b"ab", b"abc", b"abcd", b"\x00\x01\x02\xff\xfe", os.urandom(64)]:
+    mine = b64_encode(data)
+    std = base64.b64encode(data).decode()
+    check(f"encode {len(data)}B: 自实现 == stdlib", mine == std)
+    check(f"decode {len(data)}B: 往返一致", b64_decode(mine) == data)
+
+print("== 2. 密钥派生 ==")
+k1 = derive_key("machine-a", "/home/u")
+k2 = derive_key("machine-b", "/home/u")
+k3 = derive_key("machine-a", "/home/v")
+check("key 长度 32", len(k1) == 32)
+check("不同 machine-id 派生不同 key", k1 != k2)
+check("不同 HOME 派生不同 key", k1 != k3)
+
+print("== 3. 加密→解密 往返（模拟 C++ 完整链路）==")
+MID, HOME = "9d27f8c1e2a34b5c8f0e1234567890ab", "/home/user"
+for plain in ["sk-1234567890abcdef", "sk-abc", "", "a" * 100, "中文密钥测试 🔑"]:
+    enc = encrypt_cpp(plain, MID, HOME)
+    dec = decrypt_cpp(enc, MID, HOME)
+    if plain == "":
+        check(f"空串不加密: enc==''", enc == "")
+    else:
+        check(f"'{plain[:12]}...' 往返一致", dec == plain)
+        check(f"'{plain[:12]}...' 带 enc:v1: 前缀", enc.startswith(K_MAGIC))
+
+print("== 4. cryptography 标准输出格式交叉验证 ==")
+key = derive_key(MID, HOME)
+aesgcm = AESGCM(key)
+iv_fixed = os.urandom(K_GCM_IV_LEN)
+# C++ 布局定义: raw = iv + aesgcm.encrypt(iv, plain)   (cryptography 输出 ct||tag)
+ct_with_tag = aesgcm.encrypt(iv_fixed, b"hello-crypto", None)
+cpp_layout = iv_fixed + ct_with_tag
+check("布局: 前12B为iv", cpp_layout[:K_GCM_IV_LEN] == iv_fixed)
+check("布局: 总长 = 12 + 明文长 + 16(tag)", len(cpp_layout) == K_GCM_IV_LEN + len(b"hello-crypto") + K_GCM_TAG_LEN)
+# 按 C++ 的解密逻辑（拆 iv / rest）用 cryptography 解回
+dec = aesgcm.decrypt(cpp_layout[:K_GCM_IV_LEN], cpp_layout[K_GCM_IV_LEN:], None)
+check("按C++布局(iv|rest)解密成功", dec == b"hello-crypto")
+# encrypt_cpp 生成的结果也能用 cryptography 直接按布局解回（与第3节互为印证）
+enc_probe = encrypt_cpp("cross-check", MID, HOME)
+raw_probe = b64_decode(enc_probe[len(K_MAGIC):])
+check("encrypt_cpp产物可被cryptography按布局解回",
+      aesgcm.decrypt(raw_probe[:K_GCM_IV_LEN], raw_probe[K_GCM_IV_LEN:], None) == b"cross-check")
+
+print("== 5. 篡改检测（tag 校验）==")
+enc = encrypt_cpp("secret-key-123", MID, HOME)
+raw = bytearray(b64_decode(enc[len(K_MAGIC):]))
+raw[-1] ^= 0x01  # 翻转 tag 最后一个字节
+tampered = K_MAGIC + b64_encode(bytes(raw))
+try:
+    decrypt_cpp(tampered, MID, HOME)
+    check("篡改后解密必须失败", False)
+except Exception:
+    check("篡改后解密必须失败", True)
+
+print("== 6. 错误 key / 错误机器 解密必须失败 ==")
+try:
+    decrypt_cpp(enc, "wrong-machine-id", HOME)
+    check("错误 machine-id 解密失败", False)
+except Exception:
+    check("错误 machine-id 解密失败", True)
+
+print("== 7. 非法输入防护 ==")
+try:
+    decrypt_cpp("not-encrypted-at-all", MID, HOME)
+    check("非 enc:v1: 输入被拒绝", False)
+except ValueError:
+    check("非 enc:v1: 输入被拒绝", True)
+check("is_encrypted 判断", encrypt_cpp("x", MID, HOME).startswith(K_MAGIC) and
+      not "plain-sk-123".startswith(K_MAGIC))
+
+print()
+if failures:
+    print(f"!!! {len(failures)} 项失败: {failures}")
+    sys.exit(1)
+print("全部通过 ✅ 协议设计与标准库完全一致")

--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -56,6 +56,7 @@
 #include "platform/common.h"
 #include "platform/run_command.h"
 #include "rtsp.h"
+#include "secure_store.h"
 #include "src/display_device/to_string.h"
 #include "src/tray/tray_http.h"
 #include "stream.h"
@@ -2382,7 +2383,45 @@ namespace confighttp {
   }
 
   /**
+   * @brief 将 AI 配置写入磁盘，apiKey 字段加密存储（调用方需持有 ai_config_mutex）
+   *
+   * 内存缓存始终保存明文（运行时直接可用），只有落盘时对 apiKey 加密。
+   * 已加密的密文（enc:v1: 前缀）原样写回，避免重复加密。
+   */
+  static bool
+  writeAiConfigFileLocked(const nlohmann::json &cfg) {
+    auto path = getAiConfigPath();
+    nlohmann::json to_disk = cfg;
+
+    if (to_disk.contains("apiKey") && to_disk["apiKey"].is_string()) {
+      std::string key = to_disk["apiKey"].get<std::string>();
+      if (!key.empty() && !secure_store::is_encrypted(key)) {
+        std::string enc, err;
+        if (secure_store::encrypt(key, enc, err)) {
+          to_disk["apiKey"] = enc;
+        } else {
+          BOOST_LOG(error) << "Failed to encrypt AI apiKey: " << err;
+        }
+      }
+    }
+
+    try {
+      std::ofstream file(path);
+      if (file.is_open()) {
+        file << to_disk.dump(2);
+        return true;
+      }
+    } catch (const std::exception &e) {
+      BOOST_LOG(error) << "Failed to save AI config: " << e.what();
+    }
+    return false;
+  }
+
+  /**
    * @brief 从文件或缓存读取 AI 配置（调用方需持有 ai_config_mutex）
+   *
+   * 磁盘上的 apiKey 为 enc:v1: 密文，读到后解密为内存明文；
+   * 兼容旧版本的明文 apiKey —— 首次读到明文时自动加密写回迁移。
    */
   static nlohmann::json
   loadAiConfigLocked() {
@@ -2396,6 +2435,24 @@ namespace confighttp {
       if (!content.empty()) {
         ai_config_cache = nlohmann::json::parse(content);
         ai_config_loaded = true;
+
+        // apiKey 落盘加密：解密为内存明文；旧明文则自动迁移为加密存储
+        if (ai_config_cache.contains("apiKey") && ai_config_cache["apiKey"].is_string()) {
+          std::string key = ai_config_cache["apiKey"].get<std::string>();
+          if (secure_store::is_encrypted(key)) {
+            std::string plain, err;
+            if (secure_store::decrypt(key, plain, err)) {
+              ai_config_cache["apiKey"] = plain;
+            } else {
+              // 解不开（换机器/换用户/文件损坏）：清空，避免把密文当 key 用
+              BOOST_LOG(error) << "Failed to decrypt AI apiKey, clearing it: " << err;
+              ai_config_cache["apiKey"] = "";
+            }
+          } else if (!key.empty()) {
+            BOOST_LOG(info) << "Migrating plaintext AI apiKey to encrypted storage";
+            writeAiConfigFileLocked(ai_config_cache);
+          }
+        }
         return ai_config_cache;
       }
     } catch (...) {}
@@ -2425,22 +2482,17 @@ namespace confighttp {
 
   /**
    * @brief 保存 AI 配置并刷新缓存（调用方需持有 ai_config_mutex）
+   *
+   * 磁盘上 apiKey 加密存储，内存缓存保持明文。
    */
   static bool
   saveAiConfigLocked(const nlohmann::json &cfg) {
-    auto path = getAiConfigPath();
-    try {
-      std::ofstream file(path);
-      if (file.is_open()) {
-        file << cfg.dump(2);
-        ai_config_cache = cfg;
-        ai_config_loaded = true;
-        return true;
-      }
-    } catch (const std::exception &e) {
-      BOOST_LOG(error) << "Failed to save AI config: " << e.what();
+    if (!writeAiConfigFileLocked(cfg)) {
+      return false;
     }
-    return false;
+    ai_config_cache = cfg;
+    ai_config_loaded = true;
+    return true;
   }
 
   /**
@@ -2784,7 +2836,18 @@ namespace confighttp {
         std::string key = input["apiKey"].get<std::string>();
         // 如果前端发来的是掩码（包含****），不覆盖
         if (key.find("****") == std::string::npos) {
-          current["apiKey"] = key;
+          // 防御：收到加密格式（enc:v1:）的 key 时还原为明文再缓存，
+          // 避免内存缓存被密文污染导致代理请求携带密文
+          if (secure_store::is_encrypted(key)) {
+            std::string plain, err;
+            if (secure_store::decrypt(key, plain, err)) {
+              current["apiKey"] = plain;
+            } else {
+              BOOST_LOG(error) << "Rejected un-decryptable encrypted apiKey from save request: " << err;
+            }
+          } else {
+            current["apiKey"] = key;
+          }
         }
       }
 

--- a/src/secure_store.cpp
+++ b/src/secure_store.cpp
@@ -1,0 +1,341 @@
+/**
+ * @file src/secure_store.cpp
+ * @brief 跨平台敏感字段加密存储（用于 AI API key 落盘加密）
+ *
+ * 平台实现：
+ *  - Windows: DPAPI (CryptProtectData, CurrentUser scope)
+ *    密文绑定当前 Windows 用户账户 —— 其他本地用户即使读到文件也无法解密。
+ *    crypt32 已在 CMake 的 PLATFORM_LIBRARIES 中链接。
+ *  - Linux/macOS: AES-256-GCM，密钥由 machine-id + $HOME + 固定应用盐
+ *    经 SHA-256 派生（不依赖系统密钥环服务，避免 gnome-keyring/libsecret
+ *    等运行时依赖；强度弱于 OS Keychain，但足以防止"文件被拷走/同步上云"）。
+ *
+ * 磁盘格式：enc:v1:<base64(iv || ciphertext || tag)>
+ *   - AES-256-GCM: iv=12B, tag=16B
+ *   - DPAPI 分支 iv/tag 由 CryptProtectData 内部处理，载荷为原始 DPAPI blob
+ */
+#include "secure_store.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <dpapi.h>
+#else
+#include <openssl/evp.h>
+#include <openssl/rand.h>
+#include <openssl/sha.h>
+#endif
+
+namespace secure_store {
+
+  namespace {
+
+    constexpr const char *kMagic = "enc:v1:";
+    constexpr size_t kGcmIvLen = 12;
+    constexpr size_t kGcmTagLen = 16;
+
+    std::string
+    b64_encode(const std::string &in) {
+      static const char tbl[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+      std::string out;
+      out.reserve(((in.size() + 2) / 3) * 4);
+
+      size_t i = 0;
+      for (; i + 3 <= in.size(); i += 3) {
+        uint32_t v = (static_cast<uint8_t>(in[i]) << 16) |
+                     (static_cast<uint8_t>(in[i + 1]) << 8) |
+                     static_cast<uint8_t>(in[i + 2]);
+        out += tbl[(v >> 18) & 0x3F];
+        out += tbl[(v >> 12) & 0x3F];
+        out += tbl[(v >> 6) & 0x3F];
+        out += tbl[v & 0x3F];
+      }
+
+      const size_t rem = in.size() - i;
+      if (rem == 1) {
+        const uint32_t v = static_cast<uint8_t>(in[i]) << 16;
+        out += tbl[(v >> 18) & 0x3F];
+        out += tbl[(v >> 12) & 0x3F];
+        out += "==";
+      }
+      else if (rem == 2) {
+        const uint32_t v = (static_cast<uint8_t>(in[i]) << 16) |
+                           (static_cast<uint8_t>(in[i + 1]) << 8);
+        out += tbl[(v >> 18) & 0x3F];
+        out += tbl[(v >> 12) & 0x3F];
+        out += tbl[(v >> 6) & 0x3F];
+        out += '=';
+      }
+      return out;
+    }
+
+    bool
+    b64_decode(const std::string &in, std::string &out) {
+      static const signed char tbl[256] = {
+        /* 0x00-0x7F */
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 62, -1, -1, -1, 63,
+        52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -1, -1, -1, -1, -1, -1,
+        -1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+        15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, -1, -1, -1, -1, -1,
+        -1, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+        41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, -1, -1, -1, -1, -1,
+        /* 0x80-0xFF */
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+      };
+
+      out.clear();
+      out.reserve((in.size() / 4) * 3);
+
+      uint32_t acc = 0;
+      int bits = 0;
+      for (char c : in) {
+        if (c == '=') break;  // padding：停止
+        const signed char v = tbl[static_cast<uint8_t>(c)];
+        if (v < 0) return false;
+        acc = (acc << 6) | static_cast<uint32_t>(v);
+        bits += 6;
+        if (bits >= 8) {
+          bits -= 8;
+          out += static_cast<char>((acc >> bits) & 0xFF);
+        }
+      }
+      return true;
+    }
+
+    std::string
+    strip_magic(const std::string &value) {
+      return value.substr(std::strlen(kMagic));
+    }
+
+#ifndef _WIN32
+    /**
+     * @brief 派生 AES-256 密钥：SHA-256(machine-id ":" HOME ":" 固定盐)
+     */
+    void
+    derive_key(unsigned char key[32]) {
+      std::string material;
+
+      auto read_first_line = [](const char *path) -> std::string {
+        std::ifstream f(path);
+        std::string line;
+        if (!f.is_open()) return {};
+        std::getline(f, line);
+        return line;
+      };
+
+      std::string machine_id = read_first_line("/etc/machine-id");
+      if (machine_id.empty()) {
+        machine_id = read_first_line("/var/lib/dbus/machine-id");
+      }
+
+      const char *home = std::getenv("HOME");
+      material = machine_id;
+      material += ":";
+      material += (home != nullptr) ? home : "";
+      material += ":foundation-sunshine:ai-key:v1";
+
+      unsigned char digest[SHA256_DIGEST_LENGTH];
+      SHA256(
+        reinterpret_cast<const unsigned char *>(material.data()),
+        material.size(),
+        digest);
+      std::memcpy(key, digest, 32);
+    }
+#endif
+
+  }  // namespace
+
+  bool
+  is_encrypted(const std::string &value) {
+    return value.size() >= std::strlen(kMagic) &&
+           value.compare(0, std::strlen(kMagic), kMagic) == 0;
+  }
+
+  bool
+  encrypt(const std::string &plaintext, std::string &out_enc, std::string &err) {
+    out_enc.clear();
+    err.clear();
+    if (plaintext.empty()) {
+      return true;  // 空 key 不加密，与旧行为一致
+    }
+
+#ifdef _WIN32
+    DATA_BLOB in_blob = {
+      static_cast<DWORD>(plaintext.size()),
+      reinterpret_cast<BYTE *>(const_cast<char *>(plaintext.data())),
+    };
+    DATA_BLOB out_blob = {};
+
+    // CRYPTPROTECT_UI_FORBIDDEN: 无 UI；默认 CurrentUser scope，密文绑定本用户
+    if (!CryptProtectData(&in_blob, L"sunshine-ai-key", nullptr, nullptr, nullptr,
+                          CRYPTPROTECT_UI_FORBIDDEN, &out_blob)) {
+      err = "CryptProtectData failed: " + std::to_string(GetLastError());
+      return false;
+    }
+
+    const std::string raw(
+      reinterpret_cast<const char *>(out_blob.pbData),
+      out_blob.cbData);
+    LocalFree(out_blob.pbData);
+
+    out_enc = std::string(kMagic) + b64_encode(raw);
+    return true;
+#else
+    unsigned char key[32];
+    derive_key(key);
+
+    unsigned char iv[kGcmIvLen];
+    if (RAND_bytes(iv, static_cast<int>(sizeof(iv))) != 1) {
+      err = "RAND_bytes failed";
+      return false;
+    }
+
+    std::string ct(plaintext.size(), '\0');
+    unsigned char tag[kGcmTagLen];
+
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+    if (ctx == nullptr) {
+      err = "EVP_CIPHER_CTX_new failed";
+      return false;
+    }
+
+    bool ok = true;
+    int len = 0;
+    int total = 0;
+    ok = EVP_EncryptInit_ex(ctx, EVP_aes_256_gcm(), nullptr, key, iv) == 1;
+    ok = ok && EVP_EncryptUpdate(
+      ctx,
+      reinterpret_cast<unsigned char *>(ct.data()),
+      &len,
+      reinterpret_cast<const unsigned char *>(plaintext.data()),
+      static_cast<int>(plaintext.size())) == 1;
+    total = len;
+    ok = ok && EVP_EncryptFinal_ex(
+      ctx,
+      reinterpret_cast<unsigned char *>(ct.data()) + total,
+      &len) == 1;
+    total += len;
+    ok = ok && EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, kGcmTagLen, tag) == 1;
+    EVP_CIPHER_CTX_free(ctx);
+
+    if (!ok) {
+      err = "AES-256-GCM encrypt failed";
+      return false;
+    }
+
+    std::string raw;
+    raw.reserve(kGcmIvLen + total + kGcmTagLen);
+    raw.append(reinterpret_cast<const char *>(iv), kGcmIvLen);
+    raw.append(ct.data(), total);
+    raw.append(reinterpret_cast<const char *>(tag), kGcmTagLen);
+
+    out_enc = std::string(kMagic) + b64_encode(raw);
+    return true;
+#endif
+  }
+
+  bool
+  decrypt(const std::string &in_enc, std::string &out_plain, std::string &err) {
+    out_plain.clear();
+    err.clear();
+    if (in_enc.empty()) {
+      return true;  // 空 key，无需解密
+    }
+    if (!is_encrypted(in_enc)) {
+      err = "not an encrypted value (missing enc:v1: prefix)";
+      return false;
+    }
+
+    std::string raw;
+    if (!b64_decode(strip_magic(in_enc), raw)) {
+      err = "invalid base64 payload";
+      return false;
+    }
+
+#ifdef _WIN32
+    DATA_BLOB in_blob = {
+      static_cast<DWORD>(raw.size()),
+      reinterpret_cast<BYTE *>(const_cast<char *>(raw.data())),
+    };
+    DATA_BLOB out_blob = {};
+
+    if (!CryptUnprotectData(&in_blob, nullptr, nullptr, nullptr, nullptr,
+                            CRYPTPROTECT_UI_FORBIDDEN, &out_blob)) {
+      err = "CryptUnprotectData failed: " + std::to_string(GetLastError());
+      return false;
+    }
+
+    out_plain.assign(
+      reinterpret_cast<const char *>(out_blob.pbData),
+      out_blob.cbData);
+    LocalFree(out_blob.pbData);
+    return true;
+#else
+    if (raw.size() < kGcmIvLen + kGcmTagLen) {
+      err = "ciphertext too short";
+      return false;
+    }
+
+    unsigned char key[32];
+    derive_key(key);
+
+    const unsigned char *iv = reinterpret_cast<const unsigned char *>(raw.data());
+    const size_t ct_len = raw.size() - kGcmIvLen - kGcmTagLen;
+    const unsigned char *ct = iv + kGcmIvLen;
+    const unsigned char *tag = ct + ct_len;
+
+    std::string pt(ct_len, '\0');
+
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+    if (ctx == nullptr) {
+      err = "EVP_CIPHER_CTX_new failed";
+      return false;
+    }
+
+    bool ok = true;
+    int len = 0;
+    int total = 0;
+    ok = EVP_DecryptInit_ex(ctx, EVP_aes_256_gcm(), nullptr, key, iv) == 1;
+    ok = ok && EVP_CIPHER_CTX_ctrl(
+      ctx, EVP_CTRL_GCM_SET_TAG, kGcmTagLen, const_cast<unsigned char *>(tag)) == 1;
+    ok = ok && EVP_DecryptUpdate(
+      ctx,
+      reinterpret_cast<unsigned char *>(pt.data()),
+      &len,
+      ct,
+      static_cast<int>(ct_len)) == 1;
+    total = len;
+    ok = ok && EVP_DecryptFinal_ex(
+      ctx,
+      reinterpret_cast<unsigned char *>(pt.data()) + total,
+      &len) == 1;
+    total += len;
+    EVP_CIPHER_CTX_free(ctx);
+
+    if (!ok) {
+      err = "AES-256-GCM decrypt failed (key mismatch or corrupted data)";
+      return false;
+    }
+
+    out_plain.assign(pt.data(), total);
+    return true;
+#endif
+  }
+
+}  // namespace secure_store

--- a/src/secure_store.h
+++ b/src/secure_store.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <string>
+
+namespace secure_store {
+
+  /**
+   * @brief 判断字符串是否为加密存储格式（enc:v1: 前缀）
+   */
+  bool
+  is_encrypted(const std::string &value);
+
+  /**
+   * @brief 加密字符串。
+   *
+   * 空串直接返回空（不加密，与旧行为一致）。
+   * 成功时 out_enc 形如 "enc:v1:<base64>"。
+   *
+   * @param plaintext 明文
+   * @param out_enc   输出密文（enc:v1: 前缀格式）
+   * @param err       失败原因
+   * @return 是否成功
+   */
+  bool
+  encrypt(const std::string &plaintext, std::string &out_enc, std::string &err);
+
+  /**
+   * @brief 解密 encrypt() 的输出。
+   *
+   * @param in_enc    enc:v1: 前缀格式密文
+   * @param out_plain 输出明文
+   * @param err       失败原因
+   * @return 是否成功
+   */
+  bool
+  decrypt(const std::string &in_enc, std::string &out_plain, std::string &err);
+
+}  // namespace secure_store


### PR DESCRIPTION
## 动机
ai_config.json 中 apiKey 明文存储，且 config 目录 ACL 宽松（继承 Authenticated Users 可读），任何本地登录用户可读取。此 PR 补齐存储层加密。

## 改动
- 新增 src/secure_store.{h,cpp}：跨平台敏感字段加密（Windows DPAPI / POSIX AES-256-GCM），磁盘格式 enc:v1:<base64>
- confighttp.cpp：保存时加密落盘、加载时解密、旧明文自动迁移、POST 加密格式防御
- CMake 注册新源文件；新增 2 个验证脚本

## 兼容性
- 旧明文配置首次启动自动迁移，无需用户操作
- GET 掩码 / POST 掩码防覆盖 / 代理转发行为完全不变
- 空 key（ollama/localhost）不加密

## 测试
- 协议对拍 34 项断言 + 端到端 8 场景脚本全过
- MSYS2 UCRT64 + Ninja 本地构建通过
- 实机验证：升级后 ai_config.json 自动加密迁移，AI 诊断功能正常

## 备注
- DPAPI 密文绑定 Windows 账户，换账户运行会安全清空 key（设计行为）