### PR TITLE
fix(stream): 修复锁屏下多客户端黑屏和退出流程

### DIFF
--- a/cmake/dependencies/Boost_Sunshine.cmake
+++ b/cmake/dependencies/Boost_Sunshine.cmake
@@ -9,6 +9,7 @@ set(BOOST_COMPONENTS
         atomic
         beast
         filesystem
+        function
         locale
         log
         program_options

--- a/src/launch_session_manager.cpp
+++ b/src/launch_session_manager.cpp
@@ -247,20 +247,6 @@ namespace rtsp_stream {
   }
 
   std::size_t
-  launch_session_manager_t::erase_client_sessions(std::string_view client_cert_uuid) {
-    if (client_cert_uuid.empty()) {
-      return 0;
-    }
-
-    std::lock_guard lock { _impl->mutex };
-    const auto old_size = _impl->tickets.size();
-    std::erase_if(_impl->tickets, [client_cert_uuid](const auto &ticket) {
-      return ticket.session && ticket.session->client_cert_uuid == client_cert_uuid;
-    });
-    return old_size - _impl->tickets.size();
-  }
-
-  std::size_t
   launch_session_manager_t::prune(clock_t::time_point now) {
     std::lock_guard lock { _impl->mutex };
     const auto old_size = _impl->tickets.size();

--- a/src/launch_session_manager.h
+++ b/src/launch_session_manager.h
@@ -82,9 +82,6 @@ namespace rtsp_stream {
     erase(std::uint32_t launch_session_id);
 
     std::size_t
-    erase_client_sessions(std::string_view client_cert_uuid);
-
-    std::size_t
     prune(clock_t::time_point now = clock_t::now());
 
     void

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -21,6 +21,7 @@
 
 // lib includes
 #include <Simple-Web-Server/server_http.hpp>
+#include <boost/atomic.hpp>
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/ssl/context.hpp>
 #include <boost/asio/ssl/context_base.hpp>
@@ -81,7 +82,8 @@ namespace nvhttp {
     "/favicon.ico", "/favicon.png", "/favicon.svg"
   };
 
-  std::atomic<uint32_t> session_id_counter;
+  boost::atomic<uint32_t> session_id_counter {0};
+  static boost::atomic_flag global_cancel_pending = BOOST_ATOMIC_FLAG_INIT;
 
   static tls_client_identity_store_t tls_client_identities;
 
@@ -878,21 +880,45 @@ namespace nvhttp {
       return;
     }
 
-    const auto result = rtsp_stream::cancel_client_sessions(client_cert_uuid);
-    BOOST_LOG(info) << "Client-scoped cancel [client_uuid="sv << client_cert_uuid
-                    << ", cancelled="sv << result.cancelled_sessions
-                    << ", remaining="sv << result.remaining_sessions << ']';
-
     tree.put("root.cancel", 1);
     tree.put("root.<xmlattr>.status_code", 200);
 
-    if (result.remaining_sessions == 0) {
-      if (proc::proc.running() > 0) {
-        proc::proc.terminate();
-      }
+    // GameStream 的 /cancel 表示退出当前应用，而普通断开由 RTSP/控制通道处理。
+    // 清理可能需要等待编码器和应用退出，不能阻塞 NVHTTP 工作线程。
+    if (!global_cancel_pending.test_and_set(boost::memory_order_acq_rel)) {
+      BOOST_LOG(info) << "Global app cancel accepted; stopping all streaming sessions asynchronously"sv;
+      rtsp_stream::terminate_sessions_async(stream::session::stop_reason_e::client_cancel, []() {
+        auto clear_pending = util::fail_guard([]() {
+          global_cancel_pending.clear(boost::memory_order_release);
+        });
 
-      // Preserve the legacy single-client behavior once no other session is using the host.
-      display_device::session_t::get().restore_state();
+        try {
+          if (proc::proc.running() > 0) {
+            proc::proc.terminate();
+          }
+        }
+        catch (const std::exception &e) {
+          BOOST_LOG(error) << "Failed to terminate the running application during app cancel: "sv << e.what();
+        }
+        catch (...) {
+          BOOST_LOG(error) << "Failed to terminate the running application during app cancel"sv;
+        }
+
+        try {
+          display_device::session_t::get().restore_state();
+        }
+        catch (const std::exception &e) {
+          BOOST_LOG(error) << "Failed to restore display state during app cancel: "sv << e.what();
+        }
+        catch (...) {
+          BOOST_LOG(error) << "Failed to restore display state during app cancel"sv;
+        }
+
+        BOOST_LOG(info) << "Global app cancel cleanup finished"sv;
+      });
+    }
+    else {
+      BOOST_LOG(debug) << "Global app cancel is already in progress"sv;
     }
   }
 

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -786,38 +786,6 @@ namespace rtsp_stream {
       return static_cast<int>(_launch_sessions.size());
     }
 
-    client_session_cancel_result_t
-    cancel_client_sessions(std::string_view client_cert_uuid) {
-      client_session_cancel_result_t result;
-      result.cancelled_sessions = _launch_sessions.erase_client_sessions(client_cert_uuid);
-      std::vector<std::shared_ptr<stream::session_t>> sessions_to_join;
-
-      {
-        auto lg = _session_slots.lock();
-        for (auto i = _session_slots->begin(); i != _session_slots->end();) {
-          auto &slot = *(*i);
-          if (stream::session::stop_client_session(slot, client_cert_uuid)) {
-            sessions_to_join.push_back(*i);
-            i = _session_slots->erase(i);
-            ++result.cancelled_sessions;
-          }
-          else {
-            if (stream::session::state(slot) != stream::session::state_e::STOPPING) {
-              ++result.remaining_sessions;
-            }
-            ++i;
-          }
-        }
-      }
-
-      for (const auto &session : sessions_to_join) {
-        stream::session::join(*session);
-      }
-
-      result.remaining_sessions += _launch_sessions.size();
-      return result;
-    }
-
     bool
     activate_launch_session(std::uint32_t launch_session_id) {
       return _launch_sessions.activate(launch_session_id);
@@ -851,7 +819,7 @@ namespace rtsp_stream {
      * @examples_end
      */
     void
-    clear(bool all = true) {
+    clear(bool all = true, stream::session::stop_reason_e reason = stream::session::stop_reason_e::host_terminate) {
       if (all) {
         _launch_sessions.clear();
       }
@@ -859,20 +827,55 @@ namespace rtsp_stream {
         _launch_sessions.prune();
       }
 
-      auto lg = _session_slots.lock();
+      std::vector<std::shared_ptr<stream::session_t>> sessions_to_join;
+      {
+        auto lg = _session_slots.lock();
 
-      for (auto i = _session_slots->begin(); i != _session_slots->end();) {
-        auto &slot = *(*i);
-        if (all || stream::session::state(slot) == stream::session::state_e::STOPPING) {
-          stream::session::stop(slot, stream::session::stop_reason_e::host_terminate);
-          stream::session::join(slot);
-
-          i = _session_slots->erase(i);
-        }
-        else {
-          i++;
+        for (auto i = _session_slots->begin(); i != _session_slots->end();) {
+          auto &slot = *(*i);
+          if (all || stream::session::state(slot) == stream::session::state_e::STOPPING) {
+            stream::session::stop(slot, reason);
+            sessions_to_join.push_back(*i);
+            i = _session_slots->erase(i);
+          }
+          else {
+            i++;
+          }
         }
       }
+
+      // join 可能等待编码和网络线程，等待期间不能持有会话表锁，
+      // 否则其他 RTSP/NVHTTP 请求也会被一起堵住。
+      for (const auto &session : sessions_to_join) {
+        stream::session::join(*session);
+      }
+    }
+
+    void
+    terminate_sessions_async(stream::session::stop_reason_e reason, boost::function<void()> completion) {
+      boost::asio::post(io_context, [this, reason, completion = std::move(completion)]() mutable {
+        try {
+          clear(true, reason);
+        }
+        catch (const std::exception &e) {
+          BOOST_LOG(error) << "Failed to terminate streaming sessions asynchronously: "sv << e.what();
+        }
+        catch (...) {
+          BOOST_LOG(error) << "Failed to terminate streaming sessions asynchronously"sv;
+        }
+
+        try {
+          if (completion) {
+            completion();
+          }
+        }
+        catch (const std::exception &e) {
+          BOOST_LOG(error) << "Streaming session termination callback failed: "sv << e.what();
+        }
+        catch (...) {
+          BOOST_LOG(error) << "Streaming session termination callback failed"sv;
+        }
+      });
     }
 
     /**
@@ -959,13 +962,8 @@ namespace rtsp_stream {
   }
 
   void
-  terminate_sessions() {
-    server.clear(true);
-  }
-
-  client_session_cancel_result_t
-  cancel_client_sessions(std::string_view client_cert_uuid) {
-    return server.cancel_client_sessions(client_cert_uuid);
+  terminate_sessions_async(stream::session::stop_reason_e reason, boost::function<void()> completion) {
+    server.terminate_sessions_async(reason, std::move(completion));
   }
 
   int

--- a/src/rtsp.h
+++ b/src/rtsp.h
@@ -4,23 +4,23 @@
  */
 #pragma once
 
-#include <atomic>
-#include <cstddef>
-#include <string_view>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
 
+#include <boost/function.hpp>
 #include <boost/process/v1.hpp>
 
 #include "crypto.h"
 #include "launch_session_manager.h"
-#include "thread_safe.h"
+
+namespace stream::session {
+  enum class stop_reason_e : int;
+}
 
 namespace rtsp_stream {
   constexpr auto RTSP_SETUP_PORT = 21;
-
-  struct client_session_cancel_result_t {
-    std::size_t cancelled_sessions {};
-    std::size_t remaining_sessions {};
-  };
 
   struct launch_session_t {
     uint32_t id;
@@ -92,16 +92,12 @@ namespace rtsp_stream {
   pending_session_count();
 
   /**
-   * @brief Terminates all running streaming sessions.
+   * @brief Terminates all streaming sessions on the RTSP execution context.
+   * @param reason Reason recorded for sessions that are still running.
+   * @param completion Called after the termination attempt finishes.
    */
   void
-  terminate_sessions();
-
-  /**
-   * @brief Terminates sessions owned by one authenticated client.
-   */
-  client_session_cancel_result_t
-  cancel_client_sessions(std::string_view client_cert_uuid);
+  terminate_sessions_async(stream::session::stop_reason_e reason, boost::function<void()> completion);
 
   /**
    * @brief Runs the RTSP server loop.

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -3449,16 +3449,6 @@ namespace stream {
       session.shutdown_event->raise(true);
     }
 
-    bool
-    stop_client_session(session_t &session, std::string_view client_cert_uuid) {
-      if (client_cert_uuid.empty() || session.client_cert_uuid != client_cert_uuid) {
-        return false;
-      }
-
-      stop(session, stop_reason_e::client_cancel);
-      return session.lifecycle.state() == state_e::STOPPING;
-    }
-
     void
     join(session_t &session) {
       // Current Nvidia drivers have a bug where NVENC can deadlock the encoder thread with hardware-accelerated

--- a/src/stream.h
+++ b/src/stream.h
@@ -8,7 +8,6 @@
 #include <cstdint>
 #include <mutex>
 #include <string>
-#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -158,8 +157,6 @@ namespace stream {
     start(session_t &session, const std::string &addr_string);
     void
     stop(session_t &session, stop_reason_e reason = stop_reason_e::none);
-    bool
-    stop_client_session(session_t &session, std::string_view client_cert_uuid);
     void
     join(session_t &session);
     state_e

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1035,8 +1035,15 @@ namespace video {
   using encode_session_ctx_queue_t = safe::queue_t<sync_session_ctx_t>;
   using encode_e = platf::capture_e;
 
+  struct captured_frame_t {
+    std::shared_ptr<platf::img_t> image;
+    bool is_replay {false};
+  };
+
+  using captured_frame_event_t = std::shared_ptr<safe::event_t<captured_frame_t>>;
+
   struct capture_ctx_t {
-    img_event_t images;
+    captured_frame_event_t images;
     config_t config;
   };
 
@@ -1768,8 +1775,9 @@ namespace video {
 
     constexpr auto capture_buffer_size = 12;
     std::list<std::shared_ptr<platf::img_t>> imgs(capture_buffer_size);
+    std::shared_ptr<platf::img_t> latest_captured_img;
 
-    auto append_pending_capture_contexts = [&]() -> bool {
+    auto append_pending_capture_contexts = [&](const std::shared_ptr<platf::img_t> &initial_img = {}) -> bool {
       while (capture_ctx_queue->peek()) {
         auto capture_ctx = capture_ctx_queue->pop();
         if (!capture_ctx) {
@@ -1779,6 +1787,16 @@ namespace video {
         // 同一个捕获线程中的会话共享当前显示器。手动切换显示器后加入的会话
         // 必须继承当前目标，避免后续重新初始化跳回它启动时选择的显示器。
         capture_ctx->config.display_name = target_display_name;
+        if (initial_img) {
+          // 锁屏或静态桌面可能长时间没有新的 Desktop Duplication 帧。
+          // 新会话必须先取得当前画面，不能一直编码初始化用的黑色占位帧。
+          capture_ctx->images->raise(captured_frame_t {
+            .image = initial_img,
+            .is_replay = true,
+          });
+        }
+        BOOST_LOG(debug) << "Attached streaming session to shared capture display ["sv << target_display_name
+                         << "], reused latest frame: "sv << (initial_img ? "yes"sv : "no"sv);
         capture_ctxs.emplace_back(std::move(*capture_ctx));
       }
 
@@ -1892,11 +1910,6 @@ namespace video {
 
             continue;
           }
-
-          if (frame_captured) {
-            capture_ctx->images->raise(img);
-          }
-
           ++capture_ctx;
         })
 
@@ -1904,8 +1917,19 @@ namespace video {
           return false;
         }
 
-        if (!append_pending_capture_contexts()) {
+        // 先接入新会话，再分发本次真实画面。若本次只是捕获超时，则给新会话
+        // 补发上一张真实画面，保证它与现有会话看到同一个活动显示器内容。
+        if (!append_pending_capture_contexts(frame_captured ? std::shared_ptr<platf::img_t> {} : latest_captured_img)) {
           return false;
+        }
+
+        if (frame_captured) {
+          latest_captured_img = img;
+          for (auto &capture_ctx : capture_ctxs) {
+            capture_ctx.images->raise(captured_frame_t {
+              .image = img,
+            });
+          }
         }
 
         if (switch_display_event->peek()) {
@@ -1929,6 +1953,7 @@ namespace video {
           reinit_event.raise(true);
 
           // Some classes of images contain references to the display --> display won't delete unless img is deleted
+          latest_captured_img.reset();
           for (auto &img : imgs) {
             img.reset();
           }
@@ -3021,7 +3046,7 @@ namespace video {
   encode_run(
     int &frame_nr,  // Store progress of the frame number
     safe::mail_t mail,
-    img_event_t images,
+    captured_frame_event_t images,
     config_t config,
     std::shared_ptr<platf::display_t> disp,
     std::unique_ptr<platf::encode_device_t> encode_device,
@@ -3184,19 +3209,24 @@ namespace video {
       // Encode at a minimum FPS to avoid image quality issues with static content
       // When variable_refresh_rate is enabled, only encode when we have a new frame
       if (!requested_idr_frame || images->peek()) {
-        if (auto img = pop_image_interruptible(effective_frame_time, input_activity_boost_policy.useful && !input_boost_active)) {
-          frame_timestamp = img->frame_timestamp;
-          pipeline_trace = img->pipeline_trace.value_or(platf::frame_pipeline_trace_t {});
-          if (!pipeline_trace->capture_ready) {
-            pipeline_trace->capture_ready = frame_timestamp;
+        if (auto frame = pop_image_interruptible(effective_frame_time, input_activity_boost_policy.useful && !input_boost_active)) {
+          auto &img = frame->image;
+          if (!frame->is_replay) {
+            frame_timestamp = img->frame_timestamp;
+            pipeline_trace = img->pipeline_trace.value_or(platf::frame_pipeline_trace_t {});
+            if (!pipeline_trace->capture_ready) {
+              pipeline_trace->capture_ready = frame_timestamp;
+            }
+            pipeline_trace->convert_begin = std::chrono::steady_clock::now();
           }
-          pipeline_trace->convert_begin = std::chrono::steady_clock::now();
           if (session->convert(*img)) {
             BOOST_LOG(error) << "Could not convert image"sv;
             // Don't exit permanently — break to let the outer reinit loop handle recovery
             break;
           }
-          pipeline_trace->convert_end = std::chrono::steady_clock::now();
+          if (pipeline_trace) {
+            pipeline_trace->convert_end = std::chrono::steady_clock::now();
+          }
           has_new_frame = true;
         }
         else if (!images->running()) {
@@ -3614,7 +3644,7 @@ namespace video {
     std::optional<safe::mail_raw_t::event_t<dynamic_param_t>> dynamic_param_events) {
     auto shutdown_event = mail->event<bool>(mail::shutdown);
 
-    auto images = std::make_shared<img_event_t::element_type>();
+    auto images = std::make_shared<captured_frame_event_t::element_type>();
     auto lg = util::fail_guard([&]() {
       images->stop();
       shutdown_event->raise(true);

--- a/src/video.h
+++ b/src/video.h
@@ -192,8 +192,6 @@ namespace video {
   using avcodec_frame_t = util::safe_ptr<AVFrame, free_frame>;
   using avcodec_buffer_t = util::safe_ptr<AVBufferRef, free_buffer>;
   using sws_t = util::safe_ptr<SwsContext, sws_freeContext>;
-  using img_event_t = std::shared_ptr<safe::event_t<std::shared_ptr<platf::img_t>>>;
-
   struct encoder_platform_formats_t {
     virtual ~encoder_platform_formats_t() = default;
     platf::mem_type_e dev_type;

--- a/tests/unit/test_rtsp.cpp
+++ b/tests/unit/test_rtsp.cpp
@@ -135,27 +135,6 @@ TEST(LaunchSessionManager, PreservesClaimedTicketsPastPendingExpiry) {
   EXPECT_EQ(manager.size(now + 4s), 0U);
 }
 
-TEST(LaunchSessionManager, ErasesOnlyTicketsOwnedByAuthenticatedClient) {
-  rtsp_stream::launch_session_manager_t manager;
-  const auto now = rtsp_stream::launch_session_manager_t::clock_t::now();
-
-  ASSERT_EQ(manager.register_session(make_session(40, "cert-a", "192.0.2.40"), 10s, now),
-            rtsp_stream::launch_ticket_register_e::accepted);
-  ASSERT_EQ(manager.register_session(make_session(41, "cert-b", "192.0.2.41"), 10s, now),
-            rtsp_stream::launch_ticket_register_e::accepted);
-  ASSERT_EQ(manager.register_session(make_session(42, {}, "192.0.2.42"), 10s, now),
-            rtsp_stream::launch_ticket_register_e::accepted);
-
-  EXPECT_EQ(manager.erase_client_sessions({}), 0U);
-  EXPECT_EQ(manager.erase_client_sessions("cert-a"), 1U);
-  EXPECT_EQ(manager.size(now), 2U);
-
-  EXPECT_FALSE(manager.claim_plaintext("192.0.2.40", now));
-  auto other_client = manager.claim_plaintext("192.0.2.41", now);
-  ASSERT_TRUE(other_client);
-  EXPECT_EQ(other_client->id, 41U);
-}
-
 TEST(LaunchSessionManager, SupportsOverlappingRtspConnectionsForOneLaunch) {
   rtsp_stream::launch_session_manager_t manager;
   const auto now = rtsp_stream::launch_session_manager_t::clock_t::now();


### PR DESCRIPTION
## 说明

共享捕获线程在锁屏或静态桌面没有产生新帧时，新加入的客户端只能持续编码初始化黑帧。多客户端场景下，按客户端证书范围处理 `/cancel` 也会导致退出应用后仍有其他会话存活，并让同步清理占用 NVHTTP 请求线程。

## 修改

- 缓存共享捕获线程最后一张真实画面，在没有新帧时提供给新会话，并将其标记为回放帧，避免复用旧的采集时间戳和流水线追踪信息。
- 将 `/cancel` 作为应用级退出处理，在 RTSP 执行上下文异步停止全部会话，并在锁外等待会话线程结束，再终止应用和恢复显示状态。
- 对重复的全局退出请求进行去重，同时保留 `client_cancel` 会话结束原因。
- 移除不再使用的客户端级会话筛选接口和对应测试。