### PR TITLE
fix(hdr): avoid HLG fallback during analyzer cold start

### DIFF
--- a/src/video_hdr_metadata.h
+++ b/src/video_hdr_metadata.h
@@ -684,11 +684,11 @@ namespace video::hdr_metadata {
 
     /**
      * How long a session waits for stable analyzer output before starting without
-     * dynamic metadata. Long enough for three independent GPU readbacks at any
-     * supported analysis cadence, short enough that a client waiting on the first
-     * frame reads it as startup rather than a hang.
+     * dynamic metadata. The analyzer can take several hundred milliseconds to
+     * warm up after a display or encoder reinitialization, so leave enough room
+     * for that cold-start path while still bounding the first-frame wait.
      */
-    static constexpr auto PREROLL_TIMEOUT = std::chrono::milliseconds { 500 };
+    static constexpr auto PREROLL_TIMEOUT = std::chrono::milliseconds { 1500 };
 
     vivid_startup_gate_t(
       const sunshine_colorspace_t &colorspace,

--- a/tests/unit/test_video_hdr_metadata.cpp
+++ b/tests/unit/test_video_hdr_metadata.cpp
@@ -804,6 +804,28 @@ TEST(HdrDynamicMetadata, VividStartupGateHoldsHlgUntilTheGuardConverges) {
   EXPECT_EQ(later.transition, gate_t::transition_e::none);
 }
 
+TEST(HdrDynamicMetadata, VividStartupGateAllowsAnalyzerColdStart) {
+  gate_t gate { HLG, HEVC, true };
+
+  const auto start = std::chrono::steady_clock::now();
+  auto invalid = stable_hlg_stats(1);
+  invalid.valid = false;
+
+  // A slow first analyzer readback must not force this session into permanent
+  // HLG fallback before the GPU has had a chance to produce valid samples.
+  EXPECT_EQ(gate.observe(invalid, start).decision, gate_t::decision_e::hold);
+  EXPECT_EQ(gate.observe(invalid, start + std::chrono::seconds { 1 }).decision,
+    gate_t::decision_e::hold);
+
+  EXPECT_EQ(gate.observe(stable_hlg_stats(2), start + std::chrono::seconds { 1 }).decision,
+    gate_t::decision_e::hold);
+  EXPECT_EQ(gate.observe(stable_hlg_stats(3), start + std::chrono::seconds { 1 }).decision,
+    gate_t::decision_e::hold);
+  const auto ready = gate.observe(stable_hlg_stats(4), start + std::chrono::seconds { 1 });
+  EXPECT_EQ(ready.decision, gate_t::decision_e::emit);
+  EXPECT_EQ(ready.transition, gate_t::transition_e::ready);
+}
+
 TEST(HdrDynamicMetadata, VividStartupGateGivesUpAfterTheTimeout) {
   gate_t gate { HLG, HEVC, true };
 


### PR DESCRIPTION
## 改了啥呀

- 将 HLG + HEVC 的 HDR Vivid 启动预热预算从 500ms 延长到 1.5s。
- 增加回归测试：分析器在 1s 后才恢复有效样本时，会话仍进入 Vivid，而不是永久降级成 HLG。

## 为啥要改

鸿蒙端使用 HEVC + HLG，服务端需要先拿到 3 个独立且稳定的 CUVA 分析样本，再让首个 IDR 携带 HDR Vivid。当前门禁 500ms 到期后会永久关闭动态元数据。

实际日志中前两次会话分别在约 565ms 和 633ms 才走到超时，第三次会话约 87ms ready。分析器只是冷启动慢了一点，Vivid 小门禁就先把自己关掉了，客户端于是只能看到 HLG。1.5s 仍然有明确的首帧等待上限，同时覆盖显示器/编码器重初始化后的 GPU 分析器预热。

本 PR 不改客户端、不改 HEVC 编码协商、不伪造 Vivid，也不涉及 `minimum_fps_target`；分析器确实不可用时仍按原逻辑回退 HLG。

## 验证

- `git diff --check` 通过
- 新增 `VividStartupGateAllowsAnalyzerColdStart` 回归测试
- 当前开发机缺少 CMake、Boost 和 FFmpeg 开发依赖，无法运行完整 C++ 单测；未改动代码的依赖错误已记录
