### PR TITLE
fix(webui): format reported HDR luminance

### DIFF
--- a/src_assets/common/assets/web/composables/usePin.js
+++ b/src_assets/common/assets/web/composables/usePin.js
@@ -7,6 +7,16 @@ const STATUS_RESET_DELAY = 5000
 export const isColorProfileFile = (fileName) =>
   typeof fileName === 'string' && /\.(?:icc|icm)$/i.test(fileName)
 
+export const formatHdrNits = (value, fractionDigits = 1, trimTrailingZeros = false) => {
+  const number = Number(value)
+  if (!Number.isFinite(number)) return '—'
+
+  const formatted = number.toFixed(fractionDigits)
+  return trimTrailingZeros
+    ? formatted.replace(/(?:\.0+|(\.\d*?[1-9])0+)$/, '$1')
+    : formatted
+}
+
 const isSuccessfulStatus = (status) => {
   const normalized = status?.toString().toLowerCase()
   return normalized === '1' || normalized === 'true'

--- a/src_assets/common/assets/web/tests/usePin.test.js
+++ b/src_assets/common/assets/web/tests/usePin.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { isColorProfileFile, usePin } from '../composables/usePin.js'
+import { formatHdrNits, isColorProfileFile, usePin } from '../composables/usePin.js'
 
 const jsonResponse = (data, { ok = true, status = 200 } = {}) => ({
   ok,
@@ -16,6 +16,14 @@ test('recognizes ICC and ICM color profiles case-insensitively', () => {
   assert.equal(isColorProfileFile('display.icc.backup'), false)
   assert.equal(isColorProfileFile('displayXicc'), false)
   assert.equal(isColorProfileFile(null), false)
+})
+
+test('formats runtime HDR luminance without exposing float noise', () => {
+  assert.equal(formatHdrNits(701.9262084960938), '701.9')
+  assert.equal(formatHdrNits(155.9835968017578), '156.0')
+  assert.equal(formatHdrNits(0.0010000000474974513, 4, true), '0.001')
+  assert.equal(formatHdrNits(0.0001, 4, true), '0.0001')
+  assert.equal(formatHdrNits(Number.NaN), '—')
 })
 
 test('loads installed profiles from the authenticated Core endpoint', async () => {

--- a/src_assets/common/assets/web/views/Pin.vue
+++ b/src_assets/common/assets/web/views/Pin.vue
@@ -225,9 +225,9 @@
                             {{ $t(`pin.hdr_brightness_source_${client.hdrBrightnessRuntime.source}`) }}
                           </span>
                           <span class="runtime-values">
-                            {{ $t('pin.hdr_brightness_peak') }} {{ client.hdrBrightnessRuntime.maxNits }} ·
-                            {{ $t('pin.hdr_brightness_min') }} {{ client.hdrBrightnessRuntime.minNits }} ·
-                            {{ $t('pin.hdr_brightness_full_frame') }} {{ client.hdrBrightnessRuntime.maxFullFrameNits }}
+                            {{ $t('pin.hdr_brightness_peak') }} {{ formatHdrNits(client.hdrBrightnessRuntime.maxNits) }} ·
+                            {{ $t('pin.hdr_brightness_min') }} {{ formatHdrNits(client.hdrBrightnessRuntime.minNits, 4, true) }} ·
+                            {{ $t('pin.hdr_brightness_full_frame') }} {{ formatHdrNits(client.hdrBrightnessRuntime.maxFullFrameNits) }}
                           </span>
                         </div>
                       </div>
@@ -366,7 +366,7 @@ import { onMounted, ref, nextTick, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { Tooltip } from 'bootstrap'
 import Navbar from '../components/layout/Navbar.vue'
-import { usePin } from '../composables/usePin.js'
+import { formatHdrNits, usePin } from '../composables/usePin.js'
 import { useQrPair } from '../composables/useQrPair.js'
 
 const { t } = useI18n()


### PR DESCRIPTION
## 改了啥呀

- 给客户端运行时 HDR 亮度增加统一的展示格式化。
- 峰值与全屏亮度保留 1 位小数，最低亮度保留最多 4 位并去掉多余的零。
- 非有限数值显示为 `—`，不把异常数据直接塞进表格。
- 仅格式化 UI 文本，不修改客户端原始上报、配置保存或编码使用的亮度值。

## 为啥要改

C++ `float` 经 JSON 到前端后会暴露二进制浮点尾差，例如 `0.0010000000474974513`。数值本身没坏，但整串显示既难读又会挤压表格。现在只把这类杂鱼精度噪声挡在展示层外面～

## 验证

- `npm run test:webui`：112/112 通过
- `npm run lint:webui -- --no-cache`：通过
- `git diff --check`：通过
- 新增测试覆盖峰值、全屏、极低亮度与无效数值
