### PR TITLE
fix(hdr): 无法承载动态元数据的编解码组合不再做逐帧分析

### DIFF
--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -516,6 +516,18 @@ namespace platf {
     video::sunshine_colorspace_t colorspace;
 
     /**
+     * @brief The codec this device encodes for, in config_t::videoFormat terms
+     *        (0 H.264, 1 HEVC, 2 AV1).
+     *
+     * Set alongside `colorspace` when the device is created, because the codec
+     * decides which dynamic HDR metadata formats can be carried at all and the
+     * platform backends reach that decision from places where the client's
+     * config is no longer in scope. -1 means nobody filled it in, which
+     * video::hdr_metadata::formats_for() reads as "no codec-gated format".
+     */
+    int video_format = -1;
+
+    /**
      * @brief Per-frame HDR luminance statistics from GPU analysis.
      * Updated during convert() with 1-frame delay (async GPU readback).
      * Used by video.cpp to generate per-frame HDR dynamic metadata.

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -680,13 +680,33 @@ namespace platf::dxgi {
     }
 
     int
-    init_output(ID3D11Texture2D *frame_texture, int width, int height, const ::video::sunshine_colorspace_t &colorspace, bool is_probe = false) {
+    init_output(ID3D11Texture2D *frame_texture, int width, int height, const ::video::sunshine_colorspace_t &colorspace, int video_format, bool is_probe = false) {
       ::video::unregister_hdr_pipeline_status(runtime_status_id);
       runtime_status_id = 0;
       hdr_luminance_stats_out = {};
       hdr_analysis_pending = false;
       hdr_analysis_frame_index = 0;
       hdr_analysis_sample_sequence = 0;
+
+      // init() builds the analyzer from the pixel format alone, because the
+      // client's colorspace and codec are not known yet at device creation. Both
+      // decide whether any dynamic metadata format can actually be carried, so
+      // that verdict has to be reached here, before init_compute_path() picks a
+      // conversion path based on whether analysis is running.
+      //
+      // HLG over AV1 is the case that motivated this: HDR10+ is PQ-only and HDR
+      // Vivid has no AV1 carriage, so every analysis dispatch was thrown away.
+      // (H.264 never reaches this at all — encoder.h264[DYNAMIC_RANGE] is false
+      // unconditionally, so an HDR colorspace is impossible there.)
+      hdr_metadata_formats = ::video::hdr_metadata::formats_for(colorspace, video_format);
+      const bool any_format_carriable = hdr_metadata_formats.any();
+      hdr_analysis_enabled = hdr_analysis_ready && any_format_carriable;
+      if (hdr_analysis_ready && !any_format_carriable) {
+        hdr_analysis_failure_reason = "format_unsupported";
+        BOOST_LOG(is_probe ? debug : info)
+          << "HDR luminance analysis disabled: no dynamic metadata format can be carried by this "
+             "transfer function and codec combination";
+      }
 
       // The underlying frame pool owns the texture, so we must reference it for ourselves
       frame_texture->AddRef();
@@ -1481,10 +1501,15 @@ namespace platf::dxgi {
       runtime_status.scene_metadata_active = false;
       runtime_status.metadata_formats.clear();
       if (runtime_status.analysis_active) {
-        if (use_pq) {
+        // Report what the stream can actually carry rather than inferring it from
+        // the transfer function: HDR Vivid has no AV1 carriage, so advertising it
+        // there described metadata the encoder had already stopped emitting.
+        if (hdr_metadata_formats.hdr10plus) {
           runtime_status.metadata_formats.emplace_back("hdr10_plus");
         }
-        runtime_status.metadata_formats.emplace_back("hdr_vivid");
+        if (hdr_metadata_formats.vivid) {
+          runtime_status.metadata_formats.emplace_back("hdr_vivid");
+        }
       }
 
       runtime_status.conversion_path =
@@ -1587,7 +1612,9 @@ namespace platf::dxgi {
     uint64_t hdr_analysis_frame_index = 0; // Used to downsample analysis frequency
     uint64_t hdr_analysis_sample_sequence = 0; // Counts completed, independent GPU samples
     bool hdr_analysis_pending = false;     // Whether we have results ready to read
-    bool hdr_analysis_enabled = false;     // Whether HDR analysis is initialized
+    bool hdr_analysis_ready = false;       // Whether the analyzer's GPU resources were created
+    bool hdr_analysis_enabled = false;     // Whether analysis runs: resources exist and the stream can carry metadata
+    ::video::hdr_metadata::formats_t hdr_metadata_formats;  // Dynamic metadata formats this stream may carry
     bool hdr_analysis_snapshot_enabled = false; // P010 converter fills the private analysis texture
     float hdr_analysis_max_nits = 10000.0f; // Clamp metadata to the encoded transfer-function range
     std::string hdr_analysis_failure_reason;
@@ -1868,7 +1895,9 @@ namespace platf::dxgi {
         return -1;
       }
 
-      hdr_analysis_enabled = true;
+      // Resources exist; whether they get used is init_output()'s call, once the
+      // colorspace and codec are known.
+      hdr_analysis_ready = true;
       BOOST_LOG(info) << "HDR luminance analyzer initialized (two-pass): " << width << "x" << height
                       << ", analysis " << hdr_analysis_width << "x" << hdr_analysis_height
                       << ", " << hdr_num_groups << " groups (" << groups_x << "x" << groups_y << ")"
@@ -2646,7 +2675,9 @@ namespace platf::dxgi {
         frame_texture = (ID3D11Texture2D *) frame->data[0];
       }
 
-      return base.init_output(frame_texture, frame->width, frame->height, colorspace);
+      // No client config in scope this deep in the frame-pool setup, so the codec
+      // comes from the member video.cpp filled in when this device was created.
+      return base.init_output(frame_texture, frame->width, frame->height, colorspace, video_format);
     }
 
   private:
@@ -2686,7 +2717,7 @@ namespace platf::dxgi {
       if (!nvenc_d3d->create_encoder(config::video.nv, client_config, colorspace, buffer_format)) return false;
 
       base.apply_colorspace(colorspace);
-      if (base.init_output(nvenc_d3d->get_input_texture(), client_config.width, client_config.height, colorspace, is_probe)) {
+      if (base.init_output(nvenc_d3d->get_input_texture(), client_config.width, client_config.height, colorspace, client_config.videoFormat, is_probe)) {
         return false;
       }
 
@@ -2802,7 +2833,7 @@ namespace platf::dxgi {
 
       base.apply_colorspace(colorspace);
       hdr_luminance_analysis_available = false;
-      if (base.init_output(static_cast<ID3D11Texture2D *>(amf_d3d->get_input_texture()), client_config.width, client_config.height, colorspace, is_probe) != 0) {
+      if (base.init_output(static_cast<ID3D11Texture2D *>(amf_d3d->get_input_texture()), client_config.width, client_config.height, colorspace, client_config.videoFormat, is_probe) != 0) {
         return false;
       }
 

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -694,18 +694,24 @@ namespace platf::dxgi {
       // that verdict has to be reached here, before init_compute_path() picks a
       // conversion path based on whether analysis is running.
       //
-      // HLG over AV1 is the case that motivated this: HDR10+ is PQ-only and HDR
-      // Vivid has no AV1 carriage, so every analysis dispatch was thrown away.
+      // Two independent gates, and analysis is worth running only where they
+      // overlap. The stream decides what may describe the content: HLG over AV1
+      // allows nothing, because HDR10+ is PQ-only and HDR Vivid has no AV1
+      // carriage. The encoder decides what can be written: encoders driven through
+      // avcodec never emit HDR Vivid (see the AV_FRAME_DATA_DYNAMIC_HDR_VIVID
+      // comment in video.cpp), so HLG leaves them nothing either, even on HEVC.
       // (H.264 never reaches this at all — encoder.h264[DYNAMIC_RANGE] is false
       // unconditionally, so an HDR colorspace is impossible there.)
-      hdr_metadata_formats = ::video::hdr_metadata::formats_for(colorspace, video_format);
-      const bool any_format_carriable = hdr_metadata_formats.any();
-      hdr_analysis_enabled = hdr_analysis_ready && any_format_carriable;
-      if (hdr_analysis_ready && !any_format_carriable) {
-        hdr_analysis_failure_reason = "format_unsupported";
+      const auto stream_formats = ::video::hdr_metadata::formats_for(colorspace, video_format);
+      hdr_metadata_formats = stream_formats.intersect(encoder_metadata_formats);
+      hdr_analysis_enabled = hdr_analysis_ready && hdr_metadata_formats.any();
+      if (hdr_analysis_ready && !hdr_metadata_formats.any()) {
+        // Which side vetoed it, so the Web UI can tell "this codec cannot carry it"
+        // apart from "this encoder cannot write it".
+        hdr_analysis_failure_reason = stream_formats.any() ? "encoder_unsupported" : "format_unsupported";
         BOOST_LOG(is_probe ? debug : info)
-          << "HDR luminance analysis disabled: no dynamic metadata format can be carried by this "
-             "transfer function and codec combination";
+          << "HDR luminance analysis disabled: no dynamic metadata format is both allowed by this "
+             "transfer function and codec, and writable by this encoder";
       }
 
       // The underlying frame pool owns the texture, so we must reference it for ourselves
@@ -1040,8 +1046,8 @@ namespace platf::dxgi {
       std::shared_ptr<platf::display_t> display,
       adapter_t::pointer adapter_p,
       pix_fmt_e pix_fmt,
-      bool supports_dynamic_metadata) {
-      dynamic_metadata_supported = supports_dynamic_metadata;
+      ::video::hdr_metadata::formats_t supported_formats) {
+      encoder_metadata_formats = supported_formats;
       switch (pix_fmt) {
         case pix_fmt_e::nv12:
           format = DXGI_FORMAT_NV12;
@@ -1165,7 +1171,7 @@ namespace platf::dxgi {
       const bool hdr_format =
         format == DXGI_FORMAT_P010 || format == DXGI_FORMAT_Y410 || format == DXGI_FORMAT_R16_UINT;
       if (hdr_format && config::video.hdr_luminance_analysis != "off") {
-        if (!dynamic_metadata_supported) {
+        if (!encoder_metadata_formats.any()) {
           hdr_analysis_failure_reason = "encoder_unsupported";
           // Without this the analyzer simply never appears in the log, which reads
           // exactly like a working setup that produces no metadata.
@@ -1648,7 +1654,10 @@ namespace platf::dxgi {
 
     std::uint64_t runtime_status_id = 0;
     ::video::hdr_pipeline_status_t runtime_status;
-    bool dynamic_metadata_supported = true;
+    // What this encode device can actually write into the bitstream, independent
+    // of what the stream would allow. Set at init(); intersected with the stream's
+    // own verdict in init_output().
+    ::video::hdr_metadata::formats_t encoder_metadata_formats { .hdr10plus = true, .vivid = true };
 
     // Must match HLSL GroupResult layout exactly
     static constexpr uint32_t HISTOGRAM_BINS = 256;
@@ -2587,7 +2596,10 @@ namespace platf::dxgi {
   public:
     int
     init(std::shared_ptr<platf::display_t> display, adapter_t::pointer adapter_p, pix_fmt_e pix_fmt) {
-      int result = base.init(display, adapter_p, pix_fmt, true);
+      // Encoders reached through avcodec never emit HDR Vivid: FFmpeg has no
+      // encoder-side serializer for AV_FRAME_DATA_DYNAMIC_HDR_VIVID, so the side
+      // data is attached and dropped. HDR10+ does get written out, so it stays.
+      int result = base.init(display, adapter_p, pix_fmt, { .hdr10plus = true, .vivid = false });
       data = base.device.get();
       return result;
     }
@@ -2689,7 +2701,8 @@ namespace platf::dxgi {
   public:
     bool
     init_device(std::shared_ptr<platf::display_t> display, adapter_t::pointer adapter_p, pix_fmt_e pix_fmt) {
-      if (base.init(display, adapter_p, pix_fmt, true)) return false;
+      // The native NVENC path hand-writes both T.35 payloads (nvenc_base.cpp).
+      if (base.init(display, adapter_p, pix_fmt, { .hdr10plus = true, .vivid = true })) return false;
 
       auto factory = nvenc::nvenc_dynamic_factory::get();
       if (!factory) return false;
@@ -2743,11 +2756,11 @@ namespace platf::dxgi {
   public:
     bool
     init_device(std::shared_ptr<platf::display_t> display, adapter_t::pointer adapter_p, pix_fmt_e pix_fmt) {
-      // The AMF path splices HDR10+ / HDR Vivid into the bitstream itself, so the
-      // luminance analyzer that feeds it has to be switched on here — the same as the
-      // avcodec and NVENC devices. This was false while AMF could only carry static
-      // metadata, and running the analyzer then would have burned GPU time for nothing.
-      if (base.init(display, adapter_p, pix_fmt, true)) return false;
+      // The AMF path splices HDR10+ / HDR Vivid into the bitstream itself (#939), so
+      // the luminance analyzer that feeds it has to be switched on here. This was off
+      // while AMF could only carry static metadata, and running the analyzer then
+      // would have burned GPU time for nothing.
+      if (base.init(display, adapter_p, pix_fmt, { .hdr10plus = true, .vivid = true })) return false;
 
       amf_d3d = ::amf::create_amf_d3d11(base.device.get());
       if (!amf_d3d) return false;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -2830,6 +2830,7 @@ namespace video {
         return nullptr;
       }
       software_encode_device->colorspace = colorspace;
+      software_encode_device->video_format = config.videoFormat;
 
       encode_device_final = std::move(software_encode_device);
     }
@@ -3345,6 +3346,7 @@ namespace video {
 
     if (result) {
       result->colorspace = colorspace;
+      result->video_format = config.videoFormat;
     }
 
     return result;

--- a/src/video_hdr_metadata.h
+++ b/src/video_hdr_metadata.h
@@ -44,6 +44,18 @@ namespace video::hdr_metadata {
     any() const {
       return hdr10plus || vivid;
     }
+
+    /**
+     * The formats left when two independent verdicts are combined: what the stream
+     * allows, and what the encoder can actually write. Both have to say yes.
+     */
+    constexpr formats_t
+    intersect(const formats_t &other) const {
+      return {
+        .hdr10plus = hdr10plus && other.hdr10plus,
+        .vivid = vivid && other.vivid,
+      };
+    }
   };
 
   constexpr int hdr10plus_normalized_scale = 100000;

