### PR TITLE
fix(tray): supervise desktop agent lifecycle

### DIFF
--- a/docs/tray-protocol.md
+++ b/docs/tray-protocol.md
@@ -63,10 +63,13 @@ signed-in user's session after Core starts. Failed launches are retried while
 Core remains alive, and the GUI's single-instance guard absorbs duplicate
 logon and service-start attempts.
 
-The GUI keeps its tray during a short Core restart window. If Core remains
-unreachable for 15 seconds, the GUI removes the native tray icon so the tray
-does not imply that Sunshine is still running. The background GUI agent stays
-alive and recreates the tray when the local Core becomes available again.
+The GUI keeps its tray while Core is unavailable. It switches to a distinct
+disconnected presentation, disables Core-dependent commands, and keeps local
+recovery and diagnostic commands available. On Windows, the disconnected menu
+can restart the Sunshine service. Recovery remains pending until the GUI
+receives an actual Core state response; it times out after 30 seconds so the
+user can retry. The background GUI agent reconnects and restores the live state
+when the local Core becomes available again.
 
 ## Actions and operations
 

--- a/docs/tray-protocol.md
+++ b/docs/tray-protocol.md
@@ -61,7 +61,13 @@ second polling loop.
 On Windows, the service wrapper starts the packaged GUI agent in the active
 signed-in user's session after Core starts. Failed launches are retried while
 Core remains alive, and the GUI's single-instance guard absorbs duplicate
-logon and service-start attempts.
+logon and service-start attempts. A zero GUI process exit code suppresses
+service-initiated launches for the current Core lifecycle. The wrapper still
+performs a low-frequency lookup for an instance started outside the service,
+such as an elevated or updater-launched replacement, and resumes normal process
+supervision after attaching to it. A new Core lifecycle or active console
+session also restores service-initiated launches. Nonzero exits remain crashes
+and are restarted with bounded backoff.
 
 The GUI keeps its tray while Core is unavailable. It switches to a distinct
 disconnected presentation, disables Core-dependent commands, and keeps local

--- a/docs/tray-protocol.md
+++ b/docs/tray-protocol.md
@@ -67,9 +67,18 @@ The GUI keeps its tray while Core is unavailable. It switches to a distinct
 disconnected presentation, disables Core-dependent commands, and keeps local
 recovery and diagnostic commands available. On Windows, the disconnected menu
 can restart the Sunshine service. Recovery remains pending until the GUI
-receives an actual Core state response; it times out after 30 seconds so the
-user can retry. The background GUI agent reconnects and restores the live state
-when the local Core becomes available again.
+receives a new accepted Core state response from its monitor. On Windows this
+is a local packaged-GUI command, not a Core `/api/tray/action`: the Tauri backend
+uses the existing elevated PowerShell service-restart path. Its command result
+only confirms that the restart was dispatched; it does not declare Core ready
+and is not exposed to remote tray providers.
+
+The 30-second recovery timeout starts after that restart command returns. Only
+an accepted `GET /api/tray/state` snapshot or SSE `tray-state` event received
+after the attempt began completes recovery. SSE keepalives, connection setup,
+error responses, cached state, and tray-action responses do not. Timeout clears
+the active attempt and re-enables manual retry; it does not cancel an OS restart
+already in progress or stop background Core monitoring.
 
 ## Actions and operations
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ add_test(NAME tray_state_unit_tests COMMAND tray_state_unit_tests)
 add_executable(sunshinesvc_state_unit_tests
         ${CMAKE_SOURCE_DIR}/tests/unit/test_sunshinesvc_state.cpp)
 target_include_directories(sunshinesvc_state_unit_tests PRIVATE "${CMAKE_SOURCE_DIR}")
+target_link_libraries(sunshinesvc_state_unit_tests gtest_main)
 target_compile_options(sunshinesvc_state_unit_tests PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${SUNSHINE_COMPILE_OPTIONS}>)
 set_target_properties(sunshinesvc_state_unit_tests PROPERTIES CXX_STANDARD 23)
 if (WIN32)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,16 @@ if (WIN32)
 endif ()
 add_test(NAME tray_state_unit_tests COMMAND tray_state_unit_tests)
 
+add_executable(sunshinesvc_state_unit_tests
+        ${CMAKE_SOURCE_DIR}/tests/unit/test_sunshinesvc_state.cpp)
+target_include_directories(sunshinesvc_state_unit_tests PRIVATE "${CMAKE_SOURCE_DIR}")
+target_compile_options(sunshinesvc_state_unit_tests PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${SUNSHINE_COMPILE_OPTIONS}>)
+set_target_properties(sunshinesvc_state_unit_tests PROPERTIES CXX_STANDARD 23)
+if (WIN32)
+    set_target_properties(sunshinesvc_state_unit_tests PROPERTIES LINK_SEARCH_START_STATIC 1)
+endif ()
+add_test(NAME sunshinesvc_state_unit_tests COMMAND sunshinesvc_state_unit_tests)
+
 if (WIN32)
     add_executable(vdd_prerequisite_unit_tests
             ${CMAKE_SOURCE_DIR}/tests/unit/test_vdd_prerequisite.cpp)

--- a/tests/unit/test_sunshinesvc_state.cpp
+++ b/tests/unit/test_sunshinesvc_state.cpp
@@ -25,6 +25,7 @@ namespace {
 
     return backoff.next_delay() == 1000U &&
            backoff.next_delay() == 2000U &&
+           backoff.next_delay(sunshinesvc::GUI_RESTART_STABLE_RUNTIME_MS - 1) == 4000U &&
            backoff.next_delay(sunshinesvc::GUI_RESTART_STABLE_RUNTIME_MS) == 1000U &&
            backoff.next_delay() == 2000U;
   }

--- a/tests/unit/test_sunshinesvc_state.cpp
+++ b/tests/unit/test_sunshinesvc_state.cpp
@@ -1,61 +1,66 @@
 /**
  * @file tests/unit/test_sunshinesvc_state.cpp
- * @brief Tests for the GUI agent restart policy used by sunshinesvc.
+ * @brief Tests for the GUI agent lifecycle policy used by sunshinesvc.
  */
 #include <tools/sunshinesvc_state.h>
 
 #include <array>
-#include <iostream>
+#include <gtest/gtest.h>
 
