### PR TITLE
Fix HDR10+ metadata serialization for AV1

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -186,6 +186,7 @@ set(SUNSHINE_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/clipboard_http.h"
         "${CMAKE_SOURCE_DIR}/src/video.cpp"
         "${CMAKE_SOURCE_DIR}/src/video.h"
+        "${CMAKE_SOURCE_DIR}/src/video_hdr_metadata.cpp"
         "${CMAKE_SOURCE_DIR}/src/video_hdr_metadata.h"
         "${CMAKE_SOURCE_DIR}/src/video_colorspace.cpp"
         "${CMAKE_SOURCE_DIR}/src/video_colorspace.h"

--- a/src/nvenc/common_impl/nvenc_base.cpp
+++ b/src/nvenc/common_impl/nvenc_base.cpp
@@ -9,6 +9,7 @@
 #include "src/utility.h"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 
 #define NVENC_INT_VERSION (NVENCAPI_MAJOR_VERSION * 100 + NVENCAPI_MINOR_VERSION)
@@ -599,7 +600,7 @@ namespace nvenc {
   #else
           format_config.inputPixelBitDepthMinus8 = 2;
           format_config.pixelBitDepthMinus8 = 2;
-  #endif
+#endif
         }
         format_config.colorPrimaries = colorspace.primaries;
         format_config.transferCharacteristics = colorspace.tranfer_function;
@@ -838,47 +839,52 @@ namespace nvenc {
         pic_params.codecPicParams.av1PicParams.pMasteringDisplay = &mastering_display;
         pic_params.codecPicParams.av1PicParams.pMaxCll = &content_light_level;
       }
-#endif
+  #endif
     }
 #endif
 
     // Inject HDR10+ and/or Vivid dynamic metadata as custom SEI/OBU payloads
-    std::vector<uint8_t> hdr10plus_payload;
+    std::array<uint8_t, video::hdr_metadata::hdr10plus_t35_max_payload_size> hdr10plus_payload {};
     std::vector<uint8_t> vivid_payload;
