### PR TITLE
feat(ds5): add legacy haptics rumble fallback

### DIFF
--- a/src/haptics/authored_ir.cpp
+++ b/src/haptics/authored_ir.cpp
@@ -20,7 +20,6 @@ namespace haptics {
     constexpr auto legacy_emit_period = std::chrono::milliseconds(20);
     constexpr auto legacy_watchdog_timeout = std::chrono::milliseconds(100);
     constexpr float legacy_noise_gate = 0.015f;
-    constexpr std::uint16_t legacy_change_threshold = 512;
 
     void
     write_u16(std::uint8_t *p, std::uint16_t value) {
@@ -56,12 +55,6 @@ namespace haptics {
     rumble_u16(float value) {
       return static_cast<std::uint16_t>(std::lround(
         std::clamp(value, 0.0f, 1.0f) * std::numeric_limits<std::uint16_t>::max()));
-    }
-
-    bool
-    materially_changed(std::uint16_t previous, std::uint16_t current) {
-      const auto delta = previous > current ? previous - current : current - previous;
-      return delta >= legacy_change_threshold || (previous == 0) != (current == 0);
     }
   }  // namespace
 
@@ -214,6 +207,8 @@ namespace haptics {
     float low_target = 0.0f;
     float high_target = 0.0f;
     if ((frame->flags & AH_AUTHORED_FRAME_SILENT) == 0) {
+      // Trim gains compensate ERM motors' weak response to low drive levels;
+      // transients get less because peak amplitude already overshoots RMS.
       for (const auto &lane : frame->lanes) {
         const auto low = lane.rms_amplitude * std::sqrt(std::clamp(lane.low_band_ratio, 0.0f, 1.0f));
         const auto high_band = lane.rms_amplitude * std::sqrt(std::clamp(1.0f - lane.low_band_ratio, 0.0f, 1.0f));
@@ -237,12 +232,12 @@ namespace haptics {
 
     const auto low = rumble_u16(_smoothed_low);
     const auto high = rumble_u16(_smoothed_high);
-    if (!must_stop && _last_emit != std::chrono::steady_clock::time_point {} &&
-        now - _last_emit < legacy_emit_period) {
-      return std::nullopt;
-    }
+    // The 20 ms rate limit is the only emission gate. Held silence additionally
+    // stays quiet instead of re-sending zero rumble at 50 Hz.
+    const bool silent_hold = low == 0 && high == 0 && _last_low == 0 && _last_high == 0;
     if (!must_stop && !force_emit &&
-        !materially_changed(_last_low, low) && !materially_changed(_last_high, high)) {
+        (silent_hold ||
+         (_last_emit != std::chrono::steady_clock::time_point {} && now - _last_emit < legacy_emit_period))) {
       return std::nullopt;
     }
 

--- a/src/haptics/authored_ir.cpp
+++ b/src/haptics/authored_ir.cpp
@@ -4,8 +4,11 @@
  */
 #include "authored_ir.h"
 
+#include <algorithm>
 #include <bit>
+#include <cmath>
 #include <cstring>
+#include <limits>
 
 #include <moonlight_haptics/authored_haptics.h>
 
@@ -14,8 +17,10 @@ namespace haptics {
     constexpr std::uint8_t source_stream_start = 0x01;
     constexpr std::uint8_t source_stream_end = 0x02;
     constexpr std::uint8_t source_discontinuity = 0x04;
-    constexpr std::uint8_t ir_stream_end = 0x04;
-    constexpr std::uint8_t ir_silent = 0x08;
+    constexpr auto legacy_emit_period = std::chrono::milliseconds(20);
+    constexpr auto legacy_watchdog_timeout = std::chrono::milliseconds(100);
+    constexpr float legacy_noise_gate = 0.015f;
+    constexpr std::uint16_t legacy_change_threshold = 512;
 
     void
     write_u16(std::uint8_t *p, std::uint16_t value) {
@@ -41,6 +46,23 @@ namespace haptics {
     write_float(std::uint8_t *p, float value) {
       write_u32(p, std::bit_cast<std::uint32_t>(value));
     }
+
+    float
+    gated(float value) {
+      return std::clamp((value - legacy_noise_gate) / (1.0f - legacy_noise_gate), 0.0f, 1.0f);
+    }
+
+    std::uint16_t
+    rumble_u16(float value) {
+      return static_cast<std::uint16_t>(std::lround(
+        std::clamp(value, 0.0f, 1.0f) * std::numeric_limits<std::uint16_t>::max()));
+    }
+
+    bool
+    materially_changed(std::uint16_t previous, std::uint16_t current) {
+      const auto delta = previous > current ? previous - current : current - previous;
+      return delta >= legacy_change_threshold || (previous == 0) != (current == 0);
+    }
   }  // namespace
 
   void
@@ -64,10 +86,9 @@ namespace haptics {
     return _engine != nullptr;
   }
 
-  std::optional<authored_ir_v2_wire_t>
-  authored_ir_session_t::process(std::uint16_t controller_id, std::uint8_t source_flags,
-                                 std::uint16_t frame_count, std::uint32_t sequence,
-                                 std::uint64_t presentation_time_us,
+  std::optional<authored_frame_t>
+  authored_ir_session_t::analyze(std::uint8_t source_flags, std::uint16_t frame_count,
+                                 std::uint32_t sequence, std::uint64_t presentation_time_us,
                                  std::span<const std::uint8_t> pcm) {
     const auto expected_pcm_size = static_cast<std::size_t>(frame_count) * 4;
     if (!_engine || frame_count > 240 || pcm.size() != expected_pcm_size) {
@@ -97,24 +118,51 @@ namespace haptics {
       return std::nullopt;
     }
 
-    authored_ir_v2_wire_t wire {};
-    wire[0] = 2;
-    write_u16(wire.data() + 2, authored_ir_v2_wire_size);
-    write_u16(wire.data() + 4, controller_id);
-    write_u32(wire.data() + 8, sequence);
-    write_u64(wire.data() + 12, presentation_time_us);
-    write_u32(wire.data() + 20, frame_count);
     if (output_count == 0 && (source_flags & source_stream_end)) {
-      // An empty stream has no analyzable frame, but the transport must still
-      // stop the client's actuator and clear its renderer state.
-      wire[1] = ir_stream_end | ir_silent;
-      return wire;
+      return authored_frame_t {
+        .flags = AH_AUTHORED_FRAME_STREAM_END | AH_AUTHORED_FRAME_SILENT,
+        .timestamp_us = presentation_time_us,
+        .source_sequence_number = sequence,
+        .source_frame_count = frame_count,
+      };
     }
     if (output_count != 1) {
       return std::nullopt;
     }
 
     const auto &frame = output[0];
+    authored_frame_t result {
+      .flags = frame.flags,
+      .timestamp_us = frame.timestamp_us,
+      .source_sequence_number = frame.source_sequence_number,
+      .source_frame_count = frame.source_frame_count,
+      .lane_correlation = frame.lane_correlation,
+    };
+    for (std::size_t lane = 0; lane < result.lanes.size(); ++lane) {
+      result.lanes[lane] = {
+        .rms_amplitude = frame.lanes[lane].rms_amplitude,
+        .peak_amplitude = frame.lanes[lane].peak_amplitude,
+        .transient_strength = frame.lanes[lane].transient_strength,
+        .low_band_ratio = frame.lanes[lane].low_band_ratio,
+        .zero_crossing_rate_hz = frame.lanes[lane].zero_crossing_rate_hz,
+      };
+    }
+    return result;
+  }
+
+  std::optional<authored_ir_v2_wire_t>
+  authored_ir_session_t::process(std::uint16_t controller_id, std::uint8_t source_flags,
+                                 std::uint16_t frame_count, std::uint32_t sequence,
+                                 std::uint64_t presentation_time_us,
+                                 std::span<const std::uint8_t> pcm) {
+    const auto analyzed = analyze(source_flags, frame_count, sequence, presentation_time_us, pcm);
+    if (!analyzed) return std::nullopt;
+
+    authored_ir_v2_wire_t wire {};
+    wire[0] = 2;
+    write_u16(wire.data() + 2, authored_ir_v2_wire_size);
+    write_u16(wire.data() + 4, controller_id);
+    const auto &frame = *analyzed;
     if (frame.flags & AH_AUTHORED_FRAME_DISCONTINUITY) wire[1] |= 0x01;
     if (frame.flags & AH_AUTHORED_FRAME_PARTIAL) wire[1] |= 0x02;
     if (frame.flags & AH_AUTHORED_FRAME_STREAM_END) wire[1] |= 0x04;
@@ -134,5 +182,87 @@ namespace haptics {
     write_float(wire.data() + 64, frame.lane_correlation);
     write_u32(wire.data() + 68, 0);
     return wire;
+  }
+
+  bool
+  legacy_rumble_session_t::ready() const noexcept {
+    return _analyzer.ready();
+  }
+
+  std::optional<legacy_rumble_t>
+  legacy_rumble_session_t::process(std::uint16_t controller_id, std::uint8_t source_flags,
+                                   std::uint16_t frame_count, std::uint32_t sequence,
+                                   std::uint64_t presentation_time_us,
+                                   std::span<const std::uint8_t> pcm,
+                                   std::chrono::steady_clock::time_point now) {
+    const auto frame = _analyzer.analyze(
+      source_flags, frame_count, sequence, presentation_time_us, pcm);
+    if (!frame) return std::nullopt;
+
+    _controller_id = controller_id;
+    _last_input = now;
+    _have_input = true;
+
+    const bool force_emit = (source_flags & (source_stream_start | source_discontinuity)) != 0;
+    if (force_emit) {
+      _smoothed_low = 0.0f;
+      _smoothed_high = 0.0f;
+      _last_emit = {};
+    }
+
+    const bool must_stop = (frame->flags & AH_AUTHORED_FRAME_STREAM_END) != 0;
+    float low_target = 0.0f;
+    float high_target = 0.0f;
+    if ((frame->flags & AH_AUTHORED_FRAME_SILENT) == 0) {
+      for (const auto &lane : frame->lanes) {
+        const auto low = lane.rms_amplitude * std::sqrt(std::clamp(lane.low_band_ratio, 0.0f, 1.0f));
+        const auto high_band = lane.rms_amplitude * std::sqrt(std::clamp(1.0f - lane.low_band_ratio, 0.0f, 1.0f));
+        const auto transient = lane.peak_amplitude * lane.transient_strength;
+        low_target = std::max(low_target, gated(low * 1.35f));
+        high_target = std::max(high_target, gated(std::max(high_band * 1.45f, transient * 1.15f)));
+      }
+    }
+
+    // Time-based attack/release prevents the mapping from depending on whether
+    // the sidecar happens to deliver 5 ms or larger PCM chunks.
+    const auto duration_seconds = static_cast<float>(frame->source_frame_count) / 48000.0f;
+    const auto smooth = [duration_seconds](float previous, float target) {
+      const auto tau = target > previous ? 0.010f : 0.035f;
+      const auto alpha = 1.0f - std::exp(-duration_seconds / tau);
+      return previous + (target - previous) * alpha;
+    };
+    _smoothed_low = must_stop ? 0.0f : smooth(_smoothed_low, low_target);
+    _smoothed_high = must_stop ? 0.0f : smooth(_smoothed_high, high_target);
+
+    const auto low = rumble_u16(_smoothed_low);
+    const auto high = rumble_u16(_smoothed_high);
+    if (!must_stop && _last_emit != std::chrono::steady_clock::time_point {} &&
+        now - _last_emit < legacy_emit_period) {
+      return std::nullopt;
+    }
+    if (!must_stop && !force_emit &&
+        !materially_changed(_last_low, low) && !materially_changed(_last_high, high)) {
+      return std::nullopt;
+    }
+
+    _last_emit = now;
+    _last_low = low;
+    _last_high = high;
+    return legacy_rumble_t {controller_id, low, high};
+  }
+
+  std::optional<legacy_rumble_t>
+  legacy_rumble_session_t::poll(std::chrono::steady_clock::time_point now) {
+    if (!_have_input || now - _last_input < legacy_watchdog_timeout ||
+        (_last_low == 0 && _last_high == 0)) {
+      return std::nullopt;
+    }
+    _have_input = false;
+    _smoothed_low = 0.0f;
+    _smoothed_high = 0.0f;
+    _last_low = 0;
+    _last_high = 0;
+    _last_emit = now;
+    return legacy_rumble_t {_controller_id, 0, 0};
   }
 }  // namespace haptics

--- a/src/haptics/authored_ir.cpp
+++ b/src/haptics/authored_ir.cpp
@@ -224,8 +224,9 @@ namespace haptics {
     }
 
     // Time-based attack/release prevents the mapping from depending on whether
-    // the sidecar happens to deliver 5 ms or larger PCM chunks.
-    const auto duration_seconds = static_cast<float>(frame->source_frame_count) / 48000.0f;
+    // the sidecar happens to deliver 5 ms or larger PCM chunks. A zero-frame
+    // chunk must not freeze the smoother at its previous value.
+    const auto duration_seconds = static_cast<float>(std::max(frame->source_frame_count, 1u)) / 48000.0f;
     const auto smooth = [duration_seconds](float previous, float target) {
       const auto tau = target > previous ? 0.010f : 0.035f;
       const auto alpha = 1.0f - std::exp(-duration_seconds / tau);

--- a/src/haptics/authored_ir.h
+++ b/src/haptics/authored_ir.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -17,6 +18,23 @@ namespace haptics {
   constexpr std::size_t authored_ir_v2_wire_size = 72;
   using authored_ir_v2_wire_t = std::array<std::uint8_t, authored_ir_v2_wire_size>;
 
+  struct authored_lane_t {
+    float rms_amplitude;
+    float peak_amplitude;
+    float transient_strength;
+    float low_band_ratio;
+    float zero_crossing_rate_hz;
+  };
+
+  struct authored_frame_t {
+    std::uint32_t flags;
+    std::uint64_t timestamp_us;
+    std::uint32_t source_sequence_number;
+    std::uint32_t source_frame_count;
+    std::array<authored_lane_t, 2> lanes;
+    float lane_correlation;
+  };
+
   class authored_ir_session_t {
   public:
     authored_ir_session_t();
@@ -27,6 +45,11 @@ namespace haptics {
 
     bool
     ready() const noexcept;
+
+    std::optional<authored_frame_t>
+    analyze(std::uint8_t source_flags, std::uint16_t frame_count,
+            std::uint32_t sequence, std::uint64_t presentation_time_us,
+            std::span<const std::uint8_t> pcm);
 
     std::optional<authored_ir_v2_wire_t>
     process(std::uint16_t controller_id, std::uint8_t source_flags,
@@ -39,5 +62,41 @@ namespace haptics {
       void operator()(AhAuthoredEngine *engine) const noexcept;
     };
     std::unique_ptr<AhAuthoredEngine, engine_deleter_t> _engine;
+  };
+
+  struct legacy_rumble_t {
+    std::uint16_t controller_id;
+    std::uint16_t low_frequency;
+    std::uint16_t high_frequency;
+  };
+
+  /**
+   * Converts authored DualSense actuator PCM into the two-motor rumble format
+   * understood by legacy Moonlight clients.
+   */
+  class legacy_rumble_session_t {
+  public:
+    bool
+    ready() const noexcept;
+
+    std::optional<legacy_rumble_t>
+    process(std::uint16_t controller_id, std::uint8_t source_flags,
+            std::uint16_t frame_count, std::uint32_t sequence,
+            std::uint64_t presentation_time_us, std::span<const std::uint8_t> pcm,
+            std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now());
+
+    std::optional<legacy_rumble_t>
+    poll(std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now());
+
+  private:
+    authored_ir_session_t _analyzer;
+    std::chrono::steady_clock::time_point _last_input {};
+    std::chrono::steady_clock::time_point _last_emit {};
+    std::uint16_t _controller_id = 0;
+    std::uint16_t _last_low = 0;
+    std::uint16_t _last_high = 0;
+    float _smoothed_low = 0.0f;
+    float _smoothed_high = 0.0f;
+    bool _have_input = false;
   };
 }  // namespace haptics

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -638,6 +638,10 @@ namespace stream {
 
       std::unique_ptr<haptics::authored_ir_session_t> authored_haptics;
       bool authored_haptics_init_failed = false;
+      std::unique_ptr<haptics::legacy_rumble_session_t> legacy_haptics;
+      bool legacy_haptics_init_failed = false;
+      std::unordered_map<std::uint16_t, std::pair<std::uint16_t, std::uint16_t>> compatibility_rumble;
+      std::unordered_map<std::uint16_t, std::pair<std::uint16_t, std::uint16_t>> synthesized_haptics_rumble;
     } control;
 
     std::uint32_t launch_session_id;
@@ -1303,7 +1307,8 @@ namespace stream {
    * @return 0 on success.
    */
   int
-  send_feedback_msg(session_t *session, platf::gamepad_feedback_msg_t &msg) {
+  send_feedback_msg(session_t *session, platf::gamepad_feedback_msg_t &msg,
+                    bool synthesized_haptics = false) {
     if (!session->control.peer) {
       BOOST_LOG(warning) << "Couldn't send gamepad feedback data, still waiting for PING from Moonlight"sv;
       // Still waiting for PING from Moonlight
@@ -1318,13 +1323,21 @@ namespace stream {
       plaintext.header.payloadLength = sizeof(plaintext) - sizeof(control_header_v2);
 
       auto &data = msg.data.rumble;
+      auto &source = synthesized_haptics ?
+                       session->control.synthesized_haptics_rumble :
+                       session->control.compatibility_rumble;
+      source[msg.id] = {data.lowfreq, data.highfreq};
+      const auto compatibility = session->control.compatibility_rumble[msg.id];
+      const auto synthesized = session->control.synthesized_haptics_rumble[msg.id];
+      const auto lowfreq = std::max(compatibility.first, synthesized.first);
+      const auto highfreq = std::max(compatibility.second, synthesized.second);
 
       plaintext.useless = 0xC0FFEE;
       plaintext.id = util::endian::little(msg.id);
-      plaintext.lowfreq = util::endian::little(data.lowfreq);
-      plaintext.highfreq = util::endian::little(data.highfreq);
+      plaintext.lowfreq = util::endian::little(lowfreq);
+      plaintext.highfreq = util::endian::little(highfreq);
 
-      BOOST_LOG(verbose) << "Rumble: "sv << msg.id << " :: "sv << util::hex(data.lowfreq).to_string_view() << " :: "sv << util::hex(data.highfreq).to_string_view();
+      BOOST_LOG(verbose) << "Rumble: "sv << msg.id << " :: "sv << util::hex(lowfreq).to_string_view() << " :: "sv << util::hex(highfreq).to_string_view();
       std::array<std::uint8_t,
         sizeof(control_encrypted_t) + crypto::cipher::round_to_pkcs7_padded(sizeof(plaintext)) + crypto::cipher::tag_size>
         encrypted_payload;
@@ -1406,9 +1419,6 @@ namespace stream {
     else if (msg.type == platf::gamepad_feedback_e::ds5_haptics_pcm) {
       const bool sends_raw_pcm = (session->config.mlFeatureFlags & ML_FF_DS5_HAPTICS_PCM) != 0;
       const bool sends_authored_ir = (session->config.mlFeatureFlags & ML_FF_DS5_HAPTICS_IR_V2) != 0;
-      if (!sends_raw_pcm && !sends_authored_ir) {
-        return 0;
-      }
 
       const auto &data = msg.data.ds5_haptics;
       const auto pcm_size = static_cast<std::size_t>(data.frame_count) * 4;
@@ -1426,9 +1436,33 @@ namespace stream {
         write_u32(p, static_cast<std::uint32_t>(v));
         write_u32(p + 4, static_cast<std::uint32_t>(v >> 32));
       };
+      if (!sends_raw_pcm && !sends_authored_ir) {
+        if (!session->control.legacy_haptics && !session->control.legacy_haptics_init_failed) {
+          auto legacy_haptics = std::make_unique<haptics::legacy_rumble_session_t>();
+          if (!legacy_haptics->ready()) {
+            session->control.legacy_haptics_init_failed = true;
+            BOOST_LOG(error) << "Unable to initialize legacy DualSense haptics fallback"sv;
+          }
+          else {
+            session->control.legacy_haptics = std::move(legacy_haptics);
+          }
+        }
+        if (!session->control.legacy_haptics) {
+          return 0;
+        }
+        const auto rumble = session->control.legacy_haptics->process(
+          msg.id, data.flags, data.frame_count, data.sequence, data.presentation_time_us,
+          std::span<const std::uint8_t> {data.pcm.data(), pcm_size});
+        if (!rumble) {
+          return 0;
+        }
+        auto legacy_msg = platf::gamepad_feedback_msg_t::make_rumble(
+          rumble->controller_id, rumble->low_frequency, rumble->high_frequency);
+        return send_feedback_msg(session, legacy_msg, true);
+      }
       // A malformed client that declares both modes gets the lossless physical
       // route. Official clients reject this combination before connecting.
-      if (sends_authored_ir && !sends_raw_pcm) {
+      else if (sends_authored_ir && !sends_raw_pcm) {
         if (!session->control.authored_haptics && !session->control.authored_haptics_init_failed) {
           auto authored_haptics = std::make_unique<haptics::authored_ir_session_t>();
           if (!authored_haptics->ready()) {
@@ -2290,12 +2324,21 @@ namespace stream {
           }
           else {
             has_ds5_haptics_session |=
-              (session->config.mlFeatureFlags & (ML_FF_DS5_HAPTICS_PCM | ML_FF_DS5_HAPTICS_IR_V2)) != 0;
+              (session->config.mlFeatureFlags & (ML_FF_DS5_HAPTICS_PCM | ML_FF_DS5_HAPTICS_IR_V2)) != 0 ||
+              (config::input.ds5_enabled && config::input.ds5_audio_haptics);
             auto &feedback_queue = session->control.feedback_queue;
             while (feedback_queue->peek()) {
               auto feedback_msg = feedback_queue->pop();
 
               send_feedback_msg(session, *feedback_msg);
+            }
+
+            if (session->control.legacy_haptics) {
+              if (const auto rumble = session->control.legacy_haptics->poll(now)) {
+                auto legacy_msg = platf::gamepad_feedback_msg_t::make_rumble(
+                  rumble->controller_id, rumble->low_frequency, rumble->high_frequency);
+                send_feedback_msg(session, legacy_msg, true);
+              }
             }
 
             auto &hdr_queue = session->control.hdr_queue;

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -638,7 +638,10 @@ namespace stream {
 
       std::unique_ptr<haptics::authored_ir_session_t> authored_haptics;
       bool authored_haptics_init_failed = false;
-      std::unique_ptr<haptics::legacy_rumble_session_t> legacy_haptics;
+      // One fallback session per controller: smoothing, throttle and watchdog
+      // state must not bleed between pads, and the watchdog stop has to reach
+      // the pad that actually stopped sending PCM.
+      std::unordered_map<std::uint16_t, std::unique_ptr<haptics::legacy_rumble_session_t>> legacy_haptics;
       bool legacy_haptics_init_failed = false;
       std::unordered_map<std::uint16_t, std::pair<std::uint16_t, std::uint16_t>> compatibility_rumble;
       std::unordered_map<std::uint16_t, std::pair<std::uint16_t, std::uint16_t>> synthesized_haptics_rumble;
@@ -1437,28 +1440,28 @@ namespace stream {
         write_u32(p + 4, static_cast<std::uint32_t>(v >> 32));
       };
       if (!sends_raw_pcm && !sends_authored_ir) {
-        if (!session->control.legacy_haptics && !session->control.legacy_haptics_init_failed) {
-          auto legacy_haptics = std::make_unique<haptics::legacy_rumble_session_t>();
-          if (!legacy_haptics->ready()) {
-            session->control.legacy_haptics_init_failed = true;
-            BOOST_LOG(error) << "Unable to initialize legacy DualSense haptics fallback"sv;
+        if (!session->control.legacy_haptics_init_failed) {
+          auto [controller_session, inserted] = session->control.legacy_haptics.try_emplace(msg.id);
+          if (inserted) {
+            auto created = std::make_unique<haptics::legacy_rumble_session_t>();
+            if (!created->ready()) {
+              session->control.legacy_haptics.erase(controller_session);
+              session->control.legacy_haptics_init_failed = true;
+              BOOST_LOG(error) << "Unable to initialize legacy DualSense haptics fallback"sv;
+              return 0;
+            }
+            controller_session->second = std::move(created);
           }
-          else {
-            session->control.legacy_haptics = std::move(legacy_haptics);
+          const auto rumble = controller_session->second->process(
+            msg.id, data.flags, data.frame_count, data.sequence, data.presentation_time_us,
+            std::span<const std::uint8_t> {data.pcm.data(), pcm_size});
+          if (rumble) {
+            auto legacy_msg = platf::gamepad_feedback_msg_t::make_rumble(
+              rumble->controller_id, rumble->low_frequency, rumble->high_frequency);
+            return send_feedback_msg(session, legacy_msg, true);
           }
         }
-        if (!session->control.legacy_haptics) {
-          return 0;
-        }
-        const auto rumble = session->control.legacy_haptics->process(
-          msg.id, data.flags, data.frame_count, data.sequence, data.presentation_time_us,
-          std::span<const std::uint8_t> {data.pcm.data(), pcm_size});
-        if (!rumble) {
-          return 0;
-        }
-        auto legacy_msg = platf::gamepad_feedback_msg_t::make_rumble(
-          rumble->controller_id, rumble->low_frequency, rumble->high_frequency);
-        return send_feedback_msg(session, legacy_msg, true);
+        return 0;
       }
       // A malformed client that declares both modes gets the lossless physical
       // route. Official clients reject this combination before connecting.
@@ -2333,10 +2336,10 @@ namespace stream {
               send_feedback_msg(session, *feedback_msg);
             }
 
-            if (session->control.legacy_haptics) {
-              if (const auto rumble = session->control.legacy_haptics->poll(now)) {
+            for (auto &[controller_id, controller_haptics] : session->control.legacy_haptics) {
+              if (const auto rumble = controller_haptics->poll(now)) {
                 auto legacy_msg = platf::gamepad_feedback_msg_t::make_rumble(
-                  rumble->controller_id, rumble->low_frequency, rumble->high_frequency);
+                  controller_id, rumble->low_frequency, rumble->high_frequency);
                 send_feedback_msg(session, legacy_msg, true);
               }
             }

--- a/tests/unit/test_authored_ir.cpp
+++ b/tests/unit/test_authored_ir.cpp
@@ -110,8 +110,7 @@ TEST(AuthoredDualSenseIr, LegacyFallbackProducesAndStopsRumble) {
   EXPECT_FALSE(session.process(2, 0, 240, 2, 5000, pcm, start + 5ms).has_value());
 
   // Once the 20 ms emit period has elapsed a louder chunk must come through,
-  // proving the suppression above was the rate limit rather than the change
-  // threshold.
+  // proving the suppression above was the rate limit.
   const auto louder = sine_pcm(100.0, 32000.0);
   const auto updated = session.process(2, 0, 240, 3, 25000, louder, start + 25ms);
   ASSERT_TRUE(updated.has_value());
@@ -128,6 +127,10 @@ TEST(AuthoredDualSenseIr, LegacyFallbackProducesAndStopsRumble) {
   ASSERT_TRUE(restarted_silent.has_value());
   EXPECT_EQ(restarted_silent->low_frequency, 0);
   EXPECT_EQ(restarted_silent->high_frequency, 0);
+
+  // Past the emit period again, held silence stays quiet instead of
+  // re-sending zero rumble at 50 Hz.
+  EXPECT_FALSE(session.process(2, 0, 240, 6, 60000, silence, start + 60ms).has_value());
 }
 
 TEST(AuthoredDualSenseIr, LegacyFallbackWatchdogReleasesMotors) {

--- a/tests/unit/test_authored_ir.cpp
+++ b/tests/unit/test_authored_ir.cpp
@@ -109,14 +109,22 @@ TEST(AuthoredDualSenseIr, LegacyFallbackProducesAndStopsRumble) {
   // to 50 Hz to avoid flooding clients and platform vibration APIs.
   EXPECT_FALSE(session.process(2, 0, 240, 2, 5000, pcm, start + 5ms).has_value());
 
+  // Once the 20 ms emit period has elapsed a louder chunk must come through,
+  // proving the suppression above was the rate limit rather than the change
+  // threshold.
+  const auto louder = sine_pcm(100.0, 32000.0);
+  const auto updated = session.process(2, 0, 240, 3, 25000, louder, start + 25ms);
+  ASSERT_TRUE(updated.has_value());
+  EXPECT_GT(updated->low_frequency, first->low_frequency);
+
   const std::span<const std::uint8_t> empty_pcm;
-  const auto stopped = session.process(2, 0x02, 0, 3, 10000, empty_pcm, start + 10ms);
+  const auto stopped = session.process(2, 0x02, 0, 4, 30000, empty_pcm, start + 30ms);
   ASSERT_TRUE(stopped.has_value());
   EXPECT_EQ(stopped->low_frequency, 0);
   EXPECT_EQ(stopped->high_frequency, 0);
 
   const std::vector<std::uint8_t> silence(240 * 4);
-  const auto restarted_silent = session.process(2, 0x01, 240, 4, 15000, silence, start + 15ms);
+  const auto restarted_silent = session.process(2, 0x01, 240, 5, 35000, silence, start + 35ms);
   ASSERT_TRUE(restarted_silent.has_value());
   EXPECT_EQ(restarted_silent->low_frequency, 0);
   EXPECT_EQ(restarted_silent->high_frequency, 0);

--- a/tests/unit/test_authored_ir.cpp
+++ b/tests/unit/test_authored_ir.cpp
@@ -1,4 +1,5 @@
 #include <cmath>
+#include <chrono>
 #include <cstdint>
 #include <cstring>
 #include <vector>
@@ -22,6 +23,20 @@ namespace {
     auto &parsed = *static_cast<parsed_frame_t *>(context);
     parsed.called = true;
     parsed.frame = *frame;
+  }
+
+  std::vector<std::uint8_t>
+  sine_pcm(double frequency_hz, double amplitude) {
+    std::vector<std::int16_t> pcm(240 * 2);
+    for (std::size_t frame = 0; frame < 240; ++frame) {
+      const auto sample = static_cast<std::int16_t>(
+        std::sin(static_cast<double>(frame) * frequency_hz * 6.283185307 / 48000.0) * amplitude);
+      pcm[frame * 2] = sample;
+      pcm[frame * 2 + 1] = sample;
+    }
+    std::vector<std::uint8_t> bytes(pcm.size() * sizeof(std::int16_t));
+    std::memcpy(bytes.data(), pcm.data(), bytes.size());
+    return bytes;
   }
 }
 
@@ -76,4 +91,53 @@ TEST(AuthoredDualSenseIr, EmitsStreamEndFrame) {
     wire->data(), static_cast<int>(wire->size()), capture_frame, &parsed));
   EXPECT_NE(parsed.frame.flags & LI_DS5_HAPTICS_IR_FLAG_STREAM_END, 0);
   EXPECT_NE(parsed.frame.flags & LI_DS5_HAPTICS_IR_FLAG_SILENT, 0);
+}
+
+TEST(AuthoredDualSenseIr, LegacyFallbackProducesAndStopsRumble) {
+  using namespace std::chrono_literals;
+  haptics::legacy_rumble_session_t session;
+  ASSERT_TRUE(session.ready());
+  const auto start = std::chrono::steady_clock::time_point {1s};
+  const auto pcm = sine_pcm(100.0, 24000.0);
+
+  const auto first = session.process(2, 0x01, 240, 1, 0, pcm, start);
+  ASSERT_TRUE(first.has_value());
+  EXPECT_EQ(first->controller_id, 2);
+  EXPECT_GT(first->low_frequency, 0);
+
+  // Source PCM arrives every 5 ms, but legacy rumble is deliberately limited
+  // to 50 Hz to avoid flooding clients and platform vibration APIs.
+  EXPECT_FALSE(session.process(2, 0, 240, 2, 5000, pcm, start + 5ms).has_value());
+
+  const std::span<const std::uint8_t> empty_pcm;
+  const auto stopped = session.process(2, 0x02, 0, 3, 10000, empty_pcm, start + 10ms);
+  ASSERT_TRUE(stopped.has_value());
+  EXPECT_EQ(stopped->low_frequency, 0);
+  EXPECT_EQ(stopped->high_frequency, 0);
+
+  const std::vector<std::uint8_t> silence(240 * 4);
+  const auto restarted_silent = session.process(2, 0x01, 240, 4, 15000, silence, start + 15ms);
+  ASSERT_TRUE(restarted_silent.has_value());
+  EXPECT_EQ(restarted_silent->low_frequency, 0);
+  EXPECT_EQ(restarted_silent->high_frequency, 0);
+}
+
+TEST(AuthoredDualSenseIr, LegacyFallbackWatchdogReleasesMotors) {
+  using namespace std::chrono_literals;
+  haptics::legacy_rumble_session_t session;
+  ASSERT_TRUE(session.ready());
+  const auto start = std::chrono::steady_clock::time_point {1s};
+  const auto pcm = sine_pcm(1000.0, 24000.0);
+
+  const auto first = session.process(1, 0x01, 240, 1, 0, pcm, start);
+  ASSERT_TRUE(first.has_value());
+  EXPECT_GT(first->high_frequency, 0);
+  EXPECT_FALSE(session.poll(start + 99ms).has_value());
+
+  const auto stopped = session.poll(start + 100ms);
+  ASSERT_TRUE(stopped.has_value());
+  EXPECT_EQ(stopped->controller_id, 1);
+  EXPECT_EQ(stopped->low_frequency, 0);
+  EXPECT_EQ(stopped->high_frequency, 0);
+  EXPECT_FALSE(session.poll(start + 200ms).has_value());
 }


### PR DESCRIPTION
## 改了啥呀

- 为没有声明 DualSense PCM / IR v2 能力的旧客户端增加主机端降级：Sunshine 使用现有 haptics SDK 分析 DS5 PCM，再通过传统双马达 rumble 协议发送
- 保留原始 PCM 与 IR v2 两条增强路径，common-c 的 IR v2 能力无需回滚
- 为降级输出加入 50 Hz 限频、噪声门、快启动/慢释放平滑，以及 100 ms 断流 watchdog
- 分开保存普通 rumble 与 PCM 合成振动并按马达取较大值，免得两路杂鱼状态互相覆盖或叠加过强
- DS5 音频触觉启用时维持 5 ms 控制循环，避免旧客户端因为没有特性位而落回 150 ms 调度

## 为啥要改

此前 `ds5_haptics_pcm` 只服务声明了原始 PCM 或 IR v2 的客户端；两种能力都未声明时，Sunshine 会直接丢弃触觉 PCM。结果就是虚拟 DS5 可以正常创建，但旧客户端无法从 HD Haptics 获得任何兼容振动。

现在新协议只是渐进增强，不再是获得基础振动的前置条件。旧客户端无需修改，也能继续使用已有 rumble 回调。

## 验证

- `cmake --build build-ucrt --target test_sunshine -j 4`
- `build-ucrt/tests/test_sunshine.exe --gtest_filter=AuthoredDualSenseIr.*`：5/5 通过
- 完整单测：393 项中 381 通过、11 跳过；唯一失败为既有 httpbin 重定向用例，外部服务返回 HTTP 302，单独复跑结果一致，与本次改动无关