-namespace {
+TEST(GuiRestartBackoff, BacksOffRepeatedFailures) {
+  sunshinesvc::GuiRestartBackoff backoff;
+  constexpr std::array expected { 1000U, 2000U, 4000U, 8000U, 16000U, 30000U, 30000U };
 
-  bool
-  backs_off_repeated_failures() {
-    sunshinesvc::GuiRestartBackoff backoff;
-    constexpr std::array expected { 1000U, 2000U, 4000U, 8000U, 16000U, 30000U, 30000U };
-
-    return std::ranges::all_of(expected, [&backoff](const auto delay) {
-      return backoff.next_delay() == delay;
-    });
+  for (std::size_t index = 0; index < expected.size(); ++index) {
+    SCOPED_TRACE(index);
+    EXPECT_EQ(backoff.next_delay(), expected[index]);
   }
+}
 
-  bool
-  resets_after_stable_runtime() {
-    sunshinesvc::GuiRestartBackoff backoff;
+TEST(GuiRestartBackoff, ResetsOnlyAfterStableRuntime) {
+  sunshinesvc::GuiRestartBackoff backoff;
 
-    return backoff.next_delay() == 1000U &&
-           backoff.next_delay() == 2000U &&
-           backoff.next_delay(sunshinesvc::GUI_RESTART_STABLE_RUNTIME_MS - 1) == 4000U &&
-           backoff.next_delay(sunshinesvc::GUI_RESTART_STABLE_RUNTIME_MS) == 1000U &&
-           backoff.next_delay() == 2000U;
-  }
+  EXPECT_EQ(backoff.next_delay(), 1000U);
+  EXPECT_EQ(backoff.next_delay(), 2000U);
+  EXPECT_EQ(backoff.next_delay(sunshinesvc::GUI_RESTART_STABLE_RUNTIME_MS - 1), 4000U);
+  EXPECT_EQ(backoff.next_delay(sunshinesvc::GUI_RESTART_STABLE_RUNTIME_MS), 1000U);
+  EXPECT_EQ(backoff.next_delay(), 2000U);
+}
 
-  bool
-  explicit_reset_starts_at_initial_delay() {
-    sunshinesvc::GuiRestartBackoff backoff;
+TEST(GuiRestartBackoff, ExplicitResetStartsAtInitialDelay) {
+  sunshinesvc::GuiRestartBackoff backoff;
 
-    if (backoff.next_delay() != 1000U || backoff.next_delay() != 2000U) {
-      return false;
-    }
-    backoff.reset();
-    return backoff.next_delay() == 1000U;
-  }
+  EXPECT_EQ(backoff.next_delay(), 1000U);
+  EXPECT_EQ(backoff.next_delay(), 2000U);
+  backoff.reset();
+  EXPECT_EQ(backoff.next_delay(), 1000U);
+}
 
-}  // namespace
+TEST(GuiAgentRestartPolicy, CleanExitIsSuppressedUntilNextCoreLifecycle) {
+  sunshinesvc::GuiAgentRestartPolicy policy;
 
-int
-main() {
-  if (!backs_off_repeated_failures()) {
-    std::cerr << "repeated failure backoff test failed\n";
-    return 1;
-  }
-  if (!resets_after_stable_runtime()) {
-    std::cerr << "stable runtime reset test failed\n";
-    return 1;
-  }
-  if (!explicit_reset_starts_at_initial_delay()) {
-    std::cerr << "explicit reset test failed\n";
-    return 1;
-  }
-  return 0;
+  EXPECT_TRUE(policy.restart_allowed());
+  policy.suppress_until_core_restart();
+  EXPECT_FALSE(policy.restart_allowed());
+  policy.begin_core_lifecycle();
+  EXPECT_TRUE(policy.restart_allowed());
+}
+
+TEST(GuiAgentCrashLogLimiter, LogsOnlyCrashLoopStateChanges) {
+  sunshinesvc::GuiAgentCrashLogLimiter limiter;
+
+  EXPECT_TRUE(limiter.should_log_acquisition(false));
+  EXPECT_FALSE(limiter.should_log_acquisition(false));
+
+  EXPECT_TRUE(limiter.should_log_exit(1, 1000));
+  EXPECT_TRUE(limiter.should_log_acquisition(false));
+  EXPECT_FALSE(limiter.should_log_exit(1, 1000));
+  EXPECT_FALSE(limiter.should_log_acquisition(false));
+
+  EXPECT_TRUE(limiter.should_log_exit(1, 2000));
+  EXPECT_TRUE(limiter.should_log_exit(2, 2000));
+  EXPECT_TRUE(limiter.should_log_acquisition(true));
+
+  limiter.reset();
+  EXPECT_TRUE(limiter.should_log_acquisition(false));
 }

--- a/tests/unit/test_sunshinesvc_state.cpp
+++ b/tests/unit/test_sunshinesvc_state.cpp
@@ -36,29 +36,32 @@ TEST(GuiRestartBackoff, ExplicitResetStartsAtInitialDelay) {
   EXPECT_EQ(backoff.next_delay(), 1000U);
 }
 
-TEST(GuiAgentRestartPolicy, CleanExitIsSuppressedUntilNextCoreLifecycle) {
+TEST(GuiAgentRestartPolicy, CleanExitSuppressesLaunchUntilSupervisionResumes) {
   sunshinesvc::GuiAgentRestartPolicy policy;
 
-  EXPECT_TRUE(policy.restart_allowed());
-  policy.suppress_until_core_restart();
-  EXPECT_FALSE(policy.restart_allowed());
-  policy.begin_core_lifecycle();
-  EXPECT_TRUE(policy.restart_allowed());
+  EXPECT_TRUE(policy.launch_allowed());
+  policy.suppress_launch();
+  EXPECT_FALSE(policy.launch_allowed());
+  policy.resume_supervision();
+  EXPECT_TRUE(policy.launch_allowed());
 }
 
-TEST(GuiAgentCrashLogLimiter, LogsOnlyCrashLoopStateChanges) {
+TEST(GuiAgentCrashLogLimiter, LogsStateChangesAndPeriodicReminders) {
   sunshinesvc::GuiAgentCrashLogLimiter limiter;
 
   EXPECT_TRUE(limiter.should_log_acquisition(false));
   EXPECT_FALSE(limiter.should_log_acquisition(false));
 
-  EXPECT_TRUE(limiter.should_log_exit(1, 1000));
+  EXPECT_TRUE(limiter.should_log_exit(1, 1000, 0));
   EXPECT_TRUE(limiter.should_log_acquisition(false));
-  EXPECT_FALSE(limiter.should_log_exit(1, 1000));
+  EXPECT_FALSE(limiter.should_log_exit(1, 1000, sunshinesvc::GUI_CRASH_LOG_REMINDER_MS - 1));
   EXPECT_FALSE(limiter.should_log_acquisition(false));
+  EXPECT_TRUE(limiter.should_log_exit(1, 1000, sunshinesvc::GUI_CRASH_LOG_REMINDER_MS));
+  EXPECT_TRUE(limiter.should_log_acquisition(false));
 
-  EXPECT_TRUE(limiter.should_log_exit(1, 2000));
-  EXPECT_TRUE(limiter.should_log_exit(2, 2000));
+  EXPECT_TRUE(limiter.should_log_exit(1, 2000, sunshinesvc::GUI_CRASH_LOG_REMINDER_MS + 1));
+  EXPECT_TRUE(limiter.should_log_exit(2, 2000, sunshinesvc::GUI_CRASH_LOG_REMINDER_MS + 2));
+  EXPECT_TRUE(limiter.should_log_acquisition(false));
   EXPECT_TRUE(limiter.should_log_acquisition(true));
 
   limiter.reset();

--- a/tests/unit/test_sunshinesvc_state.cpp
+++ b/tests/unit/test_sunshinesvc_state.cpp
@@ -1,0 +1,60 @@
+/**
+ * @file tests/unit/test_sunshinesvc_state.cpp
+ * @brief Tests for the GUI agent restart policy used by sunshinesvc.
+ */
+#include <tools/sunshinesvc_state.h>
+
+#include <array>
+#include <iostream>
+
+namespace {
+
+  bool
+  backs_off_repeated_failures() {
+    sunshinesvc::GuiRestartBackoff backoff;
+    constexpr std::array expected { 1000U, 2000U, 4000U, 8000U, 16000U, 30000U, 30000U };
+
+    return std::ranges::all_of(expected, [&backoff](const auto delay) {
+      return backoff.next_delay() == delay;
+    });
+  }
+
+  bool
+  resets_after_stable_runtime() {
+    sunshinesvc::GuiRestartBackoff backoff;
+
+    return backoff.next_delay() == 1000U &&
+           backoff.next_delay() == 2000U &&
+           backoff.next_delay(sunshinesvc::GUI_RESTART_STABLE_RUNTIME_MS) == 1000U &&
+           backoff.next_delay() == 2000U;
+  }
+
+  bool
+  explicit_reset_starts_at_initial_delay() {
+    sunshinesvc::GuiRestartBackoff backoff;
+
+    if (backoff.next_delay() != 1000U || backoff.next_delay() != 2000U) {
+      return false;
+    }
+    backoff.reset();
+    return backoff.next_delay() == 1000U;
+  }
+
+}  // namespace
+
+int
+main() {
+  if (!backs_off_repeated_failures()) {
+    std::cerr << "repeated failure backoff test failed\n";
+    return 1;
+  }
+  if (!resets_after_stable_runtime()) {
+    std::cerr << "stable runtime reset test failed\n";
+    return 1;
+  }
+  if (!explicit_reset_starts_at_initial_delay()) {
+    std::cerr << "explicit reset test failed\n";
+    return 1;
+  }
+  return 0;
+}

--- a/tools/sunshinesvc.cpp
+++ b/tools/sunshinesvc.cpp
@@ -298,7 +298,10 @@ AcquireGuiAgent(DWORD console_session_id, GuiAgentProcess &agent, bool &attached
     gui_directory.c_str(),
     &startup_info,
     &process_info);
-  const auto launch_error = launched ? ERROR_SUCCESS : GetLastError();
+  auto launch_error = launched ? ERROR_SUCCESS : GetLastError();
+  if (!launched && launch_error == ERROR_SUCCESS) {
+    launch_error = ERROR_GEN_FAILURE;
+  }
 
   if (launched) {
     CloseHandle(process_info.hThread);
@@ -483,16 +486,21 @@ ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
   DWORD gui_agent_last_error = ERROR_SUCCESS;
   ULONGLONG gui_agent_retry_at_ms = 0;
   sunshinesvc::GuiRestartBackoff gui_agent_backoff;
+  sunshinesvc::GuiAgentRestartPolicy gui_agent_restart_policy;
+  sunshinesvc::GuiAgentCrashLogLimiter gui_agent_log_limiter;
 
   const auto acquire_gui_agent = [&]() {
     bool attached_to_existing = false;
     const auto error = AcquireGuiAgent(gui_agent_session_id, gui_agent, attached_to_existing);
     if (error == ERROR_SUCCESS) {
+      const bool recovered_from_error = gui_agent_last_error != ERROR_SUCCESS;
       const auto recovery = gui_agent_last_error == ERROR_SUCCESS ? "acquired" : "recovered";
-      WriteServiceLog(log_file_handle,
-        "GUI agent " + std::string(recovery) + " for session " + std::to_string(gui_agent_session_id) +
-          " (PID " + std::to_string(gui_agent.process_id) +
-          (attached_to_existing ? ", existing process)" : ", launched process)"));
+      if (gui_agent_log_limiter.should_log_acquisition(recovered_from_error)) {
+        WriteServiceLog(log_file_handle,
+          "GUI agent " + std::string(recovery) + " for session " + std::to_string(gui_agent_session_id) +
+            " (PID " + std::to_string(gui_agent.process_id) +
+            (attached_to_existing ? ", existing process)" : ", launched process)"));
+      }
       gui_agent_last_error = ERROR_SUCCESS;
       gui_agent_retry_at_ms = 0;
       return;
@@ -523,6 +531,8 @@ ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
       gui_agent_last_error = ERROR_SUCCESS;
       gui_agent_retry_at_ms = 0;
       gui_agent_backoff.reset();
+      gui_agent_restart_policy.begin_core_lifecycle();
+      gui_agent_log_limiter.reset();
     }
 
     auto console_token = DuplicateTokenForSession(console_session_id);
@@ -563,10 +573,20 @@ ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
       continue;
     }
 
+    if (!gui_agent_restart_policy.restart_allowed()) {
+      gui_agent_restart_policy.begin_core_lifecycle();
+      gui_agent_last_error = ERROR_SUCCESS;
+      gui_agent_retry_at_ms = 0;
+      gui_agent_backoff.reset();
+      gui_agent_log_limiter.reset();
+    }
+
     // Keep the tray agent in the signed-in user's session so HKCU settings and
     // single-instance ownership remain scoped to that user. Preserve the
     // handle across Core restarts in the same session.
-    if (gui_agent.handle == NULL && RetryWaitTimeout(gui_agent_retry_at_ms) == 0) {
+    if (gui_agent.handle == NULL &&
+        gui_agent_restart_policy.restart_allowed() &&
+        RetryWaitTimeout(gui_agent_retry_at_ms) == 0) {
       acquire_gui_agent();
     }
 
@@ -576,10 +596,20 @@ ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
       // process rather than polling by executable name.
       const HANDLE wait_objects[] = { stop_event, process_info.hProcess, session_change_event, gui_agent.handle };
       const DWORD wait_object_count = gui_agent.handle == NULL ? 3 : 4;
-      const DWORD wait_timeout = gui_agent.handle == NULL ? RetryWaitTimeout(gui_agent_retry_at_ms) : INFINITE;
+      const DWORD wait_timeout = gui_agent.handle == NULL && gui_agent_restart_policy.restart_allowed() ?
+                                   RetryWaitTimeout(gui_agent_retry_at_ms) :
+                                   INFINITE;
       const auto wait_result = WaitForMultipleObjects(wait_object_count, wait_objects, FALSE, wait_timeout);
       switch (wait_result) {
         case WAIT_TIMEOUT:
+          // The stop/Core handles may have become signaled after the wait timed
+          // out but before process acquisition. Let the next wait dispatch the
+          // lifecycle event instead of reviving the GUI during shutdown.
+          if (WaitForSingleObject(stop_event, 0) == WAIT_OBJECT_0 ||
+              WaitForSingleObject(process_info.hProcess, 0) == WAIT_OBJECT_0) {
+            still_running = true;
+            break;
+          }
           acquire_gui_agent();
           still_running = true;
           break;
@@ -622,14 +652,29 @@ ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
           const auto exited_process_id = gui_agent.process_id;
           CloseGuiAgentHandle(gui_agent);
 
+          if (exit_code == ERROR_SUCCESS) {
+            gui_agent_restart_policy.suppress_until_core_restart();
+            gui_agent_retry_at_ms = 0;
+            gui_agent_last_error = ERROR_SUCCESS;
+            gui_agent_backoff.reset();
+            WriteServiceLog(log_file_handle,
+              "GUI agent exited cleanly in session " + std::to_string(console_session_id) +
+                " (PID " + std::to_string(exited_process_id) +
+                "); restart suppressed until the next Core lifecycle");
+            still_running = true;
+            break;
+          }
+
           const auto retry_delay_ms = gui_agent_backoff.next_delay(runtime_ms);
           gui_agent_retry_at_ms = GetTickCount64() + retry_delay_ms;
           gui_agent_last_error = ERROR_SUCCESS;
-          WriteServiceLog(log_file_handle,
-            "GUI agent exited in session " + std::to_string(console_session_id) +
-              " (PID " + std::to_string(exited_process_id) + ", exit code " +
-              std::to_string(exit_code) + ", runtime " + std::to_string(runtime_ms) +
-              " ms); restarting in " + std::to_string(retry_delay_ms) + " ms");
+          if (gui_agent_log_limiter.should_log_exit(exit_code, retry_delay_ms)) {
+            WriteServiceLog(log_file_handle,
+              "GUI agent exited in session " + std::to_string(console_session_id) +
+                " (PID " + std::to_string(exited_process_id) + ", exit code " +
+                std::to_string(exit_code) + ", runtime " + std::to_string(runtime_ms) +
+                " ms); restarting in " + std::to_string(retry_delay_ms) + " ms");
+          }
           still_running = true;
           break;
         }

--- a/tools/sunshinesvc.cpp
+++ b/tools/sunshinesvc.cpp
@@ -557,6 +557,38 @@ ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
         " (PID " + std::to_string(gui_agent.process_id) + ", existing process)");
   };
 
+  const auto handle_gui_agent_exit = [&]() {
+    DWORD exit_code = ERROR_PROCESS_ABORTED;
+    GetExitCodeProcess(gui_agent.handle, &exit_code);
+    const auto exit_at_ms = GetTickCount64();
+    const auto runtime_ms = exit_at_ms - gui_agent.acquired_at_ms;
+    const auto exited_process_id = gui_agent.process_id;
+    CloseGuiAgentHandle(gui_agent);
+
+    if (exit_code == ERROR_SUCCESS) {
+      gui_agent_restart_policy.suppress_launch();
+      gui_agent_retry_at_ms = exit_at_ms + sunshinesvc::GUI_REATTACH_POLL_MS;
+      gui_agent_last_error = ERROR_SUCCESS;
+      gui_agent_backoff.reset();
+      WriteServiceLog(log_file_handle,
+        "GUI agent exited cleanly in session " + std::to_string(gui_agent_session_id) +
+          " (PID " + std::to_string(exited_process_id) +
+          "); automatic launch suppressed while existing-process reattach remains active");
+      return;
+    }
+
+    const auto retry_delay_ms = gui_agent_backoff.next_delay(runtime_ms);
+    gui_agent_retry_at_ms = exit_at_ms + retry_delay_ms;
+    gui_agent_last_error = ERROR_SUCCESS;
+    if (gui_agent_log_limiter.should_log_exit(exit_code, retry_delay_ms, exit_at_ms)) {
+      WriteServiceLog(log_file_handle,
+        "GUI agent exited in session " + std::to_string(gui_agent_session_id) +
+          " (PID " + std::to_string(exited_process_id) + ", exit code " +
+          std::to_string(exit_code) + ", runtime " + std::to_string(runtime_ms) +
+          " ms); restarting in " + std::to_string(retry_delay_ms) + " ms");
+    }
+  };
+
   // Loop every 3 seconds until the stop event is set or Sunshine.exe is running
   while (WaitForSingleObject(stop_event, 3000) != WAIT_OBJECT_0) {
     auto console_session_id = WTSGetActiveConsoleSessionId();
@@ -611,6 +643,14 @@ ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
       CloseHandle(console_token);
       CloseHandle(job_handle);
       continue;
+    }
+
+    // The GUI may have exited after the previous Core stopped, while no inner
+    // wait loop was active. Reap that lifecycle's process before a new Core
+    // lifecycle restores launch permission or decides whether acquisition is
+    // needed.
+    if (gui_agent.handle != NULL && WaitForSingleObject(gui_agent.handle, 0) == WAIT_OBJECT_0) {
+      handle_gui_agent_exit();
     }
 
     if (!gui_agent_restart_policy.launch_allowed()) {
@@ -690,36 +730,7 @@ ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
         }
 
         case WAIT_OBJECT_0 + 3: {
-          DWORD exit_code = ERROR_PROCESS_ABORTED;
-          GetExitCodeProcess(gui_agent.handle, &exit_code);
-          const auto exit_at_ms = GetTickCount64();
-          const auto runtime_ms = exit_at_ms - gui_agent.acquired_at_ms;
-          const auto exited_process_id = gui_agent.process_id;
-          CloseGuiAgentHandle(gui_agent);
-
-          if (exit_code == ERROR_SUCCESS) {
-            gui_agent_restart_policy.suppress_launch();
-            gui_agent_retry_at_ms = exit_at_ms + sunshinesvc::GUI_REATTACH_POLL_MS;
-            gui_agent_last_error = ERROR_SUCCESS;
-            gui_agent_backoff.reset();
-            WriteServiceLog(log_file_handle,
-              "GUI agent exited cleanly in session " + std::to_string(console_session_id) +
-                " (PID " + std::to_string(exited_process_id) +
-                "); automatic launch suppressed while existing-process reattach remains active");
-            still_running = true;
-            break;
-          }
-
-          const auto retry_delay_ms = gui_agent_backoff.next_delay(runtime_ms);
-          gui_agent_retry_at_ms = exit_at_ms + retry_delay_ms;
-          gui_agent_last_error = ERROR_SUCCESS;
-          if (gui_agent_log_limiter.should_log_exit(exit_code, retry_delay_ms, exit_at_ms)) {
-            WriteServiceLog(log_file_handle,
-              "GUI agent exited in session " + std::to_string(console_session_id) +
-                " (PID " + std::to_string(exited_process_id) + ", exit code " +
-                std::to_string(exit_code) + ", runtime " + std::to_string(runtime_ms) +
-                " ms); restarting in " + std::to_string(retry_delay_ms) + " ms");
-          }
+          handle_gui_agent_exit();
           still_running = true;
           break;
         }

--- a/tools/sunshinesvc.cpp
+++ b/tools/sunshinesvc.cpp
@@ -3,12 +3,19 @@
  * @brief Handles launching Sunshine.exe into user sessions as SYSTEM
  */
 #define WIN32_LEAN_AND_MEAN
+// MinGW's ToolHelp header depends on the Windows base types.
+// clang-format off
 #include <Windows.h>
+#include <TlHelp32.h>
+// clang-format on
 #include <userenv.h>
 #include <wtsapi32.h>
 
+#include <algorithm>
 #include <string>
 #include <vector>
+
+#include "sunshinesvc_state.h"
 
 // PROC_THREAD_ATTRIBUTE_JOB_LIST is currently missing from MinGW headers
 #ifndef PROC_THREAD_ATTRIBUTE_JOB_LIST
@@ -122,8 +129,22 @@ DuplicateTokenForSession(DWORD console_session_id) {
   return new_token;
 }
 
+struct GuiAgentProcess {
+  HANDLE handle = NULL;
+  DWORD process_id = 0;
+  ULONGLONG acquired_at_ms = 0;
+};
+
+void
+CloseGuiAgentHandle(GuiAgentProcess &process) {
+  if (process.handle != NULL) {
+    CloseHandle(process.handle);
+  }
+  process = {};
+}
+
 DWORD
-LaunchGuiAgent(DWORD console_session_id) {
+ResolveGuiAgentPath(std::wstring &gui_directory, std::wstring &gui_path) {
   std::wstring service_path(32768, L'\0');
   const auto service_path_length =
     GetModuleFileNameW(NULL, service_path.data(), static_cast<DWORD>(service_path.size()));
@@ -146,14 +167,79 @@ LaunchGuiAgent(DWORD console_session_id) {
   }
 
   const auto install_directory = service_path.substr(0, install_separator);
-  const auto gui_directory = install_directory + L"\\assets\\gui";
-  const auto gui_path = gui_directory + L"\\sunshine-gui.exe";
+  gui_directory = install_directory + L"\\assets\\gui";
+  gui_path = gui_directory + L"\\sunshine-gui.exe";
   const auto gui_attributes = GetFileAttributesW(gui_path.c_str());
   if (gui_attributes == INVALID_FILE_ATTRIBUTES) {
     return GetLastError();
   }
   if (gui_attributes & FILE_ATTRIBUTE_DIRECTORY) {
     return ERROR_FILE_NOT_FOUND;
+  }
+  return ERROR_SUCCESS;
+}
+
+HANDLE
+OpenExistingGuiAgent(DWORD console_session_id, const std::wstring &gui_path, DWORD &process_id) {
+  const auto snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+  if (snapshot == INVALID_HANDLE_VALUE) {
+    return NULL;
+  }
+
+  PROCESSENTRY32W entry = {};
+  entry.dwSize = sizeof(entry);
+  auto found_process = (HANDLE) NULL;
+  if (Process32FirstW(snapshot, &entry)) {
+    do {
+      if (_wcsicmp(entry.szExeFile, L"sunshine-gui.exe") != 0) {
+        continue;
+      }
+
+      DWORD session_id = 0;
+      if (!ProcessIdToSessionId(entry.th32ProcessID, &session_id) || session_id != console_session_id) {
+        continue;
+      }
+
+      const auto candidate = OpenProcess(SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION, FALSE, entry.th32ProcessID);
+      if (candidate == NULL) {
+        continue;
+      }
+
+      std::wstring candidate_path(32768, L'\0');
+      DWORD candidate_path_length = static_cast<DWORD>(candidate_path.size());
+      if (QueryFullProcessImageNameW(candidate, 0, candidate_path.data(), &candidate_path_length)) {
+        candidate_path.resize(candidate_path_length);
+        if (_wcsicmp(candidate_path.c_str(), gui_path.c_str()) == 0) {
+          found_process = candidate;
+          process_id = entry.th32ProcessID;
+          break;
+        }
+      }
+      CloseHandle(candidate);
+    } while (Process32NextW(snapshot, &entry));
+  }
+
+  CloseHandle(snapshot);
+  return found_process;
+}
+
+DWORD
+AcquireGuiAgent(DWORD console_session_id, GuiAgentProcess &agent, bool &attached_to_existing) {
+  std::wstring gui_directory;
+  std::wstring gui_path;
+  const auto path_error = ResolveGuiAgentPath(gui_directory, gui_path);
+  if (path_error != ERROR_SUCCESS) {
+    return path_error;
+  }
+
+  DWORD existing_process_id = 0;
+  const auto existing_process = OpenExistingGuiAgent(console_session_id, gui_path, existing_process_id);
+  if (existing_process != NULL) {
+    agent.handle = existing_process;
+    agent.process_id = existing_process_id;
+    agent.acquired_at_ms = GetTickCount64();
+    attached_to_existing = true;
+    return ERROR_SUCCESS;
   }
 
   HANDLE user_token = NULL;
@@ -192,7 +278,10 @@ LaunchGuiAgent(DWORD console_session_id) {
 
   if (launched) {
     CloseHandle(process_info.hThread);
-    CloseHandle(process_info.hProcess);
+    agent.handle = process_info.hProcess;
+    agent.process_id = process_info.dwProcessId;
+    agent.acquired_at_ms = GetTickCount64();
+    attached_to_existing = false;
   }
   DestroyEnvironmentBlock(environment);
   CloseHandle(user_token);
@@ -206,21 +295,14 @@ WriteServiceLog(HANDLE log_file, const std::string &message) {
   WriteFile(log_file, line.data(), static_cast<DWORD>(line.size()), &bytes_written, NULL);
 }
 
-bool
-ReconcileGuiAgent(HANDLE log_file, DWORD console_session_id, DWORD &last_error) {
-  const auto error = LaunchGuiAgent(console_session_id);
-  if (error == ERROR_SUCCESS) {
-    if (last_error != ERROR_SUCCESS) {
-      WriteServiceLog(log_file, "GUI agent launch recovered for session " + std::to_string(console_session_id));
-    }
+DWORD
+RetryWaitTimeout(ULONGLONG retry_at_ms) {
+  const auto now = GetTickCount64();
+  if (retry_at_ms <= now) {
+    return 0;
   }
-  else if (error != last_error) {
-    WriteServiceLog(log_file,
-      "GUI agent launch failed for session " + std::to_string(console_session_id) +
-        " (Win32 error " + std::to_string(error) + "); retrying");
-  }
-  last_error = error;
-  return error == ERROR_SUCCESS;
+
+  return static_cast<DWORD>(std::min<ULONGLONG>(retry_at_ms - now, MAXDWORD - 1));
 }
 
 HANDLE
@@ -372,12 +454,51 @@ ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
   service_status.dwCurrentState = SERVICE_RUNNING;
   SetServiceStatus(service_status_handle, &service_status);
 
+  GuiAgentProcess gui_agent;
+  DWORD gui_agent_session_id = 0xFFFFFFFF;
+  DWORD gui_agent_last_error = ERROR_SUCCESS;
+  ULONGLONG gui_agent_retry_at_ms = 0;
+  sunshinesvc::GuiRestartBackoff gui_agent_backoff;
+
+  const auto acquire_gui_agent = [&]() {
+    bool attached_to_existing = false;
+    const auto error = AcquireGuiAgent(gui_agent_session_id, gui_agent, attached_to_existing);
+    if (error == ERROR_SUCCESS) {
+      const auto recovery = gui_agent_last_error == ERROR_SUCCESS ? "acquired" : "recovered";
+      WriteServiceLog(log_file_handle,
+        "GUI agent " + std::string(recovery) + " for session " + std::to_string(gui_agent_session_id) +
+          " (PID " + std::to_string(gui_agent.process_id) +
+          (attached_to_existing ? ", existing process)" : ", launched process)"));
+      gui_agent_last_error = ERROR_SUCCESS;
+      gui_agent_retry_at_ms = 0;
+      return;
+    }
+
+    const auto retry_delay_ms = gui_agent_backoff.next_delay();
+    gui_agent_retry_at_ms = GetTickCount64() + retry_delay_ms;
+    if (error != gui_agent_last_error) {
+      WriteServiceLog(log_file_handle,
+        "GUI agent acquisition failed for session " + std::to_string(gui_agent_session_id) +
+          " (Win32 error " + std::to_string(error) + "); retrying in " +
+          std::to_string(retry_delay_ms) + " ms");
+    }
+    gui_agent_last_error = error;
+  };
+
   // Loop every 3 seconds until the stop event is set or Sunshine.exe is running
   while (WaitForSingleObject(stop_event, 3000) != WAIT_OBJECT_0) {
     auto console_session_id = WTSGetActiveConsoleSessionId();
     if (console_session_id == 0xFFFFFFFF) {
       // No console session yet
       continue;
+    }
+
+    if (gui_agent_session_id != console_session_id) {
+      CloseGuiAgentHandle(gui_agent);
+      gui_agent_session_id = console_session_id;
+      gui_agent_last_error = ERROR_SUCCESS;
+      gui_agent_retry_at_ms = 0;
+      gui_agent_backoff.reset();
     }
 
     auto console_token = DuplicateTokenForSession(console_session_id);
@@ -418,20 +539,24 @@ ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
       continue;
     }
 
-    // Launch the tray in the signed-in user's session so HKCU settings and
-    // single-instance ownership remain scoped to that user.
-    DWORD gui_agent_error = ERROR_SUCCESS;
-    bool gui_agent_started = ReconcileGuiAgent(log_file_handle, console_session_id, gui_agent_error);
+    // Keep the tray agent in the signed-in user's session so HKCU settings and
+    // single-instance ownership remain scoped to that user. Preserve the
+    // handle across Core restarts in the same session.
+    if (gui_agent.handle == NULL && RetryWaitTimeout(gui_agent_retry_at_ms) == 0) {
+      acquire_gui_agent();
+    }
 
     bool still_running;
     do {
-      // Wait for the stop event to be set, Sunshine.exe to terminate, or the console session to change
-      const HANDLE wait_objects[] = { stop_event, process_info.hProcess, session_change_event };
-      const auto wait_result =
-        WaitForMultipleObjects(_countof(wait_objects), wait_objects, FALSE, gui_agent_started ? INFINITE : 3000);
+      // Wait for service/Core/session events and supervise the exact GUI agent
+      // process rather than polling by executable name.
+      const HANDLE wait_objects[] = { stop_event, process_info.hProcess, session_change_event, gui_agent.handle };
+      const DWORD wait_object_count = gui_agent.handle == NULL ? 3 : 4;
+      const DWORD wait_timeout = gui_agent.handle == NULL ? RetryWaitTimeout(gui_agent_retry_at_ms) : INFINITE;
+      const auto wait_result = WaitForMultipleObjects(wait_object_count, wait_objects, FALSE, wait_timeout);
       switch (wait_result) {
         case WAIT_TIMEOUT:
-          gui_agent_started = ReconcileGuiAgent(log_file_handle, console_session_id, gui_agent_error);
+          acquire_gui_agent();
           still_running = true;
           break;
 
@@ -442,6 +567,7 @@ ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
             continue;
           }
           // Fall-through to terminate Sunshine.exe and start it again.
+          [[fallthrough]];
         case WAIT_OBJECT_0:
           // The service is shutting down, so try to gracefully terminate Sunshine.exe.
           // If it doesn't terminate in 20 seconds, we will forcefully terminate it.
@@ -465,6 +591,25 @@ ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
           break;
         }
 
+        case WAIT_OBJECT_0 + 3: {
+          DWORD exit_code = ERROR_PROCESS_ABORTED;
+          GetExitCodeProcess(gui_agent.handle, &exit_code);
+          const auto runtime_ms = GetTickCount64() - gui_agent.acquired_at_ms;
+          const auto exited_process_id = gui_agent.process_id;
+          CloseGuiAgentHandle(gui_agent);
+
+          const auto retry_delay_ms = gui_agent_backoff.next_delay(runtime_ms);
+          gui_agent_retry_at_ms = GetTickCount64() + retry_delay_ms;
+          gui_agent_last_error = ERROR_SUCCESS;
+          WriteServiceLog(log_file_handle,
+            "GUI agent exited in session " + std::to_string(console_session_id) +
+              " (PID " + std::to_string(exited_process_id) + ", exit code " +
+              std::to_string(exit_code) + ", runtime " + std::to_string(runtime_ms) +
+              " ms); restarting in " + std::to_string(retry_delay_ms) + " ms");
+          still_running = true;
+          break;
+        }
+
         default:
           SetEvent(stop_event);
           still_running = false;
@@ -477,6 +622,8 @@ ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
     CloseHandle(console_token);
     CloseHandle(job_handle);
   }
+
+  CloseGuiAgentHandle(gui_agent);
 
   // Let SCM know we've stopped
   service_status.dwCurrentState = SERVICE_STOPPED;

--- a/tools/sunshinesvc.cpp
+++ b/tools/sunshinesvc.cpp
@@ -245,16 +245,21 @@ OpenExistingGuiAgent(DWORD console_session_id, const std::wstring &gui_path) {
   return result;
 }
 
+GuiAgentLookup
+FindExistingGuiAgent(DWORD console_session_id, std::wstring &gui_directory, std::wstring &gui_path) {
+  GuiAgentLookup result;
+  result.error = ResolveGuiAgentPath(gui_directory, gui_path);
+  if (result.error != ERROR_SUCCESS) {
+    return result;
+  }
+  return OpenExistingGuiAgent(console_session_id, gui_path);
+}
+
 DWORD
 AcquireGuiAgent(DWORD console_session_id, GuiAgentProcess &agent, bool &attached_to_existing) {
   std::wstring gui_directory;
   std::wstring gui_path;
-  const auto path_error = ResolveGuiAgentPath(gui_directory, gui_path);
-  if (path_error != ERROR_SUCCESS) {
-    return path_error;
-  }
-
-  const auto existing_process = OpenExistingGuiAgent(console_session_id, gui_path);
+  const auto existing_process = FindExistingGuiAgent(console_session_id, gui_directory, gui_path);
   if (existing_process.error != ERROR_SUCCESS) {
     return existing_process.error;
   }
@@ -517,6 +522,41 @@ ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
     gui_agent_last_error = error;
   };
 
+  const auto reattach_gui_agent = [&]() {
+    std::wstring gui_directory;
+    std::wstring gui_path;
+    auto existing_process = FindExistingGuiAgent(gui_agent_session_id, gui_directory, gui_path);
+    gui_agent_retry_at_ms = GetTickCount64() + sunshinesvc::GUI_REATTACH_POLL_MS;
+
+    if (existing_process.error != ERROR_SUCCESS) {
+      if (existing_process.error != gui_agent_last_error) {
+        WriteServiceLog(log_file_handle,
+          "GUI agent reattach probe failed for session " + std::to_string(gui_agent_session_id) +
+            " (Win32 error " + std::to_string(existing_process.error) + "); retrying in " +
+            std::to_string(sunshinesvc::GUI_REATTACH_POLL_MS) + " ms");
+      }
+      gui_agent_last_error = existing_process.error;
+      return;
+    }
+
+    if (existing_process.handle == NULL) {
+      gui_agent_last_error = ERROR_SUCCESS;
+      return;
+    }
+
+    gui_agent.handle = existing_process.handle;
+    gui_agent.process_id = existing_process.process_id;
+    gui_agent.acquired_at_ms = GetTickCount64();
+    gui_agent_restart_policy.resume_supervision();
+    gui_agent_last_error = ERROR_SUCCESS;
+    gui_agent_retry_at_ms = 0;
+    gui_agent_backoff.reset();
+    gui_agent_log_limiter.reset();
+    WriteServiceLog(log_file_handle,
+      "GUI agent reattached for session " + std::to_string(gui_agent_session_id) +
+        " (PID " + std::to_string(gui_agent.process_id) + ", existing process)");
+  };
+
   // Loop every 3 seconds until the stop event is set or Sunshine.exe is running
   while (WaitForSingleObject(stop_event, 3000) != WAIT_OBJECT_0) {
     auto console_session_id = WTSGetActiveConsoleSessionId();
@@ -531,7 +571,7 @@ ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
       gui_agent_last_error = ERROR_SUCCESS;
       gui_agent_retry_at_ms = 0;
       gui_agent_backoff.reset();
-      gui_agent_restart_policy.begin_core_lifecycle();
+      gui_agent_restart_policy.resume_supervision();
       gui_agent_log_limiter.reset();
     }
 
@@ -573,8 +613,8 @@ ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
       continue;
     }
 
-    if (!gui_agent_restart_policy.restart_allowed()) {
-      gui_agent_restart_policy.begin_core_lifecycle();
+    if (!gui_agent_restart_policy.launch_allowed()) {
+      gui_agent_restart_policy.resume_supervision();
       gui_agent_last_error = ERROR_SUCCESS;
       gui_agent_retry_at_ms = 0;
       gui_agent_backoff.reset();
@@ -585,20 +625,19 @@ ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
     // single-instance ownership remain scoped to that user. Preserve the
     // handle across Core restarts in the same session.
     if (gui_agent.handle == NULL &&
-        gui_agent_restart_policy.restart_allowed() &&
+        gui_agent_restart_policy.launch_allowed() &&
         RetryWaitTimeout(gui_agent_retry_at_ms) == 0) {
       acquire_gui_agent();
     }
 
     bool still_running;
     do {
-      // Wait for service/Core/session events and supervise the exact GUI agent
-      // process rather than polling by executable name.
+      // Wait on the exact GUI process while it is managed. After a clean exit,
+      // only a low-frequency lookup runs so externally launched replacements
+      // can be reattached without allowing the service to revive the GUI.
       const HANDLE wait_objects[] = { stop_event, process_info.hProcess, session_change_event, gui_agent.handle };
       const DWORD wait_object_count = gui_agent.handle == NULL ? 3 : 4;
-      const DWORD wait_timeout = gui_agent.handle == NULL && gui_agent_restart_policy.restart_allowed() ?
-                                   RetryWaitTimeout(gui_agent_retry_at_ms) :
-                                   INFINITE;
+      const DWORD wait_timeout = gui_agent.handle == NULL ? RetryWaitTimeout(gui_agent_retry_at_ms) : INFINITE;
       const auto wait_result = WaitForMultipleObjects(wait_object_count, wait_objects, FALSE, wait_timeout);
       switch (wait_result) {
         case WAIT_TIMEOUT:
@@ -610,7 +649,12 @@ ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
             still_running = true;
             break;
           }
-          acquire_gui_agent();
+          if (gui_agent_restart_policy.launch_allowed()) {
+            acquire_gui_agent();
+          }
+          else {
+            reattach_gui_agent();
+          }
           still_running = true;
           break;
 
@@ -648,27 +692,28 @@ ServiceMain(DWORD dwArgc, LPTSTR *lpszArgv) {
         case WAIT_OBJECT_0 + 3: {
           DWORD exit_code = ERROR_PROCESS_ABORTED;
           GetExitCodeProcess(gui_agent.handle, &exit_code);
-          const auto runtime_ms = GetTickCount64() - gui_agent.acquired_at_ms;
+          const auto exit_at_ms = GetTickCount64();
+          const auto runtime_ms = exit_at_ms - gui_agent.acquired_at_ms;
           const auto exited_process_id = gui_agent.process_id;
           CloseGuiAgentHandle(gui_agent);
 
           if (exit_code == ERROR_SUCCESS) {
-            gui_agent_restart_policy.suppress_until_core_restart();
-            gui_agent_retry_at_ms = 0;
+            gui_agent_restart_policy.suppress_launch();
+            gui_agent_retry_at_ms = exit_at_ms + sunshinesvc::GUI_REATTACH_POLL_MS;
             gui_agent_last_error = ERROR_SUCCESS;
             gui_agent_backoff.reset();
             WriteServiceLog(log_file_handle,
               "GUI agent exited cleanly in session " + std::to_string(console_session_id) +
                 " (PID " + std::to_string(exited_process_id) +
-                "); restart suppressed until the next Core lifecycle");
+                "); automatic launch suppressed while existing-process reattach remains active");
             still_running = true;
             break;
           }
 
           const auto retry_delay_ms = gui_agent_backoff.next_delay(runtime_ms);
-          gui_agent_retry_at_ms = GetTickCount64() + retry_delay_ms;
+          gui_agent_retry_at_ms = exit_at_ms + retry_delay_ms;
           gui_agent_last_error = ERROR_SUCCESS;
-          if (gui_agent_log_limiter.should_log_exit(exit_code, retry_delay_ms)) {
+          if (gui_agent_log_limiter.should_log_exit(exit_code, retry_delay_ms, exit_at_ms)) {
             WriteServiceLog(log_file_handle,
               "GUI agent exited in session " + std::to_string(console_session_id) +
                 " (PID " + std::to_string(exited_process_id) + ", exit code " +

--- a/tools/sunshinesvc.cpp
+++ b/tools/sunshinesvc.cpp
@@ -135,6 +135,12 @@ struct GuiAgentProcess {
   ULONGLONG acquired_at_ms = 0;
 };
 
+struct GuiAgentLookup {
+  HANDLE handle = NULL;
+  DWORD process_id = 0;
+  DWORD error = ERROR_SUCCESS;
+};
+
 void
 CloseGuiAgentHandle(GuiAgentProcess &process) {
   if (process.handle != NULL) {
@@ -179,48 +185,64 @@ ResolveGuiAgentPath(std::wstring &gui_directory, std::wstring &gui_path) {
   return ERROR_SUCCESS;
 }
 
-HANDLE
-OpenExistingGuiAgent(DWORD console_session_id, const std::wstring &gui_path, DWORD &process_id) {
+GuiAgentLookup
+OpenExistingGuiAgent(DWORD console_session_id, const std::wstring &gui_path) {
+  GuiAgentLookup result;
   const auto snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
   if (snapshot == INVALID_HANDLE_VALUE) {
-    return NULL;
+    result.error = GetLastError();
+    if (result.error == ERROR_SUCCESS) {
+      result.error = ERROR_GEN_FAILURE;
+    }
+    return result;
   }
 
   PROCESSENTRY32W entry = {};
   entry.dwSize = sizeof(entry);
-  auto found_process = (HANDLE) NULL;
-  if (Process32FirstW(snapshot, &entry)) {
-    do {
-      if (_wcsicmp(entry.szExeFile, L"sunshine-gui.exe") != 0) {
-        continue;
-      }
+  if (!Process32FirstW(snapshot, &entry)) {
+    result.error = GetLastError();
+    if (result.error == ERROR_NO_MORE_FILES) {
+      result.error = ERROR_SUCCESS;
+    }
+    else if (result.error == ERROR_SUCCESS) {
+      result.error = ERROR_GEN_FAILURE;
+    }
+    CloseHandle(snapshot);
+    return result;
+  }
 
+  while (true) {
+    if (_wcsicmp(entry.szExeFile, L"sunshine-gui.exe") == 0) {
       DWORD session_id = 0;
-      if (!ProcessIdToSessionId(entry.th32ProcessID, &session_id) || session_id != console_session_id) {
-        continue;
-      }
-
-      const auto candidate = OpenProcess(SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION, FALSE, entry.th32ProcessID);
-      if (candidate == NULL) {
-        continue;
-      }
-
-      std::wstring candidate_path(32768, L'\0');
-      DWORD candidate_path_length = static_cast<DWORD>(candidate_path.size());
-      if (QueryFullProcessImageNameW(candidate, 0, candidate_path.data(), &candidate_path_length)) {
-        candidate_path.resize(candidate_path_length);
-        if (_wcsicmp(candidate_path.c_str(), gui_path.c_str()) == 0) {
-          found_process = candidate;
-          process_id = entry.th32ProcessID;
-          break;
+      if (ProcessIdToSessionId(entry.th32ProcessID, &session_id) && session_id == console_session_id) {
+        const auto candidate = OpenProcess(SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION, FALSE, entry.th32ProcessID);
+        if (candidate != NULL) {
+          std::wstring candidate_path(32768, L'\0');
+          DWORD candidate_path_length = static_cast<DWORD>(candidate_path.size());
+          if (QueryFullProcessImageNameW(candidate, 0, candidate_path.data(), &candidate_path_length)) {
+            candidate_path.resize(candidate_path_length);
+            if (_wcsicmp(candidate_path.c_str(), gui_path.c_str()) == 0) {
+              result.handle = candidate;
+              result.process_id = entry.th32ProcessID;
+              break;
+            }
+          }
+          CloseHandle(candidate);
         }
       }
-      CloseHandle(candidate);
-    } while (Process32NextW(snapshot, &entry));
+    }
+
+    if (!Process32NextW(snapshot, &entry)) {
+      const auto error = GetLastError();
+      if (error != ERROR_NO_MORE_FILES) {
+        result.error = error == ERROR_SUCCESS ? ERROR_GEN_FAILURE : error;
+      }
+      break;
+    }
   }
 
   CloseHandle(snapshot);
-  return found_process;
+  return result;
 }
 
 DWORD
@@ -232,11 +254,13 @@ AcquireGuiAgent(DWORD console_session_id, GuiAgentProcess &agent, bool &attached
     return path_error;
   }
 
-  DWORD existing_process_id = 0;
-  const auto existing_process = OpenExistingGuiAgent(console_session_id, gui_path, existing_process_id);
-  if (existing_process != NULL) {
-    agent.handle = existing_process;
-    agent.process_id = existing_process_id;
+  const auto existing_process = OpenExistingGuiAgent(console_session_id, gui_path);
+  if (existing_process.error != ERROR_SUCCESS) {
+    return existing_process.error;
+  }
+  if (existing_process.handle != NULL) {
+    agent.handle = existing_process.handle;
+    agent.process_id = existing_process.process_id;
     agent.acquired_at_ms = GetTickCount64();
     attached_to_existing = true;
     return ERROR_SUCCESS;

--- a/tools/sunshinesvc_state.h
+++ b/tools/sunshinesvc_state.h
@@ -12,6 +12,8 @@ namespace sunshinesvc {
   constexpr std::uint32_t GUI_RESTART_INITIAL_DELAY_MS = 1000;
   constexpr std::uint32_t GUI_RESTART_MAX_DELAY_MS = 30000;
   constexpr std::uint64_t GUI_RESTART_STABLE_RUNTIME_MS = 60000;
+  constexpr std::uint32_t GUI_REATTACH_POLL_MS = 3000;
+  constexpr std::uint64_t GUI_CRASH_LOG_REMINDER_MS = 300000;
 
   class GuiRestartBackoff {
   public:
@@ -41,36 +43,42 @@ namespace sunshinesvc {
   class GuiAgentRestartPolicy {
   public:
     void
-    suppress_until_core_restart() {
-      restart_suppressed_ = true;
+    suppress_launch() {
+      launch_suppressed_ = true;
     }
 
     void
-    begin_core_lifecycle() {
-      restart_suppressed_ = false;
+    resume_supervision() {
+      launch_suppressed_ = false;
     }
 
     bool
-    restart_allowed() const {
-      return !restart_suppressed_;
+    launch_allowed() const {
+      return !launch_suppressed_;
     }
 
   private:
-    bool restart_suppressed_ = false;
+    bool launch_suppressed_ = false;
   };
 
   class GuiAgentCrashLogLimiter {
   public:
     bool
-    should_log_exit(std::uint32_t exit_code, std::uint32_t retry_delay_ms) {
+    should_log_exit(std::uint32_t exit_code, std::uint32_t retry_delay_ms, std::uint64_t now_ms) {
       const bool changed = !has_last_exit_ ||
                            exit_code != last_exit_code_ ||
                            retry_delay_ms != last_retry_delay_ms_;
+      const bool reminder_due = has_last_exit_ &&
+                                now_ms - last_exit_log_at_ms_ >= GUI_CRASH_LOG_REMINDER_MS;
+      const bool should_log = changed || reminder_due;
       has_last_exit_ = true;
       last_exit_code_ = exit_code;
       last_retry_delay_ms_ = retry_delay_ms;
-      acquisition_log_pending_ = changed;
-      return changed;
+      if (should_log) {
+        last_exit_log_at_ms_ = now_ms;
+      }
+      acquisition_log_pending_ = should_log;
+      return should_log;
     }
 
     bool
@@ -85,6 +93,7 @@ namespace sunshinesvc {
       has_last_exit_ = false;
       last_exit_code_ = 0;
       last_retry_delay_ms_ = 0;
+      last_exit_log_at_ms_ = 0;
       acquisition_log_pending_ = true;
     }
 
@@ -93,6 +102,7 @@ namespace sunshinesvc {
     bool acquisition_log_pending_ = true;
     std::uint32_t last_exit_code_ = 0;
     std::uint32_t last_retry_delay_ms_ = 0;
+    std::uint64_t last_exit_log_at_ms_ = 0;
   };
 
 }  // namespace sunshinesvc

--- a/tools/sunshinesvc_state.h
+++ b/tools/sunshinesvc_state.h
@@ -38,4 +38,61 @@ namespace sunshinesvc {
     std::uint32_t failures_ = 0;
   };
 
+  class GuiAgentRestartPolicy {
+  public:
+    void
+    suppress_until_core_restart() {
+      restart_suppressed_ = true;
+    }
+
+    void
+    begin_core_lifecycle() {
+      restart_suppressed_ = false;
+    }
+
+    bool
+    restart_allowed() const {
+      return !restart_suppressed_;
+    }
+
+  private:
+    bool restart_suppressed_ = false;
+  };
+
+  class GuiAgentCrashLogLimiter {
+  public:
+    bool
+    should_log_exit(std::uint32_t exit_code, std::uint32_t retry_delay_ms) {
+      const bool changed = !has_last_exit_ ||
+                           exit_code != last_exit_code_ ||
+                           retry_delay_ms != last_retry_delay_ms_;
+      has_last_exit_ = true;
+      last_exit_code_ = exit_code;
+      last_retry_delay_ms_ = retry_delay_ms;
+      acquisition_log_pending_ = changed;
+      return changed;
+    }
+
+    bool
+    should_log_acquisition(bool recovered_from_error) {
+      const bool should_log = acquisition_log_pending_ || recovered_from_error;
+      acquisition_log_pending_ = false;
+      return should_log;
+    }
+
+    void
+    reset() {
+      has_last_exit_ = false;
+      last_exit_code_ = 0;
+      last_retry_delay_ms_ = 0;
+      acquisition_log_pending_ = true;
+    }
+
+  private:
+    bool has_last_exit_ = false;
+    bool acquisition_log_pending_ = true;
+    std::uint32_t last_exit_code_ = 0;
+    std::uint32_t last_retry_delay_ms_ = 0;
+  };
+
 }  // namespace sunshinesvc

--- a/tools/sunshinesvc_state.h
+++ b/tools/sunshinesvc_state.h
@@ -1,0 +1,41 @@
+/**
+ * @file tools/sunshinesvc_state.h
+ * @brief Platform-independent lifecycle policy for the Windows GUI agent supervisor.
+ */
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+
+namespace sunshinesvc {
+
+  constexpr std::uint32_t GUI_RESTART_INITIAL_DELAY_MS = 1000;
+  constexpr std::uint32_t GUI_RESTART_MAX_DELAY_MS = 30000;
+  constexpr std::uint64_t GUI_RESTART_STABLE_RUNTIME_MS = 60000;
+
+  class GuiRestartBackoff {
+  public:
+    std::uint32_t
+    next_delay(std::uint64_t previous_runtime_ms = 0) {
+      if (previous_runtime_ms >= GUI_RESTART_STABLE_RUNTIME_MS) {
+        failures_ = 0;
+      }
+
+      const auto shift = std::min(failures_, 5U);
+      const auto delay = std::min(
+        GUI_RESTART_INITIAL_DELAY_MS << shift,
+        GUI_RESTART_MAX_DELAY_MS);
+      ++failures_;
+      return delay;
+    }
+
+    void
+    reset() {
+      failures_ = 0;
+    }
+
+  private:
+    std::uint32_t failures_ = 0;
+  };
+
+}  // namespace sunshinesvc


### PR DESCRIPTION
## 改了啥呀

- `sunshinesvc` 现在持有并监管当前用户会话里的准确 GUI 进程句柄
- GUI 意外退出后按 1/2/4/8/16/30 秒退避重启，稳定运行 60 秒后重置退避
- 服务启动时会按会话和完整安装路径接管已有 GUI，避免重复托盘和误认同名进程
- Core 在同一会话内重启时保留 GUI；用户会话切换时重新绑定正确的桌面代理
- 增加平台无关的退避策略测试，并更新托盘协议中的离线恢复契约
- 更新 GUI 子模块到 qiin2333/sunshine-control-panel#78

## 为啥要改

旧服务只尝试启动一次 GUI，随后只监管 Core。GUI 一旦崩掉，Core 还活得好好的，托盘却永久消失了——这种杂鱼半在线状态既难恢复，也让用户误以为整个 Sunshine 都挂了。

现在服务负责 GUI 进程生命周期，GUI 自己负责离线呈现和恢复入口，两层职责清楚，不再靠轮询进程名碰运气。

## 验证

- `cmake --build build-ucrt-trayfix --target sunshinesvc_state_unit_tests sunshinesvc -j 2`
- `build-ucrt-trayfix/tests/sunshinesvc_state_unit_tests.exe`
- LLVM `clang-format --dry-run --Werror`：通过
- 本机服务烟测：结束 GUI 后约 1 秒自动拉起；重启 SunshineService/Core 时 GUI 保持运行并重新连接
- GUI 子模块验证见 qiin2333/sunshine-control-panel#78（85 项 Rust 测试通过）
