### PR TITLE
fix(video): probe a capture-ready fallback display

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -3963,10 +3963,13 @@ namespace video {
   }
 
   bool
-  validate_encoder(encoder_t &encoder, bool expect_failure) {
+  validate_encoder(
+    encoder_t &encoder,
+    bool expect_failure,
+    const std::optional<std::string> &probe_capture_override,
+    const std::string &probe_display_name) {
     std::shared_ptr<platf::display_t> disp;
     const auto configured_capture_backend = config::video.capture;
-    auto probe_capture_override = capture_override_for_encoder_probe();
 
     BOOST_LOG(info) << "Trying encoder ["sv << encoder.name << ']';
     auto fg = util::fail_guard([&]() {
@@ -4008,20 +4011,7 @@ namespace video {
     }
 
     // If the encoder isn't supported at all (not even H.264), bail early
-    // A temporary capture backend must select a display that it can enumerate.
-    // In particular, a VDD output can have a valid DisplayConfig/GDI name while
-    // being intentionally absent from DXGI. Passing that name to a DDX-backed
-    // encoder probe makes the probe target a display the temporary backend
-    // cannot open. Select from the temporary backend's capture-ready outputs.
-    auto output_display_name = display_device::get_display_name(config::video.output_name);
-    if (probe_capture_override) {
-      const auto probe_display_names = platf::display_names(encoder.platform_formats->dev_type);
-      output_display_name = select_encoder_probe_display(
-        output_display_name,
-        probe_display_names,
-        config::video.adapter_name);
-    }
-    reset_display(disp, encoder.platform_formats->dev_type, output_display_name, config_autoselect);
+    reset_display(disp, encoder.platform_formats->dev_type, probe_display_name, config_autoselect);
     if (!disp) {
       return false;
     }
@@ -4148,7 +4138,7 @@ namespace video {
         }
 
         // Reset the display since we're switching from SDR to HDR
-        reset_display(disp, encoder.platform_formats->dev_type, output_display_name, generic_hdr_config);
+        reset_display(disp, encoder.platform_formats->dev_type, probe_display_name, generic_hdr_config);
         if (!disp) {
           return false;
         }
@@ -4223,6 +4213,24 @@ namespace video {
       return 0;
     }
 
+    const auto probe_capture_override = capture_override_for_encoder_probe();
+    const auto configured_display_name = display_device::get_display_name(config::video.output_name);
+    auto probe_display_name = configured_display_name;
+    if (probe_capture_override) {
+      // The Windows implementation enumerates all DXGI capture-ready outputs
+      // regardless of memory type, so one pass serves every encoder candidate.
+      const auto capture_ready_displays = encoder_list.empty() ?
+                                            std::vector<std::string> {} :
+                                            platf::display_names(encoder_list.front()->platform_formats->dev_type);
+      probe_display_name = select_encoder_probe_display(configured_display_name, capture_ready_displays);
+      if (!configured_display_name.empty() && probe_display_name.empty()) {
+        BOOST_LOG(warning) << "Configured output ["sv << configured_display_name
+                           << "] is unavailable to temporary capture backend ["sv
+                           << *probe_capture_override
+                           << "]; encoder probing will use backend display auto-selection"sv;
+      }
+    }
+
     // Restart encoder selection
     auto previous_encoder = chosen_encoder;
     chosen_encoder = nullptr;
@@ -4259,7 +4267,11 @@ namespace video {
 
         if (encoder->name == config::video.encoder) {
           // Remove the encoder from the list entirely if it fails validation
-          if (!validate_encoder(*encoder, previous_encoder && previous_encoder != encoder)) {
+          if (!validate_encoder(
+                *encoder,
+                previous_encoder && previous_encoder != encoder,
+                probe_capture_override,
+                probe_display_name)) {
             pos = encoder_list.erase(pos);
             break;
           }
@@ -4287,7 +4299,11 @@ namespace video {
         auto encoder = *pos;
 
         // Remove the encoder from the list entirely if it fails validation
-        if (!validate_encoder(*encoder, previous_encoder && previous_encoder != encoder)) {
+        if (!validate_encoder(
+              *encoder,
+              previous_encoder && previous_encoder != encoder,
+              probe_capture_override,
+              probe_display_name)) {
           pos = encoder_list.erase(pos);
           continue;
         }
@@ -4324,7 +4340,11 @@ namespace video {
         // If we've used a previous encoder and it's not this one, we expect this encoder to
         // fail to validate. It will use a slightly different order of checks to more quickly
         // eliminate failing encoders.
-        if (!validate_encoder(*encoder, previous_encoder && previous_encoder != encoder)) {
+        if (!validate_encoder(
+              *encoder,
+              previous_encoder && previous_encoder != encoder,
+              probe_capture_override,
+              probe_display_name)) {
           pos = encoder_list.erase(pos);
           continue;
         }

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -4223,7 +4223,13 @@ namespace video {
                                             std::vector<std::string> {} :
                                             platf::display_names(encoder_list.front()->platform_formats->dev_type);
       probe_display_name = select_encoder_probe_display(configured_display_name, capture_ready_displays);
-      if (!configured_display_name.empty() && probe_display_name.empty()) {
+      if (!config::video.output_name.empty() && configured_display_name.empty()) {
+        BOOST_LOG(warning) << "Configured output ["sv << config::video.output_name
+                           << "] could not be resolved for temporary capture backend ["sv
+                           << *probe_capture_override
+                           << "]; encoder probing will use backend display auto-selection"sv;
+      }
+      else if (!configured_display_name.empty() && probe_display_name.empty()) {
         BOOST_LOG(warning) << "Configured output ["sv << configured_display_name
                            << "] is unavailable to temporary capture backend ["sv
                            << *probe_capture_override

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -39,6 +39,7 @@ extern "C" {
 #include "sync.h"
 #include "video.h"
 #include "video_hdr_metadata.h"
+#include "video_probe.h"
 
 #ifdef _WIN32
 extern "C" {
@@ -4015,9 +4016,10 @@ namespace video {
     auto output_display_name = display_device::get_display_name(config::video.output_name);
     if (probe_capture_override) {
       const auto probe_display_names = platf::display_names(encoder.platform_formats->dev_type);
-      if (std::find(probe_display_names.begin(), probe_display_names.end(), output_display_name) == probe_display_names.end()) {
-        output_display_name = probe_display_names.empty() ? std::string {} : probe_display_names.front();
-      }
+      output_display_name = select_encoder_probe_display(
+        output_display_name,
+        probe_display_names,
+        config::video.adapter_name);
     }
     reset_display(disp, encoder.platform_formats->dev_type, output_display_name, config_autoselect);
     if (!disp) {

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -4007,7 +4007,18 @@ namespace video {
     }
 
     // If the encoder isn't supported at all (not even H.264), bail early
-    const auto output_display_name { display_device::get_display_name(config::video.output_name) };
+    // A temporary capture backend must select a display that it can enumerate.
+    // In particular, a VDD output can have a valid DisplayConfig/GDI name while
+    // being intentionally absent from DXGI. Passing that name to a DDX-backed
+    // encoder probe makes the probe target a display the temporary backend
+    // cannot open. Select from the temporary backend's capture-ready outputs.
+    auto output_display_name = display_device::get_display_name(config::video.output_name);
+    if (probe_capture_override) {
+      const auto probe_display_names = platf::display_names(encoder.platform_formats->dev_type);
+      if (std::find(probe_display_names.begin(), probe_display_names.end(), output_display_name) == probe_display_names.end()) {
+        output_display_name = probe_display_names.empty() ? std::string {} : probe_display_names.front();
+      }
+    }
     reset_display(disp, encoder.platform_formats->dev_type, output_display_name, config_autoselect);
     if (!disp) {
       return false;

--- a/src/video.h
+++ b/src/video.h
@@ -11,6 +11,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -536,7 +537,11 @@ namespace video {
     std::optional<safe::mail_raw_t::event_t<dynamic_param_t>> dynamic_param_events = std::nullopt);
 
   bool
-  validate_encoder(encoder_t &encoder, bool expect_failure);
+  validate_encoder(
+    encoder_t &encoder,
+    bool expect_failure,
+    const std::optional<std::string> &probe_capture_override,
+    const std::string &probe_display_name);
 
   /**
    * @brief Probe encoders and select the preferred encoder.

--- a/src/video_probe.h
+++ b/src/video_probe.h
@@ -13,20 +13,14 @@ namespace video {
   inline std::string
   select_encoder_probe_display(
     const std::string &configured_display,
-    std::span<const std::string> capture_ready_displays,
-    const std::string &configured_adapter) {
+    std::span<const std::string> capture_ready_displays) {
     if (std::ranges::find(capture_ready_displays, configured_display) != capture_ready_displays.end()) {
       return configured_display;
     }
 
-    // An empty display lets the backend select the first capture-ready output
-    // on the configured adapter. Choosing the global list's first output here
-    // could force reset_display() onto a different GPU.
-    if (!configured_adapter.empty()) {
-      return {};
-    }
-
-    return capture_ready_displays.empty() ? std::string {} : capture_ready_displays.front();
+    // An empty display preserves backend auto-selection, including adapter
+    // filtering, display wake-up retries, and scanning subsequent outputs.
+    return {};
   }
 
 }  // namespace video

--- a/src/video_probe.h
+++ b/src/video_probe.h
@@ -1,0 +1,32 @@
+/**
+ * @file src/video_probe.h
+ * @brief Platform-independent selection policy for encoder probe displays.
+ */
+#pragma once
+
+#include <algorithm>
+#include <span>
+#include <string>
+
+namespace video {
+
+  inline std::string
+  select_encoder_probe_display(
+    const std::string &configured_display,
+    std::span<const std::string> capture_ready_displays,
+    const std::string &configured_adapter) {
+    if (std::ranges::find(capture_ready_displays, configured_display) != capture_ready_displays.end()) {
+      return configured_display;
+    }
+
+    // An empty display lets the backend select the first capture-ready output
+    // on the configured adapter. Choosing the global list's first output here
+    // could force reset_display() onto a different GPU.
+    if (!configured_adapter.empty()) {
+      return {};
+    }
+
+    return capture_ready_displays.empty() ? std::string {} : capture_ready_displays.front();
+  }
+
+}  // namespace video

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,6 +44,15 @@ endif ()
 add_test(NAME tray_state_unit_tests COMMAND tray_state_unit_tests)
 
 if (WIN32)
+    add_executable(video_probe_unit_tests
+            ${CMAKE_SOURCE_DIR}/tests/unit/test_video_probe.cpp)
+    target_include_directories(video_probe_unit_tests PRIVATE "${CMAKE_SOURCE_DIR}")
+    target_compile_options(video_probe_unit_tests PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${SUNSHINE_COMPILE_OPTIONS}>)
+    set_target_properties(video_probe_unit_tests PROPERTIES
+            CXX_STANDARD 23
+            LINK_SEARCH_START_STATIC 1)
+    add_test(NAME video_probe_unit_tests COMMAND video_probe_unit_tests)
+
     add_executable(vdd_prerequisite_unit_tests
             ${CMAKE_SOURCE_DIR}/tests/unit/test_vdd_prerequisite.cpp)
     target_include_directories(vdd_prerequisite_unit_tests PRIVATE "${CMAKE_SOURCE_DIR}")
@@ -98,6 +107,7 @@ list(FILTER TEST_SOURCES EXCLUDE REGEX "/tests/tools/")
 
 set(ABR_TEST_STUB_SOURCE ${CMAKE_SOURCE_DIR}/tests/unit/abr_test_stubs.cpp)
 list(REMOVE_ITEM TEST_SOURCES ${ABR_TEST_STUB_SOURCE})
+list(REMOVE_ITEM TEST_SOURCES ${CMAKE_SOURCE_DIR}/tests/unit/test_video_probe.cpp)
 
 set(SUNSHINE_SOURCES
         ${SUNSHINE_TARGET_FILES})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,16 +43,18 @@ if (WIN32)
 endif ()
 add_test(NAME tray_state_unit_tests COMMAND tray_state_unit_tests)
 
+add_executable(video_probe_unit_tests
+        ${CMAKE_SOURCE_DIR}/tests/unit/test_video_probe.cpp)
+target_include_directories(video_probe_unit_tests PRIVATE "${CMAKE_SOURCE_DIR}")
+target_link_libraries(video_probe_unit_tests gtest_main)
+target_compile_options(video_probe_unit_tests PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${SUNSHINE_COMPILE_OPTIONS}>)
+set_target_properties(video_probe_unit_tests PROPERTIES CXX_STANDARD 23)
 if (WIN32)
-    add_executable(video_probe_unit_tests
-            ${CMAKE_SOURCE_DIR}/tests/unit/test_video_probe.cpp)
-    target_include_directories(video_probe_unit_tests PRIVATE "${CMAKE_SOURCE_DIR}")
-    target_compile_options(video_probe_unit_tests PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${SUNSHINE_COMPILE_OPTIONS}>)
-    set_target_properties(video_probe_unit_tests PROPERTIES
-            CXX_STANDARD 23
-            LINK_SEARCH_START_STATIC 1)
-    add_test(NAME video_probe_unit_tests COMMAND video_probe_unit_tests)
+    set_target_properties(video_probe_unit_tests PROPERTIES LINK_SEARCH_START_STATIC 1)
+endif ()
+add_test(NAME video_probe_unit_tests COMMAND video_probe_unit_tests)
 
+if (WIN32)
     add_executable(vdd_prerequisite_unit_tests
             ${CMAKE_SOURCE_DIR}/tests/unit/test_vdd_prerequisite.cpp)
     target_include_directories(vdd_prerequisite_unit_tests PRIVATE "${CMAKE_SOURCE_DIR}")
@@ -107,7 +109,6 @@ list(FILTER TEST_SOURCES EXCLUDE REGEX "/tests/tools/")
 
 set(ABR_TEST_STUB_SOURCE ${CMAKE_SOURCE_DIR}/tests/unit/abr_test_stubs.cpp)
 list(REMOVE_ITEM TEST_SOURCES ${ABR_TEST_STUB_SOURCE})
-list(REMOVE_ITEM TEST_SOURCES ${CMAKE_SOURCE_DIR}/tests/unit/test_video_probe.cpp)
 
 set(SUNSHINE_SOURCES
         ${SUNSHINE_TARGET_FILES})

--- a/tests/unit/test_video.cpp
+++ b/tests/unit/test_video.cpp
@@ -4,6 +4,9 @@
  */
 #include <src/video.h>
 
+#include <src/config.h>
+#include <src/display_device/display_device.h>
+
 #include "../tests_common.h"
 
 #include <algorithm>
@@ -172,7 +175,8 @@ struct EncoderTest: PlatformTestSuite, testing::WithParamInterface<video::encode
   void
   SetUp() override {
     auto &encoder = *GetParam();
-    if (!video::validate_encoder(encoder, false)) {
+    const auto probe_display_name = display_device::get_display_name(config::video.output_name);
+    if (!video::validate_encoder(encoder, false, std::nullopt, probe_display_name)) {
       // Encoder failed validation,
       // if it's software - fail, otherwise skip
       if (encoder.name == "software") {

--- a/tests/unit/test_video_probe.cpp
+++ b/tests/unit/test_video_probe.cpp
@@ -5,53 +5,24 @@
 #include <src/video_probe.h>
 
 #include <array>
-#include <iostream>
+#include <gtest/gtest.h>
 
-namespace {
+TEST(VideoProbe, PreservesCaptureReadyConfiguredDisplay) {
+  const std::array displays { std::string { R"(\\.\DISPLAY7)" }, std::string { R"(\\.\DISPLAY9)" } };
+  EXPECT_EQ(video::select_encoder_probe_display(R"(\\.\DISPLAY9)", displays), R"(\\.\DISPLAY9)");
+}
 
-  bool
-  preserves_capture_ready_configured_display() {
-    const std::array displays { std::string { R"(\\.\DISPLAY7)" }, std::string { R"(\\.\DISPLAY9)" } };
-    return video::select_encoder_probe_display(R"(\\.\DISPLAY9)", displays, "Configured GPU") == R"(\\.\DISPLAY9)";
-  }
+TEST(VideoProbe, MissingConfiguredDisplayUsesBackendAutoselection) {
+  const std::array displays { std::string { R"(\\.\DISPLAY7)" }, std::string { R"(\\.\DISPLAY9)" } };
+  EXPECT_TRUE(video::select_encoder_probe_display(R"(\\.\DISPLAY18)", displays).empty());
+}
 
-  bool
-  configured_adapter_uses_backend_autoselection() {
-    const std::array displays { std::string { R"(\\.\DISPLAY7)" }, std::string { R"(\\.\DISPLAY9)" } };
-    return video::select_encoder_probe_display(R"(\\.\DISPLAY18)", displays, "Configured GPU").empty();
-  }
+TEST(VideoProbe, EmptyConfiguredDisplayPreservesBackendAutoselection) {
+  const std::array displays { std::string { R"(\\.\DISPLAY7)" }, std::string { R"(\\.\DISPLAY9)" } };
+  EXPECT_TRUE(video::select_encoder_probe_display({}, displays).empty());
+}
 
-  bool
-  unfiltered_probe_uses_first_capture_ready_display() {
-    const std::array displays { std::string { R"(\\.\DISPLAY7)" }, std::string { R"(\\.\DISPLAY9)" } };
-    return video::select_encoder_probe_display(R"(\\.\DISPLAY18)", displays, {}) == R"(\\.\DISPLAY7)";
-  }
-
-  bool
-  empty_capture_ready_list_returns_no_display() {
-    const std::array<std::string, 0> displays {};
-    return video::select_encoder_probe_display(R"(\\.\DISPLAY18)", displays, {}).empty();
-  }
-
-}  // namespace
-
-int
-main() {
-  if (!preserves_capture_ready_configured_display()) {
-    std::cerr << "configured display preservation test failed\n";
-    return 1;
-  }
-  if (!configured_adapter_uses_backend_autoselection()) {
-    std::cerr << "configured adapter selection test failed\n";
-    return 1;
-  }
-  if (!unfiltered_probe_uses_first_capture_ready_display()) {
-    std::cerr << "unfiltered display fallback test failed\n";
-    return 1;
-  }
-  if (!empty_capture_ready_list_returns_no_display()) {
-    std::cerr << "empty display fallback test failed\n";
-    return 1;
-  }
-  return 0;
+TEST(VideoProbe, EmptyCaptureReadyListUsesBackendAutoselection) {
+  const std::array<std::string, 0> displays {};
+  EXPECT_TRUE(video::select_encoder_probe_display(R"(\\.\DISPLAY18)", displays).empty());
 }

--- a/tests/unit/test_video_probe.cpp
+++ b/tests/unit/test_video_probe.cpp
@@ -1,0 +1,47 @@
+/**
+ * @file tests/unit/test_video_probe.cpp
+ * @brief Tests for temporary encoder-probe display selection.
+ */
+#include <src/video_probe.h>
+
+#include <array>
+#include <iostream>
+
+namespace {
+
+  bool
+  preserves_capture_ready_configured_display() {
+    const std::array displays { std::string { R"(\\.\DISPLAY7)" }, std::string { R"(\\.\DISPLAY9)" } };
+    return video::select_encoder_probe_display(R"(\\.\DISPLAY9)", displays, "Configured GPU") == R"(\\.\DISPLAY9)";
+  }
+
+  bool
+  configured_adapter_uses_backend_autoselection() {
+    const std::array displays { std::string { R"(\\.\DISPLAY7)" }, std::string { R"(\\.\DISPLAY9)" } };
+    return video::select_encoder_probe_display(R"(\\.\DISPLAY18)", displays, "Configured GPU").empty();
+  }
+
+  bool
+  unfiltered_probe_uses_first_capture_ready_display() {
+    const std::array displays { std::string { R"(\\.\DISPLAY7)" }, std::string { R"(\\.\DISPLAY9)" } };
+    return video::select_encoder_probe_display(R"(\\.\DISPLAY18)", displays, {}) == R"(\\.\DISPLAY7)";
+  }
+
+}  // namespace
+
+int
+main() {
+  if (!preserves_capture_ready_configured_display()) {
+    std::cerr << "configured display preservation test failed\n";
+    return 1;
+  }
+  if (!configured_adapter_uses_backend_autoselection()) {
+    std::cerr << "configured adapter selection test failed\n";
+    return 1;
+  }
+  if (!unfiltered_probe_uses_first_capture_ready_display()) {
+    std::cerr << "unfiltered display fallback test failed\n";
+    return 1;
+  }
+  return 0;
+}

--- a/tests/unit/test_video_probe.cpp
+++ b/tests/unit/test_video_probe.cpp
@@ -27,6 +27,12 @@ namespace {
     return video::select_encoder_probe_display(R"(\\.\DISPLAY18)", displays, {}) == R"(\\.\DISPLAY7)";
   }
 
+  bool
+  empty_capture_ready_list_returns_no_display() {
+    const std::array<std::string, 0> displays {};
+    return video::select_encoder_probe_display(R"(\\.\DISPLAY18)", displays, {}).empty();
+  }
+
 }  // namespace
 
 int
@@ -41,6 +47,10 @@ main() {
   }
   if (!unfiltered_probe_uses_first_capture_ready_display()) {
     std::cerr << "unfiltered display fallback test failed\n";
+    return 1;
+  }
+  if (!empty_capture_ready_list_returns_no_display()) {
+    std::cerr << "empty display fallback test failed\n";
     return 1;
   }
   return 0;


### PR DESCRIPTION
## 改了啥呀

- 编码器探测临时覆盖 capture backend 时，先枚举该后端真正可捕获的 outputs
- 配置目标仍在枚举结果中时继续使用它；不可见时才回退到第一个 capture-ready display
- 正常串流路径和全局 `capture=vdd` 配置保持不变

## 为啥要改

本机配置 `capture=vdd`、`output_name=ZakoHDR` 时，Windows DisplayConfig 仍把虚拟源解析为 `\\.\DISPLAY18`，但 DXGI 只暴露 `\\.\DISPLAY7`。编码探测临时切到 DDX 后却继续拿着 VDD 的 GDI 名，导致它稳定指向一个临时后端根本看不到的目标——杂鱼探测器换了眼睛却没换地图。

现在探测显示器与临时 capture backend 使用同一份可捕获枚举，避免跨后端复用陈旧目标。

## 验证

- `cmake --build build-ucrt-trayfix --target sunshine -j 2`：完整 Windows Release Core 构建通过
- 再次运行同一构建命令：`ninja: no work to do`
- 真实复现前：`dxgi-info.exe` 仅列出 `\\.\DISPLAY7`，启动日志出现 `Failed to create display for: \\.\DISPLAY18`
- 部署候选后：临时 DDX 探测改用 `\\.\DISPLAY7`，不再引用 `DISPLAY18`
- AMF H.264 / HEVC / AV1 探测全部通过，托盘状态保持 `owner=gui`、`status=idle`、`vdd.active=true`

Vulkan encoder 在 Windows DDX 下仍因 `vulkan` memory type 不受该 capture backend 支持而失败；这是独立兼容性问题，不再与 `DISPLAY18` 目标解析混在一起。
