### PR TITLE
feat(ds5): tune legacy haptics fallback

### DIFF
--- a/src/haptics/authored_ir.cpp
+++ b/src/haptics/authored_ir.cpp
@@ -21,10 +21,11 @@ namespace haptics {
     constexpr auto legacy_watchdog_timeout = std::chrono::milliseconds(100);
     constexpr float legacy_gate_open = 0.020f;
     constexpr float legacy_gate_close = 0.010f;
+    constexpr float legacy_gate_hold_seconds = 0.060f;
     constexpr float legacy_output_floor = 0.004f;
     constexpr float legacy_low_band_trim = 1.15f;
     constexpr float legacy_high_band_trim = 1.20f;
-    constexpr float legacy_transient_trim = 1.05f;
+    constexpr float legacy_transient_trim = 1.15f;
     constexpr float legacy_low_makeup_gain = 1.35f;
     constexpr float legacy_high_makeup_gain = 1.45f;
     constexpr float legacy_low_attack_seconds = 0.012f;
@@ -58,20 +59,22 @@ namespace haptics {
     }
 
     float
-    shaped(float value, float makeup_gain, bool &gate_open) {
+    shaped(float value, float makeup_gain, gate_state_t &gate, float duration_seconds) {
       value = std::clamp(value, 0.0f, 1.0f);
-      if (gate_open) {
-        if (value <= legacy_gate_close) {
-          gate_open = false;
-          return 0.0f;
+      if (value >= legacy_gate_open) {
+        gate.open = true;
+        gate.hold_seconds = legacy_gate_hold_seconds;
+      }
+      else if (gate.open) {
+        // Hysteresis only bridges short dips. Without the hold budget a level
+        // parked between the two thresholds -- which is exactly where residual
+        // out-of-band energy lands -- would keep the gate latched forever.
+        gate.hold_seconds -= duration_seconds;
+        if (value <= legacy_gate_close || gate.hold_seconds <= 0.0f) {
+          gate.open = false;
         }
       }
-      else if (value < legacy_gate_open) {
-        return 0.0f;
-      }
-      else {
-        gate_open = true;
-      }
+      if (!gate.open) return 0.0f;
 
       const auto gated = std::clamp(
         (value - legacy_gate_close) / (1.0f - legacy_gate_close), 0.0f, 1.0f);
@@ -227,8 +230,8 @@ namespace haptics {
     if (force_emit) {
       _smoothed_low = 0.0f;
       _smoothed_high = 0.0f;
-      _low_gate_open = false;
-      _high_gate_open = false;
+      _low_gate = {};
+      _high_gate = {};
       _last_emit = {};
     }
 
@@ -236,6 +239,8 @@ namespace haptics {
     float low_energy = 0.0f;
     float high_energy = 0.0f;
     if ((frame->flags & AH_AUTHORED_FRAME_SILENT) == 0) {
+      // Trim gains compensate ERM motors' weak response to low drive levels;
+      // transients get less because peak amplitude already overshoots RMS.
       for (const auto &lane : frame->lanes) {
         const auto low = lane.rms_amplitude * std::sqrt(std::clamp(lane.low_band_ratio, 0.0f, 1.0f));
         const auto high_band = lane.rms_amplitude * std::sqrt(std::clamp(1.0f - lane.low_band_ratio, 0.0f, 1.0f));
@@ -245,19 +250,20 @@ namespace haptics {
           high_band * legacy_high_band_trim, transient * legacy_transient_trim));
       }
     }
-    auto low_target = shaped(low_energy, legacy_low_makeup_gain, _low_gate_open);
-    auto high_target = shaped(high_energy, legacy_high_makeup_gain, _high_gate_open);
-    if (must_stop) {
-      low_target = 0.0f;
-      high_target = 0.0f;
-      _low_gate_open = false;
-      _high_gate_open = false;
-    }
 
     // The heavier low motor keeps body slightly longer; the lighter high motor
     // tracks texture and impacts quickly. Time-based coefficients keep this
     // independent of the sidecar's chunk boundaries.
     const auto duration_seconds = static_cast<float>(std::max(frame->source_frame_count, 1u)) / 48000.0f;
+    if (must_stop) {
+      _low_gate = {};
+      _high_gate = {};
+    }
+    const auto low_target = must_stop ? 0.0f : shaped(
+      low_energy, legacy_low_makeup_gain, _low_gate, duration_seconds);
+    const auto high_target = must_stop ? 0.0f : shaped(
+      high_energy, legacy_high_makeup_gain, _high_gate, duration_seconds);
+
     const auto smooth = [duration_seconds](float previous, float target,
                                            float attack, float release) {
       const auto tau = target > previous ? attack : release;
@@ -268,8 +274,8 @@ namespace haptics {
       _smoothed_low, low_target, legacy_low_attack_seconds, legacy_low_release_seconds);
     _smoothed_high = must_stop ? 0.0f : smooth(
       _smoothed_high, high_target, legacy_high_attack_seconds, legacy_high_release_seconds);
-    if (low_target == 0.0f && _smoothed_low < legacy_output_floor) _smoothed_low = 0.0f;
-    if (high_target == 0.0f && _smoothed_high < legacy_output_floor) _smoothed_high = 0.0f;
+    if (low_target <= 0.0f && _smoothed_low < legacy_output_floor) _smoothed_low = 0.0f;
+    if (high_target <= 0.0f && _smoothed_high < legacy_output_floor) _smoothed_high = 0.0f;
 
     const auto low = rumble_u16(_smoothed_low);
     const auto high = rumble_u16(_smoothed_high);
@@ -290,17 +296,18 @@ namespace haptics {
 
   std::optional<legacy_rumble_t>
   legacy_rumble_session_t::poll(std::chrono::steady_clock::time_point now) {
-    if (!_have_input || now - _last_input < legacy_watchdog_timeout ||
-        (_last_low == 0 && _last_high == 0)) {
+    if (!_have_input || now - _last_input < legacy_watchdog_timeout) {
       return std::nullopt;
     }
+    const bool had_output = _last_low != 0 || _last_high != 0;
     _have_input = false;
     _smoothed_low = 0.0f;
     _smoothed_high = 0.0f;
-    _low_gate_open = false;
-    _high_gate_open = false;
+    _low_gate = {};
+    _high_gate = {};
     _last_low = 0;
     _last_high = 0;
+    if (!had_output) return std::nullopt;
     _last_emit = now;
     return legacy_rumble_t {_controller_id, 0, 0};
   }

--- a/src/haptics/authored_ir.cpp
+++ b/src/haptics/authored_ir.cpp
@@ -19,7 +19,18 @@ namespace haptics {
     constexpr std::uint8_t source_discontinuity = 0x04;
     constexpr auto legacy_emit_period = std::chrono::milliseconds(20);
     constexpr auto legacy_watchdog_timeout = std::chrono::milliseconds(100);
-    constexpr float legacy_noise_gate = 0.015f;
+    constexpr float legacy_gate_open = 0.020f;
+    constexpr float legacy_gate_close = 0.010f;
+    constexpr float legacy_output_floor = 0.004f;
+    constexpr float legacy_low_band_trim = 1.15f;
+    constexpr float legacy_high_band_trim = 1.20f;
+    constexpr float legacy_transient_trim = 1.05f;
+    constexpr float legacy_low_makeup_gain = 1.35f;
+    constexpr float legacy_high_makeup_gain = 1.45f;
+    constexpr float legacy_low_attack_seconds = 0.012f;
+    constexpr float legacy_low_release_seconds = 0.040f;
+    constexpr float legacy_high_attack_seconds = 0.006f;
+    constexpr float legacy_high_release_seconds = 0.025f;
 
     void
     write_u16(std::uint8_t *p, std::uint16_t value) {
@@ -47,8 +58,24 @@ namespace haptics {
     }
 
     float
-    gated(float value) {
-      return std::clamp((value - legacy_noise_gate) / (1.0f - legacy_noise_gate), 0.0f, 1.0f);
+    shaped(float value, float makeup_gain, bool &gate_open) {
+      value = std::clamp(value, 0.0f, 1.0f);
+      if (gate_open) {
+        if (value <= legacy_gate_close) {
+          gate_open = false;
+          return 0.0f;
+        }
+      }
+      else if (value < legacy_gate_open) {
+        return 0.0f;
+      }
+      else {
+        gate_open = true;
+      }
+
+      const auto gated = std::clamp(
+        (value - legacy_gate_close) / (1.0f - legacy_gate_close), 0.0f, 1.0f);
+      return std::tanh(makeup_gain * gated) / std::tanh(makeup_gain);
     }
 
     std::uint16_t
@@ -200,35 +227,49 @@ namespace haptics {
     if (force_emit) {
       _smoothed_low = 0.0f;
       _smoothed_high = 0.0f;
+      _low_gate_open = false;
+      _high_gate_open = false;
       _last_emit = {};
     }
 
     const bool must_stop = (frame->flags & AH_AUTHORED_FRAME_STREAM_END) != 0;
-    float low_target = 0.0f;
-    float high_target = 0.0f;
+    float low_energy = 0.0f;
+    float high_energy = 0.0f;
     if ((frame->flags & AH_AUTHORED_FRAME_SILENT) == 0) {
-      // Trim gains compensate ERM motors' weak response to low drive levels;
-      // transients get less because peak amplitude already overshoots RMS.
       for (const auto &lane : frame->lanes) {
         const auto low = lane.rms_amplitude * std::sqrt(std::clamp(lane.low_band_ratio, 0.0f, 1.0f));
         const auto high_band = lane.rms_amplitude * std::sqrt(std::clamp(1.0f - lane.low_band_ratio, 0.0f, 1.0f));
         const auto transient = lane.peak_amplitude * lane.transient_strength;
-        low_target = std::max(low_target, gated(low * 1.35f));
-        high_target = std::max(high_target, gated(std::max(high_band * 1.45f, transient * 1.15f)));
+        low_energy = std::max(low_energy, low * legacy_low_band_trim);
+        high_energy = std::max(high_energy, std::max(
+          high_band * legacy_high_band_trim, transient * legacy_transient_trim));
       }
     }
+    auto low_target = shaped(low_energy, legacy_low_makeup_gain, _low_gate_open);
+    auto high_target = shaped(high_energy, legacy_high_makeup_gain, _high_gate_open);
+    if (must_stop) {
+      low_target = 0.0f;
+      high_target = 0.0f;
+      _low_gate_open = false;
+      _high_gate_open = false;
+    }
 
-    // Time-based attack/release prevents the mapping from depending on whether
-    // the sidecar happens to deliver 5 ms or larger PCM chunks. A zero-frame
-    // chunk must not freeze the smoother at its previous value.
+    // The heavier low motor keeps body slightly longer; the lighter high motor
+    // tracks texture and impacts quickly. Time-based coefficients keep this
+    // independent of the sidecar's chunk boundaries.
     const auto duration_seconds = static_cast<float>(std::max(frame->source_frame_count, 1u)) / 48000.0f;
-    const auto smooth = [duration_seconds](float previous, float target) {
-      const auto tau = target > previous ? 0.010f : 0.035f;
+    const auto smooth = [duration_seconds](float previous, float target,
+                                           float attack, float release) {
+      const auto tau = target > previous ? attack : release;
       const auto alpha = 1.0f - std::exp(-duration_seconds / tau);
       return previous + (target - previous) * alpha;
     };
-    _smoothed_low = must_stop ? 0.0f : smooth(_smoothed_low, low_target);
-    _smoothed_high = must_stop ? 0.0f : smooth(_smoothed_high, high_target);
+    _smoothed_low = must_stop ? 0.0f : smooth(
+      _smoothed_low, low_target, legacy_low_attack_seconds, legacy_low_release_seconds);
+    _smoothed_high = must_stop ? 0.0f : smooth(
+      _smoothed_high, high_target, legacy_high_attack_seconds, legacy_high_release_seconds);
+    if (low_target == 0.0f && _smoothed_low < legacy_output_floor) _smoothed_low = 0.0f;
+    if (high_target == 0.0f && _smoothed_high < legacy_output_floor) _smoothed_high = 0.0f;
 
     const auto low = rumble_u16(_smoothed_low);
     const auto high = rumble_u16(_smoothed_high);
@@ -256,6 +297,8 @@ namespace haptics {
     _have_input = false;
     _smoothed_low = 0.0f;
     _smoothed_high = 0.0f;
+    _low_gate_open = false;
+    _high_gate_open = false;
     _last_low = 0;
     _last_high = 0;
     _last_emit = now;

--- a/src/haptics/authored_ir.h
+++ b/src/haptics/authored_ir.h
@@ -97,6 +97,8 @@ namespace haptics {
     std::uint16_t _last_high = 0;
     float _smoothed_low = 0.0f;
     float _smoothed_high = 0.0f;
+    bool _low_gate_open = false;
+    bool _high_gate_open = false;
     bool _have_input = false;
   };
 }  // namespace haptics

--- a/src/haptics/authored_ir.h
+++ b/src/haptics/authored_ir.h
@@ -71,6 +71,15 @@ namespace haptics {
   };
 
   /**
+   * Noise-gate state for one motor. The hold budget bounds how long hysteresis
+   * may keep the gate open without the input re-crossing the open threshold.
+   */
+  struct gate_state_t {
+    bool open = false;
+    float hold_seconds = 0.0f;
+  };
+
+  /**
    * Converts authored DualSense actuator PCM into the two-motor rumble format
    * understood by legacy Moonlight clients.
    */
@@ -97,8 +106,8 @@ namespace haptics {
     std::uint16_t _last_high = 0;
     float _smoothed_low = 0.0f;
     float _smoothed_high = 0.0f;
-    bool _low_gate_open = false;
-    bool _high_gate_open = false;
+    gate_state_t _low_gate;
+    gate_state_t _high_gate;
     bool _have_input = false;
   };
 }  // namespace haptics

--- a/tests/unit/test_authored_ir.cpp
+++ b/tests/unit/test_authored_ir.cpp
@@ -2,6 +2,7 @@
 #include <chrono>
 #include <cstdint>
 #include <cstring>
+#include <optional>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -26,11 +27,11 @@ namespace {
   }
 
   std::vector<std::uint8_t>
-  sine_pcm(double frequency_hz, double amplitude) {
+  sine_pcm(double frequency_hz, double amplitude, std::size_t first_frame = 0) {
     std::vector<std::int16_t> pcm(240 * 2);
     for (std::size_t frame = 0; frame < 240; ++frame) {
       const auto sample = static_cast<std::int16_t>(
-        std::sin(static_cast<double>(frame) * frequency_hz * 6.283185307 / 48000.0) * amplitude);
+        std::sin(static_cast<double>(first_frame + frame) * frequency_hz * 6.283185307 / 48000.0) * amplitude);
       pcm[frame * 2] = sample;
       pcm[frame * 2 + 1] = sample;
     }
@@ -133,12 +134,41 @@ TEST(AuthoredDualSenseIr, LegacyFallbackProducesAndStopsRumble) {
   EXPECT_FALSE(session.process(2, 0, 240, 6, 60000, silence, start + 60ms).has_value());
 }
 
+TEST(AuthoredDualSenseIr, LegacyFallbackSeparatesTactileBandsAndRejectsHiss) {
+  using namespace std::chrono_literals;
+  const auto measure = [](double frequency_hz) {
+    haptics::legacy_rumble_session_t session;
+    std::optional<haptics::legacy_rumble_t> latest;
+    const auto start = std::chrono::steady_clock::time_point {1s};
+    for (std::uint32_t chunk = 0; chunk <= 20; ++chunk) {
+      const auto pcm = sine_pcm(frequency_hz, 24000.0, chunk * 240U);
+      const auto output = session.process(
+        0, chunk == 0 ? 0x01 : 0, 240, chunk,
+        static_cast<std::uint64_t>(chunk) * 5000U, pcm,
+        start + std::chrono::milliseconds(chunk * 5U));
+      if (output) latest = output;
+    }
+    return latest;
+  };
+
+  const auto body = measure(120.0);
+  const auto texture = measure(300.0);
+  const auto hiss = measure(1000.0);
+  ASSERT_TRUE(body.has_value());
+  ASSERT_TRUE(texture.has_value());
+  ASSERT_TRUE(hiss.has_value());
+  EXPECT_GT(body->low_frequency, texture->low_frequency);
+  EXPECT_GT(texture->high_frequency, body->high_frequency);
+  EXPECT_GT(body->low_frequency, hiss->low_frequency * 8U);
+  EXPECT_GT(texture->high_frequency, hiss->high_frequency * 8U);
+}
+
 TEST(AuthoredDualSenseIr, LegacyFallbackWatchdogReleasesMotors) {
   using namespace std::chrono_literals;
   haptics::legacy_rumble_session_t session;
   ASSERT_TRUE(session.ready());
   const auto start = std::chrono::steady_clock::time_point {1s};
-  const auto pcm = sine_pcm(1000.0, 24000.0);
+  const auto pcm = sine_pcm(300.0, 24000.0);
 
   const auto first = session.process(1, 0x01, 240, 1, 0, pcm, start);
   ASSERT_TRUE(first.has_value());

--- a/tests/unit/test_authored_ir.cpp
+++ b/tests/unit/test_authored_ir.cpp
@@ -182,17 +182,26 @@ TEST(AuthoredDualSenseIr, LegacyFallbackGateReleasesAfterLoudOnset) {
   const auto opened = session.process(3, 0x01, 240, 0, 0, burst, start);
   ASSERT_TRUE(opened.has_value());
   EXPECT_GT(opened->low_frequency, 0);
+  EXPECT_GT(opened->high_frequency, 0);
 
   // Hysteresis must not keep them open on a level parked between the open and
   // close thresholds; the hold budget has to expire and mute the motors.
   std::optional<haptics::legacy_rumble_t> latest;
+  std::optional<haptics::legacy_rumble_t> at_240ms;
   for (std::uint32_t chunk = 1; chunk <= 60; ++chunk) {
     const auto pcm = sine_pcm(1000.0, 24000.0, chunk * 240U);
     const auto output = session.process(
       3, 0, 240, chunk, static_cast<std::uint64_t>(chunk) * 5000U, pcm,
       start + std::chrono::milliseconds(chunk * 5U));
     if (output) latest = output;
+    if (chunk == 48) at_240ms = latest;
   }
+  // Both motors reach zero by 200 ms: a 60 ms hold budget plus the low motor's
+  // 40 ms release tail. Checking at 240 ms bounds the budget instead of only
+  // proving that the gate eventually closes.
+  ASSERT_TRUE(at_240ms.has_value());
+  EXPECT_EQ(at_240ms->low_frequency, 0u);
+  EXPECT_EQ(at_240ms->high_frequency, 0u);
   ASSERT_TRUE(latest.has_value());
   EXPECT_EQ(latest->low_frequency, 0u);
   EXPECT_EQ(latest->high_frequency, 0u);

--- a/tests/unit/test_authored_ir.cpp
+++ b/tests/unit/test_authored_ir.cpp
@@ -136,11 +136,11 @@ TEST(AuthoredDualSenseIr, LegacyFallbackProducesAndStopsRumble) {
 
 TEST(AuthoredDualSenseIr, LegacyFallbackSeparatesTactileBandsAndRejectsHiss) {
   using namespace std::chrono_literals;
-  const auto measure = [](double frequency_hz) {
+  const auto measure = [](double frequency_hz, std::uint32_t chunks) {
     haptics::legacy_rumble_session_t session;
     std::optional<haptics::legacy_rumble_t> latest;
     const auto start = std::chrono::steady_clock::time_point {1s};
-    for (std::uint32_t chunk = 0; chunk <= 20; ++chunk) {
+    for (std::uint32_t chunk = 0; chunk <= chunks; ++chunk) {
       const auto pcm = sine_pcm(frequency_hz, 24000.0, chunk * 240U);
       const auto output = session.process(
         0, chunk == 0 ? 0x01 : 0, 240, chunk,
@@ -151,16 +151,51 @@ TEST(AuthoredDualSenseIr, LegacyFallbackSeparatesTactileBandsAndRejectsHiss) {
     return latest;
   };
 
-  const auto body = measure(120.0);
-  const auto texture = measure(300.0);
-  const auto hiss = measure(1000.0);
+  const auto body = measure(120.0, 20);
+  const auto texture = measure(300.0, 20);
+  const auto hiss = measure(1000.0, 20);
   ASSERT_TRUE(body.has_value());
   ASSERT_TRUE(texture.has_value());
   ASSERT_TRUE(hiss.has_value());
   EXPECT_GT(body->low_frequency, texture->low_frequency);
   EXPECT_GT(texture->high_frequency, body->high_frequency);
-  EXPECT_GT(body->low_frequency, hiss->low_frequency * 8U);
-  EXPECT_GT(texture->high_frequency, hiss->high_frequency * 8U);
+  // Out-of-band hiss must reach exactly zero rather than merely a small value,
+  // otherwise the noise gate has latched open on the onset transient.
+  EXPECT_EQ(hiss->low_frequency, 0u);
+  EXPECT_EQ(hiss->high_frequency, 0u);
+
+  // Sustained residual stays gated no matter how long it runs.
+  const auto long_hiss = measure(1000.0, 400);
+  ASSERT_TRUE(long_hiss.has_value());
+  EXPECT_EQ(long_hiss->low_frequency, 0u);
+  EXPECT_EQ(long_hiss->high_frequency, 0u);
+}
+
+TEST(AuthoredDualSenseIr, LegacyFallbackGateReleasesAfterLoudOnset) {
+  using namespace std::chrono_literals;
+  haptics::legacy_rumble_session_t session;
+  ASSERT_TRUE(session.ready());
+  const auto start = std::chrono::steady_clock::time_point {1s};
+
+  // A loud in-band burst opens both gates.
+  const auto burst = sine_pcm(120.0, 32000.0);
+  const auto opened = session.process(3, 0x01, 240, 0, 0, burst, start);
+  ASSERT_TRUE(opened.has_value());
+  EXPECT_GT(opened->low_frequency, 0);
+
+  // Hysteresis must not keep them open on a level parked between the open and
+  // close thresholds; the hold budget has to expire and mute the motors.
+  std::optional<haptics::legacy_rumble_t> latest;
+  for (std::uint32_t chunk = 1; chunk <= 60; ++chunk) {
+    const auto pcm = sine_pcm(1000.0, 24000.0, chunk * 240U);
+    const auto output = session.process(
+      3, 0, 240, chunk, static_cast<std::uint64_t>(chunk) * 5000U, pcm,
+      start + std::chrono::milliseconds(chunk * 5U));
+    if (output) latest = output;
+  }
+  ASSERT_TRUE(latest.has_value());
+  EXPECT_EQ(latest->low_frequency, 0u);
+  EXPECT_EQ(latest->high_frequency, 0u);
 }
 
 TEST(AuthoredDualSenseIr, LegacyFallbackWatchdogReleasesMotors) {


### PR DESCRIPTION
## 改了啥呀

- 更新 `moonlight-audio-haptics`，接入 [SDK 触觉频带优化 #4](https://github.com/AlkaidLab/moonlight-audio-haptics/pull/4)。
- 将 DS5 authored PCM 的 50–400 Hz 特征映射到传统低/高频振动出口，客户端协议不用跟着折腾。
- 为两颗电机分别加入迟滞门限、软增益和 Attack/Release：低频保留主体，高频更快跟随纹理与冲击。
- 保留 20 ms 发送节流、静音保持、流结束归零和 100 ms watchdog，避免杂鱼尾振赖着不走。
- IR v2 ABI 和 72 字节线格式保持不变。

## 为啥要改

DS5 的 authored haptics PCM 直接压成传统双电机时，范围外低频漂移、高频嘶声和分块抖动可能表现成莫名的连续小振动。现在先由 SDK 隔离触觉频带，再由 Sunshine 按电机特性做门限与时间平滑，所有现有客户端都能继续接收传统 rumble。

量化结果中，20 Hz 低频输出约从 8355 降到 933，1 kHz 高频输出约从 8009 降到 659；120 Hz 低频主体和 300 Hz 高频纹理分别提升到约 45500、49343。

## 验证

- SDK：`cmake --build build --parallel 8`
- SDK：`ctest --test-dir build --output-on-failure`，10/10 passed
- Sunshine：分别编译 `authored_ir.cpp` 与 `test_authored_ir.cpp` 目标
- Sunshine：最小真实 SDK/common-c 链路执行 `AuthoredDualSenseIr.*`，6/6 passed
- `git diff --check`

本机完整 `test_sunshine` 聚合目标仍会被主线已有的 GCC 13 / AMD `config.cpp` 编译错误阻断；本 PR 涉及的实现与测试对象均已成功编译，后续交给 CI 再做完整环境验证。
