### PR TITLE
ci: 让聚合测试套件真正在 CI 上运行，并把 Windows job 压到 15 分钟

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,6 +113,7 @@ jobs:
           # Let pacman install the full toolchain at the current upstream version.
           dependencies=(
             "git"
+            "mingw-w64-ucrt-x86_64-ccache"
             "mingw-w64-ucrt-x86_64-cmake"
             "mingw-w64-ucrt-x86_64-ninja"
             "mingw-w64-ucrt-x86_64-cppwinrt"
@@ -165,6 +166,17 @@ jobs:
           $env:SUNSHINE_ASSETS_DIR = "${{ github.workspace }}\build"
           npm run build
 
+      - name: Cache compiler objects
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}\.ccache
+          # The key must be unique per run for the cache to be written at all,
+          # so the prefix restore-key is what actually produces the hits: every
+          # run seeds itself from the most recent previous one.
+          key: ccache-windows-${{ github.run_id }}
+          restore-keys: |
+            ccache-windows-
+
       - name: Build Windows
         shell: msys2 {0}
         env:
@@ -172,6 +184,14 @@ jobs:
           BUILD_VERSION: ${{ needs.setup_release.outputs.release_tag }}.杂鱼
           COMMIT: ${{ needs.setup_release.outputs.release_commit }}
           GITHUB_TOKEN: ${{ secrets.DRIVER_DOWNLOAD_TOKEN }}
+          # ccache.exe is a native binary, so it reads the Windows-style path
+          # straight out of the environment even under the msys2 shell.
+          CCACHE_DIR: ${{ github.workspace }}\.ccache
+          CCACHE_MAXSIZE: 2G
+          # msys2 is set to `update: true`, so the toolchain can move underneath
+          # us between runs. Hashing the compiler binary instead of its mtime
+          # keeps the cache valid across runs that did not actually change gcc.
+          CCACHE_COMPILERCHECK: content
           # Fork PRs cannot access org-scoped secrets, so private-repo driver
           # downloads (vmouse) may fail. Downgrade missing drivers from
           # FATAL_ERROR to WARNING so the build/configure still succeeds; the
@@ -179,6 +199,7 @@ jobs:
           DRIVER_DEPS_REQUIRED: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) && 'OFF' || 'ON' }}
         run: |
           mkdir -p build
+          ccache --zero-stats
           cmake \
             -B build \
             -G Ninja \
@@ -187,12 +208,18 @@ jobs:
             -DBUILD_TESTS=ON \
             -DBUILD_TRAY_TESTS=ON \
             -DBUILD_WEB_UI=OFF \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DSUNSHINE_ASSETS_DIR=assets \
             -DDRIVER_DEPS_REQUIRED=${DRIVER_DEPS_REQUIRED} \
             -DSUNSHINE_PUBLISHER_NAME='${{ github.repository_owner }}' \
             -DSUNSHINE_PUBLISHER_WEBSITE='https://github.com/AlkaidLab/foundation-sunshine' \
             -DSUNSHINE_PUBLISHER_ISSUE_URL='https://github.com/AlkaidLab/foundation-sunshine/issues'
           ninja -C build
+
+          # Printed so a run that suddenly gets slow can be diagnosed as a cache
+          # miss rather than guessed at.
+          ccache --show-stats
 
       - name: Run native tests
         shell: msys2 {0}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,7 +91,9 @@ jobs:
         uses: msys2/setup-msys2@v2
         with:
           msystem: ucrt64
-          update: true
+          # No `update: true` here: the next step runs `pacman -Syu` itself with
+          # the full dependency list, so asking setup-msys2 to upgrade first
+          # means paying for the same system upgrade twice.
           install: >-
             wget
             curl
@@ -188,9 +190,9 @@ jobs:
           # straight out of the environment even under the msys2 shell.
           CCACHE_DIR: ${{ github.workspace }}\.ccache
           CCACHE_MAXSIZE: 2G
