### PR TITLE
fix(hdr): HDR10+ 按 10000 尼特 PQ 基准归一化，并补上保留槽位与时间平滑

### DIFF
--- a/src/nvenc/common_impl/nvenc_base.cpp
+++ b/src/nvenc/common_impl/nvenc_base.cpp
@@ -763,6 +763,7 @@ namespace nvenc {
     dynamic_hdr_formats = {};
     luminance_stats = {};
     vivid_filter.reset();
+    hdr10plus_ema.reset();
   }
 
   nvenc_encoded_frame
@@ -852,12 +853,13 @@ namespace nvenc {
     if (luminance_stats.valid && hdr_metadata && (video_format == 1 || video_format == 2)) {
       uint16_t max_lum = hdr_metadata->maxDisplayLuminance;
       const auto vivid_metadata = vivid_filter.update(luminance_stats);
+      hdr10plus_ema.update(luminance_stats);
 
       // HDR10+ (PQ only — HDR10+ requires absolute luminance)
       size_t hdr10plus_payload_size = 0;
       if (dynamic_hdr_formats.hdr10plus) {
         hdr10plus_payload_size = video::hdr_metadata::serialize_hdr10plus_t35(
-          luminance_stats, max_lum, hdr10plus_payload);
+          hdr10plus_ema.smoothed(luminance_stats), max_lum, hdr10plus_payload);
       }
       if (hdr10plus_payload_size > 0) {
         dynamic_payloads[dynamic_payload_count].payloadSize =

--- a/src/nvenc/common_impl/nvenc_base.h
+++ b/src/nvenc/common_impl/nvenc_base.h
@@ -142,6 +142,9 @@ namespace nvenc {
     platf::hdr_frame_luminance_stats_t luminance_stats;
     video::hdr_metadata::formats_t dynamic_hdr_formats;
     video::hdr_metadata::vivid_temporal_filter_t vivid_filter;
+    // HDR10+ needs its own smoothing: vivid_filter averages in the PQ code-value
+    // domain, while the ST 2094-40 fields are built from luminance in nits.
+    video::hdr_metadata::hdr_luminance_ema_t hdr10plus_ema;
 
   };
 }

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -525,71 +525,6 @@ namespace video {
     std::array<entry_t, 256> entries {};
   };
 
-  /**
-   * @brief Temporal EMA (Exponential Moving Average) state for HDR luminance stats.
-   * Prevents frame-to-frame brightness jitter/flicker in tone mapping by smoothing
-   * the raw per-frame GPU statistics over time.
-   *
-   * This state is owned by the encode session. It must not be shared across sessions:
-   * carrying a previous stream's converged luminance into a new one biases the first
-   * frames of dynamic metadata until the EMA re-converges.
-   */
-  struct hdr_luminance_ema_t {
-    float min_maxrgb = 0.0f;
-    float max_maxrgb = 0.0f;
-    float avg_maxrgb = 0.0f;
-    float percentile_95 = 0.0f;
-    float percentile_99 = 0.0f;
-    /// Smoothed maxRGB (nits) at each hdr_metadata::hdr10plus_percentages entry.
-    float distribution_maxrgb[platf::hdr_frame_luminance_stats_t::HDR10PLUS_PERCENTILES] = {};
-    bool initialized = false;
-
-    /// EMA smoothing factor: 0.15 = responsive to changes while avoiding flicker.
-    /// Lower α = more smoothing (less flicker, slower adaptation).
-    /// Scene cuts are handled by fast-tracking when the change exceeds a threshold.
-    static constexpr float ALPHA = 0.15f;
-    static constexpr float SCENE_CUT_THRESHOLD = 3.0f;  // Ratio threshold for scene cut detection
-
-    /**
-     * @brief Apply EMA smoothing to raw per-frame stats.
-     * On first frame or scene cuts (>3x luminance change), snaps to current value.
-     * Otherwise applies exponential smoothing: smoothed = α·current + (1-α)·previous.
-     */
-    void
-    update(const platf::hdr_frame_luminance_stats_t &raw) {
-      if (!raw.valid) return;
-
-      if (!initialized) {
-        // First frame: snap to current values
-        min_maxrgb = raw.min_maxrgb;
-        max_maxrgb = raw.max_maxrgb;
-        avg_maxrgb = raw.avg_maxrgb;
-        percentile_95 = raw.percentile_95;
-        percentile_99 = raw.percentile_99;
-        std::copy(std::begin(raw.distribution_maxrgb), std::end(raw.distribution_maxrgb),
-          std::begin(distribution_maxrgb));
-        initialized = true;
-        return;
-      }
-
-      // Scene cut detection: if peak luminance changes dramatically, snap immediately
-      float ratio = (max_maxrgb > 1.0f) ? raw.max_maxrgb / max_maxrgb : SCENE_CUT_THRESHOLD + 1.0f;
-      float alpha = (ratio > SCENE_CUT_THRESHOLD || ratio < 1.0f / SCENE_CUT_THRESHOLD)
-                    ? 1.0f  // Scene cut: snap to new values
-                    : ALPHA; // Normal: smooth transition
-
-      min_maxrgb = alpha * raw.min_maxrgb + (1.0f - alpha) * min_maxrgb;
-      max_maxrgb = alpha * raw.max_maxrgb + (1.0f - alpha) * max_maxrgb;
-      avg_maxrgb = alpha * raw.avg_maxrgb + (1.0f - alpha) * avg_maxrgb;
-      percentile_95 = alpha * raw.percentile_95 + (1.0f - alpha) * percentile_95;
-      percentile_99 = alpha * raw.percentile_99 + (1.0f - alpha) * percentile_99;
-      for (size_t i = 0; i < std::size(distribution_maxrgb); ++i) {
-        distribution_maxrgb[i] =
-          alpha * raw.distribution_maxrgb[i] + (1.0f - alpha) * distribution_maxrgb[i];
-      }
-    }
-  };
-
   class avcodec_encode_session_t: public encode_session_t {
   public:
     avcodec_encode_session_t() = default;
@@ -733,7 +668,7 @@ namespace video {
 
     // Temporal filters are session-local so a new stream cannot inherit metadata
     // history from the previous stream.
-    hdr_luminance_ema_t hdr_ema;
+    hdr_metadata::hdr_luminance_ema_t hdr_ema;
     hdr_metadata::vivid_temporal_filter_t vivid_filter;
 
     cbs::nal_t sps;
@@ -2087,7 +2022,7 @@ namespace video {
   void
   update_hdr_dynamic_metadata(
     AVFrame *frame,
-    const hdr_luminance_ema_t &ema,
+    const hdr_metadata::hdr_luminance_ema_t &ema,
     const hdr_metadata::vivid_metadata_t &vivid_metadata,
     uint16_t max_display_luminance) {
     if (!frame) return;

--- a/src/video_hdr_metadata.h
+++ b/src/video_hdr_metadata.h
@@ -107,8 +107,10 @@ namespace video::hdr_metadata {
    * shared by the AVCodec side-data and native NVENC paths.
    *
    * distribution carries maxRGB in nits at each hdr10plus_percentages entry. A null
-   * pointer, or any non-finite or negative entry, leaves the distribution at zero —
-   * callers must then omit it rather than send a partially filled one.
+   * pointer leaves the distribution at zero. Any non-finite or negative entry
+   * discards the whole distribution the same way. Either way the reserved slots keep
+   * their fixed 8.5.4 values: V1 = 0 tells a consumer to fall back to maxSCL, which
+   * stays valid, so the frame is still worth sending.
    */
   inline hdr10plus_frame_metadata_t
   hdr10plus_from_luminance(float percentile_95, float average_maxrgb,
@@ -141,19 +143,22 @@ namespace video::hdr_metadata {
       for (size_t i = 0; i < hdr10plus_percentages.size(); ++i) {
         if (!std::isfinite(distribution[i]) || distribution[i] < 0.0f) {
           result.distribution_maxrgb = {};
-          return result;
+          break;
         }
         result.distribution_maxrgb[i] = normalize(distribution[i]);
       }
+    }
 
-      // Overwrite the two reserved slots last, so an analyzer percentile can never
-      // reach the wire there. An all-zero distribution from the rejection path
-      // above is left alone: V1 = 0 is the sentinel that makes a consumer fall
-      // back to maxSCL, which is what we want when the analysis is unusable.
-      if constexpr (hdr10plus_application_version == 1) {
-        result.distribution_maxrgb[hdr10plus_reserved_v1_index] = hdr10plus_reserved_v1;
-        result.distribution_maxrgb[hdr10plus_reserved_v2_index] = hdr10plus_reserved_v2;
-      }
+    // Overwrite the two reserved slots last, so an analyzer percentile can never
+    // reach the wire there. 8.5.4 fixes V1 and V2 unconditionally in
+    // application_version 1, so this has to run on every path out of here, not just
+    // the one that filled a distribution in: the serializer always emits all nine
+    // percentiles, so a caller that passes no distribution at all would otherwise
+    // ship V2 = 0. V1 stays 0 either way, which is the sentinel that makes a
+    // consumer fall back to maxSCL — what we want when there is no usable analysis.
+    if constexpr (hdr10plus_application_version == 1) {
+      result.distribution_maxrgb[hdr10plus_reserved_v1_index] = hdr10plus_reserved_v1;
+      result.distribution_maxrgb[hdr10plus_reserved_v2_index] = hdr10plus_reserved_v2;
     }
 
     return result;

--- a/src/video_hdr_metadata.h
+++ b/src/video_hdr_metadata.h
@@ -33,6 +33,20 @@ namespace video::hdr_metadata {
   constexpr int hdr10plus_normalized_scale = 100000;
   constexpr uint8_t hdr10plus_application_version = 1;
   constexpr size_t hdr10plus_t35_prefix_size = 6;
+
+  /**
+   * The SMPTE ST 2084 reference peak that every ST 2094-40 luminance field is
+   * normalized against.
+   *
+   * maxSCL, average_maxrgb and the maxRGB distribution describe absolute content
+   * luminance as a fraction of this peak, never a fraction of the target display.
+   * A consumer recovers nits by multiplying straight back out — libplacebo does
+   * `scene_max[i] = 10000 * av_q2d(maxscl[i])` in pl_map_hdr_metadata — so
+   * normalizing against anything else scales the whole picture by the ratio.
+   * The target display belongs in targeted_system_display_maximum_luminance,
+   * which is a separate, non-normalized field carried in nits.
+   */
+  constexpr float hdr10plus_pq_reference_nits = 10000.0f;
   // Large enough for FFmpeg's maximum ST 2094-40 body plus the T.35 prefix,
   // without exposing FFmpeg headers to this shared, unit-testable header.
   constexpr size_t hdr10plus_t35_max_payload_size = 1024;
@@ -46,6 +60,33 @@ namespace video::hdr_metadata {
    * parses back cleanly while still being non-conformant on the wire.
    */
   inline constexpr std::array<uint8_t, 9> hdr10plus_percentages { 1, 5, 10, 25, 50, 75, 90, 95, 99 };
+
+  /**
+   * ST 2094-40 8.5.4 excludes the 5% and 10% slots from the CDF in
+   * application_version 1 and reserves them at the fixed values V1 = 0.00000 and
+   * V2 = 0.00255. ST 2094-50 redefines the same two slots as V1 = scene luminance
+   * at 99.99% of the frame and V2 = percentage of pixels at or below 100 nits, so
+   * a consumer that finds a nonzero V1 reads it as the frame peak.
+   *
+   * libplacebo does exactly that: pl_map_hdr_metadata derives max_pq_y from slot 1
+   * whenever application_version is 1 with the nine standard percentages, then
+   * pl_color_space_nominal_luma_ex prefers those CIE-Y values over maxSCL. Writing
+   * a real 5th percentile there reports the darkest part of the frame as its peak,
+   * which is why the V1 = 0 sentinel exists — it is how a conformant stream tells
+   * the consumer to fall back to maxSCL.
+   *
+   * The analyzer's 5% and 10% percentiles are therefore computed but not carried.
+   * The slots stay in the table so the array keeps lining up with
+   * hdr10plus_percentages and with the analyzer's distribution_maxrgb[].
+   */
+  constexpr size_t hdr10plus_reserved_v1_index = 1;
+  constexpr size_t hdr10plus_reserved_v2_index = 2;
+  constexpr int hdr10plus_reserved_v1 = 0;  // 0.00000
+  constexpr int hdr10plus_reserved_v2 = 255;  // 0.00255 x hdr10plus_normalized_scale
+
+  static_assert(hdr10plus_percentages[hdr10plus_reserved_v1_index] == 5 &&
+                  hdr10plus_percentages[hdr10plus_reserved_v2_index] == 10,
+    "the reserved ST 2094-40 slots are the 5% and 10% percentages");
 
   static_assert(
     hdr10plus_percentages.size() == platf::hdr_frame_luminance_stats_t::HDR10PLUS_PERCENTILES,
@@ -80,8 +121,11 @@ namespace video::hdr_metadata {
       max_display_luminance > 0 ? max_display_luminance : 1000,
       1,
       10000);
-    const auto normalize = [target_nits](float nits) {
-      const float normalized = std::clamp(nits / target_nits, 0.0f, 1.0f);
+    // Absolute, display-independent: see hdr10plus_pq_reference_nits. target_nits
+    // deliberately plays no part here — it is only reported as the targeted system
+    // display maximum luminance below.
+    const auto normalize = [](float nits) {
+      const float normalized = std::clamp(nits / hdr10plus_pq_reference_nits, 0.0f, 1.0f);
       return static_cast<int>(std::lround(normalized * hdr10plus_normalized_scale));
     };
 
@@ -99,6 +143,15 @@ namespace video::hdr_metadata {
           return result;
         }
         result.distribution_maxrgb[i] = normalize(distribution[i]);
+      }
+
+      // Overwrite the two reserved slots last, so an analyzer percentile can never
+      // reach the wire there. An all-zero distribution from the rejection path
+      // above is left alone: V1 = 0 is the sentinel that makes a consumer fall
+      // back to maxSCL, which is what we want when the analysis is unusable.
+      if constexpr (hdr10plus_application_version == 1) {
+        result.distribution_maxrgb[hdr10plus_reserved_v1_index] = hdr10plus_reserved_v1;
+        result.distribution_maxrgb[hdr10plus_reserved_v2_index] = hdr10plus_reserved_v2;
       }
     }
 

--- a/src/video_hdr_metadata.h
+++ b/src/video_hdr_metadata.h
@@ -12,6 +12,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <iterator>
 #include <span>
 #include <vector>
 
@@ -310,6 +311,106 @@ namespace video::hdr_metadata {
     result.valid = true;
     return result;
   }
+
+  /**
+   * @brief Temporal EMA (Exponential Moving Average) state for HDR luminance stats.
+   * Prevents frame-to-frame brightness jitter/flicker in tone mapping by smoothing
+   * the raw per-frame GPU statistics over time.
+   *
+   * This state is owned by the encode session. It must not be shared across sessions:
+   * carrying a previous stream's converged luminance into a new one biases the first
+   * frames of dynamic metadata until the EMA re-converges.
+   *
+   * Lives here rather than next to one encoder because both the avcodec and the
+   * native NVENC path feed HDR10+ from it. NVENC used to serialize raw analyzer
+   * output, so its HDR10+ stepped at every GPU readback while the Vivid metadata
+   * beside it was already smoothed by vivid_temporal_filter_t.
+   */
+  struct hdr_luminance_ema_t {
+    float min_maxrgb = 0.0f;
+    float max_maxrgb = 0.0f;
+    float avg_maxrgb = 0.0f;
+    float percentile_95 = 0.0f;
+    float percentile_99 = 0.0f;
+    /// Smoothed maxRGB (nits) at each hdr10plus_percentages entry.
+    float distribution_maxrgb[platf::hdr_frame_luminance_stats_t::HDR10PLUS_PERCENTILES] = {};
+    bool initialized = false;
+
+    /// EMA smoothing factor: 0.15 = responsive to changes while avoiding flicker.
+    /// Lower α = more smoothing (less flicker, slower adaptation).
+    /// Scene cuts are handled by fast-tracking when the change exceeds a threshold.
+    static constexpr float ALPHA = 0.15f;
+    static constexpr float SCENE_CUT_THRESHOLD = 3.0f;  // Ratio threshold for scene cut detection
+
+    /**
+     * @brief Apply EMA smoothing to raw per-frame stats.
+     * On first frame or scene cuts (>3x luminance change), snaps to current value.
+     * Otherwise applies exponential smoothing: smoothed = α·current + (1-α)·previous.
+     */
+    void
+    update(const platf::hdr_frame_luminance_stats_t &raw) {
+      if (!raw.valid) return;
+
+      if (!initialized) {
+        // First frame: snap to current values
+        min_maxrgb = raw.min_maxrgb;
+        max_maxrgb = raw.max_maxrgb;
+        avg_maxrgb = raw.avg_maxrgb;
+        percentile_95 = raw.percentile_95;
+        percentile_99 = raw.percentile_99;
+        std::copy(std::begin(raw.distribution_maxrgb), std::end(raw.distribution_maxrgb),
+          std::begin(distribution_maxrgb));
+        initialized = true;
+        return;
+      }
+
+      // Scene cut detection: if peak luminance changes dramatically, snap immediately
+      float ratio = (max_maxrgb > 1.0f) ? raw.max_maxrgb / max_maxrgb : SCENE_CUT_THRESHOLD + 1.0f;
+      float alpha = (ratio > SCENE_CUT_THRESHOLD || ratio < 1.0f / SCENE_CUT_THRESHOLD)
+                    ? 1.0f  // Scene cut: snap to new values
+                    : ALPHA; // Normal: smooth transition
+
+      min_maxrgb = alpha * raw.min_maxrgb + (1.0f - alpha) * min_maxrgb;
+      max_maxrgb = alpha * raw.max_maxrgb + (1.0f - alpha) * max_maxrgb;
+      avg_maxrgb = alpha * raw.avg_maxrgb + (1.0f - alpha) * avg_maxrgb;
+      percentile_95 = alpha * raw.percentile_95 + (1.0f - alpha) * percentile_95;
+      percentile_99 = alpha * raw.percentile_99 + (1.0f - alpha) * percentile_99;
+      for (size_t i = 0; i < std::size(distribution_maxrgb); ++i) {
+        distribution_maxrgb[i] =
+          alpha * raw.distribution_maxrgb[i] + (1.0f - alpha) * distribution_maxrgb[i];
+      }
+    }
+
+    void
+    reset() {
+      *this = {};
+    }
+
+    /**
+     * @brief raw with the smoothed fields substituted.
+     *
+     * For callers that hand a whole stats struct to a serializer instead of
+     * reading the individual EMA fields. Members this filter does not smooth —
+     * analysis_max_nits, sample_sequence, and the PQ-domain percentiles Vivid
+     * uses — pass through untouched.
+     */
+    platf::hdr_frame_luminance_stats_t
+    smoothed(const platf::hdr_frame_luminance_stats_t &raw) const {
+      if (!initialized) {
+        return raw;
+      }
+
+      platf::hdr_frame_luminance_stats_t result = raw;
+      result.min_maxrgb = min_maxrgb;
+      result.max_maxrgb = max_maxrgb;
+      result.avg_maxrgb = avg_maxrgb;
+      result.percentile_95 = percentile_95;
+      result.percentile_99 = percentile_99;
+      std::copy(std::begin(distribution_maxrgb), std::end(distribution_maxrgb),
+        std::begin(result.distribution_maxrgb));
+      return result;
+    }
+  };
 
   /**
    * GB/T 46269.1-2025 Annex A.9 recommends a 32-frame arithmetic mean over

--- a/tests/unit/test_video_hdr_metadata.cpp
+++ b/tests/unit/test_video_hdr_metadata.cpp
@@ -320,6 +320,84 @@ TEST(HdrDynamicMetadata, SharesHdr10PlusNormalizationAcrossEncoderPaths) {
   EXPECT_EQ(fallback.targeted_system_display_maximum_luminance, 1000);
 }
 
+TEST(HdrDynamicMetadata, SmoothsHdr10PlusLuminanceAcrossFrames) {
+  // The regression: the native NVENC path serialized raw analyzer output, so its
+  // HDR10+ stepped at every GPU readback while the Vivid metadata built from the
+  // same stats was already averaged by vivid_temporal_filter_t.
+  const auto flat = [](float nits) {
+    platf::hdr_frame_luminance_stats_t stats {};
+    stats.min_maxrgb = nits;
+    stats.max_maxrgb = nits;
+    stats.avg_maxrgb = nits;
+    stats.percentile_95 = nits;
+    stats.percentile_99 = nits;
+    for (auto &entry : stats.distribution_maxrgb) {
+      entry = nits;
+    }
+    stats.valid = true;
+    return stats;
+  };
+
+  video::hdr_metadata::hdr_luminance_ema_t ema;
+  EXPECT_FALSE(ema.initialized);
+
+  // First sample snaps: there is nothing to blend against yet.
+  ema.update(flat(100.0f));
+  EXPECT_TRUE(ema.initialized);
+  EXPECT_FLOAT_EQ(ema.percentile_95, 100.0f);
+
+  // A 2x change stays under SCENE_CUT_THRESHOLD, so it blends at ALPHA.
+  ema.update(flat(200.0f));
+  EXPECT_FLOAT_EQ(ema.percentile_95, 115.0f);
+  EXPECT_FLOAT_EQ(ema.avg_maxrgb, 115.0f);
+  EXPECT_FLOAT_EQ(ema.distribution_maxrgb[0], 115.0f);
+
+  // A scene cut past the threshold snaps instead of dragging the old scene along.
+  ema.update(flat(2000.0f));
+  EXPECT_FLOAT_EQ(ema.percentile_95, 2000.0f);
+
+  ema.reset();
+  EXPECT_FALSE(ema.initialized);
+  EXPECT_FLOAT_EQ(ema.percentile_95, 0.0f);
+}
+
+TEST(HdrDynamicMetadata, SmoothedStatsSubstituteOnlyTheFilteredFields) {
+  platf::hdr_frame_luminance_stats_t raw {};
+  raw.avg_maxrgb = 100.0f;
+  raw.max_maxrgb = 100.0f;
+  raw.percentile_95 = 100.0f;
+  raw.percentile_10_pq = 0.25f;
+  raw.percentile_90_pq = 0.75f;
+  raw.analysis_max_nits = 10000.0f;
+  raw.sample_sequence = 42;
+  raw.valid = true;
+
+  video::hdr_metadata::hdr_luminance_ema_t ema;
+
+  // Before the first sample there is nothing to substitute, so raw passes through.
+  const auto passthrough = ema.smoothed(raw);
+  EXPECT_FLOAT_EQ(passthrough.percentile_95, 100.0f);
+
+  ema.update(raw);
+  auto next = raw;
+  next.avg_maxrgb = 200.0f;
+  next.max_maxrgb = 200.0f;
+  next.percentile_95 = 200.0f;
+  ema.update(next);
+
+  const auto smoothed = ema.smoothed(next);
+  EXPECT_FLOAT_EQ(smoothed.percentile_95, 115.0f);
+  EXPECT_FLOAT_EQ(smoothed.avg_maxrgb, 115.0f);
+
+  // Fields this filter does not own must survive untouched: the PQ-domain
+  // percentiles belong to HDR Vivid, which does its own averaging.
+  EXPECT_FLOAT_EQ(smoothed.percentile_10_pq, 0.25f);
+  EXPECT_FLOAT_EQ(smoothed.percentile_90_pq, 0.75f);
+  EXPECT_FLOAT_EQ(smoothed.analysis_max_nits, 10000.0f);
+  EXPECT_EQ(smoothed.sample_sequence, 42U);
+  EXPECT_TRUE(smoothed.valid);
+}
+
 TEST(HdrDynamicMetadata, GeneratesVividFieldsInPqContentDomain) {
   platf::hdr_frame_luminance_stats_t stats;
   stats.min_maxrgb = 0.0f;

--- a/tests/unit/test_video_hdr_metadata.cpp
+++ b/tests/unit/test_video_hdr_metadata.cpp
@@ -240,20 +240,44 @@ TEST(HdrDynamicMetadata, ReservesTheHdr10PlusV1AndV2DistributionSlots) {
 }
 
 TEST(HdrDynamicMetadata, ZeroesTheWholeDistributionOnOneBadEntry) {
-  using video::hdr_metadata::hdr10plus_from_luminance;
+  using namespace video::hdr_metadata;
+
+  // One unusable entry discards the whole CDF rather than shipping a partially
+  // filled one. maxSCL and average_maxrgb survive, and V1 = 0 is what tells a
+  // consumer to use them, so the frame is still worth sending.
+  const auto check = [](const hdr10plus_frame_metadata_t &metadata) {
+    EXPECT_TRUE(metadata.valid);
+    EXPECT_GT(metadata.maxscl, 0);
+    EXPECT_GT(metadata.average_maxrgb, 0);
+
+    for (size_t i = 0; i < metadata.distribution_maxrgb.size(); ++i) {
+      if (i == hdr10plus_reserved_v1_index || i == hdr10plus_reserved_v2_index) {
+        continue;
+      }
+      EXPECT_EQ(metadata.distribution_maxrgb[i], 0) << "CDF slot " << i;
+    }
+
+    // 8.5.4 fixes these two in application_version 1 whether or not the analysis
+    // was usable, so the rejection path must not zero V2 either.
+    EXPECT_EQ(metadata.distribution_maxrgb[hdr10plus_reserved_v1_index], hdr10plus_reserved_v1);
+    EXPECT_EQ(metadata.distribution_maxrgb[hdr10plus_reserved_v2_index], hdr10plus_reserved_v2);
+  };
 
   float bad[] = { 10, 50, 100, std::numeric_limits<float>::quiet_NaN(), 300, 500, 800, 900, 1000 };
-  const auto from_nan = hdr10plus_from_luminance(900.0f, 300.0f, 1000, bad);
-  EXPECT_TRUE(from_nan.valid);
-  for (const auto value : from_nan.distribution_maxrgb) {
-    EXPECT_EQ(value, 0);
-  }
+  check(hdr10plus_from_luminance(900.0f, 300.0f, 1000, bad));
 
   float negative[] = { 10, 50, 100, 200, -1.0f, 500, 800, 900, 1000 };
-  const auto from_negative = hdr10plus_from_luminance(900.0f, 300.0f, 1000, negative);
-  for (const auto value : from_negative.distribution_maxrgb) {
-    EXPECT_EQ(value, 0);
-  }
+  check(hdr10plus_from_luminance(900.0f, 300.0f, 1000, negative));
+
+  // A bad entry in a reserved slot is still a bad analysis: the CDF goes away
+  // even though that slot's value would have been overwritten anyway.
+  float bad_reserved[] = { 10, -1.0f, 100, 200, 300, 500, 800, 900, 1000 };
+  check(hdr10plus_from_luminance(900.0f, 300.0f, 1000, bad_reserved));
+
+  // Same story with no distribution at all. The serializer emits all nine
+  // percentiles unconditionally, so the reserved slots have to be right even when
+  // the caller never offered a CDF.
+  check(hdr10plus_from_luminance(900.0f, 300.0f, 1000));
 }
 
 TEST(HdrDynamicMetadata, RejectsInvalidHdr10PlusStatsAndOutputBuffers) {

--- a/tests/unit/test_video_hdr_metadata.cpp
+++ b/tests/unit/test_video_hdr_metadata.cpp
@@ -132,10 +132,12 @@ TEST(HdrDynamicMetadata, SerializesAndRoundTripsHdr10PlusT35) {
   EXPECT_EQ(decoded.application_version, video::hdr_metadata::hdr10plus_application_version);
   EXPECT_EQ(decoded.num_windows, 1);
   EXPECT_EQ(av_cmp_q(decoded.targeted_system_display_maximum_luminance, av_make_q(1000, 1)), 0);
-  EXPECT_EQ(av_cmp_q(decoded.params[0].maxscl[0], av_make_q(50000, 100000)), 0);
-  EXPECT_EQ(av_cmp_q(decoded.params[0].maxscl[1], av_make_q(50000, 100000)), 0);
-  EXPECT_EQ(av_cmp_q(decoded.params[0].maxscl[2], av_make_q(50000, 100000)), 0);
-  EXPECT_EQ(av_cmp_q(decoded.params[0].average_maxrgb, av_make_q(10000, 100000)), 0);
+  // 500 nits and 100 nits against the ST 2084 10000-nit reference peak. The
+  // targeted display above is reported separately and must not scale these.
+  EXPECT_EQ(av_cmp_q(decoded.params[0].maxscl[0], av_make_q(5000, 100000)), 0);
+  EXPECT_EQ(av_cmp_q(decoded.params[0].maxscl[1], av_make_q(5000, 100000)), 0);
+  EXPECT_EQ(av_cmp_q(decoded.params[0].maxscl[2], av_make_q(5000, 100000)), 0);
+  EXPECT_EQ(av_cmp_q(decoded.params[0].average_maxrgb, av_make_q(1000, 100000)), 0);
   EXPECT_EQ(decoded.params[0].tone_mapping_flag, 0);
   EXPECT_EQ(decoded.params[0].color_saturation_mapping_flag, 0);
 }
@@ -167,19 +169,74 @@ TEST(HdrDynamicMetadata, CarriesTheNineHdr10PlusPercentiles) {
     EXPECT_EQ(decoded.params[0].distribution_maxrgb[i].percentage,
       video::hdr_metadata::hdr10plus_percentages[i]);
   }
-  // 10 nits and 1000 nits against a 1000 nit target, in units of 1/100000.
+  // 10 nits and 1000 nits against the 10000-nit reference peak, in units of 1/100000.
   EXPECT_EQ(av_cmp_q(decoded.params[0].distribution_maxrgb[0].percentile,
-              av_make_q(1000, 100000)),
+              av_make_q(100, 100000)),
     0);
   EXPECT_EQ(av_cmp_q(decoded.params[0].distribution_maxrgb[8].percentile,
-              av_make_q(100000, 100000)),
+              av_make_q(10000, 100000)),
     0);
-  // The distribution must not decrease across percentiles.
-  for (size_t i = 1; i < video::hdr_metadata::hdr10plus_percentages.size(); ++i) {
-    EXPECT_LE(av_cmp_q(decoded.params[0].distribution_maxrgb[i - 1].percentile,
-                decoded.params[0].distribution_maxrgb[i].percentile),
+
+  // ST 2094-40 8.5.4: the 5% and 10% slots are reserved in application_version 1
+  // and carry fixed values rather than analyzer percentiles.
+  EXPECT_EQ(av_cmp_q(decoded.params[0].distribution_maxrgb[1].percentile,
+              av_make_q(0, 100000)),
+    0);
+  EXPECT_EQ(av_cmp_q(decoded.params[0].distribution_maxrgb[2].percentile,
+              av_make_q(255, 100000)),
+    0);
+
+  // The CDF must not decrease across the slots that are actually part of it.
+  const size_t cdf_indices[] = { 0, 3, 4, 5, 6, 7, 8 };
+  for (size_t i = 1; i < std::size(cdf_indices); ++i) {
+    EXPECT_LE(av_cmp_q(decoded.params[0].distribution_maxrgb[cdf_indices[i - 1]].percentile,
+                decoded.params[0].distribution_maxrgb[cdf_indices[i]].percentile),
       0);
   }
+}
+
+TEST(HdrDynamicMetadata, NormalizesHdr10PlusAgainstTheReferencePeakNotTheDisplay) {
+  // The regression: normalizing content statistics against the target display
+  // scaled every value by 10000/peak, so a client reading maxSCL back as
+  // 10000 x the rational saw a picture up to ten times brighter than it was.
+  // Only targeted_system_display_maximum_luminance may vary with the display.
+  const auto at = [](uint16_t display_nits) {
+    return video::hdr_metadata::hdr10plus_from_luminance(500.0f, 100.0f, display_nits);
+  };
+
+  for (const uint16_t display_nits : { uint16_t { 400 }, uint16_t { 1000 }, uint16_t { 4000 } }) {
+    const auto metadata = at(display_nits);
+    ASSERT_TRUE(metadata.valid);
+    EXPECT_EQ(metadata.maxscl, 5000) << "display peak " << display_nits;
+    EXPECT_EQ(metadata.average_maxrgb, 1000) << "display peak " << display_nits;
+    EXPECT_EQ(metadata.targeted_system_display_maximum_luminance, display_nits);
+  }
+
+  // Content brighter than the display is content, not a clipped signal: it must
+  // survive normalization instead of saturating at the display peak.
+  const auto bright = video::hdr_metadata::hdr10plus_from_luminance(4000.0f, 100.0f, 400);
+  ASSERT_TRUE(bright.valid);
+  EXPECT_EQ(bright.maxscl, 40000);
+}
+
+TEST(HdrDynamicMetadata, ReservesTheHdr10PlusV1AndV2DistributionSlots) {
+  // libplacebo reads a nonzero slot 1 as ST 2094-50 V1, the 99.99% scene
+  // luminance, and prefers the CIE-Y values derived from it over maxSCL. Leaking
+  // the 5th percentile there reports the frame's darkest region as its peak.
+  const float nits[] = { 10, 50, 100, 200, 300, 500, 800, 900, 1000 };
+  const auto metadata =
+    video::hdr_metadata::hdr10plus_from_luminance(900.0f, 300.0f, 1000, nits);
+  ASSERT_TRUE(metadata.valid);
+
+  EXPECT_EQ(metadata.distribution_maxrgb[video::hdr_metadata::hdr10plus_reserved_v1_index],
+    video::hdr_metadata::hdr10plus_reserved_v1);
+  EXPECT_EQ(metadata.distribution_maxrgb[video::hdr_metadata::hdr10plus_reserved_v2_index],
+    video::hdr_metadata::hdr10plus_reserved_v2);
+
+  // Every other slot still carries the analyzer value.
+  EXPECT_EQ(metadata.distribution_maxrgb[0], 100);
+  EXPECT_EQ(metadata.distribution_maxrgb[3], 2000);
+  EXPECT_EQ(metadata.distribution_maxrgb[8], 10000);
 }
 
 TEST(HdrDynamicMetadata, ZeroesTheWholeDistributionOnOneBadEntry) {
@@ -254,8 +311,8 @@ TEST(HdrDynamicMetadata, AppliesHdr10PlusTargetLuminanceFallbackAndClamp) {
 TEST(HdrDynamicMetadata, SharesHdr10PlusNormalizationAcrossEncoderPaths) {
   const auto metadata = video::hdr_metadata::hdr10plus_from_luminance(500.0f, 100.0f, 1000);
   ASSERT_TRUE(metadata.valid);
-  EXPECT_EQ(metadata.maxscl, 50000);
-  EXPECT_EQ(metadata.average_maxrgb, 10000);
+  EXPECT_EQ(metadata.maxscl, 5000);
+  EXPECT_EQ(metadata.average_maxrgb, 1000);
   EXPECT_EQ(metadata.targeted_system_display_maximum_luminance, 1000);
 
   const auto fallback = video::hdr_metadata::hdr10plus_from_luminance(400.0f, 80.0f, 0);


### PR DESCRIPTION
> 基于 #930（`fix/av1-drop-vivid-metadata`）。这里要改的分布表是那个 PR 引入的，无法独立落到 master，所以叠在它上面。#930 合并后本 PR 的 base 会自动切到 master。

## ⚠️ 需要 CI 验证

我在 macOS 上开发，`src/video.cpp`、`src/nvenc/common_impl/nvenc_base.{h,cpp}` 是 Windows/NVENC-only 代码，**本地一行都编译不了**。第二个提交动到这三个文件，请让 CI 过一遍编译。

第一个提交（P0/P2）和 `video_hdr_metadata.h` 里全部逻辑我用独立 harness 验证过：把真文件原样搬到临时目录（`cmp` 校验字节一致），只 stub `platform/common.h`，链 libavutil 跑完整 FFmpeg 往返，**98 checks / 0 failures**。`tests/unit/test_video_hdr_metadata.cpp` 的 gtest 版本本身也没能在本地跑（macOS 上没配好 Sunshine 的 build 树），同样要 CI。

---

## 1. HDR10+ 内容统计归一化基准错了（主要问题）

`hdr10plus_from_luminance()` 拿**目标显示器峰值**做分母归一化 maxSCL、average_maxrgb 和整张 maxRGB 分布表。这三个字段是相对 SMPTE ST 2084 **10000 尼特参考峰值**的绝对内容亮度，消费端直接乘回去还原——libplacebo 的 `pl_map_hdr_metadata` 就是：

\`\`\`c
out->scene_max[0] = 10000 * av_q2d(pars->maxscl[0]);
out->scene_avg    = 10000 * av_q2d(pars->average_maxrgb);
\`\`\`

所以整幅画面被放大了 `10000/峰值` 倍。实测前后对比：

\`\`\`
BEFORE
display 400  -> maxscl=100000  slot1(V1)= 12500  slot2(V2)= 25000
display 4000 -> maxscl= 12500  slot1(V1)=  1250  slot2(V2)=  2500
client reads 500-nit content as: 10000.0 nits (display 400) / 1250.0 nits (display 4000)

AFTER
display 400  -> maxscl=  5000  slot1(V1)=     0  slot2(V2)=   255
display 4000 -> maxscl=  5000  slot1(V1)=     0  slot2(V2)=   255
client reads 500-nit content as: 500.0 nits (display 400) / 500.0 nits (display 4000)
\`\`\`

注意 400 尼特那行 **maxSCL 直接饱和到 100000（=1.0）**——不只是数值偏大，是所有超过显示器峰值的高光被压成一个平值，动态元数据反而比不发更糟。

之所以一直没被发现：VDD 的峰值就等于客户端上报的峰值，两边同一个数，所以从来没人看到"不一致"，只是整体均匀地偏亮。

**这不影响"用客户端上报亮度作为虚拟显示器亮度"的策略。** 那个值照发，只是回到它该在的字段——\`targeted_system_display_maximum_luminance\`，一个独立的、以尼特为单位的非归一化字段。HDR Vivid 一侧本来就是对的（\`vivid_from_stats()\` 全程走 \`nits_to_pq()\`，分母固定 10000），头文件注释里甚至已经写明了这条规则：

> Target display luminance is intentionally not an input: it belongs to display adaptation and optional curve parameters, not to these content statistics.

同一个规则，同一个头文件，Vivid 遵守了，HDR10+ 没有。

## 2. 分布表的两个保留槽位

ST 2094-40 8.5.4 规定 `application_version = 1` 下 5% 和 10% 两个槽位**不属于 CDF**，必须固定写 V1=0.00000、V2=0.00255。ST 2094-50 把同样的槽位重新定义为 V1 = 画面 99.99% 处的场景亮度。libplacebo 正是这么读的：

\`\`\`c
if (data->dhp->application_version == 1 && n == 9 &&
    pars->distribution_maxrgb[1].percentage == 5 &&
    pars->distribution_maxrgb[2].percentage == 10)
{
    const float v1 = av_q2d(pars->distribution_maxrgb[1].percentile);
    if (v1 > 1e-6f) {                    // V1 = 0 是哨兵，告诉消费端回退到 maxSCL
        const float y99_nits = 10000 * v1;
        out->max_pq_y = pl_hdr_rescale(PL_HDR_NITS, PL_HDR_PQ, y99_nits);
\`\`\`

`max_pq_y` 一旦置上，`pl_color_space_nominal_luma_ex` 会**优先采用这组 CIE-Y 值而非 maxSCL**——也就是说第 5 百分位（画面最暗的部分）被当成帧峰值拿去做 tone mapping。而那个 `v1 > 1e-6f` 哨兵正是标准让符合规范的流表达"请回退"的机制，之前被我们踩掉了。

分析器的 5%/10% 百分位现在仍然计算但不上线。槽位保留在表里，好让数组继续和 `hdr10plus_percentages` 及分析器的 `distribution_maxrgb[]` 对齐（有 `static_assert` 钉住）。

## 3. NVENC 路的 HDR10+ 没有任何时间平滑

同一次 NVENC 编码里，Vivid 经过 `vivid_temporal_filter_t` 的 32 帧算术平均，HDR10+ 却直接序列化未平滑的 raw `luminance_stats`。GPU 回读节奏低于编码帧率，所以 maxSCL 和整张分布表会在每次回读时整体跳一格，亮度台阶可见。

`hdr_luminance_ema_t` 之前藏在 `video.cpp` 里，是 avcodec session 的私有成员，NVENC 拿不到。挪进 `video_hdr_metadata.h` 两条路共用，加上 `reset()` 和 `smoothed()`——后者返回一份替换掉平滑字段的 stats，调用方可以把整个结构体交给序列化器。不属于这个滤波器的字段原样透传：`analysis_max_nits`、`sample_sequence`，以及 PQ 域的 `percentile_10/90`（那是 HDR Vivid 的输入，它自己另有平均）。

滤波器状态仍是 session 私有，NVENC 侧在 `vivid_filter.reset()` 旁边一起重置。

## 测试

`tests/unit/test_video_hdr_metadata.cpp` 更新了受影响的期望值，并新增四个用例：

- `NormalizesHdr10PlusAgainstTheReferencePeakNotTheDisplay` — 断言 maxSCL 在 400/1000/4000 尼特三种显示器下**恒定**，且 4000 尼特内容在 400 尼特显示器上不被截断
- `ReservesTheHdr10PlusV1AndV2DistributionSlots`
- `SmoothsHdr10PlusLuminanceAcrossFrames` — 首帧吸附、2× 变化按 ALPHA 混合、超阈值场景切换吸附、reset
- `SmoothedStatsSubstituteOnlyTheFilteredFields`

CDF 单调性检查改成只遍历真正属于 CDF 的槽位。

## 相关

客户端侧 qiin2333/moonlight-qt#164 依赖本 PR。**顺序上 host 必须先修**，否则客户端接上动态元数据就是负收益——把一个放大 10000/峰值 倍、且高光已被压平的信号交给 tone mapping，比现在完全不发更糟。

🤖 Generated with [Claude Code](https://claude.com/claude-code)