### PR TITLE
fix(windows): finalize VDD upgrades without reinstall

### DIFF
--- a/cmake/packaging/sunshine.iss.in
+++ b/cmake/packaging/sunshine.iss.in
@@ -62,8 +62,9 @@ ArchitecturesInstallIn64BitMode=x64compatible
 ; 重启管理器
 CloseApplications=yes
 RestartApplications=yes
-; Driver/helper installers may return a reboot-required exit code. Do not show
-; Inno's final reboot prompt; users can reboot later if a driver needs it.
+; Driver installation is executed from [Code], where its exit status is
+; validated. NeedRestart() requests the reboot only after a staged VDD reports
+; that its device/control interface cannot become ready in the current boot.
 RestartIfNeededByRun=no
 ; Always write %TEMP%\Setup Log*.txt. Support reports for "service did not
 ; install" / "files disappeared" are unanswerable without the per-file and
@@ -111,6 +112,7 @@ english.MsgOldNSISFailed=The previous installation could not be fully removed.%n
 english.MsgOldNSISStaleRegistry=The previous installation files appear to be gone, but registry entries remain.%nClean up the leftover registry and continue installing?
 english.MsgOldNSISCleanupFailed=Failed to clean up the previous installation registry entries.%nPlease remove HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Sunshine manually and try again.
 english.MsgServiceInstallFailed=Sunshine service could not be installed or verified.%n%nThe files were installed and are kept. Reboot and run "{app}\scripts\install-service.bat" as administrator, or use the repair action in the Sunshine GUI. The installer log in your TEMP folder has the details.
+english.MsgVDDInstallFailed=The virtual display driver could not be installed or verified.%n%nSunshine was installed but has not been started. Review the installer log in your TEMP folder, then use the repair action in the Sunshine GUI.
 english.MsgUninstallGamepad=Do you want to remove Virtual Gamepad?
 english.MsgUninstallData=Do you want to remove all data in %1?%n(This includes configuration, cover images, and settings)
 english.StatusStoppingService=Stopping Sunshine service...
@@ -152,6 +154,7 @@ chinesesimplified.MsgOldNSISFailed=无法完全移除旧版安装。%n请手动�
 chinesesimplified.MsgOldNSISStaleRegistry=旧版本的文件已经不存在，但注册表中仍残留旧版的卸载信息。%n是否清理残留的注册表项并继续安装？
 chinesesimplified.MsgOldNSISCleanupFailed=清理旧版注册表项失败。%n请手动删除 HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Sunshine 后重试。
 chinesesimplified.MsgServiceInstallFailed=无法安装或验证 Sunshine 服务。%n%n程序文件已经装好并会保留。请重启后以管理员身份运行 "{app}\scripts\install-service.bat"，或在 Sunshine 管理界面里使用修复功能。详细信息见 TEMP 目录下的安装日志。
+chinesesimplified.MsgVDDInstallFailed=无法安装或验证虚拟显示驱动。%n%nSunshine 已安装但尚未启动。请检查 TEMP 目录中的安装日志，然后在 Sunshine 管理界面中使用修复功能。
 chinesesimplified.MsgUninstallGamepad=是否移除虚拟手柄（ViGEmBus）？
 chinesesimplified.MsgUninstallData=是否删除 %1 中的所有数据？%n（包括配置文件、封面图片和设置）
 chinesesimplified.StatusStoppingService=正在停止 Sunshine 服务...
@@ -285,12 +288,10 @@ Filename: "{cmd}"; Parameters: "/c icacls ""{app}"" /reset /T /C > ""{tmp}\sunsh
 Filename: "{app}\scripts\update-path.bat"; Parameters: "add"; StatusMsg: "{cm:StatusUpdatePath}"; Flags: runhidden waituntilterminated
 Filename: "{app}\scripts\migrate-config.bat"; StatusMsg: "{cm:StatusMigrateConfig}"; Flags: runhidden waituntilterminated
 Filename: "{app}\scripts\add-firewall-rule.bat"; StatusMsg: "{cm:StatusFirewall}"; Flags: runhidden waituntilterminated; Components: firewall
-; Upgrade older VDDs, but never silently replace a healthy newer/custom driver.
-Filename: "{app}\scripts\install-vdd.bat"; Parameters: "--preserve-healthy-existing"; StatusMsg: "{cm:StatusInstallVDD}"; Flags: runhidden waituntilterminated; Components: vdd
 Filename: "{app}\scripts\install-gamepad.bat"; StatusMsg: "{cm:StatusInstallGamepad}"; Flags: runhidden waituntilterminated; Components: gamepad
 Filename: "{app}\scripts\vmouse\install-vmouse.bat"; StatusMsg: "{cm:StatusInstallVmouse}"; Flags: runhidden waituntilterminated; Components: vmouse
-Filename: "{app}\scripts\install-service.bat"; StatusMsg: "{cm:StatusInstallService}"; Flags: runhidden waituntilterminated; AfterInstall: VerifyServiceInstalled
-Filename: "{app}\scripts\autostart-service.bat"; StatusMsg: "{cm:StatusAutostart}"; Flags: runhidden waituntilterminated; Components: autostart
+Filename: "{app}\scripts\install-service.bat"; Parameters: "{code:GetServiceInstallParameters}"; StatusMsg: "{cm:StatusInstallService}"; Flags: runhidden waituntilterminated; AfterInstall: VerifyServiceInstalled
+Filename: "{app}\scripts\autostart-service.bat"; StatusMsg: "{cm:StatusAutostart}"; Flags: runhidden waituntilterminated; Components: autostart; Check: ShouldConfigureServiceAutostart
 
 ; Finish page actions - user selectable
 Filename: "https://docs.qq.com/aio/DSGdQc3htbFJjSFdO?p=DXpTjzl2kZwBjN7jlRMkRJ"; Description: "{cm:FinishOpenDocs}"; Flags: postinstall shellexec runasoriginaluser unchecked nowait skipifsilent
@@ -364,6 +365,66 @@ var
   // callers still see a failure — the GUI updater runs us with /VERYSILENT
   // and treats exit code 0 as "update installed successfully".
   ServiceVerifyFailed: Boolean;