-    NV_ENC_SEI_PAYLOAD sei_payloads[2] = {};
-    uint32_t sei_count = 0;
+    NV_ENC_SEI_PAYLOAD dynamic_payloads[2] = {};
+    uint32_t dynamic_payload_count = 0;
 
     if (luminance_stats.valid && hdr_metadata && (video_format == 1 || video_format == 2)) {
       uint16_t max_lum = hdr_metadata->maxDisplayLuminance;
       const auto vivid_metadata = vivid_filter.update(luminance_stats);
 
       // HDR10+ (PQ only — HDR10+ requires absolute luminance)
-      if (dynamic_hdr_formats.hdr10plus &&
-          serialize_hdr10plus_sei(luminance_stats, max_lum, hdr10plus_payload) > 0) {
-        sei_payloads[sei_count].payloadSize = static_cast<uint32_t>(hdr10plus_payload.size());
-        sei_payloads[sei_count].payloadType = 4;  // user_data_registered_itu_t_t35
-        sei_payloads[sei_count].payload = hdr10plus_payload.data();
-        sei_count++;
+      size_t hdr10plus_payload_size = 0;
+      if (dynamic_hdr_formats.hdr10plus) {
+        hdr10plus_payload_size = video::hdr_metadata::serialize_hdr10plus_t35(
+          luminance_stats, max_lum, hdr10plus_payload);
+      }
+      if (hdr10plus_payload_size > 0) {
+        dynamic_payloads[dynamic_payload_count].payloadSize =
+          static_cast<uint32_t>(hdr10plus_payload_size);
+        dynamic_payloads[dynamic_payload_count].payloadType = 4;  // registered ITU-T T.35
+        dynamic_payloads[dynamic_payload_count].payload = hdr10plus_payload.data();
+        dynamic_payload_count++;
       }
 
       // HDR Vivid (both PQ and HLG)
       if (dynamic_hdr_formats.vivid &&
           video::hdr_metadata::serialize_vivid_t35(vivid_metadata, vivid_payload) > 0) {
-        sei_payloads[sei_count].payloadSize = static_cast<uint32_t>(vivid_payload.size());
-        sei_payloads[sei_count].payloadType = 4;  // user_data_registered_itu_t_t35
-        sei_payloads[sei_count].payload = vivid_payload.data();
-        sei_count++;
+        dynamic_payloads[dynamic_payload_count].payloadSize = static_cast<uint32_t>(vivid_payload.size());
+        dynamic_payloads[dynamic_payload_count].payloadType = 4;  // registered ITU-T T.35
+        dynamic_payloads[dynamic_payload_count].payload = vivid_payload.data();
+        dynamic_payload_count++;
       }
 
-      if (sei_count > 0) {
+      if (dynamic_payload_count > 0) {
         if (video_format == 1) {
-          pic_params.codecPicParams.hevcPicParams.seiPayloadArrayCnt = sei_count;
-          pic_params.codecPicParams.hevcPicParams.seiPayloadArray = sei_payloads;
+          pic_params.codecPicParams.hevcPicParams.seiPayloadArrayCnt = dynamic_payload_count;
+          pic_params.codecPicParams.hevcPicParams.seiPayloadArray = dynamic_payloads;
         }
 #if NVENCAPI_MAJOR_VERSION >= 12
         else if (video_format == 2) {
-          pic_params.codecPicParams.av1PicParams.obuPayloadArrayCnt = sei_count;
-          pic_params.codecPicParams.av1PicParams.obuPayloadArray = sei_payloads;
+          pic_params.codecPicParams.av1PicParams.obuPayloadArrayCnt = dynamic_payload_count;
+          pic_params.codecPicParams.av1PicParams.obuPayloadArray = dynamic_payloads;
         }
 #endif
       }
@@ -1066,127 +1072,6 @@ namespace nvenc {
   void
   nvenc_base::set_luminance_stats(const platf::hdr_frame_luminance_stats_t &stats) {
     luminance_stats = stats;
-  }
-
-  size_t
-  nvenc_base::serialize_hdr10plus_sei(const platf::hdr_frame_luminance_stats_t &stats,
-    uint16_t max_display_luminance,
-    std::vector<uint8_t> &payload) {
-    // HDR10+ (ST 2094-40) ITU-T T.35 registered SEI payload structure:
-    //   country_code:          0xB5 (USA)
-    //   terminal_provider_code: 0x003C (Samsung)
-    //   terminal_provider_oriented_code: 0x0001 (HDR10+)
-    //   application_identifier: 4
-    //   application_version:    1
-    //   num_windows:            1
-    //   Then per-window: maxscl[3], average_maxrgb, distribution percentiles
-    //   targeted_system_display_maximum_luminance
-    //
-    // Simplified profile: no tone mapping curve, no bezier anchors, no percentile distribution
-
-    float peak_nits = max_display_luminance > 0 ? static_cast<float>(max_display_luminance) : 1000.0f;
-
-    // Use P95 as effective peak (same logic as update_hdr_dynamic_metadata in video.cpp)
-    float effective_max = stats.percentile_95;
-
-    // Normalize to [0, 1] relative to peak_nits, expressed as 27-bit values (maxscl precision)
-    // HDR10+ maxscl is in 0.00001 cd/m² units
-    auto to_maxscl = [&](float nits) -> uint32_t {
-      return static_cast<uint32_t>(std::clamp(nits, 0.0f, 100000.0f) * 10.0f);  // 0.00001 cd/m² unit → stored as integer
-    };
-
-    payload.clear();
-    payload.reserve(64);
-
-    // ITU-T T.35 header
-    payload.push_back(0xB5);        // country_code (USA)
-    payload.push_back(0x00);        // terminal_provider_code (Samsung) high byte
-    payload.push_back(0x3C);        // terminal_provider_code low byte
-    payload.push_back(0x00);        // terminal_provider_oriented_code high byte
-    payload.push_back(0x01);        // terminal_provider_oriented_code low byte
-
-    // application_identifier (4) + application_version (1) — packed as 8+8 bits
-    payload.push_back(4);           // application_identifier
-    payload.push_back(1);           // application_version
-
-    // Bitstream-packed fields follow. We pack into a bit buffer.
-    // For simplicity, we'll use byte-aligned approximation where possible.
-
-    // num_windows (2 bits) = 1 (only 1-1=0 written for extra windows, but the spec says
-    // num_windows is 2 bits and actual count; with 1 window, no extra window data needed)
-    // Then for each window i (1..num_windows-1): window geometry (skipped for window 0)
-
-    // The bitstream layout is complex. Let's use a simple bitstream writer.
-    struct bitwriter {
-      std::vector<uint8_t> &buf;
-      uint32_t accumulator = 0;
-      int bits_pending = 0;
-
-      void write(uint32_t value, int num_bits) {
-        for (int i = num_bits - 1; i >= 0; --i) {
-          accumulator = (accumulator << 1) | ((value >> i) & 1);
-          bits_pending++;
-          if (bits_pending == 8) {
-            buf.push_back(static_cast<uint8_t>(accumulator));
-            accumulator = 0;
-            bits_pending = 0;
-          }
-        }
-      }
-
-      void flush() {
-        if (bits_pending > 0) {
-          accumulator <<= (8 - bits_pending);
-          buf.push_back(static_cast<uint8_t>(accumulator));
-          accumulator = 0;
-          bits_pending = 0;
-        }
-      }
-    };
-
-    bitwriter bw { payload };
-
-    // num_windows: 2 bits (value = 1)
-    bw.write(1, 2);
-
-    // For window 0 (always present, no geometry needed):
-    // maxscl[0..2]: 17 bits each (in 0.00001 cd/m² unit)
-    uint32_t maxscl_val = to_maxscl(effective_max);
-    bw.write(maxscl_val, 17);  // maxscl[0] (R)
-    bw.write(maxscl_val, 17);  // maxscl[1] (G)
-    bw.write(maxscl_val, 17);  // maxscl[2] (B)
-
-    // average_maxrgb: 17 bits
-    uint32_t avg_val = to_maxscl(stats.avg_maxrgb);
-    bw.write(avg_val, 17);
-
-    // num_distribution_maxrgb_percentiles: 4 bits (= 0, no percentile data)
-    bw.write(0, 4);
-
-    // fraction_bright_pixels: 10 bits (= 0)
-    bw.write(0, 10);
-
-    // mastering_display_actual_peak_luminance_flag: 1 bit (= 0)
-    bw.write(0, 1);
-
-    // For each window (window 0):
-    // tone_mapping_flag: 1 bit (= 0, no tone mapping)
-    bw.write(0, 1);
-
-    // color_saturation_mapping_flag: 1 bit (= 0)
-    bw.write(0, 1);
-
-    // targeted_system_display_actual_peak_luminance_flag: 1 bit (= 0)
-    bw.write(0, 1);
-
-    // targeted_system_display_maximum_luminance: 27 bits
-    // In 0.0001 cd/m² units
-    uint32_t target_lum = static_cast<uint32_t>(peak_nits * 10000);
-    bw.write(target_lum, 27);
-
-    bw.flush();
-
-    return payload.size();
   }
 
   bool

--- a/src/nvenc/common_impl/nvenc_base.h
+++ b/src/nvenc/common_impl/nvenc_base.h
@@ -143,18 +143,5 @@ namespace nvenc {
     video::hdr_metadata::formats_t dynamic_hdr_formats;
     video::hdr_metadata::vivid_temporal_filter_t vivid_filter;
 
-    /**
-     * @brief Serialize HDR10+ dynamic metadata into ITU-T T.35 SEI payload.
-     *        Format follows ST 2094-40 (Samsung HDR10+).
-     * @param stats Per-frame luminance statistics.
-     * @param max_display_luminance Display peak luminance in nits.
-     * @param[out] payload Output buffer for serialized payload.
-     * @return Size of serialized payload in bytes, or 0 on failure.
-     */
-    size_t
-    serialize_hdr10plus_sei(const platf::hdr_frame_luminance_stats_t &stats,
-      uint16_t max_display_luminance,
-      std::vector<uint8_t> &payload);
-
   };
 }

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -2082,21 +2082,20 @@ namespace video {
     if (hdr10plus_sd && ema.initialized) {
       auto *hdr10plus = reinterpret_cast<AVDynamicHDRPlus *>(hdr10plus_sd->data);
       if (hdr10plus && hdr10plus->num_windows > 0) {
-        auto &params = hdr10plus->params[0];
-        const float peak_nits =
-          max_display_luminance > 0 ? static_cast<float>(max_display_luminance) : 1000.0f;
-        const float effective_max = ema.percentile_95;
-
-        // HDR10+ maxscl: use P95 for stability
-        float max_norm = std::clamp(effective_max / peak_nits, 0.0f, 1.0f);
-        float avg_norm = std::clamp(ema.avg_maxrgb / peak_nits, 0.0f, 1.0f);
-
-        params.maxscl[0] = av_make_q(static_cast<int>(max_norm * 100000), 100000);
-        params.maxscl[1] = av_make_q(static_cast<int>(max_norm * 100000), 100000);
-        params.maxscl[2] = av_make_q(static_cast<int>(max_norm * 100000), 100000);
-        params.average_maxrgb = av_make_q(static_cast<int>(avg_norm * 100000), 100000);
-
-        hdr10plus->targeted_system_display_maximum_luminance = av_make_q(max_display_luminance, 1);
+        const auto frame_metadata = hdr_metadata::hdr10plus_from_luminance(
+          ema.percentile_95, ema.avg_maxrgb, max_display_luminance);
+        if (frame_metadata.valid) {
+          auto &params = hdr10plus->params[0];
+          const auto maxscl = av_make_q(
+            frame_metadata.maxscl, hdr_metadata::hdr10plus_normalized_scale);
+          params.maxscl[0] = maxscl;
+          params.maxscl[1] = maxscl;
+          params.maxscl[2] = maxscl;
+          params.average_maxrgb = av_make_q(
+            frame_metadata.average_maxrgb, hdr_metadata::hdr10plus_normalized_scale);
+          hdr10plus->targeted_system_display_maximum_luminance = av_make_q(
+            frame_metadata.targeted_system_display_maximum_luminance, 1);
+        }
       }
     }
   }
@@ -2699,7 +2698,7 @@ namespace video {
           if (hdr10plus) {
             // Set default values for HDR10+
             hdr10plus->itu_t_t35_country_code = 0xB5;  // USA
-            hdr10plus->application_version = 0;
+            hdr10plus->application_version = hdr_metadata::hdr10plus_application_version;
             hdr10plus->num_windows = 1;  // Single processing window covering entire frame
 
             // Initialize the first (and only) processing window

--- a/src/video_hdr_metadata.cpp
+++ b/src/video_hdr_metadata.cpp
@@ -1,0 +1,106 @@
+/**
+ * @file src/video_hdr_metadata.cpp
+ * @brief HDR dynamic metadata serializers backed by FFmpeg.
+ */
+#include "video_hdr_metadata.h"
+
+#include <array>
+
+extern "C" {
+#include <libavutil/hdr_dynamic_metadata.h>
+#include <libavutil/rational.h>
+}
+
+namespace video::hdr_metadata {
+
+  namespace {
+
+    constexpr std::array<uint8_t, hdr10plus_t35_prefix_size> hdr10plus_t35_prefix {
+      0xB5,  // itu_t_t35_country_code: United States
+      0x00, 0x3C,  // terminal_provider_code: SMPTE
+      0x00, 0x01,  // terminal_provider_oriented_code: HDR10+
+      0x04,  // application_identifier: SMPTE ST 2094-40
+    };
+
+    bool
+    rational_equals(const AVRational &lhs, const AVRational &rhs) {
+      return av_cmp_q(lhs, rhs) == 0;
+    }
+
+  }  // namespace
+
+  size_t
+  serialize_hdr10plus_t35(const platf::hdr_frame_luminance_stats_t &stats,
+    uint16_t max_display_luminance,
+    std::span<uint8_t> payload) {
+    if (!stats.valid || payload.size() < hdr10plus_t35_prefix_size + AV_HDR_PLUS_MAX_PAYLOAD_SIZE) {
+      return 0;
+    }
+
+    const auto frame_metadata = hdr10plus_from_luminance(
+      stats.percentile_95, stats.avg_maxrgb, max_display_luminance);
+    if (!frame_metadata.valid) {
+      return 0;
+    }
+
+    AVDynamicHDRPlus metadata {};
+    metadata.itu_t_t35_country_code = hdr10plus_t35_prefix[0];
+    // FFmpeg serializes ST 2094-40 as Application Version 1.
+    metadata.application_version = hdr10plus_application_version;
+    metadata.num_windows = 1;
+    metadata.targeted_system_display_maximum_luminance = av_make_q(
+      frame_metadata.targeted_system_display_maximum_luminance, 1);
+    metadata.targeted_system_display_actual_peak_luminance_flag = 0;
+    metadata.mastering_display_actual_peak_luminance_flag = 0;
+
+    auto &params = metadata.params[0];
+    params.window_upper_left_corner_x = av_make_q(0, 1);
+    params.window_upper_left_corner_y = av_make_q(0, 1);
+    params.window_lower_right_corner_x = av_make_q(1, 1);
+    params.window_lower_right_corner_y = av_make_q(1, 1);
+
+    const AVRational maxscl = av_make_q(
+      frame_metadata.maxscl, hdr10plus_normalized_scale);
+    params.maxscl[0] = maxscl;
+    params.maxscl[1] = maxscl;
+    params.maxscl[2] = maxscl;
+    params.average_maxrgb = av_make_q(
+      frame_metadata.average_maxrgb, hdr10plus_normalized_scale);
+    params.num_distribution_maxrgb_percentiles = 0;
+    params.fraction_bright_pixels = av_make_q(0, 1);
+    params.tone_mapping_flag = 0;
+    params.color_saturation_mapping_flag = 0;
+
+    std::array<uint8_t, AV_HDR_PLUS_MAX_PAYLOAD_SIZE> body_storage {};
+    uint8_t *body = body_storage.data();
+    size_t body_size = body_storage.size();
+    if (av_dynamic_hdr_plus_to_t35(&metadata, &body, &body_size) < 0 ||
+        body != body_storage.data() || body_size == 0 || body_size > body_storage.size()) {
+      return 0;
+    }
+
+    // FFmpeg omits this 48-bit registration prefix. NVENC adds only the
+    // surrounding HEVC SEI or AV1 metadata OBU syntax.
+    std::copy(hdr10plus_t35_prefix.begin(), hdr10plus_t35_prefix.end(), payload.begin());
+    std::copy_n(body, body_size, payload.begin() + hdr10plus_t35_prefix.size());
+
+    AVDynamicHDRPlus decoded {};
+    const bool valid_round_trip =
+      av_dynamic_hdr_plus_from_t35(&decoded, body, body_size) >= 0 &&
+      decoded.application_version == metadata.application_version &&
+      decoded.num_windows == metadata.num_windows &&
+      rational_equals(decoded.targeted_system_display_maximum_luminance,
+        metadata.targeted_system_display_maximum_luminance) &&
+      rational_equals(decoded.params[0].maxscl[0], params.maxscl[0]) &&
+      rational_equals(decoded.params[0].maxscl[1], params.maxscl[1]) &&
+      rational_equals(decoded.params[0].maxscl[2], params.maxscl[2]) &&
+      rational_equals(decoded.params[0].average_maxrgb, params.average_maxrgb);
+
+    if (!valid_round_trip) {
+      return 0;
+    }
+
+    return hdr10plus_t35_prefix.size() + body_size;
+  }
+
+}  // namespace video::hdr_metadata

--- a/src/video_hdr_metadata.h
+++ b/src/video_hdr_metadata.h
@@ -12,6 +12,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <span>
 #include <vector>
 
 namespace video::hdr_metadata {
@@ -28,6 +29,60 @@ namespace video::hdr_metadata {
     bool hdr10plus = false;
     bool vivid = false;
   };
+
+  constexpr int hdr10plus_normalized_scale = 100000;
+  constexpr uint8_t hdr10plus_application_version = 1;
+  constexpr size_t hdr10plus_t35_prefix_size = 6;
+  // Large enough for FFmpeg's maximum ST 2094-40 body plus the T.35 prefix,
+  // without exposing FFmpeg headers to this shared, unit-testable header.
+  constexpr size_t hdr10plus_t35_max_payload_size = 1024;
+
+  struct hdr10plus_frame_metadata_t {
+    int maxscl = 0;
+    int average_maxrgb = 0;
+    uint16_t targeted_system_display_maximum_luminance = 1000;
+    bool valid = false;
+  };
+
+  /**
+   * Convert analyzer luminance values into the normalized ST 2094-40 fields
+   * shared by the AVCodec side-data and native NVENC paths.
+   */
+  inline hdr10plus_frame_metadata_t
+  hdr10plus_from_luminance(float percentile_95, float average_maxrgb,
+    uint16_t max_display_luminance) {
+    if (!std::isfinite(percentile_95) || !std::isfinite(average_maxrgb) ||
+        percentile_95 < 0.0f || average_maxrgb < 0.0f) {
+      return {};
+    }
+
+    const uint16_t target_nits = std::clamp<uint16_t>(
+      max_display_luminance > 0 ? max_display_luminance : 1000,
+      1,
+      10000);
+    const auto normalize = [target_nits](float nits) {
+      const float normalized = std::clamp(nits / target_nits, 0.0f, 1.0f);
+      return static_cast<int>(std::lround(normalized * hdr10plus_normalized_scale));
+    };
+
+    return {
+      .maxscl = normalize(percentile_95),
+      .average_maxrgb = normalize(average_maxrgb),
+      .targeted_system_display_maximum_luminance = target_nits,
+      .valid = true,
+    };
+  }
+
+  /**
+   * Serialize one frame of HDR10+ metadata as a complete registered ITU-T T.35
+   * payload, ready for an HEVC SEI message or an AV1 metadata OBU.
+   * Invalid input, insufficient output space, or a failed FFmpeg round trip
+   * returns zero.
+   */
+  size_t
+  serialize_hdr10plus_t35(const platf::hdr_frame_luminance_stats_t &stats,
+    uint16_t max_display_luminance,
+    std::span<uint8_t> payload);
 
   /**
    * HDR10+ is defined for PQ content. HDR Vivid can accompany either PQ or HLG.

--- a/tests/unit/test_video_hdr_metadata.cpp
+++ b/tests/unit/test_video_hdr_metadata.cpp
@@ -6,6 +6,11 @@
 
 #include <limits>
 
+extern "C" {
+#include <libavutil/hdr_dynamic_metadata.h>
+#include <libavutil/rational.h>
+}
+
 #include "../tests_common.h"
 
 namespace {
@@ -40,6 +45,99 @@ TEST(HdrDynamicMetadata, RoutesFormatsByTransferFunction) {
   const auto sdr = formats_for(sunshine_colorspace_t { colorspace_e::rec709, false, 8 });
   EXPECT_FALSE(sdr.hdr10plus);
   EXPECT_FALSE(sdr.vivid);
+}
+
+TEST(HdrDynamicMetadata, SerializesAndRoundTripsHdr10PlusT35) {
+  platf::hdr_frame_luminance_stats_t stats {};
+  stats.percentile_95 = 500.0f;
+  stats.avg_maxrgb = 100.0f;
+  stats.valid = true;
+
+  std::array<uint8_t, video::hdr_metadata::hdr10plus_t35_max_payload_size> payload {};
+  const size_t payload_size = video::hdr_metadata::serialize_hdr10plus_t35(stats, 1000, payload);
+  ASSERT_GT(payload_size, video::hdr_metadata::hdr10plus_t35_prefix_size);
+
+  const std::vector<uint8_t> expected_prefix { 0xB5, 0x00, 0x3C, 0x00, 0x01, 0x04 };
+  ASSERT_TRUE(std::equal(expected_prefix.begin(), expected_prefix.end(), payload.begin()));
+
+  AVDynamicHDRPlus decoded {};
+  ASSERT_GE(av_dynamic_hdr_plus_from_t35(
+              &decoded, payload.data() + expected_prefix.size(),
+              payload_size - expected_prefix.size()),
+    0);
+  EXPECT_EQ(decoded.application_version, video::hdr_metadata::hdr10plus_application_version);
+  EXPECT_EQ(decoded.num_windows, 1);
+  EXPECT_EQ(av_cmp_q(decoded.targeted_system_display_maximum_luminance, av_make_q(1000, 1)), 0);
+  EXPECT_EQ(av_cmp_q(decoded.params[0].maxscl[0], av_make_q(50000, 100000)), 0);
+  EXPECT_EQ(av_cmp_q(decoded.params[0].maxscl[1], av_make_q(50000, 100000)), 0);
+  EXPECT_EQ(av_cmp_q(decoded.params[0].maxscl[2], av_make_q(50000, 100000)), 0);
+  EXPECT_EQ(av_cmp_q(decoded.params[0].average_maxrgb, av_make_q(10000, 100000)), 0);
+  EXPECT_EQ(decoded.params[0].tone_mapping_flag, 0);
+  EXPECT_EQ(decoded.params[0].color_saturation_mapping_flag, 0);
+}
+
+TEST(HdrDynamicMetadata, RejectsInvalidHdr10PlusStatsAndOutputBuffers) {
+  platf::hdr_frame_luminance_stats_t stats {};
+  stats.percentile_95 = 400.0f;
+  stats.avg_maxrgb = 80.0f;
+  stats.valid = false;
+
+  std::array<uint8_t, video::hdr_metadata::hdr10plus_t35_max_payload_size> payload {};
+  EXPECT_EQ(video::hdr_metadata::serialize_hdr10plus_t35(stats, 1000, payload), 0U);
+
+  stats.valid = true;
+  std::array<uint8_t, 16> undersized_payload {};
+  EXPECT_EQ(video::hdr_metadata::serialize_hdr10plus_t35(stats, 1000, undersized_payload), 0U);
+
+  const auto rejected = [&](float percentile_95, float average_maxrgb) {
+    stats.percentile_95 = percentile_95;
+    stats.avg_maxrgb = average_maxrgb;
+    return video::hdr_metadata::serialize_hdr10plus_t35(stats, 1000, payload) == 0;
+  };
+  EXPECT_TRUE(rejected(std::numeric_limits<float>::quiet_NaN(), 80.0f));
+  EXPECT_TRUE(rejected(-1.0f, 80.0f));
+  EXPECT_TRUE(rejected(400.0f, std::numeric_limits<float>::quiet_NaN()));
+  EXPECT_TRUE(rejected(400.0f, -1.0f));
+}
+
+TEST(HdrDynamicMetadata, AppliesHdr10PlusTargetLuminanceFallbackAndClamp) {
+  platf::hdr_frame_luminance_stats_t stats {};
+  stats.percentile_95 = 400.0f;
+  stats.avg_maxrgb = 80.0f;
+  stats.valid = true;
+
+  std::array<uint8_t, video::hdr_metadata::hdr10plus_t35_max_payload_size> payload {};
+  size_t payload_size = video::hdr_metadata::serialize_hdr10plus_t35(stats, 0, payload);
+  ASSERT_GT(payload_size, video::hdr_metadata::hdr10plus_t35_prefix_size);
+  AVDynamicHDRPlus decoded {};
+  ASSERT_GE(av_dynamic_hdr_plus_from_t35(
+              &decoded,
+              payload.data() + video::hdr_metadata::hdr10plus_t35_prefix_size,
+              payload_size - video::hdr_metadata::hdr10plus_t35_prefix_size),
+    0);
+  EXPECT_EQ(av_cmp_q(decoded.targeted_system_display_maximum_luminance, av_make_q(1000, 1)), 0);
+
+  payload_size = video::hdr_metadata::serialize_hdr10plus_t35(stats, 60000, payload);
+  ASSERT_GT(payload_size, video::hdr_metadata::hdr10plus_t35_prefix_size);
+  decoded = {};
+  ASSERT_GE(av_dynamic_hdr_plus_from_t35(
+              &decoded,
+              payload.data() + video::hdr_metadata::hdr10plus_t35_prefix_size,
+              payload_size - video::hdr_metadata::hdr10plus_t35_prefix_size),
+    0);
+  EXPECT_EQ(av_cmp_q(decoded.targeted_system_display_maximum_luminance, av_make_q(10000, 1)), 0);
+}
+
+TEST(HdrDynamicMetadata, SharesHdr10PlusNormalizationAcrossEncoderPaths) {
+  const auto metadata = video::hdr_metadata::hdr10plus_from_luminance(500.0f, 100.0f, 1000);
+  ASSERT_TRUE(metadata.valid);
+  EXPECT_EQ(metadata.maxscl, 50000);
+  EXPECT_EQ(metadata.average_maxrgb, 10000);
+  EXPECT_EQ(metadata.targeted_system_display_maximum_luminance, 1000);
+
+  const auto fallback = video::hdr_metadata::hdr10plus_from_luminance(400.0f, 80.0f, 0);
+  ASSERT_TRUE(fallback.valid);
+  EXPECT_EQ(fallback.targeted_system_display_maximum_luminance, 1000);
 }
 
 TEST(HdrDynamicMetadata, GeneratesVividFieldsInPqContentDomain) {


### PR DESCRIPTION
## What changed

- replace the hand-written HDR10+ bit writer with FFmpeg's `av_dynamic_hdr_plus_to_t35()` serializer
- prepend the required 48-bit registered ITU-T T.35 header before passing the payload to NVENC
- use HDR10+ Application Version 1 consistently in serialized metadata and AVCodec side data
- validate every serialized payload by parsing it back with `av_dynamic_hdr_plus_from_t35()` and omit invalid dynamic metadata safely
- share one FFmpeg-independent luminance normalization model between the AVCodec side-data and native NVENC paths
- serialize into fixed-capacity stack buffers to avoid per-frame HDR10+ heap allocation
- reuse the same complete T.35 payload for HEVC SEI and AV1 metadata OBU injection
- add unit coverage for the registration header, ST 2094-40 values, round-trip parsing, invalid statistics, undersized output buffers, shared normalization, and target-luminance fallback/clamping

## Why

AV1 PQ streams became black in Moonlight when HDR luminance analysis was enabled, while AV1 HLG and HEVC PQ remained functional. Disabling analysis also restored AV1 PQ.

The HDR10+ path wrote ST 2094-40 fields in the wrong order and applied incorrect value scaling. HEVC decoders tolerated that malformed payload, but the AV1 decode path did not tolerate the resulting metadata OBU.

## Impact

AV1 PQ now receives standards-compliant HDR10+ Application Version 1 metadata. Serialization or validation failures degrade safely to the existing static HDR10 metadata instead of risking a broken video stream. HLG routing and HDR Vivid serialization are unchanged.

The common normalization model also prevents the AVCodec and native NVENC paths from drifting apart as the analyzer evolves.

## Validation

- `git diff --check`
- relevant serializer, unit-test, and NVENC translation units compiled during initial local validation
- expanded regression and boundary tests are running in CI
- final full build and unit suite delegated to CI after local temporary build resources were removed