-          # msys2 is set to `update: true`, so the toolchain can move underneath
-          # us between runs. Hashing the compiler binary instead of its mtime
-          # keeps the cache valid across runs that did not actually change gcc.
+          # `pacman -Syu` can move the toolchain underneath us between runs.
+          # Hashing the compiler binary instead of its mtime keeps the cache
+          # valid across runs that did not actually change gcc.
           CCACHE_COMPILERCHECK: content
           # Fork PRs cannot access org-scoped secrets, so private-repo driver
           # downloads (vmouse) may fail. Downgrade missing drivers from
@@ -272,19 +274,6 @@ jobs:
         run: |
           # Generate SHA256 checksums.
           .\scripts\generate-checksums.ps1 -Path .\artifacts -Output "SHA256SUMS.txt"
-
-      - name: Package Windows Debug Info
-        working-directory: build
-        run: |
-          # use .dbg file extension for binaries to avoid confusion with real packages
-          Get-ChildItem -File -Recurse | `
-            % { Rename-Item -Path $_.PSPath -NewName $_.Name.Replace(".exe",".dbg") }
-
-          # save the binaries with debug info
-          7z -r `
-            "-xr!CMakeFiles" `
-            "-xr!cpack_artifacts" `
-            a "../artifacts/sunshine-win32-debuginfo.7z" "*.dbg"
 
       - name: Rename release assets
         shell: msys2 {0}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -184,6 +184,7 @@ jobs:
             -G Ninja \
             -S . \
             -DBUILD_DOCS=OFF \
+            -DBUILD_TESTS=ON \
             -DBUILD_TRAY_TESTS=ON \
             -DBUILD_WEB_UI=OFF \
             -DSUNSHINE_ASSETS_DIR=assets \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,9 +91,13 @@ jobs:
         uses: msys2/setup-msys2@v2
         with:
           msystem: ucrt64
-          # No `update: true` here: the next step runs `pacman -Syu` itself with
-          # the full dependency list, so asking setup-msys2 to upgrade first
-          # means paying for the same system upgrade twice.
+          # Required, not redundant with the `pacman -Syu` below. When
+          # msys2-runtime itself needs upgrading, pacman closes every MSYS2
+          # process to finish the job, which kills the workflow shell and fails
+          # the step with exit 1. setup-msys2 performs that upgrade with the
+          # restart it needs; by the time our own step runs, the runtime is
+          # already current and only the dependency list is left to install.
+          update: true
           install: >-
             wget
             curl

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -146,6 +146,13 @@ target_compile_definitions(${PROJECT_NAME} PUBLIC ${SUNSHINE_DEFINITIONS} ${TEST
 target_compile_options(${PROJECT_NAME} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${SUNSHINE_COMPILE_OPTIONS}>;$<$<COMPILE_LANGUAGE:CUDA>:${SUNSHINE_COMPILE_OPTIONS_CUDA};-std=c++17>)  # cmake-lint: disable=C0301
 target_link_options(${PROJECT_NAME} PRIVATE)
 
+# The aggregate suite had an executable but no ctest registration, so every
+# assertion globbed into it was dead weight. The timeout is a guard, not a
+# target: nothing in here has ever run on a headless runner, so a test that
+# waits on a display or a socket should fail the job rather than hang it.
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})
+set_tests_properties(${PROJECT_NAME} PROPERTIES TIMEOUT 600)
+
 add_executable(abr_unit_tests
         ${CMAKE_SOURCE_DIR}/src/abr.cpp
         ${ABR_TEST_STUB_SOURCE})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -150,7 +150,13 @@ target_link_options(${PROJECT_NAME} PRIVATE)
 # assertion globbed into it was dead weight. The timeout is a guard, not a
 # target: nothing in here has ever run on a headless runner, so a test that
 # waits on a display or a socket should fail the job rather than hang it.
