### PR TITLE
feat(hdr): AMF 路径支持 HDR10+ / HDR Vivid 动态元数据

### DIFF
--- a/cmake/compile_definitions/common.cmake
+++ b/cmake/compile_definitions/common.cmake
@@ -188,6 +188,8 @@ set(SUNSHINE_TARGET_FILES
         "${CMAKE_SOURCE_DIR}/src/video.h"
         "${CMAKE_SOURCE_DIR}/src/video_hdr_metadata.cpp"
         "${CMAKE_SOURCE_DIR}/src/video_hdr_metadata.h"
+        "${CMAKE_SOURCE_DIR}/src/video_hdr_bitstream.cpp"
+        "${CMAKE_SOURCE_DIR}/src/video_hdr_bitstream.h"
         "${CMAKE_SOURCE_DIR}/src/video_colorspace.cpp"
         "${CMAKE_SOURCE_DIR}/src/video_colorspace.h"
         "${CMAKE_SOURCE_DIR}/src/input.cpp"

--- a/src/amf/amf_d3d11.cpp
+++ b/src/amf/amf_d3d11.cpp
@@ -1348,10 +1348,16 @@ namespace amf {
 
   void
   amf_d3d11::set_hdr_metadata(const std::optional<amf_hdr_metadata> &metadata) {
-    // Remembered even when the encoder is not ready yet: ST 2094-40 normalizes its
-    // luminance fields against the mastering display peak, so the dynamic metadata
-    // builder needs the same value the static metadata was built from.
-    max_display_luminance = metadata ? metadata->maxDisplayLuminance : 0;
+    // Remembered even when the encoder is not ready yet: ST 2094-40 reports the
+    // mastering display peak, so the dynamic metadata builder needs the same value
+    // the static metadata was built from. Held as an optional rather than a plain
+    // peak because a display may legitimately report zero (display_base.cpp copies
+    // DXGI's MaxLuminance verbatim, and the VDD path clamps to a 0 floor); what
+    // gates dynamic metadata is whether HDR was configured at all, mirroring the
+    // `hdr_metadata &&` check on the NVENC side.
+    hdr_display_luminance = metadata ?
+                              std::optional<uint16_t> { metadata->maxDisplayLuminance } :
+                              std::nullopt;
 
     if (!encoder || !context) return;
 
@@ -1408,13 +1414,15 @@ namespace amf {
 
   void
   amf_d3d11::stage_dynamic_metadata(uint64_t frame_index) {
-    // No carriage for this codec, no mastering peak to normalize against, or nothing
-    // this stream may emit: the frame goes out as the encoder produced it.
-    if (!dynamic_metadata_codec || max_display_luminance == 0 || !luminance_stats.valid) {
+    // No carriage for this codec, HDR never configured, or nothing this stream may
+    // emit: the frame goes out as the encoder produced it. A zero display peak is
+    // not a reason to skip — hdr10plus_from_luminance() falls back to 1000 nits for
+    // the targeted system display, and HDR Vivid never reads the value.
+    if (!dynamic_metadata_codec || !hdr_display_luminance || !luminance_stats.valid) {
       return;
     }
 
-    const auto payloads = dynamic_metadata.build(luminance_stats, max_display_luminance);
+    const auto payloads = dynamic_metadata.build(luminance_stats, *hdr_display_luminance);
     if (payloads.empty()) {
       return;
     }

--- a/src/amf/amf_d3d11.cpp
+++ b/src/amf/amf_d3d11.cpp
@@ -837,6 +837,21 @@ namespace amf {
     consecutive_submit_failures = 0;
     consecutive_empty_outputs = 0;
 
+    // Reset dynamic HDR metadata state so a recreated encoder cannot inherit the
+    // previous stream's temporal history or stale per-frame units.
+    dynamic_metadata_codec = video::hdr_bitstream::codec_for(video_format);
+    dynamic_metadata.configure(video::hdr_metadata::formats_for(colorspace, video_format));
+    dynamic_metadata.reset();
+    luminance_stats = {};
+    staged_metadata_units.clear();
+    if (dynamic_metadata_codec && (dynamic_metadata.formats().hdr10plus || dynamic_metadata.formats().vivid)) {
+      BOOST_LOG(info) << "AMF: dynamic HDR metadata enabled ("
+                      << (dynamic_metadata.formats().hdr10plus ? "HDR10+" : "")
+                      << (dynamic_metadata.formats().hdr10plus && dynamic_metadata.formats().vivid ? " + " : "")
+                      << (dynamic_metadata.formats().vivid ? "HDR Vivid" : "")
+                      << "), spliced into the encoded bitstream";
+    }
+
     auto codec_name = (video_format == 0) ? "H.264" :
                       (video_format == 1) ? "HEVC" :
                       (video_format == 2) ? "AV1" : "Unknown";
@@ -851,6 +866,9 @@ namespace amf {
   amf_d3d11::destroy_encoder() {
     pending_outputs.clear();
     frame_rfi_flags.clear();
+    staged_metadata_units.clear();
+    dynamic_metadata.reset();
+    luminance_stats = {};
     hwsurfaces_in_queue = 0;
     avcodec_scheduler.reset();
     if (encoder) {
@@ -984,6 +1002,7 @@ namespace amf {
     }
 
     frame_rfi_flags[frame_index] = frame_after_ref_frame_invalidation;
+    stage_dynamic_metadata(frame_index);
 
     ::amf::AMFDataPtr output_data;
     if (avcodec_compat_profile) {
@@ -995,7 +1014,7 @@ namespace amf {
                            << (res == AMF_INPUT_FULL ? "AMF_INPUT_FULL" : "AMF_DECODER_NO_FREE_SURFACES")
                            << " after retries, dropping frame " << frame_index
                            << " (in_flight=" << avcodec_scheduler.in_flight() << ")";
-        frame_rfi_flags.erase(frame_index);
+        forget_frame(frame_index);
         if (++consecutive_submit_failures >= max_consecutive_failures) {
           BOOST_LOG(error) << "AMF: " << consecutive_submit_failures
                            << " consecutive frames with AVCodec scheduler input exhaustion, signaling reinit";
@@ -1011,7 +1030,7 @@ namespace amf {
 
       if (res != AMF_OK) {
         BOOST_LOG(error) << "AMF: AVCodec scheduler SubmitInput failed, error: " << res;
-        frame_rfi_flags.erase(frame_index);
+        forget_frame(frame_index);
         if (device) {
           auto removed_reason = device->GetDeviceRemovedReason();
           if (removed_reason != S_OK) {
@@ -1086,7 +1105,7 @@ namespace amf {
         BOOST_LOG(warning) << "AMF: SubmitInput still " << (res == AMF_INPUT_FULL ? "AMF_INPUT_FULL" : "AMF_DECODER_NO_FREE_SURFACES")
                            << " after retries, dropping frame " << frame_index
                            << " (in_flight=" << hwsurfaces_in_queue << ")";
-        frame_rfi_flags.erase(frame_index);
+        forget_frame(frame_index);
         // Treat sustained INPUT_FULL exhaustion as a submit failure for the
         // watchdog: if the pipeline stays jammed for ~1s of frames the upper
         // layer will reinit instead of silently producing no output forever.
@@ -1109,7 +1128,7 @@ namespace amf {
     }
     if (res != AMF_OK) {
       BOOST_LOG(error) << "AMF: SubmitInput failed, error: " << res;
-      frame_rfi_flags.erase(frame_index);
+      forget_frame(frame_index);
       // Check if the D3D11 device is lost (TDR, driver crash, etc.)
       if (device) {
         auto removed_reason = device->GetDeviceRemovedReason();
@@ -1170,7 +1189,7 @@ namespace amf {
       result.after_ref_frame_invalidation = rfi_flag->second;
       frame_rfi_flags.erase(rfi_flag);
     }
-    while (frame_rfi_flags.size() > 256) {
+    while (frame_rfi_flags.size() > MAX_TRACKED_FRAMES) {
       frame_rfi_flags.erase(frame_rfi_flags.begin());
     }
 
@@ -1184,6 +1203,23 @@ namespace amf {
     auto data_ptr = static_cast<uint8_t *>(buffer->GetNative());
     auto data_size = buffer->GetSize();
     result.data.assign(data_ptr, data_ptr + data_size);
+
+    // Splice this frame's dynamic HDR metadata into the finished bitstream. A frame
+    // whose units cannot be placed (a header-only access unit, or an AV1 temporal
+    // unit that cannot be walked) is sent unchanged rather than dropped: losing a
+    // frame is worse than a frame without dynamic metadata.
+    auto staged = staged_metadata_units.find(result.frame_index);
+    if (staged != staged_metadata_units.end()) {
+      if (dynamic_metadata_codec &&
+          !video::hdr_bitstream::insert(*dynamic_metadata_codec, staged->second, result.data)) {
+        BOOST_LOG(debug) << "AMF: no insertion point for dynamic HDR metadata in frame "
+                         << result.frame_index << ", sending it without";
+      }
+      staged_metadata_units.erase(staged);
+    }
+    while (staged_metadata_units.size() > MAX_TRACKED_FRAMES) {
+      staged_metadata_units.erase(staged_metadata_units.begin());
+    }
 
     // Check if output frame is IDR
     amf_int64 output_type = 0;
@@ -1312,6 +1348,11 @@ namespace amf {
 
   void
   amf_d3d11::set_hdr_metadata(const std::optional<amf_hdr_metadata> &metadata) {
+    // Remembered even when the encoder is not ready yet: ST 2094-40 normalizes its
+    // luminance fields against the mastering display peak, so the dynamic metadata
+    // builder needs the same value the static metadata was built from.
+    max_display_luminance = metadata ? metadata->maxDisplayLuminance : 0;
+
     if (!encoder || !context) return;
 
     if (metadata && video_format >= 0) {
@@ -1358,6 +1399,41 @@ namespace amf {
   void *
   amf_d3d11::get_input_texture() {
     return input_texture;
+  }
+
+  void
+  amf_d3d11::set_luminance_stats(const platf::hdr_frame_luminance_stats_t &stats) {
+    luminance_stats = stats;
+  }
+
+  void
+  amf_d3d11::stage_dynamic_metadata(uint64_t frame_index) {
+    // No carriage for this codec, no mastering peak to normalize against, or nothing
+    // this stream may emit: the frame goes out as the encoder produced it.
+    if (!dynamic_metadata_codec || max_display_luminance == 0 || !luminance_stats.valid) {
+      return;
+    }
+
+    const auto payloads = dynamic_metadata.build(luminance_stats, max_display_luminance);
+    if (payloads.empty()) {
+      return;
+    }
+
+    std::vector<uint8_t> units;
+    for (auto payload : { payloads.hdr10plus, payloads.vivid }) {
+      if (!payload.empty()) {
+        video::hdr_bitstream::append_t35_unit(*dynamic_metadata_codec, payload, units);
+      }
+    }
+    if (!units.empty()) {
+      staged_metadata_units[frame_index] = std::move(units);
+    }
+  }
+
+  void
+  amf_d3d11::forget_frame(uint64_t frame_index) {
+    frame_rfi_flags.erase(frame_index);
+    staged_metadata_units.erase(frame_index);
   }
 
   std::unique_ptr<amf_d3d11>

--- a/src/amf/amf_d3d11.h
+++ b/src/amf/amf_d3d11.h
@@ -7,6 +7,9 @@
 #include "amf_avcodec_compat.h"
 #include "amf_encoder.h"
 
+#include "src/video_hdr_bitstream.h"
+#include "src/video_hdr_metadata.h"
+
 #include <d3d11.h>
 #include <deque>
 #include <memory>
@@ -49,6 +52,9 @@ namespace amf {
     void
     set_hdr_metadata(const std::optional<amf_hdr_metadata> &metadata) override;
 
+    void
+    set_luminance_stats(const platf::hdr_frame_luminance_stats_t &stats) override;
+
     void *
     get_input_texture() override;
 
@@ -73,6 +79,18 @@ namespace amf {
     template<typename T>
     void
     set_codec_property(const wchar_t *h264_name, const wchar_t *hevc_name, const wchar_t *av1_name, T value);
+
+    /**
+     * Serialize the current luminance stats into codec-specific bitstream units and
+     * remember them for this frame index, so the units can be spliced into the
+     * matching output however many frames later AMF produces it.
+     */
+    void
+    stage_dynamic_metadata(uint64_t frame_index);
+
+    /// Drop everything remembered for a frame that was dropped or has been emitted.
+    void
+    forget_frame(uint64_t frame_index);
 
     ID3D11Device *device = nullptr;
     ::amf::AMFFactory *factory = nullptr;
@@ -111,6 +129,21 @@ namespace amf {
     // Pending outputs stashed during SubmitInput retry or proactive backpressure drain
     std::deque<::amf::AMFDataPtr> pending_outputs;
     std::unordered_map<uint64_t, bool> frame_rfi_flags;
+
+    // Dynamic HDR metadata (HDR10+ / HDR Vivid). AMF exposes only static
+    // AMFHDRMetadata, so the payloads are written as an HEVC prefix SEI or an AV1
+    // metadata OBU and spliced into the encoder's output.
+    //
+    // The units are built when the frame is submitted, where the analyzer output
+    // still belongs to that frame, and keyed by frame index because AMF may return
+    // the encoded frame several submissions later. Trimmed like frame_rfi_flags so a
+    // stream that keeps dropping frames cannot grow the map without bound.
+    std::optional<video::hdr_bitstream::codec_e> dynamic_metadata_codec;
+    video::hdr_metadata::dynamic_metadata_builder_t dynamic_metadata;
+    platf::hdr_frame_luminance_stats_t luminance_stats {};
+    uint16_t max_display_luminance = 0;
+    std::unordered_map<uint64_t, std::vector<uint8_t>> staged_metadata_units;
+    static constexpr size_t MAX_TRACKED_FRAMES = 256;
 
     // FFmpeg-style proactive backpressure: track in-flight surfaces (submitted
     // but not yet retrieved via QueryOutput) so we can drain output BEFORE

--- a/src/amf/amf_d3d11.h
+++ b/src/amf/amf_d3d11.h
@@ -141,7 +141,7 @@ namespace amf {
     std::optional<video::hdr_bitstream::codec_e> dynamic_metadata_codec;
     video::hdr_metadata::dynamic_metadata_builder_t dynamic_metadata;
     platf::hdr_frame_luminance_stats_t luminance_stats {};
-    uint16_t max_display_luminance = 0;
+    std::optional<uint16_t> hdr_display_luminance;
     std::unordered_map<uint64_t, std::vector<uint8_t>> staged_metadata_units;
     static constexpr size_t MAX_TRACKED_FRAMES = 256;
 

--- a/src/amf/amf_encoder.h
+++ b/src/amf/amf_encoder.h
@@ -73,6 +73,19 @@ namespace amf {
     set_hdr_metadata(const std::optional<amf_hdr_metadata> &metadata) = 0;
 
     /**
+     * @brief Provide this frame's HDR luminance analysis for dynamic metadata.
+     *
+     * Called before encode_frame() for the frame the stats describe. AMF has no
+     * dynamic-metadata API, so the encoder serializes the payloads itself and
+     * splices them into the output bitstream; stats for a frame that is never
+     * submitted are simply superseded by the next call.
+     *
+     * @param stats Per-frame luminance analysis; an invalid one emits nothing.
+     */
+    virtual void
+    set_luminance_stats(const platf::hdr_frame_luminance_stats_t &stats) = 0;
+
+    /**
      * @brief Get the D3D11 input texture the encoder reads from.
      * @return Pointer to ID3D11Texture2D, or nullptr.
      */

--- a/src/nvenc/common_impl/nvenc_base.cpp
+++ b/src/nvenc/common_impl/nvenc_base.cpp
@@ -106,7 +106,8 @@ namespace nvenc {
 
     if (encoder) destroy_encoder();
     auto fail_guard = util::fail_guard([this] { destroy_encoder(); });
-    dynamic_hdr_formats = video::hdr_metadata::formats_for(sunshine_colorspace, client_config.videoFormat);
+    dynamic_metadata.configure(
+      video::hdr_metadata::formats_for(sunshine_colorspace, client_config.videoFormat));
 
     auto colorspace = nvenc_colorspace_from_sunshine_colorspace(sunshine_colorspace);
     auto buffer_format = nvenc_format_from_sunshine_format(sunshine_buffer_format);
@@ -760,10 +761,9 @@ namespace nvenc {
 
     encoder_state = {};
     encoder_params = {};
-    dynamic_hdr_formats = {};
     luminance_stats = {};
-    vivid_filter.reset();
-    hdr10plus_ema.reset();
+    dynamic_metadata.configure({});
+    dynamic_metadata.reset();
   }
 
   nvenc_encoded_frame
@@ -845,36 +845,20 @@ namespace nvenc {
 #endif
 
     // Inject HDR10+ and/or Vivid dynamic metadata as custom SEI/OBU payloads
-    std::array<uint8_t, video::hdr_metadata::hdr10plus_t35_max_payload_size> hdr10plus_payload {};
-    std::vector<uint8_t> vivid_payload;
     NV_ENC_SEI_PAYLOAD dynamic_payloads[2] = {};
     uint32_t dynamic_payload_count = 0;
 
     if (luminance_stats.valid && hdr_metadata && (video_format == 1 || video_format == 2)) {
-      uint16_t max_lum = hdr_metadata->maxDisplayLuminance;
-      const auto vivid_metadata = vivid_filter.update(luminance_stats);
-      hdr10plus_ema.update(luminance_stats);
-
-      // HDR10+ (PQ only — HDR10+ requires absolute luminance)
-      size_t hdr10plus_payload_size = 0;
-      if (dynamic_hdr_formats.hdr10plus) {
-        hdr10plus_payload_size = video::hdr_metadata::serialize_hdr10plus_t35(
-          hdr10plus_ema.smoothed(luminance_stats), max_lum, hdr10plus_payload);
-      }
-      if (hdr10plus_payload_size > 0) {
-        dynamic_payloads[dynamic_payload_count].payloadSize =
-          static_cast<uint32_t>(hdr10plus_payload_size);
+      // The payloads live in dynamic_metadata until the next frame, which outlasts
+      // the nvEncEncodePicture() call below.
+      const auto payloads = dynamic_metadata.build(luminance_stats, hdr_metadata->maxDisplayLuminance);
+      for (auto payload : { payloads.hdr10plus, payloads.vivid }) {
+        if (payload.empty()) {
+          continue;
+        }
+        dynamic_payloads[dynamic_payload_count].payloadSize = static_cast<uint32_t>(payload.size());
         dynamic_payloads[dynamic_payload_count].payloadType = 4;  // registered ITU-T T.35
-        dynamic_payloads[dynamic_payload_count].payload = hdr10plus_payload.data();
-        dynamic_payload_count++;
-      }
-
-      // HDR Vivid (both PQ and HLG)
-      if (dynamic_hdr_formats.vivid &&
-          video::hdr_metadata::serialize_vivid_t35(vivid_metadata, vivid_payload) > 0) {
-        dynamic_payloads[dynamic_payload_count].payloadSize = static_cast<uint32_t>(vivid_payload.size());
-        dynamic_payloads[dynamic_payload_count].payloadType = 4;  // registered ITU-T T.35
-        dynamic_payloads[dynamic_payload_count].payload = vivid_payload.data();
+        dynamic_payloads[dynamic_payload_count].payload = const_cast<uint8_t *>(payload.data());
         dynamic_payload_count++;
       }
 

--- a/src/nvenc/common_impl/nvenc_base.h
+++ b/src/nvenc/common_impl/nvenc_base.h
@@ -140,11 +140,7 @@ namespace nvenc {
 
     // Per-frame HDR luminance stats for dynamic metadata
     platf::hdr_frame_luminance_stats_t luminance_stats;
-    video::hdr_metadata::formats_t dynamic_hdr_formats;
-    video::hdr_metadata::vivid_temporal_filter_t vivid_filter;
-    // HDR10+ needs its own smoothing: vivid_filter averages in the PQ code-value
-    // domain, while the ST 2094-40 fields are built from luminance in nits.
-    video::hdr_metadata::hdr_luminance_ema_t hdr10plus_ema;
+    video::hdr_metadata::dynamic_metadata_builder_t dynamic_metadata;
 
   };
 }

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -575,6 +575,7 @@ namespace platf {
     init_encoder(const video::config_t &client_config, const video::sunshine_colorspace_t &colorspace, bool is_probe = false) = 0;
 
     amf::amf_encoder *amf = nullptr;
+    bool hdr_luminance_analysis_available = false;
   };
 
   enum class capture_e : int {

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -2745,7 +2745,13 @@ namespace platf::dxgi {
       if (!amf_d3d->create_encoder(amf_cfg, effective_config, colorspace, buffer_format)) return false;
 
       base.apply_colorspace(colorspace);
-      return base.init_output(static_cast<ID3D11Texture2D *>(amf_d3d->get_input_texture()), client_config.width, client_config.height, colorspace, is_probe) == 0;
+      hdr_luminance_analysis_available = false;
+      if (base.init_output(static_cast<ID3D11Texture2D *>(amf_d3d->get_input_texture()), client_config.width, client_config.height, colorspace, is_probe) != 0) {
+        return false;
+      }
+
+      hdr_luminance_analysis_available = base.hdr_luminance_analysis_available();
+      return true;
     }
 
     int

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -678,22 +678,62 @@ namespace video {
     int inject;
   };
 
+  /**
+   * Whether the HDR luminance analyzer can be trusted to produce samples for this
+   * encode device: the user has not turned it off and the capture backend actually
+   * implements it.
+   */
+  inline bool
+  hdr_luminance_analysis_usable(bool device_supports_analysis) {
+    return config::video.hdr_luminance_analysis != "off" && device_supports_analysis;
+  }
+
+  /**
+   * Report a vivid_startup_gate_t transition. Shared so the two native encoder
+   * paths cannot drift into describing the same decision differently in the log.
+   */
+  void
+  log_vivid_gate_transition(
+    const char *encoder_name,
+    hdr_metadata::vivid_startup_gate_t::transition_e transition,
+    const hdr_metadata::vivid_startup_gate_t &gate,
+    const platf::hdr_frame_luminance_stats_t &stats) {
+    using transition_e = hdr_metadata::vivid_startup_gate_t::transition_e;
+
+    switch (transition) {
+      case transition_e::ready:
+        BOOST_LOG(info) << encoder_name << ": HDR Vivid startup guard ready after "
+                        << gate.consecutive_samples()
+                        << " independent samples; first encoded HLG frame will be IDR with Vivid"
+                        << " (avg=" << stats.avg_maxrgb
+                        << " nits, max=" << stats.max_maxrgb
+                        << " nits, P10=" << stats.percentile_10_pq
+                        << ", P90=" << stats.percentile_90_pq << ')';
+        break;
+      case transition_e::timed_out:
+        BOOST_LOG(warning) << encoder_name << ": HDR Vivid startup guard timed out after "
+                           << hdr_metadata::vivid_startup_gate_t::PREROLL_TIMEOUT.count()
+                           << " ms; starting this session as pure HLG without dynamic metadata";
+        break;
+      case transition_e::none:
+        break;
+    }
+  }
+
   class nvenc_encode_session_t: public encode_session_t {
   public:
     nvenc_encode_session_t(std::unique_ptr<platf::nvenc_encode_device_t> encode_device, int video_format):
-        device(std::move(encode_device)) {
-      const bool use_hlg = device && colorspace_is_hlg(device->colorspace);
-      if (use_hlg) {
-        const bool analysis_available =
-          config::video.hdr_luminance_analysis != "off" &&
-          device->hdr_luminance_analysis_available;
-        vivid_metadata_mode =
-          hdr_metadata::needs_vivid_startup_preroll(device->colorspace, video_format, analysis_available) ?
-            vivid_metadata_mode_e::preroll :
-            vivid_metadata_mode_e::disabled;
-      }
-      if (vivid_metadata_mode == vivid_metadata_mode_e::preroll) {
-        BOOST_LOG(info) << "NVENC: holding HLG startup for stable HDR Vivid metadata (3 independent samples, 500 ms timeout)";
+        device(std::move(encode_device)),
+        vivid_gate(
+          device ? device->colorspace : sunshine_colorspace_t {},
+          video_format,
+          device && hdr_luminance_analysis_usable(device->hdr_luminance_analysis_available)) {
+      if (vivid_gate.prerolling()) {
+        BOOST_LOG(info) << "NVENC: holding HLG startup for stable HDR Vivid metadata ("
+                        << hdr_metadata::vivid_startup_guard_t::REQUIRED_SAMPLES
+                        << " independent samples, "
+                        << hdr_metadata::vivid_startup_gate_t::PREROLL_TIMEOUT.count()
+                        << " ms timeout)";
       }
     }
 
@@ -790,40 +830,23 @@ namespace video {
     encode_frame(uint64_t frame_index) {
       if (!device || !device->nvenc) return {};
 
-      if (vivid_metadata_mode == vivid_metadata_mode_e::preroll) {
-        const auto now = std::chrono::steady_clock::now();
-        if (!vivid_preroll_started) {
-          vivid_preroll_started = now;
-        }
-
-        if (vivid_startup_guard.observe(device->hdr_luminance_stats)) {
-          vivid_metadata_mode = vivid_metadata_mode_e::enabled;
-          force_idr = true;
-          const auto &stats = device->hdr_luminance_stats;
-          BOOST_LOG(info) << "NVENC: HDR Vivid startup guard ready after "
-                          << vivid_startup_guard.consecutive_samples()
-                          << " independent samples; first encoded HLG frame will be IDR with Vivid"
-                          << " (avg=" << stats.avg_maxrgb
-                          << " nits, max=" << stats.max_maxrgb
-                          << " nits, P10=" << stats.percentile_10_pq
-                          << ", P90=" << stats.percentile_90_pq << ')';
-        }
-        else if (now - *vivid_preroll_started >= VIVID_PREROLL_TIMEOUT) {
-          vivid_metadata_mode = vivid_metadata_mode_e::disabled;
-          force_idr = true;
-          BOOST_LOG(warning) << "NVENC: HDR Vivid startup guard timed out after 500 ms; "
-                                "starting this session as pure HLG without dynamic metadata";
-        }
-        else {
-          // Keep converting capture frames so the asynchronous GPU analyzer can
-          // produce independent samples, but do not let the client see a plain-HLG
-          // IDR followed by a mid-stream transition into HDR Vivid.
-          return { {}, frame_index, false, false };
-        }
+      using decision_e = hdr_metadata::vivid_startup_gate_t::decision_e;
+      const auto gated = vivid_gate.observe(device->hdr_luminance_stats, std::chrono::steady_clock::now());
+      if (gated.transition != hdr_metadata::vivid_startup_gate_t::transition_e::none) {
+        // The stream's metadata content changes here, so the client needs a fresh
+        // IDR rather than a P frame that references pre-transition pictures.
+        force_idr = true;
+        log_vivid_gate_transition("NVENC", gated.transition, vivid_gate, device->hdr_luminance_stats);
+      }
+      if (gated.decision == decision_e::hold) {
+        // Keep converting capture frames so the asynchronous GPU analyzer can
+        // produce independent samples, but do not let the client see a plain-HLG
+        // IDR followed by a mid-stream transition into HDR Vivid.
+        return { {}, frame_index, false, false };
       }
 
       // Pass per-frame HDR luminance stats to NVENC for dynamic metadata injection
-      if (vivid_metadata_mode != vivid_metadata_mode_e::disabled && device->hdr_luminance_stats.valid) {
+      if (gated.decision == decision_e::emit && device->hdr_luminance_stats.valid) {
         device->nvenc->set_luminance_stats(device->hdr_luminance_stats);
       }
 
@@ -851,26 +874,27 @@ namespace video {
     }
 
   private:
-    static constexpr auto VIVID_PREROLL_TIMEOUT = std::chrono::milliseconds { 500 };
-
-    enum class vivid_metadata_mode_e {
-      enabled,
-      preroll,
-      disabled,
-    };
-
     std::unique_ptr<platf::nvenc_encode_device_t> device;
     frame_timestamp_ring_t frame_timestamps;
-    hdr_metadata::vivid_startup_guard_t vivid_startup_guard;
-    std::optional<std::chrono::steady_clock::time_point> vivid_preroll_started;
-    vivid_metadata_mode_e vivid_metadata_mode = vivid_metadata_mode_e::enabled;
+    hdr_metadata::vivid_startup_gate_t vivid_gate;
     bool force_idr = false;
   };
 
   class amf_encode_session_t: public encode_session_t {
   public:
-    amf_encode_session_t(std::unique_ptr<platf::amf_encode_device_t> encode_device):
-        device(std::move(encode_device)) {
+    amf_encode_session_t(std::unique_ptr<platf::amf_encode_device_t> encode_device, int video_format):
+        device(std::move(encode_device)),
+        vivid_gate(
+          device ? device->colorspace : sunshine_colorspace_t {},
+          video_format,
+          device && hdr_luminance_analysis_usable(device->hdr_luminance_analysis_available)) {
+      if (vivid_gate.prerolling()) {
+        BOOST_LOG(info) << "AMF: holding HLG startup for stable HDR Vivid metadata ("
+                        << hdr_metadata::vivid_startup_guard_t::REQUIRED_SAMPLES
+                        << " independent samples, "
+                        << hdr_metadata::vivid_startup_gate_t::PREROLL_TIMEOUT.count()
+                        << " ms timeout)";
+      }
     }
 
     int
@@ -931,6 +955,24 @@ namespace video {
     encode_frame(uint64_t frame_index) {
       if (!device || !device->amf) return {};
 
+      using decision_e = hdr_metadata::vivid_startup_gate_t::decision_e;
+      const auto gated = vivid_gate.observe(device->hdr_luminance_stats, std::chrono::steady_clock::now());
+      if (gated.transition != hdr_metadata::vivid_startup_gate_t::transition_e::none) {
+        force_idr = true;
+        log_vivid_gate_transition("AMF", gated.transition, vivid_gate, device->hdr_luminance_stats);
+      }
+      if (gated.decision == decision_e::hold) {
+        // Same reasoning as NVENC: keep converting so the analyzer converges, but
+        // do not let the client see plain HLG before the switch into Vivid.
+        amf::amf_encoded_frame held;
+        held.frame_index = frame_index;
+        return held;
+      }
+
+      if (gated.decision == decision_e::emit && device->hdr_luminance_stats.valid) {
+        device->amf->set_luminance_stats(device->hdr_luminance_stats);
+      }
+
       auto result = device->amf->encode_frame(frame_index, force_idr);
       force_idr = false;
       return result;
@@ -957,6 +999,7 @@ namespace video {
   private:
     std::unique_ptr<platf::amf_encode_device_t> device;
     frame_timestamp_ring_t frame_timestamps;
+    hdr_metadata::vivid_startup_gate_t vivid_gate;
     bool force_idr = false;
   };
 
@@ -2869,7 +2912,7 @@ namespace video {
       }
     }
 
-    return std::make_unique<amf_encode_session_t>(std::move(encode_device));
+    return std::make_unique<amf_encode_session_t>(std::move(encode_device), client_config.videoFormat);
   }
 
   std::unique_ptr<encode_session_t>

--- a/src/video_hdr_bitstream.cpp
+++ b/src/video_hdr_bitstream.cpp
@@ -1,0 +1,259 @@
+/**
+ * @file src/video_hdr_bitstream.cpp
+ * @brief HEVC prefix SEI and AV1 metadata OBU writers for ITU-T T.35 payloads.
+ */
+#include "video_hdr_bitstream.h"
+
+namespace video::hdr_bitstream {
+
+  namespace {
+
+    // H.265 table 7-1: nal_unit_type 39 is PREFIX_SEI_NUT. Types 0..31 are the VCL
+    // types, which is what makes "first NAL with type <= 31" the picture data.
+    constexpr uint8_t hevc_prefix_sei_nut = 39;
+    constexpr uint8_t hevc_last_vcl_nut = 31;
+
+    // H.265 D.2.1: user_data_registered_itu_t_t35.
+    constexpr uint8_t sei_payload_type_t35 = 4;
+
+    // AV1 6.2.2 (OBU types) and 6.7.1 (metadata types).
+    constexpr uint8_t obu_type_frame_header = 3;
+    constexpr uint8_t obu_type_tile_group = 4;
+    constexpr uint8_t obu_type_metadata = 5;
+    constexpr uint8_t obu_type_frame = 6;
+    constexpr uint8_t obu_type_redundant_frame_header = 7;
+    constexpr uint8_t metadata_type_itut_t35 = 4;
+
+    // H.265 7.4.1.1 / AV1 5.3.4: a byte-aligned RBSP or OBU payload is terminated
+    // by a single one bit followed by zero bits.
+    constexpr uint8_t trailing_bits_byte = 0x80;
+
+    /**
+     * Append an RBSP as a NAL unit payload with emulation prevention bytes.
+     *
+     * H.265 7.4.2: an 0x03 is inserted whenever two zero bytes would otherwise be
+     * followed by a byte in 0x00..0x03, which is what keeps a payload from
+     * impersonating a start code prefix. The zero run starts at zero because the
+     * second NAL header byte this always follows is nonzero (nuh_temporal_id_plus1
+     * is at least 1), so no run can carry over from the header.
+     */
+    void
+    append_escaped_rbsp(std::span<const uint8_t> rbsp, std::vector<uint8_t> &out) {
+      int zero_run = 0;
+      for (uint8_t byte : rbsp) {
+        if (zero_run == 2 && byte <= 0x03) {
+          out.push_back(0x03);
+          zero_run = 0;
+        }
+        out.push_back(byte);
+        zero_run = (byte == 0x00) ? zero_run + 1 : 0;
+      }
+    }
+
+    /**
+     * Append a value in the ff-byte form H.265 D.2.1 uses for payloadType and
+     * payloadSize: as many 0xFF bytes as fit, then the remainder.
+     */
+    void
+    append_ff_coded(size_t value, std::vector<uint8_t> &out) {
+      while (value >= 0xFF) {
+        out.push_back(0xFF);
+        value -= 0xFF;
+      }
+      out.push_back(static_cast<uint8_t>(value));
+    }
+
+    /// AV1 4.10.5 leb128().
+    void
+    append_leb128(uint64_t value, std::vector<uint8_t> &out) {
+      do {
+        uint8_t byte = value & 0x7F;
+        value >>= 7;
+        if (value != 0) {
+          byte |= 0x80;
+        }
+        out.push_back(byte);
+      } while (value != 0);
+    }
+
+    /**
+     * Read a leb128 from offset, advancing it past the value.
+     *
+     * Returns nullopt on a truncated buffer or a value that runs past the eight
+     * bytes AV1 4.10.5 allows, both of which mean the buffer cannot be walked.
+     */
+    std::optional<uint64_t>
+    read_leb128(std::span<const uint8_t> data, size_t &offset) {
+      uint64_t value = 0;
+      for (int index = 0; index < 8; ++index) {
+        if (offset >= data.size()) {
+          return std::nullopt;
+        }
+        const uint8_t byte = data[offset++];
+        value |= static_cast<uint64_t>(byte & 0x7F) << (index * 7);
+        if ((byte & 0x80) == 0) {
+          return value;
+        }
+      }
+      return std::nullopt;
+    }
+
+    bool
+    append_hevc_prefix_sei(std::span<const uint8_t> t35, std::vector<uint8_t> &out) {
+      // Build the RBSP first so payloadSize describes the payload before escaping,
+      // which is the length a decoder recovers after it strips the 0x03 bytes.
+      std::vector<uint8_t> rbsp;
+      rbsp.reserve(t35.size() + 8);
+      append_ff_coded(sei_payload_type_t35, rbsp);
+      append_ff_coded(t35.size(), rbsp);
+      rbsp.insert(rbsp.end(), t35.begin(), t35.end());
+      rbsp.push_back(trailing_bits_byte);
+
+      // A four-byte start code, so the boundary stays unambiguous no matter what
+      // the byte before the splice point is.
+      out.insert(out.end(), { 0x00, 0x00, 0x00, 0x01 });
+      out.push_back(static_cast<uint8_t>(hevc_prefix_sei_nut << 1));  // forbidden_zero_bit 0
+      out.push_back(0x01);  // nuh_layer_id 0, nuh_temporal_id_plus1 1
+      append_escaped_rbsp(rbsp, out);
+      return true;
+    }
+
+    bool
+    append_av1_metadata_obu(std::span<const uint8_t> t35, std::vector<uint8_t> &out) {
+      // AV1 5.8.1: metadata_type, then the type's payload, then trailing bits.
+      std::vector<uint8_t> payload;
+      payload.reserve(t35.size() + 2);
+      append_leb128(metadata_type_itut_t35, payload);
+      payload.insert(payload.end(), t35.begin(), t35.end());
+      payload.push_back(trailing_bits_byte);
+
+      // AV1 5.3.2 obu_header: obu_forbidden_bit 0, obu_type, obu_extension_flag 0,
+      // obu_has_size_field 1, obu_reserved_1bit 0. No extension means temporal_id
+      // and spatial_id are 0, which matches the single-layer stream Sunshine sends.
+      out.push_back(static_cast<uint8_t>((obu_type_metadata << 3) | 0x02));
+      append_leb128(payload.size(), out);
+      out.insert(out.end(), payload.begin(), payload.end());
+      return true;
+    }
+
+    /**
+     * Offset of the first VCL NAL unit's start code prefix.
+     *
+     * The offset points at the 0x000001 prefix rather than at any zero byte in
+     * front of it. Backing up would risk claiming a byte that belongs to the
+     * previous NAL — cabac_zero_words and trailing_zero_8bits both let a NAL end
+     * in zeros — and it is not needed: the inserted unit carries its own four-byte
+     * start code, so the extra zeros simply become leading zeros ahead of it.
+     */
+    std::optional<size_t>
+    hevc_insert_offset(std::span<const uint8_t> au) {
+      for (size_t offset = 0; offset + 3 <= au.size();) {
+        if (au[offset] != 0x00 || au[offset + 1] != 0x00 || au[offset + 2] != 0x01) {
+          ++offset;
+          continue;
+        }
+
+        const size_t header = offset + 3;
+        if (header >= au.size()) {
+          return std::nullopt;
+        }
+        if (((au[header] >> 1) & 0x3F) <= hevc_last_vcl_nut) {
+          return offset;
+        }
+        offset = header + 1;
+      }
+      return std::nullopt;
+    }
+
+    /// Offset of the first OBU that carries picture data.
+    std::optional<size_t>
+    av1_insert_offset(std::span<const uint8_t> tu) {
+      size_t offset = 0;
+      while (offset < tu.size()) {
+        const uint8_t header = tu[offset];
+        if ((header & 0x80) != 0) {
+          return std::nullopt;  // obu_forbidden_bit set: not an OBU stream
+        }
+
+        switch ((header >> 3) & 0x0F) {
+          case obu_type_frame_header:
+          case obu_type_tile_group:
+          case obu_type_frame:
+          case obu_type_redundant_frame_header:
+            return offset;
+          default:
+            break;
+        }
+
+        size_t next = offset + 1 + (((header >> 2) & 0x01) ? 1 : 0);  // obu_extension_flag
+        if (((header >> 1) & 0x01) == 0) {  // obu_has_size_field
+          // Without obu_size this OBU implicitly runs to the end of the buffer, so
+          // there is no way to reach whatever follows it.
+          return std::nullopt;
+        }
+        const auto size = read_leb128(tu, next);
+        if (!size || *size > tu.size() - next) {
+          return std::nullopt;
+        }
+        offset = next + static_cast<size_t>(*size);
+      }
+      return std::nullopt;
+    }
+
+  }  // namespace
+
+  std::optional<codec_e>
+  codec_for(int video_format) {
+    switch (video_format) {
+      case 1:
+        return codec_e::hevc;
+      case 2:
+        return codec_e::av1;
+      default:
+        return std::nullopt;
+    }
+  }
+
+  bool
+  append_t35_unit(codec_e codec, std::span<const uint8_t> t35, std::vector<uint8_t> &out) {
+    if (t35.empty()) {
+      return false;
+    }
+
+    switch (codec) {
+      case codec_e::hevc:
+        return append_hevc_prefix_sei(t35, out);
+      case codec_e::av1:
+        return append_av1_metadata_obu(t35, out);
+    }
+    return false;
+  }
+
+  std::optional<size_t>
+  insert_offset(codec_e codec, std::span<const uint8_t> bitstream) {
+    switch (codec) {
+      case codec_e::hevc:
+        return hevc_insert_offset(bitstream);
+      case codec_e::av1:
+        return av1_insert_offset(bitstream);
+    }
+    return std::nullopt;
+  }
+
+  bool
+  insert(codec_e codec, std::span<const uint8_t> units, std::vector<uint8_t> &bitstream) {
+    if (units.empty()) {
+      return false;
+    }
+
+    const auto offset = insert_offset(codec, bitstream);
+    if (!offset) {
+      return false;
+    }
+
+    bitstream.insert(
+      bitstream.begin() + static_cast<std::ptrdiff_t>(*offset), units.begin(), units.end());
+    return true;
+  }
+
+}  // namespace video::hdr_bitstream

--- a/src/video_hdr_bitstream.h
+++ b/src/video_hdr_bitstream.h
@@ -1,0 +1,91 @@
+/**
+ * @file src/video_hdr_bitstream.h
+ * @brief Carriage of registered ITU-T T.35 dynamic metadata in HEVC and AV1 bitstreams.
+ *
+ * NVENC takes a T.35 payload and writes the surrounding syntax itself
+ * (NV_ENC_SEI_PAYLOAD / obuPayloadArray). AMF has no equivalent: the encoder
+ * component exposes only static AMFHDRMetadata plus AUD/parameter-set insertion,
+ * so anything ST 2094-40 or CUVA has to be spliced into the finished bitstream
+ * by hand. This is that splice, kept free of AMF, D3D and FFmpeg headers so the
+ * byte layout can be unit-tested on any platform.
+ *
+ * The payload itself is produced by video::hdr_metadata::serialize_hdr10plus_t35()
+ * and serialize_vivid_t35(), which already emit a complete registered T.35
+ * payload starting at itu_t_t35_country_code. Nothing here inspects it.
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <vector>
+
+namespace video::hdr_bitstream {
+
+  /**
+   * Codecs with a carriage for registered ITU-T T.35 metadata that Sunshine emits.
+   *
+   * H.264 is deliberately absent. It does define an equivalent SEI, but Sunshine
+   * never streams HDR over H.264, so supporting it here would be untested code
+   * guarding a state the encoder cannot reach.
+   */
+  enum class codec_e {
+    hevc,  ///< prefix SEI NAL, nal_unit_type 39, payloadType 4
+    av1,  ///< OBU_METADATA, metadata_type 4 (METADATA_TYPE_ITUT_T35)
+  };
+
+  /**
+   * Map the config_t::videoFormat convention (0 H.264, 1 HEVC, 2 AV1) onto a carriage.
+   * Returns nullopt for a format this module does not write, which is the caller's
+   * signal to skip dynamic metadata entirely.
+   */
+  std::optional<codec_e>
+  codec_for(int video_format);
+
+  /**
+   * Wrap one T.35 payload in its codec-specific container and append it to out.
+   *
+   * out accumulates units so several payloads (HDR10+ and HDR Vivid) can be
+   * spliced into an access unit as a single contiguous insert. An empty payload
+   * appends nothing and returns false; out is never left holding a partial unit.
+   */
+  bool
+  append_t35_unit(codec_e codec, std::span<const uint8_t> t35, std::vector<uint8_t> &out);
+
+  /**
+   * Byte offset in an encoded access unit (HEVC) or temporal unit (AV1) where
+   * dynamic metadata has to be spliced, or nullopt when the buffer has no valid
+   * insertion point.
+   *
+   * Both codecs require the metadata to precede the picture data it describes,
+   * and both allow it only after the headers: an HEVC prefix SEI belongs after
+   * any AUD and parameter sets but before the first VCL NAL, and an AV1 metadata
+   * OBU belongs after the temporal delimiter and sequence header but before the
+   * frame header. Landing this offset on the first unit that carries picture data
+   * satisfies both.
+   *
+   * nullopt is a normal outcome for buffers the caller should leave alone —
+   * a header-only access unit, or an AV1 temporal unit whose OBUs omit
+   * obu_size and therefore cannot be walked.
+   *
+   * For HEVC the offset points at the 0x000001 start code prefix, which for a
+   * four-byte start code is one byte past its leading zero. Splicing there can
+   * never claim a byte that belonged to the preceding NAL, and the unit written
+   * by append_t35_unit() carries its own four-byte start code, so the leftover
+   * zero simply becomes a leading zero ahead of it.
+   */
+  std::optional<size_t>
+  insert_offset(codec_e codec, std::span<const uint8_t> bitstream);
+
+  /**
+   * Splice units built by append_t35_unit() into an encoded frame.
+   *
+   * Returns false and leaves bitstream byte-identical when there is nothing to
+   * insert or no insertion point exists, so a caller can send the untouched
+   * frame rather than dropping it.
+   */
+  bool
+  insert(codec_e codec, std::span<const uint8_t> units, std::vector<uint8_t> &bitstream);
+
+}  // namespace video::hdr_bitstream

--- a/src/video_hdr_metadata.h
+++ b/src/video_hdr_metadata.h
@@ -9,10 +9,12 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <iterator>
+#include <optional>
 #include <span>
 #include <vector>
 
@@ -581,6 +583,115 @@ namespace video::hdr_metadata {
     bool ready_ = false;
   };
 
+  /**
+   * The stream-startup policy wrapped around vivid_startup_guard_t.
+   *
+   * The guard decides whether analyzer output is trustworthy; this decides what a
+   * session does about it — hold frames back, give up after a wall-clock budget, or
+   * emit from the first frame. Both native encoder paths need the identical answer,
+   * so the state machine lives here rather than being written twice: NVENC and AMF
+   * disagreeing about when HLG starts carrying Vivid would be a bug nobody notices
+   * until it is reported as "HDR looks different on my AMD box".
+   *
+   * The caller owns logging and force-IDR, which is why a transition is reported
+   * rather than acted on. A session must feed every capture frame through
+   * observe(); skipping frames while holding is what starves the guard of the
+   * independent samples it is waiting for.
+   */
+  class vivid_startup_gate_t {
+  public:
+    enum class decision_e {
+      emit,  ///< Hand this frame's stats to the encoder.
+      hold,  ///< Encode nothing yet; keep converting so the analyzer can converge.
+      disabled,  ///< This session never emits dynamic metadata.
+    };
+
+    enum class transition_e {
+      none,
+      ready,  ///< The guard just converged; the next encoded frame should be an IDR.
+      timed_out,  ///< The preroll budget just expired; start as plain HLG.
+    };
+
+    struct result_t {
+      decision_e decision = decision_e::emit;
+      transition_e transition = transition_e::none;
+    };
+
+    /**
+     * How long a session waits for stable analyzer output before starting without
+     * dynamic metadata. Long enough for three independent GPU readbacks at any
+     * supported analysis cadence, short enough that a client waiting on the first
+     * frame reads it as startup rather than a hang.
+     */
+    static constexpr auto PREROLL_TIMEOUT = std::chrono::milliseconds { 500 };
+
+    vivid_startup_gate_t(
+      const sunshine_colorspace_t &colorspace,
+      int video_format,
+      bool analysis_available) {
+      if (!colorspace_is_hlg(colorspace)) {
+        // PQ carries no plain-HDR10 fallback problem: a mid-stream switch into
+        // HDR10+ or Vivid is not visible the way an HLG one is, so there is
+        // nothing to wait for.
+        state_ = state_e::enabled;
+      }
+      else if (needs_vivid_startup_preroll(colorspace, video_format, analysis_available)) {
+        state_ = state_e::preroll;
+      }
+      else {
+        state_ = state_e::disabled;
+      }
+    }
+
+    result_t
+    observe(
+      const platf::hdr_frame_luminance_stats_t &stats,
+      std::chrono::steady_clock::time_point now) {
+      if (state_ == state_e::disabled) {
+        return { decision_e::disabled, transition_e::none };
+      }
+      if (state_ == state_e::enabled) {
+        return { decision_e::emit, transition_e::none };
+      }
+
+      if (!preroll_started_) {
+        preroll_started_ = now;
+      }
+
+      if (guard_.observe(stats)) {
+        state_ = state_e::enabled;
+        return { decision_e::emit, transition_e::ready };
+      }
+      if (now - *preroll_started_ >= PREROLL_TIMEOUT) {
+        state_ = state_e::disabled;
+        return { decision_e::disabled, transition_e::timed_out };
+      }
+      return { decision_e::hold, transition_e::none };
+    }
+
+    /// Whether this session starts by holding frames back, for a startup log line.
+    bool
+    prerolling() const {
+      return state_ == state_e::preroll;
+    }
+
+    uint32_t
+    consecutive_samples() const {
+      return guard_.consecutive_samples();
+    }
+
+  private:
+    enum class state_e {
+      enabled,
+      preroll,
+      disabled,
+    };
+
+    vivid_startup_guard_t guard_;
+    std::optional<std::chrono::steady_clock::time_point> preroll_started_;
+    state_e state_ = state_e::enabled;
+  };
+
   namespace detail {
 
     class bit_writer_t {
@@ -656,5 +767,91 @@ namespace video::hdr_metadata {
 
     return payload.size();
   }
+
+  /**
+   * Produces this frame's dynamic metadata payloads, owning the temporal state
+   * that makes them stable.
+   *
+   * Both native encoder paths need the same three things done in the same order —
+   * update the EMA and the Vivid temporal filter from the raw stats, then
+   * serialize whichever formats this stream may carry — and they differ only in
+   * how the finished payloads reach the bitstream. Keeping the sequence here means
+   * a change to smoothing or to format gating cannot land on one encoder and miss
+   * the other.
+   *
+   * The returned spans point into this object and stay valid until the next
+   * build() or reset() call. That is enough for both callers: NVENC hands the
+   * pointers straight to nvEncEncodePicture(), and AMF copies them into a spliced
+   * bitstream unit, both within the same frame.
+   */
+  class dynamic_metadata_builder_t {
+  public:
+    struct payloads_t {
+      /// Complete registered T.35 payloads, empty when that format is not emitted.
+      std::span<const uint8_t> hdr10plus;
+      std::span<const uint8_t> vivid;
+
+      bool
+      empty() const {
+        return hdr10plus.empty() && vivid.empty();
+      }
+    };
+
+    /// Which formats this stream may carry, from formats_for().
+    void
+    configure(formats_t formats) {
+      formats_ = formats;
+    }
+
+    const formats_t &
+    formats() const {
+      return formats_;
+    }
+
+    /**
+     * Update the temporal state from one frame of analyzer output and serialize.
+     *
+     * The filters are updated even for a format this stream does not emit, so a
+     * stream that only carries one of the two still keeps the other's state warm
+     * and comparable frame to frame.
+     */
+    payloads_t
+    build(const platf::hdr_frame_luminance_stats_t &stats, uint16_t max_display_luminance) {
+      payloads_t payloads;
+      if (!stats.valid) {
+        return payloads;
+      }
+
+      const auto vivid = vivid_filter_.update(stats);
+      hdr10plus_ema_.update(stats);
+
+      if (formats_.hdr10plus) {
+        const auto size = serialize_hdr10plus_t35(
+          hdr10plus_ema_.smoothed(stats), max_display_luminance, hdr10plus_storage_);
+        if (size > 0) {
+          payloads.hdr10plus = std::span(hdr10plus_storage_).first(size);
+        }
+      }
+      if (formats_.vivid && serialize_vivid_t35(vivid, vivid_storage_) > 0) {
+        payloads.vivid = vivid_storage_;
+      }
+      return payloads;
+    }
+
+    /// Drop temporal history, e.g. when an encoder is recreated mid-session.
+    void
+    reset() {
+      hdr10plus_ema_.reset();
+      vivid_filter_.reset();
+      vivid_storage_.clear();
+    }
+
+  private:
+    formats_t formats_ {};
+    hdr_luminance_ema_t hdr10plus_ema_;
+    vivid_temporal_filter_t vivid_filter_;
+    std::array<uint8_t, hdr10plus_t35_max_payload_size> hdr10plus_storage_ {};
+    std::vector<uint8_t> vivid_storage_;
+  };
 
 }  // namespace video::hdr_metadata

--- a/tests/unit/test_video_hdr_bitstream.cpp
+++ b/tests/unit/test_video_hdr_bitstream.cpp
@@ -1,0 +1,253 @@
+/**
+ * @file tests/unit/test_video_hdr_bitstream.cpp
+ * @brief Tests for HEVC prefix SEI and AV1 metadata OBU carriage of T.35 payloads.
+ */
+#include <src/video_hdr_bitstream.h>
+
+#include "../tests_common.h"
+
+namespace {
+
+  using video::hdr_bitstream::append_t35_unit;
+  using video::hdr_bitstream::codec_e;
+  using video::hdr_bitstream::codec_for;
+  using video::hdr_bitstream::insert;
+  using video::hdr_bitstream::insert_offset;
+
+  using bytes_t = std::vector<uint8_t>;
+
+  /**
+   * Strip emulation prevention bytes the way a decoder does, so the round trip
+   * proves the escape is reversible rather than merely plausible.
+   */
+  bytes_t
+  unescape(std::span<const uint8_t> nal_payload) {
+    bytes_t out;
+    int zero_run = 0;
+    for (const uint8_t byte : nal_payload) {
+      if (zero_run == 2 && byte == 0x03) {
+        zero_run = 0;
+        continue;
+      }
+      out.push_back(byte);
+      zero_run = (byte == 0x00) ? zero_run + 1 : 0;
+    }
+    return out;
+  }
+
+}  // namespace
+
+TEST(HdrBitstream, MapsVideoFormatToCarriage) {
+  // H.264 defines an equivalent SEI, but Sunshine never streams HDR over it, so
+  // there is deliberately no carriage here to reach.
+  EXPECT_FALSE(codec_for(0).has_value());
+  EXPECT_EQ(codec_for(1), codec_e::hevc);
+  EXPECT_EQ(codec_for(2), codec_e::av1);
+  EXPECT_FALSE(codec_for(7).has_value());
+}
+
+TEST(HdrBitstream, WritesHevcPrefixSei) {
+  const bytes_t t35 { 0xB5, 0x00, 0x3C, 0x00, 0x01, 0x04, 0x40 };
+  bytes_t unit;
+  ASSERT_TRUE(append_t35_unit(codec_e::hevc, t35, unit));
+
+  EXPECT_EQ(unit,
+    bytes_t({
+      0x00, 0x00, 0x00, 0x01,  // start code prefix
+      0x4E, 0x01,  // nal_unit_type 39 (PREFIX_SEI_NUT), nuh_temporal_id_plus1 1
+      0x04,  // payloadType 4 (user_data_registered_itu_t_t35)
+      0x07,  // payloadSize
+      0xB5, 0x00, 0x3C, 0x00, 0x01, 0x04, 0x40,
+      0x80,  // rbsp_trailing_bits
+    }));
+}
+
+TEST(HdrBitstream, EscapesStartCodePatternsInHevcPayload) {
+  // A payload holding both 00 00 01 and a trailing 00 00, i.e. exactly the patterns
+  // that would otherwise read as a start code prefix (H.265 7.4.2).
+  const bytes_t t35 { 0xB5, 0x00, 0x00, 0x01, 0x00, 0x00, 0x02, 0x00, 0x00 };
+  bytes_t unit;
+  ASSERT_TRUE(append_t35_unit(codec_e::hevc, t35, unit));
+
+  EXPECT_EQ(unit,
+    bytes_t({
+      0x00, 0x00, 0x00, 0x01, 0x4E, 0x01,
+      0x04, 0x09,
+      0xB5, 0x00, 0x00, 0x03, 0x01, 0x00, 0x00, 0x03, 0x02, 0x00, 0x00,
+      0x80,
+    }));
+
+  // payloadSize describes the payload as a decoder recovers it, after the 0x03
+  // bytes are stripped — not the escaped length on the wire.
+  const auto rbsp = unescape(std::span(unit).subspan(6));
+  ASSERT_EQ(rbsp.size(), 2 + t35.size() + 1);
+  EXPECT_EQ(rbsp[0], 0x04);
+  EXPECT_EQ(rbsp[1], t35.size());
+  EXPECT_TRUE(std::equal(t35.begin(), t35.end(), rbsp.begin() + 2));
+  EXPECT_EQ(rbsp.back(), 0x80);
+}
+
+TEST(HdrBitstream, WritesHevcPayloadSizeAsFfBytes) {
+  bytes_t unit;
+  ASSERT_TRUE(append_t35_unit(codec_e::hevc, bytes_t(300, 0xAA), unit));
+  EXPECT_EQ(bytes_t(unit.begin() + 6, unit.begin() + 9), bytes_t({ 0x04, 0xFF, 0x2D }));
+  // 0xAA never triggers escaping, so the length is exact.
+  EXPECT_EQ(unit.size(), 4 + 2 + 1 + 2 + 300 + 1);
+
+  // 255 needs a continuation byte plus a zero remainder, not a bare 0xFF.
+  unit.clear();
+  ASSERT_TRUE(append_t35_unit(codec_e::hevc, bytes_t(255, 0xAA), unit));
+  EXPECT_EQ(bytes_t(unit.begin() + 6, unit.begin() + 9), bytes_t({ 0x04, 0xFF, 0x00 }));
+}
+
+TEST(HdrBitstream, WritesAv1MetadataObu) {
+  const bytes_t t35 { 0xB5, 0x00, 0x3C, 0x00, 0x01, 0x04 };
+  bytes_t unit;
+  ASSERT_TRUE(append_t35_unit(codec_e::av1, t35, unit));
+
+  EXPECT_EQ(unit,
+    bytes_t({
+      0x2A,  // OBU_METADATA (5), obu_has_size_field 1
+      0x08,  // obu_size: metadata_type + 6 payload bytes + trailing bits
+      0x04,  // metadata_type METADATA_TYPE_ITUT_T35
+      0xB5, 0x00, 0x3C, 0x00, 0x01, 0x04,
+      0x80,  // trailing bits
+    }));
+
+  // obu_size crossing the one-byte leb128 boundary.
+  unit.clear();
+  ASSERT_TRUE(append_t35_unit(codec_e::av1, bytes_t(200, 0xAA), unit));
+  EXPECT_EQ(bytes_t(unit.begin(), unit.begin() + 3), bytes_t({ 0x2A, 0xCA, 0x01 }));
+  EXPECT_EQ(unit.size(), 1 + 2 + 202);
+}
+
+TEST(HdrBitstream, RejectsEmptyPayloadWithoutTouchingOutput) {
+  bytes_t unit { 0xFF };
+  EXPECT_FALSE(append_t35_unit(codec_e::hevc, {}, unit));
+  EXPECT_FALSE(append_t35_unit(codec_e::av1, {}, unit));
+  EXPECT_EQ(unit, bytes_t({ 0xFF }));
+}
+
+TEST(HdrBitstream, SplicesHevcUnitBeforeTheFirstVclNal) {
+  // VPS(32), SPS(33), PPS(34), prefix SEI(39), then an IDR_W_RADL slice(19).
+  const bytes_t au {
+    0x00, 0x00, 0x00, 0x01, 0x40, 0x01, 0x0C,  // VPS
+    0x00, 0x00, 0x00, 0x01, 0x42, 0x01, 0x01,  // SPS
+    0x00, 0x00, 0x00, 0x01, 0x44, 0x01, 0xC0,  // PPS
+    0x00, 0x00, 0x00, 0x01, 0x4E, 0x01, 0x04,  // prefix SEI
+    0x00, 0x00, 0x00, 0x01, 0x26, 0x01, 0xAF,  // IDR_W_RADL slice
+  };
+
+  // Byte 28 is the leading zero of the slice's four-byte start code; the offset
+  // deliberately points one past it, at the 00 00 01 prefix, so the splice can never
+  // claim a byte that belongs to the previous NAL (which may legally end in zeros).
+  const auto offset = insert_offset(codec_e::hevc, au);
+  ASSERT_TRUE(offset.has_value());
+  EXPECT_EQ(*offset, 29U);
+
+  bytes_t frame = au;
+  const bytes_t unit { 0xDE, 0xAD };
+  ASSERT_TRUE(insert(codec_e::hevc, unit, frame));
+  ASSERT_EQ(frame.size(), au.size() + unit.size());
+  EXPECT_EQ(frame[29], 0xDE);
+  EXPECT_EQ(frame[30], 0xAD);
+  EXPECT_TRUE(std::equal(au.begin(), au.begin() + 29, frame.begin())) << "headers changed";
+  EXPECT_TRUE(std::equal(au.begin() + 29, au.end(), frame.begin() + 31)) << "slice changed";
+}
+
+TEST(HdrBitstream, FindsHevcOffsetWithThreeByteStartCodes) {
+  const bytes_t au {
+    0x00, 0x00, 0x01, 0x4E, 0x01, 0x04,  // prefix SEI
+    0x00, 0x00, 0x01, 0x02, 0x01, 0xAF,  // TRAIL_R slice (nal_unit_type 1)
+  };
+  const auto offset = insert_offset(codec_e::hevc, au);
+  ASSERT_TRUE(offset.has_value());
+  EXPECT_EQ(*offset, 6U);
+}
+
+TEST(HdrBitstream, HevcScanIsDeterministicAboutEmbeddedStartCodes) {
+  // A NAL body holding an unescaped 00 00 01 26 reads as a VCL NAL, which is
+  // precisely why real encoders escape it. Pin the behavior rather than leave it
+  // to chance.
+  const bytes_t au {
+    0x00, 0x00, 0x00, 0x01, 0x40, 0x01, 0x00, 0x00, 0x01, 0x26,
+    0x00, 0x00, 0x00, 0x01, 0x02, 0x01, 0xAF,
+  };
+  const auto offset = insert_offset(codec_e::hevc, au);
+  ASSERT_TRUE(offset.has_value());
+  EXPECT_EQ(*offset, 6U);
+}
+
+TEST(HdrBitstream, LeavesHevcBufferUntouchedWhenThereIsNoInsertionPoint) {
+  const bytes_t headers_only {
+    0x00, 0x00, 0x00, 0x01, 0x40, 0x01, 0x0C,
+    0x00, 0x00, 0x00, 0x01, 0x42, 0x01, 0x01,
+  };
+  EXPECT_FALSE(insert_offset(codec_e::hevc, headers_only).has_value());
+
+  bytes_t frame = headers_only;
+  EXPECT_FALSE(insert(codec_e::hevc, bytes_t({ 0xDE, 0xAD }), frame));
+  EXPECT_EQ(frame, headers_only) << "a failed splice must leave the frame sendable";
+
+  EXPECT_FALSE(insert_offset(codec_e::hevc, {}).has_value());
+  EXPECT_FALSE(insert_offset(codec_e::hevc, bytes_t({ 0x00, 0x00, 0x01 })).has_value());
+}
+
+TEST(HdrBitstream, SplicesAv1UnitBeforeTheFirstPictureDataObu) {
+  // OBU_TEMPORAL_DELIMITER(2, empty), OBU_SEQUENCE_HEADER(1), OBU_FRAME(6).
+  const bytes_t tu {
+    0x12, 0x00,  // temporal delimiter, obu_size 0
+    0x0A, 0x03, 0x00, 0x00, 0x00,  // sequence header, obu_size 3
+    0x32, 0x02, 0xAA, 0xBB,  // frame OBU, obu_size 2
+  };
+  const auto offset = insert_offset(codec_e::av1, tu);
+  ASSERT_TRUE(offset.has_value());
+  EXPECT_EQ(*offset, 7U);
+
+  bytes_t frame = tu;
+  const bytes_t unit { 0xDE, 0xAD };
+  ASSERT_TRUE(insert(codec_e::av1, unit, frame));
+  ASSERT_EQ(frame.size(), tu.size() + unit.size());
+  EXPECT_EQ(frame[7], 0xDE);
+  EXPECT_EQ(frame[8], 0xAD);
+  EXPECT_TRUE(std::equal(tu.begin(), tu.begin() + 7, frame.begin()));
+  EXPECT_TRUE(std::equal(tu.begin() + 7, tu.end(), frame.begin() + 9));
+}
+
+TEST(HdrBitstream, AccountsForAv1ExtensionHeaderByte) {
+  const bytes_t tu {
+    0x12, 0x00,  // temporal delimiter
+    0x0E, 0x00, 0x02, 0x00, 0x00,  // sequence header with obu_extension_flag set
+    0x1A, 0x01, 0xAA,  // OBU_FRAME_HEADER
+    0x22, 0x01, 0xBB,  // OBU_TILE_GROUP
+  };
+  const auto offset = insert_offset(codec_e::av1, tu);
+  ASSERT_TRUE(offset.has_value());
+  EXPECT_EQ(*offset, 7U);
+}
+
+TEST(HdrBitstream, BailsOutOfAv1TemporalUnitsItCannotWalk) {
+  // Without obu_size the OBU implicitly runs to the end of the buffer, so whatever
+  // follows it can never be located.
+  EXPECT_FALSE(insert_offset(codec_e::av1, bytes_t({ 0x12, 0x00, 0x08, 0xAA, 0xBB })).has_value());
+  // obu_forbidden_bit set: not an OBU stream at all.
+  EXPECT_FALSE(insert_offset(codec_e::av1, bytes_t({ 0x92, 0x00 })).has_value());
+  // obu_size 64 with a single byte left.
+  EXPECT_FALSE(insert_offset(codec_e::av1, bytes_t({ 0x0A, 0x40, 0x00 })).has_value());
+  // Headers only, no picture data.
+  EXPECT_FALSE(insert_offset(codec_e::av1, bytes_t({ 0x12, 0x00, 0x0A, 0x01, 0x00 })).has_value());
+}
+
+TEST(HdrBitstream, SplicesSeveralUnitsAsOneContiguousInsert) {
+  // HDR10+ and HDR Vivid share one access unit; both must land ahead of the slice
+  // and in the order they were appended.
+  bytes_t units;
+  ASSERT_TRUE(append_t35_unit(codec_e::hevc, bytes_t({ 0xB5, 0x01 }), units));
+  ASSERT_TRUE(append_t35_unit(codec_e::hevc, bytes_t({ 0x26, 0x02 }), units));
+
+  bytes_t frame { 0x00, 0x00, 0x00, 0x01, 0x26, 0x01, 0xAF };
+  ASSERT_TRUE(insert(codec_e::hevc, units, frame));
+  ASSERT_EQ(frame.size(), 7 + units.size());
+  EXPECT_TRUE(std::equal(units.begin(), units.end(), frame.begin() + 1));
+  EXPECT_EQ(frame.back(), 0xAF);
+}

--- a/tests/unit/test_video_hdr_metadata.cpp
+++ b/tests/unit/test_video_hdr_metadata.cpp
@@ -587,6 +587,116 @@ TEST(HdrDynamicMetadata, VividStartupGuardRejectsInvalidAndTransitionSamples) {
   EXPECT_TRUE(guard.observe(stable_hlg_stats(8, 500.0f, 930.0f)));
 }
 
+namespace {
+
+  using gate_t = video::hdr_metadata::vivid_startup_gate_t;
+
+  constexpr video::sunshine_colorspace_t HLG { video::colorspace_e::bt2020hlg, false, 10 };
+  constexpr video::sunshine_colorspace_t PQ { video::colorspace_e::bt2020, false, 10 };
+
+}  // namespace
+
+TEST(HdrDynamicMetadata, VividStartupGateEmitsImmediatelyForPq) {
+  // PQ has no plain-HDR10 fallback problem, so there is nothing to wait for.
+  gate_t gate { PQ, HEVC, true };
+  EXPECT_FALSE(gate.prerolling());
+
+  const auto now = std::chrono::steady_clock::now();
+  const auto first = gate.observe(stable_hlg_stats(1), now);
+  EXPECT_EQ(first.decision, gate_t::decision_e::emit);
+  EXPECT_EQ(first.transition, gate_t::transition_e::none);
+}
+
+TEST(HdrDynamicMetadata, VividStartupGateHoldsHlgUntilTheGuardConverges) {
+  gate_t gate { HLG, HEVC, true };
+  EXPECT_TRUE(gate.prerolling());
+
+  const auto start = std::chrono::steady_clock::now();
+  for (uint64_t sequence = 1; sequence <= 2; ++sequence) {
+    const auto held = gate.observe(stable_hlg_stats(sequence), start);
+    EXPECT_EQ(held.decision, gate_t::decision_e::hold) << "sequence=" << sequence;
+    EXPECT_EQ(held.transition, gate_t::transition_e::none) << "sequence=" << sequence;
+  }
+
+  // The third independent sample flips the gate and asks the caller for an IDR.
+  const auto ready = gate.observe(stable_hlg_stats(3), start);
+  EXPECT_EQ(ready.decision, gate_t::decision_e::emit);
+  EXPECT_EQ(ready.transition, gate_t::transition_e::ready);
+  EXPECT_EQ(gate.consecutive_samples(), video::hdr_metadata::vivid_startup_guard_t::REQUIRED_SAMPLES);
+  EXPECT_FALSE(gate.prerolling());
+
+  // Once open the gate stays open, and reports the transition only once. The
+  // timeout no longer applies.
+  const auto later = gate.observe(stable_hlg_stats(4), start + gate_t::PREROLL_TIMEOUT * 4);
+  EXPECT_EQ(later.decision, gate_t::decision_e::emit);
+  EXPECT_EQ(later.transition, gate_t::transition_e::none);
+}
+
+TEST(HdrDynamicMetadata, VividStartupGateGivesUpAfterTheTimeout) {
+  gate_t gate { HLG, HEVC, true };
+
+  const auto start = std::chrono::steady_clock::now();
+  auto invalid = stable_hlg_stats(1);
+  invalid.valid = false;
+  EXPECT_EQ(gate.observe(invalid, start).decision, gate_t::decision_e::hold);
+  // One millisecond short of the budget is still a hold.
+  EXPECT_EQ(gate.observe(invalid, start + gate_t::PREROLL_TIMEOUT - std::chrono::milliseconds { 1 }).decision,
+    gate_t::decision_e::hold);
+
+  const auto expired = gate.observe(invalid, start + gate_t::PREROLL_TIMEOUT);
+  EXPECT_EQ(expired.decision, gate_t::decision_e::disabled);
+  EXPECT_EQ(expired.transition, gate_t::transition_e::timed_out);
+
+  // Stays disabled, and does not report the transition again: a stream that starts
+  // as plain HLG must not switch into Vivid later.
+  const auto after = gate.observe(stable_hlg_stats(2), start + gate_t::PREROLL_TIMEOUT * 2);
+  EXPECT_EQ(after.decision, gate_t::decision_e::disabled);
+  EXPECT_EQ(after.transition, gate_t::transition_e::none);
+}
+
+TEST(HdrDynamicMetadata, VividStartupGateDisablesHlgWithNothingToWaitFor) {
+  const auto now = std::chrono::steady_clock::now();
+
+  // No analyzer: HLG can never carry Vivid, so holding frames would only delay
+  // the first frame by the full timeout.
+  gate_t without_analysis { HLG, HEVC, false };
+  EXPECT_FALSE(without_analysis.prerolling());
+  EXPECT_EQ(without_analysis.observe(stable_hlg_stats(1), now).decision, gate_t::decision_e::disabled);
+
+  // AV1 has no HDR Vivid carriage at all.
+  gate_t av1 { HLG, AV1, true };
+  EXPECT_FALSE(av1.prerolling());
+  EXPECT_EQ(av1.observe(stable_hlg_stats(1), now).decision, gate_t::decision_e::disabled);
+}
+
+TEST(HdrDynamicMetadata, DynamicMetadataBuilderFollowsTheFormatGates) {
+  const auto stats = stable_hlg_stats(1);
+
+  // Unconfigured: nothing is emitted, even from valid stats.
+  video::hdr_metadata::dynamic_metadata_builder_t builder;
+  EXPECT_TRUE(builder.build(stats, 1000).empty());
+
+  // PQ over HEVC carries both formats.
+  builder.configure(video::hdr_metadata::formats_for(PQ, HEVC));
+  const auto both = builder.build(stats, 1000);
+  EXPECT_FALSE(both.hdr10plus.empty());
+  EXPECT_FALSE(both.vivid.empty());
+  // Both are registered T.35 payloads, distinguished by their country code.
+  EXPECT_EQ(both.hdr10plus.front(), 0xB5);  // United States (SMPTE ST 2094-40)
+  EXPECT_EQ(both.vivid.front(), 0x26);  // China (CUVA)
+
+  // HLG carries Vivid only: HDR10+ describes absolute luminance.
+  builder.configure(video::hdr_metadata::formats_for(HLG, HEVC));
+  const auto vivid_only = builder.build(stats, 1000);
+  EXPECT_TRUE(vivid_only.hdr10plus.empty());
+  EXPECT_FALSE(vivid_only.vivid.empty());
+
+  // Invalid analyzer output emits nothing rather than a frame of zeros.
+  auto invalid = stats;
+  invalid.valid = false;
+  EXPECT_TRUE(builder.build(invalid, 1000).empty());
+}
+
 // Regression guard for the representation of
 // AVHDRVividColorToneMappingParams::targeted_system_display_maximum_luminance.
 //

--- a/tests/unit/test_video_hdr_metadata.cpp
+++ b/tests/unit/test_video_hdr_metadata.cpp
@@ -697,6 +697,14 @@ TEST(HdrDynamicMetadata, DynamicMetadataBuilderFollowsTheFormatGates) {
   EXPECT_FALSE(hdr10plus_only.hdr10plus.empty());
   EXPECT_TRUE(hdr10plus_only.vivid.empty());
 
+  // A display peak of zero is a real reading (DXGI reports MaxLuminance verbatim
+  // and the VDD path clamps to a 0 floor), not a reason to stop emitting: HDR10+
+  // falls back to a 1000-nit targeted system display and Vivid never reads it.
+  builder.configure(video::hdr_metadata::formats_for(PQ, HEVC));
+  const auto zero_peak = builder.build(stats, 0);
+  EXPECT_FALSE(zero_peak.hdr10plus.empty());
+  EXPECT_FALSE(zero_peak.vivid.empty());
+
   // Invalid analyzer output emits nothing rather than a frame of zeros.
   auto invalid = stats;
   invalid.valid = false;

--- a/tests/unit/test_video_hdr_metadata.cpp
+++ b/tests/unit/test_video_hdr_metadata.cpp
@@ -691,6 +691,12 @@ TEST(HdrDynamicMetadata, DynamicMetadataBuilderFollowsTheFormatGates) {
   EXPECT_TRUE(vivid_only.hdr10plus.empty());
   EXPECT_FALSE(vivid_only.vivid.empty());
 
+  // AV1 has no Vivid carriage, so PQ over AV1 is HDR10+ only (see #930).
+  builder.configure(video::hdr_metadata::formats_for(PQ, AV1));
+  const auto hdr10plus_only = builder.build(stats, 1000);
+  EXPECT_FALSE(hdr10plus_only.hdr10plus.empty());
+  EXPECT_TRUE(hdr10plus_only.vivid.empty());
+
   // Invalid analyzer output emits nothing rather than a frame of zeros.
   auto invalid = stats;
   invalid.valid = false;


### PR DESCRIPTION
## 背景

NVENC 路径已经能逐帧发送 HDR10+ / HDR Vivid 动态元数据,AMD 用户拿到的还是纯静态 HDR10 / HLG。

原因是 AMF SDK 根本没有动态元数据接口:只有静态的 `AMF_VIDEO_ENCODER_{,HEVC_,AV1_}INPUT_HDR_METADATA`(`AMFHDRMetadata`),FFmpeg 的 `hevc_amf` 同样直接忽略 `AV_FRAME_DATA_DYNAMIC_HDR_PLUS` / `AV_FRAME_DATA_DYNAMIC_HDR_VIVID`。所以唯一可行的做法是自己把负载写成码流单元,拼接进编码器输出的码流。

## 改动

**新增 `video::hdr_bitstream`(与编码器无关、无外部依赖)**

- HEVC:prefix SEI NAL(`nal_unit_type` 39)、`payloadType` 4(`user_data_registered_itu_t_t35`)、payloadType/payloadSize 按 H.265 D.2.1 的 ff 字节编码、`rbsp_trailing_bits`、按 H.265 7.4.2 插入防竞争字节 `0x03`
- AV1:`OBU_METADATA`(type 5)+ leb128 `obu_size` + `metadata_type` 4(`METADATA_TYPE_ITUT_T35`)
- 插入点:HEVC 首个 VCL NAL(type 0–31)之前,AV1 首个 picture data OBU(FRAME_HEADER / TILE_GROUP / FRAME / REDUNDANT_FRAME_HEADER)之前
- 定位失败(只有参数集的 AU、走不通的 AV1 temporal unit)时返回 false 且**保证缓冲区逐字节不变**,该帧原样发送——丢帧比丢元数据严重

**AMF 编码器**

AMF 可能在若干帧之后才返回编码结果,所以:

- 提交时构建(此时亮度分析结果仍属于这一帧),按 `frame_index` 暂存
- 输出时按 `result.frame_index` 拼接,复用 `frame_rfi_flags` 的 256 条裁剪策略
- `forget_frame()` 统一清理,保证丢帧时 RFI 表和暂存表不会失配

**顺手抽掉两处即将出现的重复**

- `vivid_startup_gate_t`:HLG 启动预热策略(3 个独立样本、500 ms 超时、状态切换时强制 IDR)。NVENC 和 AMF 对"HLG 什么时候开始带 Vivid"给出不同答案,是那种一直到用户报"我 AMD 机器上 HDR 看起来不一样"才会被发现的 bug
- `dynamic_metadata_builder_t`:时域滤波 + 序列化的固定顺序,两边共用一份

两者都是对 NVENC 现有行为的等价重构,并由单测兜住。

## 测试

- `tests/unit/test_video_hdr_bitstream.cpp`:14 个用例,覆盖 SEI/OBU 字节级布局、ff 字节长度编码(300 → `FF 2D`,255 → `FF 00`)、防竞争字节的解码侧往返、多字节 leb128、OBU 扩展头、三/四字节起始码、插入点定位失败时缓冲区不变、两个单元一次性连续插入
- `tests/unit/test_video_hdr_metadata.cpp`:新增 5 个用例覆盖门控(PQ 立即放行 / HLG 收敛后放行 / 恰好超时 / 无分析器与 AV1 直接禁用)与构建器的格式门控
- 本地用独立 harness 跑通了新码流层(48 项断言)与门控/构建器(32 项断言),`clang++ -std=c++20 -fsyntax-only -Wall -Wextra` 干净

## ⚠️ 验证边界

本机是 macOS,没有可用的 cmake/ffmpeg/boost/gtest,`third-party/AMF` 子模块也没有 checkout。

**CI 已验证**(Windows job,21m42s 通过):`src/amf/amf_d3d11.cpp`、`src/platform/windows/display_vram.cpp`、`src/video.cpp`、`src/nvenc/common_impl/nvenc_base.cpp` 全部编译通过(MSYS2/UCRT64,`-Wall`)。

**CI 没有验证**:两个测试文件都没被编译或执行。它们只被 `tests/CMakeLists.txt` 里 `BUILD_TESTS` 才启用的聚合目标 `test_sunshine` glob 到,而 CI 只传 `-DBUILD_TRAY_TESTS=ON`,`ctest` 跑的是 5 个独立小目标。这是 #935 就存在的既有缺口(那个 PR 加的 `test_video_hdr_metadata.cpp` 同样从未在 CI 跑过),不在本 PR 范围内修,已单独记下。

本地改用独立 harness 直接编译真实源文件验证(`clang++ -std=c++20 -Wall -Wextra`):码流层 48 项断言、门控与构建器 34 项断言,全部通过。

## 手动验收

需要在 AMD 显卡上验证:

1. HEVC + PQ:客户端应同时收到 HDR10+ 与 HDR Vivid
2. HEVC + HLG:启动预热后第一个 IDR 起携带 Vivid,日志中有 `HDR Vivid startup guard ready`
3. AV1 + PQ:只有 HDR10+(#930 已确认 AV1 不发 Vivid)
4. AV1 + HLG:不发动态元数据,日志中有相应说明
5. 三种情况都应确认播放端不出现花屏——这是码流拼接最直接的失败表现

🤖 Generated with [Claude Code](https://claude.com/claude-code)
