### PR TITLE
feat(ds5): 传统触觉回退补关键路径可观测性日志

### DIFF
--- a/src/haptics/authored_ir.cpp
+++ b/src/haptics/authored_ir.cpp
@@ -12,6 +12,8 @@
 
 #include <moonlight_haptics/authored_haptics.h>
 
+#include "src/logging.h"
+
 namespace haptics {
   namespace {
     constexpr std::uint8_t source_stream_start = 0x01;
@@ -212,12 +214,21 @@ namespace haptics {
     return _analyzer.ready();
   }
 
+  legacy_rumble_session_t::~legacy_rumble_session_t() {
+    BOOST_LOG(info) << "DualSense legacy haptics fallback summary for controller "
+                    << _controller_id << ": pcm_packets=" << _pcm_packets
+                    << ", rumbles_emitted=" << _emitted_rumbles
+                    << ", peak_low_energy=" << _peak_low_energy
+                    << ", peak_high_energy=" << _peak_high_energy;
+  }
+
   std::optional<legacy_rumble_t>
   legacy_rumble_session_t::process(std::uint16_t controller_id, std::uint8_t source_flags,
                                    std::uint16_t frame_count, std::uint32_t sequence,
                                    std::uint64_t presentation_time_us,
                                    std::span<const std::uint8_t> pcm,
                                    std::chrono::steady_clock::time_point now) {
+    _pcm_packets++;
     const auto frame = _analyzer.analyze(
       source_flags, frame_count, sequence, presentation_time_us, pcm);
     if (!frame) return std::nullopt;
@@ -249,6 +260,8 @@ namespace haptics {
         high_energy = std::max(high_energy, std::max(
           high_band * legacy_high_band_trim, transient * legacy_transient_trim));
       }
+      _peak_low_energy = std::max(_peak_low_energy, low_energy);
+      _peak_high_energy = std::max(_peak_high_energy, high_energy);
     }
 
     // The heavier low motor keeps body slightly longer; the lighter high motor
@@ -291,6 +304,12 @@ namespace haptics {
     _last_emit = now;
     _last_low = low;
     _last_high = high;
+    _emitted_rumbles++;
+    if (!_first_emit_logged) {
+      _first_emit_logged = true;
+      BOOST_LOG(info) << "DualSense legacy haptics fallback emitted first rumble for controller "
+                      << _controller_id << " (low=" << low << ", high=" << high << ')';
+    }
     return legacy_rumble_t {controller_id, low, high};
   }
 

--- a/src/haptics/authored_ir.h
+++ b/src/haptics/authored_ir.h
@@ -85,6 +85,12 @@ namespace haptics {
    */
   class legacy_rumble_session_t {
   public:
+    legacy_rumble_session_t() = default;
+    ~legacy_rumble_session_t();
+
+    legacy_rumble_session_t(const legacy_rumble_session_t &) = delete;
+    legacy_rumble_session_t &operator=(const legacy_rumble_session_t &) = delete;
+
     bool
     ready() const noexcept;
 
@@ -108,6 +114,11 @@ namespace haptics {
     float _smoothed_high = 0.0f;
     gate_state_t _low_gate;
     gate_state_t _high_gate;
+    std::uint64_t _pcm_packets = 0;
+    std::uint64_t _emitted_rumbles = 0;
+    float _peak_low_energy = 0.0f;
+    float _peak_high_energy = 0.0f;
     bool _have_input = false;
+    bool _first_emit_logged = false;
   };
 }  // namespace haptics

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -1451,6 +1451,7 @@ namespace stream {
               return 0;
             }
             controller_session->second = std::move(created);
+            BOOST_LOG(info) << "DualSense legacy haptics fallback engaged for controller "sv << msg.id;
           }
           const auto rumble = controller_session->second->process(
             msg.id, data.flags, data.frame_count, data.sequence, data.presentation_time_us,


### PR DESCRIPTION
## Summary

排查 Pocket EVO(未声明 PCM/IR 能力位)无振动问题时发现:legacy 回退路径从激活到输出全程零日志,PCM 是否到达、分析是否输出、rumble 是否发出均不可观测(现有日志只能证明 DS5 分配与 composite attach 成功,rumble 传输链由 ControllerMeta 验证健康)。

新增三类 info 日志:

1. **激活**:首条 PCM 到达并创建回退会话时(`fallback engaged for controller N`)
2. **首条输出**:第一次实际发出 rumble 时(含 low/high 值)
3. **会话摘要**(会话释放时):`pcm_packets / rumbles_emitted / peak_low_energy / peak_high_energy`

摘要的判读表:

| 观测 | 结论 |
|---|---|
| 无 engaged 日志 | PCM 从未到达 Core(端点层断:游戏没写 ch3/4) |
| pcm_packets > 0, rumbles_emitted = 0, peak = 0 | PCM 到达但全静音 |
| pcm_packets > 0, rumbles_emitted = 0, 0 < peak < 0.020 | 内容低于噪声门 open 阈值,被门拦截 |
| rumbles_emitted > 0 但客户端无感 | 客户端应用侧 |

计数器仅增量记录,不改变任何决策逻辑;现有 authored_ir 测试行为不变。

## Test plan

- [ ] CI Windows/Linux/macOS 构建与既有测试
- [ ] EVO 复跑一次原场景,按上表判读 sunshine.log