-add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})
+#
+# DownloadFileTests fetches from httpbin.org, so as a gate it reports on a third
+# party's uptime rather than on this repository. It stays in the binary — run it
+# deliberately with --gtest_filter when changing http::download_file — but it
+# does not get a vote on whether a pull request is mergeable.
+add_test(NAME ${PROJECT_NAME}
+        COMMAND ${PROJECT_NAME} --gtest_filter=-DownloadFileTests/*)
 set_tests_properties(${PROJECT_NAME} PROPERTIES TIMEOUT 600)
 
 add_executable(abr_unit_tests


### PR DESCRIPTION
## 问题

`tests/CMakeLists.txt` 有个 `if (NOT BUILD_TESTS) return()`。之前声明的 5 个独立 target 一直在 CI 上跑；`return()` 之后被 glob 进聚合 target `test_sunshine` 的**所有**断言从来没有构建过——而且即使构建了也不会执行,因为那个 target 从来没有 `add_test`。

`BUILD_TESTS` 在 `cmake/prep/options.cmake:11` 默认 OFF,`main.yml` 只传了 `-DBUILD_TRAY_TESTS=ON`。

后果:`tests/unit/` 下 40 多个测试文件的 **356 条断言是死代码**。HDR 动态元数据、SEI/OBU 位流往返、stream、rtsp、file_mapping、webhook 全在其中。这也是 `p99 > maxSCL` 那个问题能一路跑到手机上才被发现的原因:回归测试写了,从没执行过。

## 改动

1. **`-DBUILD_TESTS=ON`** — 让聚合套件参与构建。
2. **`add_test(NAME test_sunshine ...)` + `TIMEOUT 600`** — 让它参与执行。超时是护栏不是目标:这些断言从没在无显示器 runner 上跑过,等显示器或等 socket 的测试应该让 job 失败而不是挂住。
3. **`--gtest_filter=-DownloadFileTests/*`** — 那两条去请求 `httpbin.org`,作为门禁报告的是第三方站点的可用性。断言留在二进制里,改 `http::download_file` 时可显式跑。
4. **ccache** — 抵掉编译开销,见下。
5. **删掉 `Package Windows Debug Info`** — `sunshine-win32-debuginfo.7z` 写进 `artifacts/` 后无人消费:不在 `upload-artifact` 的 path 列表,`create-release-action` 没传 assets,`sign-and-repackage.yml` 从 release 资产下载。全仓库对 debuginfo 的引用只有这一处。每次 run 花一分钟压整棵构建树然后丢弃。

## 结果

`ctest` 从 5 个 target 涨到 10 个,断言从个位数涨到 **356 条**(342 通过,12 disabled,2 条网络测试已排除门禁)。

同时 Windows job **32m24s → 15m27s**:

| 步骤 | 前 | 后 |
|---|---|---|
| cmake + ninja | 23m13s | **8m16s** |
| Checkout(递归子模块) | 2m27s | 2m32s |
| msys2 + pacman | 2m30s | 2m21s |
| Node + Web UI | 1m40s | 38s |
| ctest | 0s | 9s |
| 打包 + 上传 | 56s | 53s |
| debuginfo 7z | 1m02s | 已删 |
| **总计** | **32m24s** | **15m27s** |

ccache 稳态命中 **494/527 (93.74%)**,缓存 0.1 GB / 2 GB。33 个 miss 是 `version.h` 那条链:版本号每个 commit 变,包含它的少数文件重编。

两个必要的实现细节:
- `CCACHE_COMPILERCHECK=content` — `pacman -Syu` 会在 run 之间移动工具链,按 mtime 判定会让缓存整体白失效。
- 缓存键每次 run 唯一才会被写回,真正产生命中的是前缀 `restore-keys`,每次 run 从上一次的缓存里播种自己。

## 一个负面结果

试过去掉 `setup-msys2` 的 `update: true`,认为它和后面的 `pacman -Syu` 重复。实测是错的:`msys2-runtime` 自身需要升级时,pacman 会关闭所有 MSYS2 进程,workflow 的 shell 被一起杀掉,该步以 exit 1 结束。已恢复并在 workflow 里注释了原因。

## 打包安全性

`cmake/packaging/windows.cmake` 里的 `install()` 全是显式 target,`test_sunshine` 不在任何一条里,ZIP 和 Inno 产物不受影响——本 PR 的产物已正常构建上传。

## 覆盖率的保留意见

356 条断言通过不等于覆盖到位。这些断言里有多少真的在断言行为、有多少只是构造完就走过场,我没有逐条审过。本 PR 解决的是"写了的测试从不执行",不是"测试写得够好"。

🤖 Generated with [Claude Code](https://claude.com/claude-code)