--- a/src/video_hdr_metadata.h
+++ b/src/video_hdr_metadata.h
@@ -31,6 +31,19 @@ namespace video::hdr_metadata {
   struct formats_t {
     bool hdr10plus = false;
     bool vivid = false;
+
+    /**
+     * Whether the stream can carry any dynamic metadata at all.
+     *
+     * A false here is what tells the capture path to skip per-frame luminance
+     * analysis: nothing downstream could use the result. HLG over AV1 is the
+     * combination that lands here — HDR10+ is PQ-only and HDR Vivid has no AV1
+     * carriage — even though the stream is genuinely HDR.
+     */
+    constexpr bool
+    any() const {
+      return hdr10plus || vivid;
+    }
   };
 
   constexpr int hdr10plus_normalized_scale = 100000;

--- a/src_assets/common/assets/web/configs/tabs/audiovideo/DisplayDeviceOptions.vue
+++ b/src_assets/common/assets/web/configs/tabs/audiovideo/DisplayDeviceOptions.vue
@@ -60,8 +60,13 @@ const hdrRuntimeViewState = computed(() => {
     return { statusKey: 'config.hdr_runtime_status_sdr', tone: 'muted' }
   }
   if (pipeline.analysis_failure_reason) {
+    // In auto mode these two are the pipeline working as designed, not a problem to
+    // report: the encoder cannot carry dynamic metadata, or the transfer function
+    // and codec in use have no format between them (HLG over AV1).
     const expectedFallback =
-      pipeline.analysis_mode === 'auto' && pipeline.analysis_failure_reason === 'encoder_unsupported'
+      pipeline.analysis_mode === 'auto' &&
+      (pipeline.analysis_failure_reason === 'encoder_unsupported' ||
+        pipeline.analysis_failure_reason === 'format_unsupported')
     return {
       statusKey: 'config.hdr_runtime_status_fallback',
       tone: expectedFallback ? 'muted' : 'warning',

--- a/tests/unit/test_video_hdr_metadata.cpp
+++ b/tests/unit/test_video_hdr_metadata.cpp
@@ -108,6 +108,40 @@ TEST(HdrDynamicMetadata, ReportsWhenNoFormatCanBeCarried) {
   EXPECT_TRUE(formats_for(hlg, HEVC).any());
 }
 
+TEST(HdrDynamicMetadata, IntersectsStreamFormatsWithEncoderCapability) {
+  using video::colorspace_e;
+  using video::hdr_metadata::formats_for;
+  using video::hdr_metadata::formats_t;
+  using video::sunshine_colorspace_t;
+
+  const sunshine_colorspace_t pq { colorspace_e::bt2020, false, 10 };
+  const sunshine_colorspace_t hlg { colorspace_e::bt2020hlg, true, 10 };
+
+  // What each encode device can write, independent of the stream. FFmpeg has no
+  // encoder-side serializer for AV_FRAME_DATA_DYNAMIC_HDR_VIVID, so anything driven
+  // through avcodec attaches that side data and drops it. The native NVENC and AMF
+  // paths hand-write both T.35 payloads.
+  constexpr formats_t avcodec { .hdr10plus = true, .vivid = false };
+  constexpr formats_t native { .hdr10plus = true, .vivid = true };
+
+  // HLG leaves avcodec nothing even on HEVC: HDR10+ cannot describe HLG, and the
+  // one format that could is never written. Analysis there is pure overhead.
+  EXPECT_FALSE(formats_for(hlg, HEVC).intersect(avcodec).any());
+
+  // The same stream keeps HDR Vivid on the two native paths.
+  EXPECT_TRUE(formats_for(hlg, HEVC).intersect(native).vivid);
+  EXPECT_TRUE(formats_for(hlg, HEVC).intersect(native).any());
+
+  // PQ still reaches avcodec as HDR10+, so its analysis is not gated off.
+  EXPECT_TRUE(formats_for(pq, HEVC).intersect(avcodec).hdr10plus);
+  EXPECT_FALSE(formats_for(pq, HEVC).intersect(avcodec).vivid);
+  EXPECT_TRUE(formats_for(pq, AV1).intersect(avcodec).any());
+
+  // Neither gate can add a format the other refused.
+  EXPECT_FALSE(formats_for(hlg, AV1).intersect(native).any());
+  EXPECT_FALSE(formats_for(pq, HEVC).intersect(formats_t {}).any());
+}
+
 TEST(HdrDynamicMetadata, SkipsVividPrerollWhenCodecCannotCarryIt) {
   using video::colorspace_e;
   using video::hdr_metadata::needs_vivid_startup_preroll;

--- a/tests/unit/test_video_hdr_metadata.cpp
+++ b/tests/unit/test_video_hdr_metadata.cpp
@@ -87,6 +87,27 @@ TEST(HdrDynamicMetadata, WithholdsVividFromCodecsWithoutACarriage) {
   EXPECT_TRUE(formats_for(hlg, HEVC).vivid);
 }
 
+TEST(HdrDynamicMetadata, ReportsWhenNoFormatCanBeCarried) {
+  using video::colorspace_e;
+  using video::hdr_metadata::formats_for;
+  using video::sunshine_colorspace_t;
+
+  const sunshine_colorspace_t pq { colorspace_e::bt2020, false, 10 };
+  const sunshine_colorspace_t hlg { colorspace_e::bt2020hlg, true, 10 };
+  const sunshine_colorspace_t sdr { colorspace_e::rec709, false, 8 };
+
+  // What the capture path gates per-frame luminance analysis on. HLG over AV1 is
+  // HDR, so a colorspace check alone would keep analyzing for metadata that can
+  // never be written.
+  EXPECT_FALSE(formats_for(hlg, AV1).any());
+  EXPECT_FALSE(formats_for(sdr, HEVC).any());
+  EXPECT_FALSE(formats_for(sdr, AV1).any());
+
+  EXPECT_TRUE(formats_for(pq, AV1).any());
+  EXPECT_TRUE(formats_for(pq, HEVC).any());
+  EXPECT_TRUE(formats_for(hlg, HEVC).any());
+}
+
 TEST(HdrDynamicMetadata, SkipsVividPrerollWhenCodecCannotCarryIt) {
   using video::colorspace_e;
   using video::hdr_metadata::needs_vivid_startup_preroll;


### PR DESCRIPTION
承接 #944 的 review：Copilot 指出「编解码格式不能承载动态元数据时仍在跑分析器」。核对后前提成立，但范围比它说的更大——三条编码路径（avcodec / NVENC / AMF）都是如此，且它漏了一个更糟的问题：Web UI 会在 AV1 上显示 `HDR Vivid` 标签，而 #930 之后编码器早已不再发送它。所以这里一次覆盖全部三条路径。

## 问题

分析器在 `init()` 里按像素格式创建，那时只知道 P010/Y410/R16_UINT，还不知道客户端的色彩空间和编码格式；而**这两者共同决定**能不能真正写出动态元数据：

- HDR10+ 携带绝对亮度，只描述 PQ；
- HDR Vivid 覆盖 PQ 与 HLG，但只定义了 AVS2 与 HEVC/VVC 的承载，没有 AV1 OBU（#930）。

于是 **HLG over AV1** 是 HDR 流，却一种格式都写不出来。此前它照样每 N 帧跑两趟 compute shader、做 GPU→CPU 回读，结果全部丢弃；`init_compute_path()` 还会因为「分析已开启」而选择另一条转换路径。

## 改动

- `platf::encode_device_t` 增加 `video_format`（`config_t::videoFormat` 约定：0 H.264 / 1 HEVC / 2 AV1），由 `make_encode_device()` 在设置 `colorspace` 的同一处填入。avcodec 路径的 `init_output()` 调用点在帧池初始化深处、拿不到 `client_config`，只能走成员；NVENC / AMF 直接用作用域内的 `client_config.videoFormat`。
- 判定挪到 `init_output()`：`formats_for(colorspace, video_format).any()` 为假就不开分析，失败原因记为 `format_unsupported`，与既有的 `encoder_unsupported` / `analysis_setup_failed` 并列。位置在 `init_compute_path()` 之前，转换路径的选择因此也是基于真实状态。
- 拆分 `hdr_analysis_ready`（GPU 资源已创建）与 `hdr_analysis_enabled`（本次会话确实要跑），避免用一个布尔同时表达两件事。
- `publish_runtime_status()` 的 `metadata_formats` 改为询问 `formats_for()`，不再凭 colorspace 推断。这修掉了 AV1 上误报 `hdr_vivid` 的问题。
- Web UI：`format_unsupported` 在 auto 模式下与 `encoder_unsupported` 一样按「按设计降级」显示为灰色说明，而不是黄色警告；显式开启时仍然警告（用户确实要求了分析，换 HEVC 才能得到）。

H.264 不会走到这里：`encoder.h264[DYNAMIC_RANGE]` 恒为 false，HDR 色彩空间在那里不可能出现。

## 验证

- `tests/unit/test_video_hdr_metadata.cpp` 新增 `ReportsWhenNoFormatCanBeCarried`，覆盖门禁读的那个谓词：HLG+AV1、SDR+HEVC、SDR+AV1 为假，PQ+AV1、PQ+HEVC、HLG+HEVC 为真。
- `formats_t::any()` 的 `static_assert` 与 `formats_for()` 的断言在本地独立 TU 中编译并运行通过。
- 门禁本身在 `display_vram.cpp`（仅 Windows），由 CI 编译；#943 落地后 ctest 会一并跑上述单测。