+  // 0 = ready/not selected, 101 = failed, 3010 = reboot required.
+  VDDResultCode: Integer;
+
+function VDDComponentSelected(): Boolean;
+begin
+  Result := WizardIsComponentSelected('vdd');
+end;
+
+function GetServiceInstallParameters(Param: String): String;
+begin
+  if VDDResultCode = 0 then
+    Result := ''
+  else
+    Result := '--no-start';
+end;
+
+function ShouldConfigureServiceAutostart(): Boolean;
+begin
+  Result := VDDResultCode <> 101;
+end;
+
+procedure InstallAndVerifyVDD();
+var
+  ResultCode: Integer;
+  Params, Detail: String;
+begin
+  if not VDDComponentSelected() then
+    Exit;
+
+  WizardForm.StatusLabel.Caption := CustomMessage('StatusInstallVDD');
+  Params := '--preserve-healthy-existing';
+  ResultCode := -1;
+  if not Exec(ExpandConstant('{app}\scripts\install-vdd.bat'), Params, '',
+              SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+  begin
+    VDDResultCode := 101;
+    Log('Could not launch the VDD installer helper.');
+  end
+  else if ResultCode = 0 then
+  begin
+    Log('VDD installation and control-interface verification succeeded.');
+  end
+  else if ResultCode = 3010 then
+  begin
+    VDDResultCode := 3010;
+    Log('VDD installation requires a Windows restart; Sunshine will not start in this boot.');
+  end
+  else
+  begin
+    VDDResultCode := 101;
+    Log('VDD installation or verification failed with exit code ' + IntToStr(ResultCode) + '.');
+  end;
+
+  if (VDDResultCode = 101) and (not WizardSilent) then
+  begin
+    Detail := CustomMessage('MsgVDDInstallFailed') + #13#10 + #13#10 +
+              'Exit code: ' + IntToStr(ResultCode);
+    MsgBox(Detail, mbError, MB_OK);
+  end;
+end;
 
 procedure InitializeWizard();
 var
@@ -756,11 +817,14 @@ end;
 // Report a nonzero exit code when the service could not be verified. Inno
 // returns 0 on a completed install, and callers such as the GUI's auto-updater
 // (`/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-`, success := code = 0) would
-// otherwise report a broken install as a successful update. 100 is outside the
-// range Inno itself uses (1-8).
+// otherwise report a broken install as successful. Codes 100/101 are outside
+// Inno's own range (1-8), while 3010 is the standard Windows reboot-required
+// result consumed by unattended updaters.
 function GetCustomSetupExitCode(): Integer;
 begin
-  if ServiceVerifyFailed then
+  if VDDResultCode <> 0 then
+    Result := VDDResultCode
+  else if ServiceVerifyFailed then
     Result := 100
   else
     Result := 0;
@@ -879,10 +943,19 @@ procedure CurStepChanged(CurStep: TSetupStep);
 begin
   if CurStep = ssPostInstall then
   begin
+    // Upgrade older VDDs and make driver readiness a hard gate before the
+    // Sunshine service is allowed to start. A bound-but-not-ready device is
+    // kept for Windows to finish during the requested reboot.
+    InstallAndVerifyVDD();
     // Delete portable scripts in installed version
     DeleteFile(ExpandConstant('{app}\install_portable.bat'));
     DeleteFile(ExpandConstant('{app}\uninstall_portable.bat'));
   end;
+end;
+
+function NeedRestart(): Boolean;
+begin
+  Result := VDDResultCode = 3010;
 end;
 
 // Custom uninstall: ask about gamepad and data removal

--- a/src_assets/windows/misc/service/install-service.bat
+++ b/src_assets/windows/misc/service/install-service.bat
@@ -2,6 +2,11 @@
 set "PATH=%SystemRoot%\System32;%SystemRoot%;%SystemRoot%\System32\Wbem;%SystemRoot%\System32\WindowsPowerShell\v1.0"
 setlocal enabledelayedexpansion
 
+set "SKIP_START="
+for %%A in (%*) do (
+    if /I "%%~A"=="--no-start" set "SKIP_START=1"
+)
+
 rem Get sunshine root directory
 for %%I in ("%~dp0\..") do set "ROOT_DIR=%%~fI"
 
@@ -87,6 +92,11 @@ if /I "!SERVICE_START_TYPE!"=="delayed-auto" (
 rem Description is metadata only; AV / SCM contention may transiently
 rem block it. Never abort install over a missing description string.
 sc description %SERVICE_NAME% "Sunshine is a self-hosted game stream host for Moonlight." >nul 2>&1
+
+if defined SKIP_START (
+    echo %SERVICE_NAME% installed without starting; a pending driver operation must finish first.
+    exit /b 0
+)
 
 if /I "!SERVICE_START_TYPE!"=="disabled" (
     echo %SERVICE_NAME% installed with disabled start type; not starting.

--- a/src_assets/windows/misc/vdd/smoke-test-vdd-device-helper.ps1
+++ b/src_assets/windows/misc/vdd/smoke-test-vdd-device-helper.ps1
@@ -37,7 +37,7 @@ if (-not (Test-Path -LiteralPath $HelperScript)) {
 . $HelperScript
 
 $nativeExitCode = Invoke-Nefcon $env:ComSpec @('/d', '/c', 'exit', '37')
-Assert-Equal 37 $nativeExitCode 'The native process wrapper must return the child exit code.'
+Assert-Equal -Expected 37 -Actual $nativeExitCode -Message 'The native process wrapper must return the child exit code.'
 
 $missingExitCodeRejected = $false
 try {
@@ -46,7 +46,7 @@ try {
 catch {
     $missingExitCodeRejected = $_.Exception.Message -like '*did not report an exit code*'
 }
-Assert-Equal $true $missingExitCodeRejected 'A missing native exit code must fail explicitly.'
+Assert-Equal -Expected $true -Actual $missingExitCodeRejected -Message 'A missing native exit code must fail explicitly.'
 
 $originalInvokeNefcon = ${function:Invoke-Nefcon}
 $originalGetVddDevices = ${function:Get-VddDevices}
@@ -83,19 +83,19 @@ try {
     }
 
     [void] (Install-VddDeviceFromInf $HelperScript $HelperScript '100.0.16.6')
-    Assert-Equal 2 $script:installNefconCalls `
-        'A restart-suggested driver bind must continue to the readiness check.'
-    Assert-Equal $true ($script:readinessChecks -ge 1) `
-        'A restart-suggested driver bind must check device readiness.'
-    Assert-Equal 120 $script:receivedWaitSeconds `
+    Assert-Equal -Expected 2 -Actual $script:installNefconCalls `
+        -Message 'A restart-suggested driver bind must continue to the readiness check.'
+    Assert-Equal -Expected $true -Actual ($script:readinessChecks -ge 1) `
+        -Message 'A restart-suggested driver bind must check device readiness.'
+    Assert-Equal -Expected 120 -Actual $script:receivedWaitSeconds -Message `
         'VDD readiness checks must retain the 120-second timeout.'
-    Assert-Equal $true ($script:controlInterfaceChecks -ge 1) `
+    Assert-Equal -Expected $true -Actual ($script:controlInterfaceChecks -ge 1) -Message `
         'A ready VDD must verify that its control interface is available.'
 
     $script:forceWaitTimeout = $true
     $script:installTestDevice = New-TestDevice '100.0.16.6' 'ERROR'
     $timeoutResult = Install-VddDeviceFromInf $HelperScript $HelperScript '100.0.16.6'
-    Assert-Equal $vddDeviceRestartRequired $timeoutResult `
+    Assert-Equal -Expected $vddDeviceRestartRequired -Actual $timeoutResult -Message `
         'A timed-out device bound to the expected version must require a restart.'
 
     $script:vddRestartRequired = $false
@@ -107,9 +107,9 @@ try {
     catch {
         $wrongVersionRejected = $_.Exception.Message -like '*did not bind and become ready*version 100.0.16.6*'
     }
-    Assert-Equal $true $wrongVersionRejected `
+    Assert-Equal -Expected $true -Actual $wrongVersionRejected -Message `
         'A timed-out device bound to a different version must fail instead of requesting a restart.'
-    Assert-Equal $false $script:vddRestartRequired `
+    Assert-Equal -Expected $false -Actual $script:vddRestartRequired -Message `
         'A wrong-version timeout must not request a restart.'
 }
 finally {
@@ -126,24 +126,24 @@ finally {
     $script:vddRestartRequired = $false
 }
 
-Assert-Equal $false (Test-VddVersionAtLeast '100.0.16.5' '100.0.16.6') `
-    'An older driver version must not satisfy the bundled minimum.'
-Assert-Equal $true (Test-VddVersionAtLeast '100.0.16.7' '100.0.16.6') `
-    'A newer driver version must satisfy the bundled minimum.'
-Assert-Equal $true (Test-VddVersionAtLeast 'custom-build' '100.0.16.6') `
-    'An incomparable healthy custom driver must be preserved.'
-Assert-Equal $false (Test-VddVersionAtLeast '100.0.15.6' '15.0.15.7') `
-    'A legacy 100.x Win10 driver must migrate to the safe 15.x version line.'
-Assert-Equal $false (Test-VddVersionAtLeast '99.8.8.1123' '15.0.15.7') `
-    'A legacy 99.x Win10 driver must migrate to the safe 15.x version line.'
-Assert-Equal $true (Test-VddVersionAtLeast '15.0.15.8' '15.0.15.7') `
-    'A newer safe Win10 driver must still be preserved.'
-Assert-Equal $true (Test-VddVersionAtLeast '100.0.17.2' '100.0.17.2') `
-    'The Win11 100.x version policy must remain unchanged.'
-Assert-Equal $true (Test-VddDeviceBound (New-TestDevice '15.0.15.8' 'ERROR') '15.0.15.8') `
-    'A non-started device with the expected published package must be eligible for reboot recovery.'
-Assert-Equal $false (Test-VddDeviceBound (New-TestDevice '15.0.15.7') '15.0.15.8') `
-    'A device bound to the wrong package must not be treated as a reboot-only result.'
+Assert-Equal -Expected $false -Actual (Test-VddVersionAtLeast '100.0.16.5' '100.0.16.6') `
+    -Message 'An older driver version must not satisfy the bundled minimum.'
+Assert-Equal -Expected $true -Actual (Test-VddVersionAtLeast '100.0.16.7' '100.0.16.6') `
+    -Message 'A newer driver version must satisfy the bundled minimum.'
+Assert-Equal -Expected $true -Actual (Test-VddVersionAtLeast 'custom-build' '100.0.16.6') `
+    -Message 'An incomparable healthy custom driver must be preserved.'
+Assert-Equal -Expected $false -Actual (Test-VddVersionAtLeast '100.0.15.6' '15.0.15.7') `
+    -Message 'A legacy 100.x Win10 driver must migrate to the safe 15.x version line.'
+Assert-Equal -Expected $false -Actual (Test-VddVersionAtLeast '99.8.8.1123' '15.0.15.7') `
+    -Message 'A legacy 99.x Win10 driver must migrate to the safe 15.x version line.'
+Assert-Equal -Expected $true -Actual (Test-VddVersionAtLeast '15.0.15.8' '15.0.15.7') `
+    -Message 'A newer safe Win10 driver must still be preserved.'
+Assert-Equal -Expected $true -Actual (Test-VddVersionAtLeast '100.0.17.2' '100.0.17.2') `
+    -Message 'The Win11 100.x version policy must remain unchanged.'
+Assert-Equal -Expected $true -Actual (Test-VddDeviceBound (New-TestDevice '15.0.15.8' 'ERROR') '15.0.15.8') `
+    -Message 'A non-started device with the expected published package must be eligible for reboot recovery.'
+Assert-Equal -Expected $false -Actual (Test-VddDeviceBound (New-TestDevice '15.0.15.7') '15.0.15.8') `
+    -Message 'A device bound to the wrong package must not be treated as a reboot-only result.'
 
 $cases = @(
     @{
@@ -216,11 +216,11 @@ $results = foreach ($case in $cases) {
         $true
     }
     $decision = Get-VddDecision $case.Devices '100.0.16.6' $controlAvailable
-    Assert-Equal $case.Count $decision.DeviceCount "$($case.Name): wrong device count"
-    Assert-Equal $case.Cleanup $decision.CleanupRequired "$($case.Name): wrong cleanup decision"
-    Assert-Equal $case.Install $decision.InstallRequired "$($case.Name): wrong install decision"
-    Assert-Equal ([int]$controlAvailable) $decision.ControlAvailable `
-        "$($case.Name): wrong control-interface decision"
+    Assert-Equal -Expected $case.Count -Actual $decision.DeviceCount -Message "$($case.Name): wrong device count"
+    Assert-Equal -Expected $case.Cleanup -Actual $decision.CleanupRequired -Message "$($case.Name): wrong cleanup decision"
+    Assert-Equal -Expected $case.Install -Actual $decision.InstallRequired -Message "$($case.Name): wrong install decision"
+    Assert-Equal -Expected ([int]$controlAvailable) -Actual $decision.ControlAvailable `
+        -Message "$($case.Name): wrong control-interface decision"
 
     [pscustomobject]@{
         Case = $case.Name
@@ -237,8 +237,8 @@ $packages = @(
     [pscustomobject]@{ InfName = 'oem43.inf' }
 )
 $stalePackages = @(Get-VddPackagesToRemove $packages 'oem42.inf')
-Assert-Equal 2 $stalePackages.Count 'Package pruning must keep exactly the active OEM INF.'
-Assert-Equal 'oem40.inf,oem43.inf' ($stalePackages.InfName -join ',') 'Wrong stale package selection.'
+Assert-Equal -Expected 2 -Actual $stalePackages.Count -Message 'Package pruning must keep exactly the active OEM INF.'
+Assert-Equal -Expected 'oem40.inf,oem43.inf' -Actual ($stalePackages.InfName -join ',') -Message 'Wrong stale package selection.'
 
 $invalidKeepWasRejected = $false
 try {
@@ -247,7 +247,7 @@ try {
 catch {
     $invalidKeepWasRejected = $true
 }
-Assert-Equal $true $invalidKeepWasRejected 'Package pruning must reject a non-published INF name.'
+Assert-Equal -Expected $true -Actual $invalidKeepWasRejected -Message 'Package pruning must reject a non-published INF name.'
 
 $originalGetChildItem = ${function:Get-ChildItem}
 $originalSelectString = ${function:Select-String}
@@ -279,10 +279,10 @@ try {
 
     $foundPackages = @(Get-PublishedVddPackages `
         -RequiredInfNames @('oem42.inf'))
-    Assert-Equal 1 $foundPackages.Count 'An unreadable unrelated INF must not abort the package scan.'
-    Assert-Equal 'oem42.inf' $foundPackages[0].InfName 'The readable VDD package must still be detected.'
-    Assert-Equal 'Root\ZakoVDD,ZakoVDD' ($script:lastInfPatterns -join ',') `
-        'Package discovery must recognize current and legacy hardware IDs.'
+    Assert-Equal -Expected 1 -Actual $foundPackages.Count -Message 'An unreadable unrelated INF must not abort the package scan.'
+    Assert-Equal -Expected 'oem42.inf' -Actual $foundPackages[0].InfName -Message 'The readable VDD package must still be detected.'
+    Assert-Equal -Expected 'Root\ZakoVDD,ZakoVDD' -Actual ($script:lastInfPatterns -join ',') `
+        -Message 'Package discovery must recognize current and legacy hardware IDs.'
 
     $activeReadFailedClosed = $false
     try {
@@ -291,7 +291,7 @@ try {
     catch {
         $activeReadFailedClosed = $_.Exception.Message -like '*active VDD package oem40.inf*'
     }
-    Assert-Equal $true $activeReadFailedClosed 'An unreadable active VDD package must abort the scan.'
+    Assert-Equal -Expected $true -Actual $activeReadFailedClosed -Message 'An unreadable active VDD package must abort the scan.'
 }
 finally {
     if ($originalGetChildItem) {
@@ -323,7 +323,7 @@ try {
     catch {
         $probeFailedClosed = $_.Exception.Message -like '*simulated device enumeration failure*'
     }
-    Assert-Equal $true $probeFailedClosed 'A device enumeration failure must abort the probe.'
+    Assert-Equal -Expected $true -Actual $probeFailedClosed -Message 'A device enumeration failure must abort the probe.'
 }
 finally {
     ${function:Get-VddDevices} = $originalGetVddDevices
@@ -366,10 +366,10 @@ try {
     }
 
     $timedOutExitCode = Invoke-PnpUtilDeviceRemoval 'ROOT\DISPLAY\0042'
-    Assert-Equal $win32ErrorTimeout $timedOutExitCode `
-        'A hung pnputil process must return the Windows timeout error.'
-    Assert-Equal 1 $script:stoppedPnpProcesses `
-        'A hung pnputil process must be force-stopped.'
+    Assert-Equal -Expected $win32ErrorTimeout -Actual $timedOutExitCode `
+        -Message 'A hung pnputil process must return the Windows timeout error.'
+    Assert-Equal -Expected 1 -Actual $script:stoppedPnpProcesses `
+        -Message 'A hung pnputil process must be force-stopped.'
 
     $script:fakePnpProcess = [pscustomobject]@{
         HasExited = $true
@@ -377,8 +377,8 @@ try {
     }
     $script:pnpWaitTimesOut = $false
     $completedExitCode = Invoke-PnpUtilDeviceRemoval 'ROOT\DISPLAY\0042'
-    Assert-Equal 3010 $completedExitCode `
-        'A completed pnputil process must preserve its exit code.'
+    Assert-Equal -Expected 3010 -Actual $completedExitCode `
+        -Message 'A completed pnputil process must preserve its exit code.'
 }
 finally {
     foreach ($name in @('Start-Process', 'Wait-Process', 'Stop-Process')) {
@@ -426,9 +426,9 @@ try {
     }
 
     [void] (Remove-AllVddDevices $HelperScript 2)
-    Assert-Equal 0 $script:fakeDevices.Count 'All duplicate device nodes must be removed.'
-    Assert-Equal 1 $script:removalCalls 'An asynchronous removal must not receive overlapping requests.'
-    Assert-Equal 0 $script:targetedRemovalCalls 'Live nodes must not receive overlapping targeted removal requests.'
+    Assert-Equal -Expected 0 -Actual $script:fakeDevices.Count -Message 'All duplicate device nodes must be removed.'
+    Assert-Equal -Expected 1 -Actual $script:removalCalls -Message 'An asynchronous removal must not receive overlapping requests.'
+    Assert-Equal -Expected 0 -Actual $script:targetedRemovalCalls -Message 'Live nodes must not receive overlapping targeted removal requests.'
 
     $legacyDevice = New-TestDevice '100.0.16.5' 'MISSING' 'oem40.inf' 'ZakoVDD'
     $legacyDevice.InstanceId = 'ROOT\DISPLAY\0043'
@@ -453,10 +453,10 @@ try {
     }
 
     [void] (Remove-AllVddDevices $HelperScript 2)
-    Assert-Equal 2 $script:removalCalls 'Root and legacy hardware IDs must both be reconciled.'
-    Assert-Equal 'Root\ZakoVDD,ZakoVDD' ($script:removedHardwareIds -join ',') `
-        'Removal must target both managed hardware IDs.'
-    Assert-Equal 1 $script:targetedRemovalCalls 'A disconnected legacy node must receive targeted cleanup.'
+    Assert-Equal -Expected 2 -Actual $script:removalCalls -Message 'Root and legacy hardware IDs must both be reconciled.'
+    Assert-Equal -Expected 'Root\ZakoVDD,ZakoVDD' -Actual ($script:removedHardwareIds -join ',') `
+        -Message 'Removal must target both managed hardware IDs.'
+    Assert-Equal -Expected 1 -Actual $script:targetedRemovalCalls -Message 'A disconnected legacy node must receive targeted cleanup.'
 
     $script:fakeDevices = @(New-TestDevice '100.0.16.6' 'ERROR')
     $script:removalCalls = 0
@@ -473,8 +473,8 @@ try {
     }
 
     [void] (Remove-AllVddDevices $HelperScript 2)
-    Assert-Equal 1 $script:removalCalls 'An error-state node must first receive the normal removal request.'
-    Assert-Equal 1 $script:targetedRemovalCalls 'An error-state node must receive targeted cleanup.'
+    Assert-Equal -Expected 1 -Actual $script:removalCalls -Message 'An error-state node must first receive the normal removal request.'
+    Assert-Equal -Expected 1 -Actual $script:targetedRemovalCalls -Message 'An error-state node must receive targeted cleanup.'
 
     $script:fakeDevices = @(New-TestDevice '100.0.16.6' 'MISSING')
     $script:removalCalls = 0
@@ -492,8 +492,8 @@ try {
     catch {
         $removalFailedClosed = $_.Exception.Message -like '*exit code 1*'
     }
-    Assert-Equal $true $removalFailedClosed 'A failed nefcon request must abort immediately.'
-    Assert-Equal 1 $script:removalCalls 'A stalled removal must not repeatedly invoke nefcon.'
+    Assert-Equal -Expected $true -Actual $removalFailedClosed -Message 'A failed nefcon request must abort immediately.'
+    Assert-Equal -Expected 1 -Actual $script:removalCalls -Message 'A stalled removal must not repeatedly invoke nefcon.'
 
     $script:fakeDevices = @(New-TestDevice '100.0.16.6' 'ERROR')
     $script:removalCalls = 0
@@ -509,9 +509,9 @@ try {
     catch {
         $removalMadeNoProgress = $_.Exception.Message -like '*made no progress*pnputil=0*'
     }
-    Assert-Equal $true $removalMadeNoProgress 'A successful request without PnP progress must fail with diagnostics.'
-    Assert-Equal 1 $script:removalCalls 'A stalled removal must not repeatedly invoke nefcon.'
-    Assert-Equal 1 $script:targetedRemovalCalls 'A stalled error-state node must receive one targeted cleanup request.'
+    Assert-Equal -Expected $true -Actual $removalMadeNoProgress -Message 'A successful request without PnP progress must fail with diagnostics.'
+    Assert-Equal -Expected 1 -Actual $script:removalCalls -Message 'A stalled removal must not repeatedly invoke nefcon.'
+    Assert-Equal -Expected 1 -Actual $script:targetedRemovalCalls -Message 'A stalled error-state node must receive one targeted cleanup request.'
 
     $script:fakeDevices = @(New-TestDevice '100.0.16.6' 'OK')
     $script:removalCalls = 0
@@ -523,8 +523,8 @@ try {
     catch {
         $liveRemovalTimedOut = $_.Exception.Message -like '*timed out*'
     }
-    Assert-Equal $true $liveRemovalTimedOut 'A live asynchronous removal must keep the normal timeout path.'
-    Assert-Equal 0 $script:targetedRemovalCalls 'A live node must not receive the disconnected-node fallback.'
+    Assert-Equal -Expected $true -Actual $liveRemovalTimedOut -Message 'A live asynchronous removal must keep the normal timeout path.'
+    Assert-Equal -Expected 0 -Actual $script:targetedRemovalCalls -Message 'A live node must not receive the disconnected-node fallback.'
 }
 finally {
     ${function:Get-VddDevices} = $originalGetVddDevices
@@ -562,19 +562,21 @@ try {
 
     Save-VddTransaction $transactionPayload $transactionPreviousDevice
     Recover-VddTransaction $transactionPayload '100.0.16.6'
-    Assert-Equal 1 $script:transactionRestoreCalls `
-        'An interrupted replacement without a ready VDD must restore the previous package.'
-    Assert-Equal $false (Test-Path -LiteralPath (Get-VddTransactionPath $transactionPayload)) `
-        'A recovered VDD transaction must be cleared.'
+    Assert-Equal -Expected 1 -Actual $script:transactionRestoreCalls `
+        -Message 'An interrupted replacement without a ready VDD must restore the previous package.'
+    Assert-Equal -Expected $false -Actual (Test-Path -LiteralPath (Get-VddTransactionPath $transactionPayload)) `
+        -Message 'A recovered VDD transaction must be cleared.'
 
     Save-VddTransaction $transactionPayload $transactionPreviousDevice
     $script:transactionRestoreResult = $vddDeviceRestartRequired
     $recoveryResult = Recover-VddTransaction $transactionPayload '100.0.16.6'
-    Assert-Equal $vddDeviceRestartRequired $recoveryResult `
+    Assert-Equal -Expected $vddDeviceRestartRequired -Actual $recoveryResult -Message `
         'A rollback that binds but is not ready must propagate the restart requirement.'
-    Assert-Equal $true (Test-Path -LiteralPath (Get-VddTransactionPath $transactionPayload)) `
+    Assert-Equal -Expected $true `
+        -Actual (Test-Path -LiteralPath (Get-VddTransactionPath $transactionPayload)) `
+        -Message `
         'A reboot-pending rollback must preserve its update transaction.'
-    Assert-Equal $false $script:vddRestartRequired `
+    Assert-Equal -Expected $false -Actual $script:vddRestartRequired -Message `
         'Transaction recovery must propagate the internal result without relying on a test-double side effect.'
     Clear-VddTransaction $transactionPayload
     $script:transactionRestoreResult = $vddDeviceReady
@@ -583,7 +585,7 @@ try {
     Save-VddTransaction $transactionPayload $transactionPreviousDevice
     $script:transactionDevices = @(New-TestDevice '100.0.16.6')
     Recover-VddTransaction $transactionPayload '100.0.16.6'
-    Assert-Equal 2 $script:transactionRestoreCalls `
+    Assert-Equal -Expected 2 -Actual $script:transactionRestoreCalls -Message `
         'A completed replacement must not roll back the new ready VDD.'
 
     Save-VddTransaction $transactionPayload $transactionPreviousDevice
@@ -595,8 +597,8 @@ try {
     catch {
         $unexpectedDriverWasRejected = $_.Exception.Message -like '*different healthy driver*'
     }
-    Assert-Equal $true $unexpectedDriverWasRejected `
-        'Recovery must not replace a different healthy VDD automatically.'
+    Assert-Equal -Expected $true -Actual $unexpectedDriverWasRejected `
+        -Message 'Recovery must not replace a different healthy VDD automatically.'
 }
 finally {
     ${function:Get-VddDevices} = $originalGetVddDevices
@@ -698,8 +700,8 @@ try {
         CurrentInf = 'oem42.inf'
     }
     Invoke-VddInstall $PSScriptRoot 'Run'
-    Assert-Equal 'Stage,Configure,Cleanup:100.0.16.6' ($script:workflowCalls -join ',') `
-        'A healthy matching device must keep its package and skip reinstall.'
+    Assert-Equal -Expected 'Stage,Configure,Cleanup:100.0.16.6' -Actual ($script:workflowCalls -join ',') `
+        -Message 'A healthy matching device must keep its package and skip reinstall.'
 
     $script:workflowCalls = @()
     $script:workflowDevices = @(New-TestDevice '100.0.16.5' 'OK' 'oem40.inf')
@@ -714,24 +716,24 @@ try {
         CurrentInf = 'oem40.inf'
     }
     Invoke-VddInstall $PSScriptRoot 'Run'
-    Assert-Equal 'Stage,Configure,Package,Journal,Remove,Install,Clear,Cleanup:100.0.16.6' ($script:workflowCalls -join ',') `
-        'An upgrade must stage the replacement before removing the working device and prune only after verification.'
+    Assert-Equal -Expected 'Stage,Configure,Package,Journal,Remove,Install,Clear,Cleanup:100.0.16.6' -Actual ($script:workflowCalls -join ',') `
+        -Message 'An upgrade must stage the replacement before removing the working device and prune only after verification.'
 
     $script:workflowCalls = @()
     $script:workflowRequestsRestart = $true
     Invoke-VddInstall $PSScriptRoot 'Run'
-    Assert-Equal 'Stage,Configure,Package,Journal,Remove,Install' ($script:workflowCalls -join ',') `
-        'A reboot-pending upgrade must preserve its rollback journal and previous driver package.'
-    Assert-Equal $true $script:vddRestartRequired `
-        'A reboot-pending upgrade must propagate the restart requirement to the caller.'
+    Assert-Equal -Expected 'Stage,Configure,Package,Journal,Remove,Install' -Actual ($script:workflowCalls -join ',') `
+        -Message 'A reboot-pending upgrade must preserve its rollback journal and previous driver package.'
+    Assert-Equal -Expected $true -Actual $script:vddRestartRequired `
+        -Message 'A reboot-pending upgrade must propagate the restart requirement to the caller.'
     $script:workflowRequestsRestart = $false
     $script:vddRestartRequired = $false
 
     $script:workflowCalls = @()
     Invoke-VddInstall $PSScriptRoot 'Run' -PreserveHealthyExisting
-    Assert-Equal 'Stage,Configure,Package,Journal,Remove,Install,Clear,Cleanup:100.0.16.6' `
-        ($script:workflowCalls -join ',') `
-        'An unattended upgrade must replace a healthy older driver.'
+    Assert-Equal -Expected 'Stage,Configure,Package,Journal,Remove,Install,Clear,Cleanup:100.0.16.6' `
+        -Actual ($script:workflowCalls -join ',') `
+        -Message 'An unattended upgrade must replace a healthy older driver.'
 
     $script:workflowCalls = @()
     $script:workflowDevices = @(New-TestDevice '100.0.16.7' 'OK' 'oem43.inf')
@@ -746,8 +748,8 @@ try {
         CurrentInf = 'oem43.inf'
     }
     Invoke-VddInstall $PSScriptRoot 'Run' -PreserveHealthyExisting
-    Assert-Equal 'Stage,Configure' ($script:workflowCalls -join ',') `
-        'An unattended upgrade must not downgrade a healthy newer driver.'
+    Assert-Equal -Expected 'Stage,Configure' -Actual ($script:workflowCalls -join ',') `
+        -Message 'An unattended upgrade must not downgrade a healthy newer driver.'
 
     $script:workflowCalls = @()
     $script:workflowDevices = @(New-TestDevice '100.0.16.6')
@@ -762,9 +764,9 @@ try {
         CurrentInf = 'oem42.inf'
     }
     Invoke-VddInstall $PSScriptRoot 'Run' -PreserveHealthyExisting
-    Assert-Equal 'Stage,Configure,Package,Journal,Remove,Install,Clear,Cleanup:100.0.16.6' `
-        ($script:workflowCalls -join ',') `
-        'An unattended upgrade must repair a driver whose required control interface is missing.'
+    Assert-Equal -Expected 'Stage,Configure,Package,Journal,Remove,Install,Clear,Cleanup:100.0.16.6' `
+        -Actual ($script:workflowCalls -join ',') `
+        -Message 'An unattended upgrade must repair a driver whose required control interface is missing.'
 
     $script:workflowDevices = @(New-TestDevice '100.0.16.5' 'OK' 'oem40.inf')
     $script:workflowDecision = [pscustomobject]@{
@@ -786,9 +788,9 @@ try {
     catch {
         $packageValidationFailed = $_.Exception.Message -like '*simulated package validation failure*'
     }
-    Assert-Equal $true $packageValidationFailed 'A rejected replacement package must abort the update.'
-    Assert-Equal 'Stage,Configure,Package' ($script:workflowCalls -join ',') `
-        'A rejected replacement package must not remove the working VDD.'
+    Assert-Equal -Expected $true -Actual $packageValidationFailed -Message 'A rejected replacement package must abort the update.'
+    Assert-Equal -Expected 'Stage,Configure,Package' -Actual ($script:workflowCalls -join ',') `
+        -Message 'A rejected replacement package must not remove the working VDD.'
     $script:failWorkflowPackage = $false
 
     $script:workflowCalls = @()
@@ -800,9 +802,9 @@ try {
     catch {
         $installFailed = $_.Exception.Message -like '*simulated install failure*'
     }
-    Assert-Equal $true $installFailed 'A failed driver replacement must report the original failure.'
-    Assert-Equal 'Stage,Configure,Package,Journal,Remove,Install,Restore,Clear' ($script:workflowCalls -join ',') `
-        'A failed driver replacement must restore the previous healthy driver.'
+    Assert-Equal -Expected $true -Actual $installFailed -Message 'A failed driver replacement must report the original failure.'
+    Assert-Equal -Expected 'Stage,Configure,Package,Journal,Remove,Install,Restore,Clear' -Actual ($script:workflowCalls -join ',') `
+        -Message 'A failed driver replacement must restore the previous healthy driver.'
 
     $script:workflowCalls = @()
     $script:workflowRestoreRequestsRestart = $true
@@ -814,11 +816,13 @@ try {
     catch {
         $rollbackPendingThrew = $true
     }
-    Assert-Equal $false $rollbackPendingThrew `
+    Assert-Equal -Expected $false -Actual $rollbackPendingThrew -Message `
         'A reboot-pending rollback must propagate 3010 instead of the original install failure.'
-    Assert-Equal 'Stage,Configure,Package,Journal,Remove,Install,Restore' ($script:workflowCalls -join ',') `
+    Assert-Equal -Expected 'Stage,Configure,Package,Journal,Remove,Install,Restore' `
+        -Actual ($script:workflowCalls -join ',') `
+        -Message `
         'A reboot-pending rollback must stop before clearing the update transaction.'
-    Assert-Equal $true $script:vddRestartRequired `
+    Assert-Equal -Expected $true -Actual $script:vddRestartRequired -Message `
         'A reboot-pending rollback must propagate the restart requirement to the caller.'
     $script:failWorkflowInstall = $false
     $script:workflowRestoreRequestsRestart = $false
@@ -826,8 +830,8 @@ try {
 
     $script:workflowCalls = @()
     Invoke-VddUninstall $PSScriptRoot
-    Assert-Equal 'Remove,Cleanup:,Clear,Registry' ($script:workflowCalls -join ',') `
-        'Uninstall must remove devices before packages and always clean the registry.'
+    Assert-Equal -Expected 'Remove,Cleanup:,Clear,Registry' -Actual ($script:workflowCalls -join ',') `
+        -Message 'Uninstall must remove devices before packages and always clean the registry.'
 }
 finally {
     ${function:Resolve-VddPayload} = $originalResolveVddPayload

--- a/src_assets/windows/misc/vdd/smoke-test-vdd-device-helper.ps1
+++ b/src_assets/windows/misc/vdd/smoke-test-vdd-device-helper.ps1
@@ -55,6 +55,8 @@ $originalWaitUntil = ${function:Wait-Until}
 try {
     $script:installNefconCalls = 0
     $script:readinessChecks = 0
+    $script:controlInterfaceChecks = 0
+    $script:receivedWaitSeconds = 0
     $script:forceWaitTimeout = $false
     $script:installTestDevice = New-TestDevice '100.0.16.6'
     function Invoke-Nefcon([string] $Path, [string[]] $Arguments) {
@@ -69,9 +71,11 @@ try {
         return @($script:installTestDevice)
     }
     function Test-VddControlInterfaceAvailable {
+        $script:controlInterfaceChecks++
         return $true
     }
     function Wait-Until([scriptblock] $Condition, [int] $WaitSeconds) {
+        $script:receivedWaitSeconds = $WaitSeconds
         if ($script:forceWaitTimeout) {
             return $false
         }
@@ -83,6 +87,10 @@ try {
         'A restart-suggested driver bind must continue to the readiness check.'
     Assert-Equal $true ($script:readinessChecks -ge 1) `
         'A restart-suggested driver bind must check device readiness.'
+    Assert-Equal 120 $script:receivedWaitSeconds `
+        'VDD readiness checks must retain the 120-second timeout.'
+    Assert-Equal $true ($script:controlInterfaceChecks -ge 1) `
+        'A ready VDD must verify that its control interface is available.'
 
     $script:forceWaitTimeout = $true
     $script:installTestDevice = New-TestDevice '100.0.16.6' 'ERROR'
@@ -101,6 +109,8 @@ try {
     }
     Assert-Equal $true $wrongVersionRejected `
         'A timed-out device bound to a different version must fail instead of requesting a restart.'
+    Assert-Equal $false $script:vddRestartRequired `
+        'A wrong-version timeout must not request a restart.'
 }
 finally {
     ${function:Invoke-Nefcon} = $originalInvokeNefcon
@@ -109,6 +119,8 @@ finally {
     ${function:Wait-Until} = $originalWaitUntil
     Remove-Variable -Name installNefconCalls -Scope Script -ErrorAction SilentlyContinue
     Remove-Variable -Name readinessChecks -Scope Script -ErrorAction SilentlyContinue
+    Remove-Variable -Name controlInterfaceChecks -Scope Script -ErrorAction SilentlyContinue
+    Remove-Variable -Name receivedWaitSeconds -Scope Script -ErrorAction SilentlyContinue
     Remove-Variable -Name forceWaitTimeout -Scope Script -ErrorAction SilentlyContinue
     Remove-Variable -Name installTestDevice -Scope Script -ErrorAction SilentlyContinue
     $script:vddRestartRequired = $false
@@ -545,9 +557,6 @@ try {
     function Get-VddDevices { return @($script:transactionDevices) }
     function Restore-VddDevice {
         $script:transactionRestoreCalls++
-        if ($script:transactionRestoreResult -eq $vddDeviceRestartRequired) {
-            $script:vddRestartRequired = $true
-        }
         return $script:transactionRestoreResult
     }
 
@@ -565,8 +574,8 @@ try {
         'A rollback that binds but is not ready must propagate the restart requirement.'
     Assert-Equal $true (Test-Path -LiteralPath (Get-VddTransactionPath $transactionPayload)) `
         'A reboot-pending rollback must preserve its update transaction.'
-    Assert-Equal $true $script:vddRestartRequired `
-        'A reboot-pending rollback must cause the helper to return 3010.'
+    Assert-Equal $false $script:vddRestartRequired `
+        'Transaction recovery must propagate the internal result without relying on a test-double side effect.'
     Clear-VddTransaction $transactionPayload
     $script:transactionRestoreResult = $vddDeviceReady
     $script:vddRestartRequired = $false
@@ -658,7 +667,6 @@ try {
             throw 'simulated install failure'
         }
         if ($script:workflowRequestsRestart) {
-            $script:vddRestartRequired = $true
             return $vddDeviceRestartRequired
         }
         return $vddDeviceReady
@@ -666,7 +674,6 @@ try {
     function Restore-VddDevice {
         $script:workflowCalls += 'Restore'
         if ($script:workflowRestoreRequestsRestart) {
-            $script:vddRestartRequired = $true
             return $vddDeviceRestartRequired
         }
         return $vddDeviceReady

--- a/src_assets/windows/misc/vdd/smoke-test-vdd-device-helper.ps1
+++ b/src_assets/windows/misc/vdd/smoke-test-vdd-device-helper.ps1
@@ -97,6 +97,10 @@ Assert-Equal $true (Test-VddVersionAtLeast '15.0.15.8' '15.0.15.7') `
     'A newer safe Win10 driver must still be preserved.'
 Assert-Equal $true (Test-VddVersionAtLeast '100.0.17.2' '100.0.17.2') `
     'The Win11 100.x version policy must remain unchanged.'
+Assert-Equal $true (Test-VddDeviceBound (New-TestDevice '15.0.15.8' 'ERROR') '15.0.15.8') `
+    'A non-started device with the expected published package must be eligible for reboot recovery.'
+Assert-Equal $false (Test-VddDeviceBound (New-TestDevice '15.0.15.7') '15.0.15.8') `
+    'A device bound to the wrong package must not be treated as a reboot-only result.'
 
 $cases = @(
     @{
@@ -598,6 +602,9 @@ try {
     function Set-VddConfiguration { $script:workflowCalls += 'Configure' }
     function Install-VddDevice {
         $script:workflowCalls += 'Install'
+        if ($script:workflowRequestsRestart) {
+            $script:vddRestartRequired = $true
+        }
         if ($script:failWorkflowInstall) {
             throw 'simulated install failure'
         }
@@ -610,6 +617,7 @@ try {
     $script:workflowDevices = @(New-TestDevice '100.0.16.6')
     $script:failWorkflowInstall = $false
     $script:failWorkflowPackage = $false
+    $script:workflowRequestsRestart = $false
     $script:workflowDecision = [pscustomobject]@{
         DeviceCount = 1
         CleanupRequired = 0
@@ -639,6 +647,16 @@ try {
     Invoke-VddInstall $PSScriptRoot 'Run'
     Assert-Equal 'Stage,Configure,Package,Journal,Remove,Install,Clear,Cleanup:100.0.16.6' ($script:workflowCalls -join ',') `
         'An upgrade must stage the replacement before removing the working device and prune only after verification.'
+
+    $script:workflowCalls = @()
+    $script:workflowRequestsRestart = $true
+    Invoke-VddInstall $PSScriptRoot 'Run'
+    Assert-Equal 'Stage,Configure,Package,Journal,Remove,Install' ($script:workflowCalls -join ',') `
+        'A reboot-pending upgrade must preserve its rollback journal and previous driver package.'
+    Assert-Equal $true $script:vddRestartRequired `
+        'A reboot-pending upgrade must propagate the restart requirement to the caller.'
+    $script:workflowRequestsRestart = $false
+    $script:vddRestartRequired = $false
 
     $script:workflowCalls = @()
     Invoke-VddInstall $PSScriptRoot 'Run' -PreserveHealthyExisting
@@ -742,6 +760,8 @@ finally {
     Remove-Variable -Name workflowDevices -Scope Script -ErrorAction SilentlyContinue
     Remove-Variable -Name failWorkflowInstall -Scope Script -ErrorAction SilentlyContinue
     Remove-Variable -Name failWorkflowPackage -Scope Script -ErrorAction SilentlyContinue
+    Remove-Variable -Name workflowRequestsRestart -Scope Script -ErrorAction SilentlyContinue
+    $script:vddRestartRequired = $false
 }
 
 $results | Format-Table -AutoSize

--- a/src_assets/windows/misc/vdd/smoke-test-vdd-device-helper.ps1
+++ b/src_assets/windows/misc/vdd/smoke-test-vdd-device-helper.ps1
@@ -510,8 +510,15 @@ $originalRestoreVddDevice = ${function:Restore-VddDevice}
 try {
     $script:transactionDevices = @()
     $script:transactionRestoreCalls = 0
+    $script:transactionRestoreResult = $vddDeviceReady
     function Get-VddDevices { return @($script:transactionDevices) }
-    function Restore-VddDevice { $script:transactionRestoreCalls++ }
+    function Restore-VddDevice {
+        $script:transactionRestoreCalls++
+        if ($script:transactionRestoreResult -eq $vddDeviceRestartRequired) {
+            $script:vddRestartRequired = $true
+        }
+        return $script:transactionRestoreResult
+    }
 
     Save-VddTransaction $transactionPayload $transactionPreviousDevice
     Recover-VddTransaction $transactionPayload '100.0.16.6'
@@ -521,9 +528,22 @@ try {
         'A recovered VDD transaction must be cleared.'
 
     Save-VddTransaction $transactionPayload $transactionPreviousDevice
+    $script:transactionRestoreResult = $vddDeviceRestartRequired
+    $recoveryResult = Recover-VddTransaction $transactionPayload '100.0.16.6'
+    Assert-Equal $vddDeviceRestartRequired $recoveryResult `
+        'A rollback that binds but is not ready must propagate the restart requirement.'
+    Assert-Equal $true (Test-Path -LiteralPath (Get-VddTransactionPath $transactionPayload)) `
+        'A reboot-pending rollback must preserve its update transaction.'
+    Assert-Equal $true $script:vddRestartRequired `
+        'A reboot-pending rollback must cause the helper to return 3010.'
+    Clear-VddTransaction $transactionPayload
+    $script:transactionRestoreResult = $vddDeviceReady
+    $script:vddRestartRequired = $false
+
+    Save-VddTransaction $transactionPayload $transactionPreviousDevice
     $script:transactionDevices = @(New-TestDevice '100.0.16.6')
     Recover-VddTransaction $transactionPayload '100.0.16.6'
-    Assert-Equal 1 $script:transactionRestoreCalls `
+    Assert-Equal 2 $script:transactionRestoreCalls `
         'A completed replacement must not roll back the new ready VDD.'
 
     Save-VddTransaction $transactionPayload $transactionPreviousDevice
@@ -546,6 +566,7 @@ finally {
     }
     Remove-Variable -Name transactionDevices -Scope Script -ErrorAction SilentlyContinue
     Remove-Variable -Name transactionRestoreCalls -Scope Script -ErrorAction SilentlyContinue
+    Remove-Variable -Name transactionRestoreResult -Scope Script -ErrorAction SilentlyContinue
 }
 
 $originalResolveVddPayload = ${function:Resolve-VddPayload}
@@ -602,14 +623,23 @@ try {
     function Set-VddConfiguration { $script:workflowCalls += 'Configure' }
     function Install-VddDevice {
         $script:workflowCalls += 'Install'
-        if ($script:workflowRequestsRestart) {
-            $script:vddRestartRequired = $true
-        }
         if ($script:failWorkflowInstall) {
             throw 'simulated install failure'
         }
+        if ($script:workflowRequestsRestart) {
+            $script:vddRestartRequired = $true
+            return $vddDeviceRestartRequired
+        }
+        return $vddDeviceReady
     }
-    function Restore-VddDevice { $script:workflowCalls += 'Restore' }
+    function Restore-VddDevice {
+        $script:workflowCalls += 'Restore'
+        if ($script:workflowRestoreRequestsRestart) {
+            $script:vddRestartRequired = $true
+            return $vddDeviceRestartRequired
+        }
+        return $vddDeviceReady
+    }
     function Save-VddTransaction { $script:workflowCalls += 'Journal' }
     function Clear-VddTransaction { $script:workflowCalls += 'Clear' }
 
@@ -618,6 +648,7 @@ try {
     $script:failWorkflowInstall = $false
     $script:failWorkflowPackage = $false
     $script:workflowRequestsRestart = $false
+    $script:workflowRestoreRequestsRestart = $false
     $script:workflowDecision = [pscustomobject]@{
         DeviceCount = 1
         CleanupRequired = 0
@@ -734,7 +765,26 @@ try {
     Assert-Equal $true $installFailed 'A failed driver replacement must report the original failure.'
     Assert-Equal 'Stage,Configure,Package,Journal,Remove,Install,Restore,Clear' ($script:workflowCalls -join ',') `
         'A failed driver replacement must restore the previous healthy driver.'
+
+    $script:workflowCalls = @()
+    $script:workflowRestoreRequestsRestart = $true
+    $script:vddRestartRequired = $false
+    $rollbackPendingThrew = $false
+    try {
+        Invoke-VddInstall $PSScriptRoot 'Run'
+    }
+    catch {
+        $rollbackPendingThrew = $true
+    }
+    Assert-Equal $false $rollbackPendingThrew `
+        'A reboot-pending rollback must propagate 3010 instead of the original install failure.'
+    Assert-Equal 'Stage,Configure,Package,Journal,Remove,Install,Restore' ($script:workflowCalls -join ',') `
+        'A reboot-pending rollback must stop before clearing the update transaction.'
+    Assert-Equal $true $script:vddRestartRequired `
+        'A reboot-pending rollback must propagate the restart requirement to the caller.'
     $script:failWorkflowInstall = $false
+    $script:workflowRestoreRequestsRestart = $false
+    $script:vddRestartRequired = $false
 
     $script:workflowCalls = @()
     Invoke-VddUninstall $PSScriptRoot
@@ -761,6 +811,7 @@ finally {
     Remove-Variable -Name failWorkflowInstall -Scope Script -ErrorAction SilentlyContinue
     Remove-Variable -Name failWorkflowPackage -Scope Script -ErrorAction SilentlyContinue
     Remove-Variable -Name workflowRequestsRestart -Scope Script -ErrorAction SilentlyContinue
+    Remove-Variable -Name workflowRestoreRequestsRestart -Scope Script -ErrorAction SilentlyContinue
     $script:vddRestartRequired = $false
 }
 

--- a/src_assets/windows/misc/vdd/smoke-test-vdd-device-helper.ps1
+++ b/src_assets/windows/misc/vdd/smoke-test-vdd-device-helper.ps1
@@ -51,9 +51,12 @@ Assert-Equal $true $missingExitCodeRejected 'A missing native exit code must fai
 $originalInvokeNefcon = ${function:Invoke-Nefcon}
 $originalGetVddDevices = ${function:Get-VddDevices}
 $originalTestVddControlInterfaceAvailable = ${function:Test-VddControlInterfaceAvailable}
+$originalWaitUntil = ${function:Wait-Until}
 try {
     $script:installNefconCalls = 0
     $script:readinessChecks = 0
+    $script:forceWaitTimeout = $false
+    $script:installTestDevice = New-TestDevice '100.0.16.6'
     function Invoke-Nefcon([string] $Path, [string[]] $Arguments) {
         $script:installNefconCalls++
         if ($Arguments[0] -eq '--install-driver') {
@@ -63,10 +66,16 @@ try {
     }
     function Get-VddDevices {
         $script:readinessChecks++
-        return @(New-TestDevice '100.0.16.6')
+        return @($script:installTestDevice)
     }
     function Test-VddControlInterfaceAvailable {
         return $true
+    }
+    function Wait-Until([scriptblock] $Condition, [int] $WaitSeconds) {
+        if ($script:forceWaitTimeout) {
+            return $false
+        }
+        return [bool] (& $Condition)
     }
 
     [void] (Install-VddDeviceFromInf $HelperScript $HelperScript '100.0.16.6')
@@ -74,13 +83,35 @@ try {
         'A restart-suggested driver bind must continue to the readiness check.'
     Assert-Equal $true ($script:readinessChecks -ge 1) `
         'A restart-suggested driver bind must check device readiness.'
+
+    $script:forceWaitTimeout = $true
+    $script:installTestDevice = New-TestDevice '100.0.16.6' 'ERROR'
+    $timeoutResult = Install-VddDeviceFromInf $HelperScript $HelperScript '100.0.16.6'
+    Assert-Equal $vddDeviceRestartRequired $timeoutResult `
+        'A timed-out device bound to the expected version must require a restart.'
+
+    $script:vddRestartRequired = $false
+    $script:installTestDevice = New-TestDevice '100.0.16.5' 'ERROR'
+    $wrongVersionRejected = $false
+    try {
+        [void] (Install-VddDeviceFromInf $HelperScript $HelperScript '100.0.16.6')
+    }
+    catch {
+        $wrongVersionRejected = $_.Exception.Message -like '*did not bind and become ready*version 100.0.16.6*'
+    }
+    Assert-Equal $true $wrongVersionRejected `
+        'A timed-out device bound to a different version must fail instead of requesting a restart.'
 }
 finally {
     ${function:Invoke-Nefcon} = $originalInvokeNefcon
     ${function:Get-VddDevices} = $originalGetVddDevices
     ${function:Test-VddControlInterfaceAvailable} = $originalTestVddControlInterfaceAvailable
+    ${function:Wait-Until} = $originalWaitUntil
     Remove-Variable -Name installNefconCalls -Scope Script -ErrorAction SilentlyContinue
     Remove-Variable -Name readinessChecks -Scope Script -ErrorAction SilentlyContinue
+    Remove-Variable -Name forceWaitTimeout -Scope Script -ErrorAction SilentlyContinue
+    Remove-Variable -Name installTestDevice -Scope Script -ErrorAction SilentlyContinue
+    $script:vddRestartRequired = $false
 }
 
 Assert-Equal $false (Test-VddVersionAtLeast '100.0.16.5' '100.0.16.6') `

--- a/src_assets/windows/misc/vdd/vdd-device-helper.ps1
+++ b/src_assets/windows/misc/vdd/vdd-device-helper.ps1
@@ -29,6 +29,8 @@ $deviceTimeoutSeconds = 120
 $targetedRemovalTimeoutSeconds = 10
 $win32ErrorTimeout = 1460
 $script:vddRestartRequired = $false
+$vddDeviceReady = 'Ready'
+$vddDeviceRestartRequired = 'RestartRequired'
 $vddControlInterfaceGuid = 'DA9F8C2B-7E4F-49A1-9D4E-6F2B0E1A0C4D'
 $requiredDriverFiles = @('ZakoVDD.inf', 'ZakoVDD.dll', 'zakovdd.cat', 'ZakoVDD.cer')
 
@@ -701,7 +703,7 @@ function Install-VddDeviceFromInf(
         }
     }
 
-    Write-Output 'Creating VDD adapter...'
+    Write-Host 'Creating VDD adapter...'
     $nefconExitCode = Invoke-Nefcon $NefconPath @(
         '--create-device-node',
         '--hardware-id', $hardwareId,
@@ -718,7 +720,7 @@ function Install-VddDeviceFromInf(
     }
     $restartSuggested = $nefconExitCode -eq 3010
     if ($restartSuggested) {
-        Write-Output 'Windows suggested a restart after binding the VDD driver; checking whether the device is already ready...'
+        Write-Host 'Windows suggested a restart after binding the VDD driver; checking whether the device is already ready...'
     }
 
     $isReady = Wait-Until {
@@ -735,15 +737,16 @@ function Install-VddDeviceFromInf(
             (Test-VddDeviceBound $devices[0] $ExpectedVersion)) {
             $script:vddRestartRequired = $true
             Write-Warning 'The expected VDD package is bound, but the device or control interface is not ready. A Windows restart is required.'
-            return
+            return $vddDeviceRestartRequired
         }
 
         $readiness = if ($RequireControlInterface) { ' with its control interface' } else { '' }
         throw "VDD did not bind and become ready$readiness at version $ExpectedVersion."
     }
     if ($restartSuggested) {
-        Write-Output 'VDD is ready; continuing without a restart.'
+        Write-Host 'VDD is ready; continuing without a restart.'
     }
+    return $vddDeviceReady
 }
 
 function Install-VddDevice([object] $Payload, [string] $ExpectedVersion) {
@@ -763,24 +766,29 @@ function Restore-VddDevice([object] $Payload, [object] $PreviousDevice) {
     $previousDeviceStillReady = $devices.Count -eq 1 -and
         (Test-VddDeviceReady $devices[0] $PreviousDevice.Version) -and
         $devices[0].InfName -ieq $PreviousDevice.InfName
+    $restoreResult = $vddDeviceReady
     if (-not $previousDeviceStillReady) {
         if ($devices.Count -gt 0) {
             Remove-AllVddDevices $Payload.Paths.Nefcon
         }
-        Write-Output "Restoring previous VDD version $($PreviousDevice.Version)..."
-        Install-VddDeviceFromInf `
+        Write-Host "Restoring previous VDD version $($PreviousDevice.Version)..."
+        $restoreResult = Install-VddDeviceFromInf `
             $Payload.Paths.Nefcon `
             $previousInf `
             $PreviousDevice.Version `
             $false
+        if ($restoreResult -eq $vddDeviceRestartRequired) {
+            return $restoreResult
+        }
     }
 
     try {
-        Cleanup-VddPackages $PreviousDevice.Version
+        Cleanup-VddPackages $PreviousDevice.Version | Out-Host
     }
     catch {
         Write-Warning "Previous VDD was restored, but staged package cleanup failed: $($_.Exception.Message)"
     }
+    return $restoreResult
 }
 
 function Get-VddTransactionPath([object] $Payload) {
@@ -811,7 +819,7 @@ function Clear-VddTransaction([object] $Payload) {
 function Recover-VddTransaction([object] $Payload, [string] $BundledVersion) {
     $transactionPath = Get-VddTransactionPath $Payload
     if (-not (Test-Path -LiteralPath $transactionPath)) {
-        return
+        return $vddDeviceReady
     }
 
     try {
@@ -834,17 +842,21 @@ function Recover-VddTransaction([object] $Payload, [string] $BundledVersion) {
     if ($readyDevice) {
         if ($readyDevice.Version -in @($BundledVersion, $transaction.PreviousVersion)) {
             Clear-VddTransaction $Payload
-            return
+            return $vddDeviceReady
         }
         throw 'A pending VDD update exists, but a different healthy driver is active; refusing automatic recovery.'
     }
 
-    Write-Output 'Recovering an interrupted VDD driver update...'
-    Restore-VddDevice $Payload ([pscustomobject]@{
+    Write-Host 'Recovering an interrupted VDD driver update...'
+    $restoreResult = Restore-VddDevice $Payload ([pscustomobject]@{
         Version = [string] $transaction.PreviousVersion
         InfName = [string] $transaction.PreviousInf
     })
+    if ($restoreResult -eq $vddDeviceRestartRequired) {
+        return $restoreResult
+    }
     Clear-VddTransaction $Payload
+    return $vddDeviceReady
 }
 
 function Invoke-VddInstall(
@@ -871,7 +883,11 @@ function Invoke-VddInstall(
     $state = Get-VddState (Join-Path $payload.DriverDir 'ZakoVDD.inf')
     if ($InstallMode -eq 'Run' -and
         (Test-Path -LiteralPath (Get-VddTransactionPath $payload))) {
-        Recover-VddTransaction $payload $state.BundledVersion
+        $recoveryResult = Recover-VddTransaction $payload $state.BundledVersion
+        if ($recoveryResult -eq $vddDeviceRestartRequired) {
+            Write-Output 'VDD rollback is pending a Windows restart; preserving the update transaction.'
+            return
+        }
         $state = Get-VddState (Join-Path $payload.DriverDir 'ZakoVDD.inf')
     }
     $decision = $state.Decision
@@ -927,8 +943,12 @@ function Invoke-VddInstall(
             if ($decision.CleanupRequired) {
                 Remove-AllVddDevices $payload.Paths.Nefcon
             }
-            Install-VddDevice $payload $state.BundledVersion
-            if ($previousDevice -and -not $script:vddRestartRequired) {
+            $installResult = Install-VddDevice $payload $state.BundledVersion
+            if ($installResult -eq $vddDeviceRestartRequired) {
+                Write-Output 'VDD installation is pending a Windows restart; preserving the previous package and update transaction.'
+                return
+            }
+            if ($previousDevice) {
                 Clear-VddTransaction $payload
             }
         }
@@ -936,7 +956,11 @@ function Invoke-VddInstall(
             $installFailure = $_
             if ($previousDevice) {
                 try {
-                    Restore-VddDevice $payload $previousDevice
+                    $restoreResult = Restore-VddDevice $payload $previousDevice
+                    if ($restoreResult -eq $vddDeviceRestartRequired) {
+                        Write-Warning 'The VDD update failed; restoring the previous driver requires a Windows restart. Preserving the update transaction.'
+                        return
+                    }
                     Clear-VddTransaction $payload
                     Write-Warning 'The VDD update failed; the previous working driver was restored.'
                 }
@@ -945,11 +969,6 @@ function Invoke-VddInstall(
                 }
             }
             throw $installFailure
-        }
-
-        if ($script:vddRestartRequired) {
-            Write-Output 'VDD installation is pending a Windows restart; preserving the previous package and update transaction.'
-            return
         }
 
         try {

--- a/src_assets/windows/misc/vdd/vdd-device-helper.ps1
+++ b/src_assets/windows/misc/vdd/vdd-device-helper.ps1
@@ -735,7 +735,6 @@ function Install-VddDeviceFromInf(
         $devices = @(Get-VddDevices)
         if ($devices.Count -eq 1 -and
             (Test-VddDeviceBound $devices[0] $ExpectedVersion)) {
-            $script:vddRestartRequired = $true
             Write-Warning 'The expected VDD package is bound, but the device or control interface is not ready. A Windows restart is required.'
             return $vddDeviceRestartRequired
         }
@@ -885,6 +884,7 @@ function Invoke-VddInstall(
         (Test-Path -LiteralPath (Get-VddTransactionPath $payload))) {
         $recoveryResult = Recover-VddTransaction $payload $state.BundledVersion
         if ($recoveryResult -eq $vddDeviceRestartRequired) {
+            $script:vddRestartRequired = $true
             Write-Output 'VDD rollback is pending a Windows restart; preserving the update transaction.'
             return
         }
@@ -945,6 +945,7 @@ function Invoke-VddInstall(
             }
             $installResult = Install-VddDevice $payload $state.BundledVersion
             if ($installResult -eq $vddDeviceRestartRequired) {
+                $script:vddRestartRequired = $true
                 Write-Output 'VDD installation is pending a Windows restart; preserving the previous package and update transaction.'
                 return
             }
@@ -958,6 +959,7 @@ function Invoke-VddInstall(
                 try {
                     $restoreResult = Restore-VddDevice $payload $previousDevice
                     if ($restoreResult -eq $vddDeviceRestartRequired) {
+                        $script:vddRestartRequired = $true
                         Write-Warning 'The VDD update failed; restoring the previous driver requires a Windows restart. Preserving the update transaction.'
                         return
                     }

--- a/src_assets/windows/misc/vdd/vdd-device-helper.ps1
+++ b/src_assets/windows/misc/vdd/vdd-device-helper.ps1
@@ -28,6 +28,7 @@ $crBufferSmall = 0x0000001A
 $deviceTimeoutSeconds = 120
 $targetedRemovalTimeoutSeconds = 10
 $win32ErrorTimeout = 1460
+$script:vddRestartRequired = $false
 $vddControlInterfaceGuid = 'DA9F8C2B-7E4F-49A1-9D4E-6F2B0E1A0C4D'
 $requiredDriverFiles = @('ZakoVDD.inf', 'ZakoVDD.dll', 'zakovdd.cat', 'ZakoVDD.cer')
 
@@ -239,6 +240,12 @@ function Test-VddDeviceReady([object] $Device, [string] $ExpectedVersion = '') {
         $Device.Status -eq 'OK' -and
         $Device.InfName -match '(?i)^oem\d+\.inf$' -and
         (-not $ExpectedVersion -or $Device.Version -eq $ExpectedVersion))
+}
+
+function Test-VddDeviceBound([object] $Device, [string] $ExpectedVersion) {
+    return [bool]($Device -and
+        $Device.InfName -match '(?i)^oem\d+\.inf$' -and
+        $Device.Version -eq $ExpectedVersion)
 }
 
 function Test-VddVersionAtLeast([string] $InstalledVersion, [string] $BundledVersion) {
@@ -714,15 +721,25 @@ function Install-VddDeviceFromInf(
         Write-Output 'Windows suggested a restart after binding the VDD driver; checking whether the device is already ready...'
     }
 
-    if (-not (Wait-Until {
+    $isReady = Wait-Until {
         $devices = @(Get-VddDevices)
         $devices.Count -eq 1 -and
             (Test-VddDeviceReady $devices[0] $ExpectedVersion) -and
             (-not $RequireControlInterface -or
                 (Test-VddControlInterfaceAvailable 1 0))
-    } $deviceTimeoutSeconds)) {
+    } $deviceTimeoutSeconds
+
+    if (-not $isReady) {
+        $devices = @(Get-VddDevices)
+        if ($devices.Count -eq 1 -and
+            (Test-VddDeviceBound $devices[0] $ExpectedVersion)) {
+            $script:vddRestartRequired = $true
+            Write-Warning 'The expected VDD package is bound, but the device or control interface is not ready. A Windows restart is required.'
+            return
+        }
+
         $readiness = if ($RequireControlInterface) { ' with its control interface' } else { '' }
-        throw "VDD did not become ready$readiness at version $ExpectedVersion."
+        throw "VDD did not bind and become ready$readiness at version $ExpectedVersion."
     }
     if ($restartSuggested) {
         Write-Output 'VDD is ready; continuing without a restart.'
@@ -911,7 +928,7 @@ function Invoke-VddInstall(
                 Remove-AllVddDevices $payload.Paths.Nefcon
             }
             Install-VddDevice $payload $state.BundledVersion
-            if ($previousDevice) {
+            if ($previousDevice -and -not $script:vddRestartRequired) {
                 Clear-VddTransaction $payload
             }
         }
@@ -928,6 +945,11 @@ function Invoke-VddInstall(
                 }
             }
             throw $installFailure
+        }
+
+        if ($script:vddRestartRequired) {
+            Write-Output 'VDD installation is pending a Windows restart; preserving the previous package and update transaction.'
+            return
         }
 
         try {
@@ -996,6 +1018,10 @@ function Invoke-VddDeviceHelper {
 if ($MyInvocation.InvocationName -ne '.') {
     try {
         Invoke-VddDeviceHelper
+        if ($script:vddRestartRequired) {
+            Write-Output 'VDD_RESTART_REQUIRED=1'
+            exit 3010
+        }
         exit 0
     }
     catch {


### PR DESCRIPTION
## 改了啥呀

- 把 VDD 安装移到 Inno Setup 可控的安装阶段，等待 helper 完成并真正消费 `0` / `3010` / 失败退出码
- helper 最多等待 120 秒验证设备状态、目标驱动版本和控制接口；若预期 OEM INF 已绑定但本轮仍未就绪，保留事务并返回标准 `3010`
- `3010` 时注册 Sunshine 服务但传入 `--no-start`，让 Windows 重启后走正常服务自启；硬失败返回 `101` 且不启动服务
- 保留 `NeedRestart()` 和静默安装退出码语义，避免第一次安装留下 503、第二次安装才碰巧完成上一次枚举
- 增加绑定未就绪、错误版本、事务保留及 `--no-start` 的回归覆盖

## 为啥要改

Win10 从旧 VDD 升级到 15.x 时，驱动包、设备节点和 UMDF/IddCx 控制接口并不总在同一时刻完成。旧流程虽然会发现验证失败，但 Inno `[Run]` 没有消费 helper 的退出码，后面仍然启动 Sunshine；于是用户看到 503，再运行一次安装包才恢复，像个把“需重启”伪装成“安装成功”的小杂鱼状态。

现在一次安装会完成所有持久化操作：本轮可就绪就直接成功；若新包已正确绑定但必须跨启动周期，则明确返回 `3010` 并只要求重启，不需要再运行安装包。

## Win10 22H2 VM 实测

测试路径：`101.15.3.8` → 单次运行本 PR helper 安装 `15.0.15.8` → 仅重启一次 → 启动后只运行 `ProbeOnly`。

- 升级前：build `19045`，旧驱动 `101.15.3.8`，设备 `OK`，控制接口可用
- 单次升级：新驱动绑定为 `oem3.inf`，helper 退出 `0`；立即探测为 `15.0.15.8 / OK / control interface true`
- 测试脚本明确记录：`installer/helper will not be run again`
- 重启后：`ProbeExit=0`、`IoctlExit=0`、`CreateExit=0`、`Passed=true`
- `ROOT\DISPLAY\0000` 为 `Zako Display Adapter / CM_PROB_NONE`
- `DISPLAY\ZAK2333...` 枚举为 `Generic PnP Monitor / OK`

## 其他验证

- `src_assets/windows/misc/vdd/smoke-test-vdd-device-helper.ps1`
- `src_assets/windows/misc/vdd/smoke-test-install-vdd-selection.ps1`
- CMake 重新生成 `sunshine_installer.iss`
- Inno Setup 6.7.3 完整编译安装器
- `git diff --check`
- GitHub Actions：Windows、Setup Release、VDD helper smoke tests 全部通过
- CodeRabbit 通过

本机完整 Sunshine C++ target 另被当前构建目录中的 AMD 配置声明不匹配阻塞；本 PR 未修改 C++，安装器、VDD 专项测试与 Win10 VM 升级链路均已通过。