### PR TITLE
feat(hdr): anchor SDR band to client SDR white; tolerate luminance jitter

### DIFF
--- a/src/display_device/session.cpp
+++ b/src/display_device/session.cpp
@@ -760,7 +760,7 @@ namespace display_device {
                                 !current_client_id.empty() &&
                                 current_vdd_client_id != current_client_id;
     const bool hdr_capabilities_changed = !current_vdd_hdr_brightness ||
-                                          *current_vdd_hdr_brightness != hdr_brightness;
+                                          !current_vdd_hdr_brightness->nearly_equal(hdr_brightness);
 
     // An existing VDD must be rebuilt when its advertised HDR capabilities no
     // longer match this session. A shared VDD may otherwise be reused across

--- a/src/display_device/vdd_utils.h
+++ b/src/display_device/vdd_utils.h
@@ -2,7 +2,9 @@
 
 #define WIN32_LEAN_AND_MEAN
 
+#include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <cstdint>
 #include <functional>
 #include <string>
@@ -33,6 +35,18 @@ namespace display_device::vdd_utils {
     float max_full_nits = 1000.0f;
 
     bool operator==(const hdr_brightness_t &) const = default;
+
+    // 实测上报的亮度逐会话存在小抖动;容差内视为能力未变,避免无谓重建 VDD
+    bool
+    nearly_equal(const hdr_brightness_t &other) const {
+      constexpr auto close = [](float a, float b) {
+        const float scale = std::min(std::abs(a), std::abs(b));
+        return std::abs(a - b) <= std::max(25.0f, 0.05f * scale);
+      };
+      return close(max_nits, other.max_nits) &&
+             close(min_nits, other.min_nits) &&
+             close(max_full_nits, other.max_full_nits);
+    }
   };
 
   // 物理尺寸结构（厘米）

--- a/src/hdr/client_display_capabilities.cpp
+++ b/src/hdr/client_display_capabilities.cpp
@@ -174,7 +174,10 @@ namespace hdr {
         return result;
       }
 
+      // A manual override adjusts the tone-map targets; the measured SDR
+      // reference white stays whatever the client actually reported.
       result.capabilities = validated.capabilities;
+      result.capabilities.sdr_white_nits = reported_capabilities.sdr_white_nits;
       result.source = target_source_e::manual_override;
       return result;
     }

--- a/src/hdr/client_display_capabilities.h
+++ b/src/hdr/client_display_capabilities.h
@@ -18,6 +18,10 @@ namespace hdr {
     float max_nits { default_max_nits };
     float min_nits { default_min_nits };
     float max_full_frame_nits { default_max_full_frame_nits };
+    // Client-measured SDR reference white in nits; 0 = client did not report one.
+    // Independently parsed (sdrBrightness launch arg), not part of the atomic
+    // three-field validation above.
+    float sdr_white_nits { 0.0f };
   };
 
   enum class target_source_e {

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -8,6 +8,7 @@
 // standard includes
 #include <algorithm>
 #include <array>
+#include <charconv>
 #include <chrono>
 #include <filesystem>
 #include <memory>
@@ -290,8 +291,11 @@ namespace nvhttp {
     // Optional client-measured SDR reference white (moonlight-harmony extension).
     // Parsed independently: a missing or out-of-range value simply leaves 0.
     if (const auto sdr_white = find_arg(args, "sdrBrightness")) {
-      const int parsed_sdr_white = std::atoi(std::string { *sdr_white }.c_str());
-      if (parsed_sdr_white >= 50 && parsed_sdr_white <= 1000) {
+      int parsed_sdr_white = 0;
+      const char *begin = sdr_white->data();
+      const char *end = begin + sdr_white->size();
+      const auto [position, parse_error] = std::from_chars(begin, end, parsed_sdr_white);
+      if (parse_error == std::errc {} && position == end && parsed_sdr_white >= 50 && parsed_sdr_white <= 1000) {
         launch_session->reported_hdr_capabilities.sdr_white_nits = static_cast<float>(parsed_sdr_white);
         launch_session->hdr_capabilities.sdr_white_nits = static_cast<float>(parsed_sdr_white);
         BOOST_LOG(info) << "Client reported SDR white level: " << parsed_sdr_white << " nits";

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -287,6 +287,20 @@ namespace nvhttp {
       BOOST_LOG(warning) << hdr_capabilities.fallback_reason << "; using safe HDR luminance defaults";
     }
 
+    // Optional client-measured SDR reference white (moonlight-harmony extension).
+    // Parsed independently: a missing or out-of-range value simply leaves 0.
+    if (const auto sdr_white = find_arg(args, "sdrBrightness")) {
+      const int parsed_sdr_white = std::atoi(std::string { *sdr_white }.c_str());
+      if (parsed_sdr_white >= 50 && parsed_sdr_white <= 1000) {
+        launch_session->reported_hdr_capabilities.sdr_white_nits = static_cast<float>(parsed_sdr_white);
+        launch_session->hdr_capabilities.sdr_white_nits = static_cast<float>(parsed_sdr_white);
+        BOOST_LOG(info) << "Client reported SDR white level: " << parsed_sdr_white << " nits";
+      }
+      else {
+        BOOST_LOG(warning) << "Ignoring out-of-range client SDR white level: " << *sdr_white;
+      }
+    }
+
     // Get display_name from query parameter if provided
     std::string display_name = get_arg(args, "display_name", "");
     if (!display_name.empty()) {

--- a/src/platform/common.h
+++ b/src/platform/common.h
@@ -331,6 +331,7 @@ namespace platf {
     constexpr caps_t touchpad_frame = 0x20;  // Native precision touchpad frame events
     constexpr caps_t cursor_shape = 0x40;  // Client-rendered cursor shape updates
     constexpr caps_t ds5_haptics_pcm = 0x80;  // Native DualSense authored haptics PCM
+    constexpr caps_t dynamic_sdr_white = 0x100;  // Runtime client SDR reference white updates
   };  // namespace platform_caps
 
   struct gamepad_state_t {
@@ -538,6 +539,11 @@ namespace platf {
 
     virtual int
     convert(platf::img_t &img) = 0;
+
+    // Optional: supported HLG converters can apply this at a frame boundary.
+    virtual void
+    set_client_sdr_white_nits(float) {
+    }
 
     video::sunshine_colorspace_t colorspace;
 

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -377,7 +377,9 @@ namespace platf::dxgi {
 
     gpu_cursor_t cursor_alpha;
     gpu_cursor_t cursor_xor;
-    float cursor_white_multiplier_value = 300.0f / 80.0f;
+    // Written from the capture/cursor thread, read from the encode path
+    // (composed_sdr_white_nits), so it must be an atomic snapshot.
+    std::atomic<float> cursor_white_multiplier_value { 300.0f / 80.0f };
     bool cursor_white_normalization_enabled = false;
     bool cursor_pipeline_ready = false;
 

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -357,6 +357,14 @@ namespace platf::dxgi {
     std::unique_ptr<amf_encode_device_t>
     make_amf_encode_device(pix_fmt_e pix_fmt) override;
 
+    /**
+     * @brief Current composed SDR white level in nits, as tracked by cursor
+     *        normalization (300-nit fallback until the driver reports one).
+     *        nullopt when cursor normalization is disabled.
+     */
+    std::optional<float>
+    composed_sdr_white_nits() const;
+
     std::atomic<uint32_t> next_image_id;
 
   protected:
@@ -399,14 +407,6 @@ namespace platf::dxgi {
      */
     void
     set_cursor_sdr_white_level(UINT32 sdr_white_level_x1000);
-
-    /**
-     * @brief Current composed SDR white level in nits, as tracked by cursor
-     *        normalization (300-nit fallback until the driver reports one).
-     *        nullopt when cursor normalization is disabled.
-     */
-    std::optional<float>
-    composed_sdr_white_nits() const;
 
     /**
      * @brief Draw the currently-configured cursor_alpha / cursor_xor onto the

--- a/src/platform/windows/display.h
+++ b/src/platform/windows/display.h
@@ -399,6 +399,14 @@ namespace platf::dxgi {
     set_cursor_sdr_white_level(UINT32 sdr_white_level_x1000);
 
     /**
+     * @brief Current composed SDR white level in nits, as tracked by cursor
+     *        normalization (300-nit fallback until the driver reports one).
+     *        nullopt when cursor normalization is disabled.
+     */
+    std::optional<float>
+    composed_sdr_white_nits() const;
+
+    /**
      * @brief Draw the currently-configured cursor_alpha / cursor_xor onto the
      *        given render target. Caller must hold the capture mutex for the
      *        underlying image. After the draw the blend state is reset to

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -3360,7 +3360,7 @@ namespace platf::dxgi {
 
       // Keep the established 300-nit fallback for backends without producer
       // white-level metadata. VDD replaces it with the driver's current value.
-      float white_multiplier_data[16 / sizeof(float)] { cursor_white_multiplier_value };  // aligned to 16-byte
+      float white_multiplier_data[16 / sizeof(float)] { cursor_white_multiplier_value.load(std::memory_order_relaxed) };  // aligned to 16-byte
       cursor_white_multiplier = make_buffer(device.get(), white_multiplier_data);
       if (!cursor_white_multiplier) {
         BOOST_LOG(warning) << "Failed to create cursor blending (normalized white) white multiplier constant buffer";
@@ -3405,7 +3405,7 @@ namespace platf::dxgi {
     }
 
     const float next_multiplier = sdr_white_nits / 80.0f;
-    if (std::abs(next_multiplier - cursor_white_multiplier_value) < 0.0001f) {
+    if (std::abs(next_multiplier - cursor_white_multiplier_value.load(std::memory_order_relaxed)) < 0.0001f) {
       return;
     }
 
@@ -3425,7 +3425,7 @@ namespace platf::dxgi {
     if (!cursor_white_normalization_enabled) {
       return std::nullopt;
     }
-    return cursor_white_multiplier_value * 80.0f;
+    return cursor_white_multiplier_value.load(std::memory_order_relaxed) * 80.0f;
   }
 
   void

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -296,7 +296,11 @@ namespace platf::dxgi {
     struct alignas(16) HlgDisplayParams {
       float peakNits;
       float systemGamma;
-      float pad[2];
+      // SDR band re-anchoring: gain applied to scRGB levels at or below
+      // sdrBandTopScrgb (Windows SDR white / 80), fading back to 1.0 by 2x.
+      // gain 1.0 / top 0 leaves the signal untouched.
+      float sdrBandGain;
+      float sdrBandTopScrgb;
     };
     static_assert(sizeof(HlgDisplayParams) == 16);
 
@@ -613,6 +617,8 @@ namespace platf::dxgi {
       hlg_display_cbuf.reset();
       ID3D11Buffer *null_cbuf = nullptr;
       device_ctx->PSSetConstantBuffers(3, 1, &null_cbuf);
+      hlg_sdr_band_gain_value = 1.0f;
+      hlg_sdr_band_top_value = 0.0f;
 
       float analysis_max_nits = 10000.0f;
       if (use_hlg_shader) {
@@ -626,10 +632,13 @@ namespace platf::dxgi {
                                   ? static_cast<float>(metadata.maxDisplayLuminance)
                                   : 1000.0f;
         const float system_gamma = ::video::hlg_system_gamma(peak_nits);
+        hlg_peak_nits_value = peak_nits;
+        hlg_system_gamma_value = system_gamma;
         const HlgDisplayParams params {
           peak_nits,
           system_gamma,
-          {},
+          1.0f,
+          0.0f,
         };
 
         auto hlg_params = make_buffer(device.get(), params);
@@ -677,6 +686,53 @@ namespace platf::dxgi {
       }
 
       return 0;
+    }
+
+    void
+    set_client_sdr_white(float nits) {
+      client_sdr_white_nits = std::isfinite(nits) && nits > 0.0f ? nits : 0.0f;
+    }
+
+    // Re-anchor SDR-referenced content to the client's SDR reference white.
+    // Called per frame before the HLG conversion dispatch; cheap float compare,
+    // the constant buffer is only rebuilt when the gain actually changes.
+    void
+    update_sdr_band_gain() {
+      if (client_sdr_white_nits <= 0.0f || !hlg_display_cbuf || hlg_peak_nits_value <= 0.0f) {
+        return;
+      }
+      auto vram_display = std::dynamic_pointer_cast<platf::dxgi::display_vram_t>(display);
+      if (!vram_display) {
+        return;
+      }
+      const auto windows_white = vram_display->composed_sdr_white_nits();
+      if (!windows_white || *windows_white < 50.0f) {
+        return;
+      }
+
+      const float gain = std::clamp(client_sdr_white_nits / *windows_white, 0.5f, 2.5f);
+      const float band_top = *windows_white / 80.0f;
+      if (std::abs(gain - hlg_sdr_band_gain_value) < 0.01f &&
+          std::abs(band_top - hlg_sdr_band_top_value) < 0.01f) {
+        return;
+      }
+
+      const HlgDisplayParams params {
+        hlg_peak_nits_value,
+        hlg_system_gamma_value,
+        gain,
+        band_top,
+      };
+      auto next_buffer = make_buffer(device.get(), params);
+      if (!next_buffer) {
+        BOOST_LOG(warning) << "Failed to update HLG SDR band gain; retaining previous value"sv;
+        return;
+      }
+      hlg_display_cbuf = std::move(next_buffer);
+      hlg_sdr_band_gain_value = gain;
+      hlg_sdr_band_top_value = band_top;
+      BOOST_LOG(info) << "SDR band gain: phone " << client_sdr_white_nits
+                      << " nits, windows " << *windows_white << " nits, gain " << gain;
     }
 
     int
@@ -1542,6 +1598,13 @@ namespace platf::dxgi {
     buf_t subsample_offset;
     buf_t color_matrix;
     buf_t hlg_display_cbuf;
+
+    // Client-reported SDR reference white (nits); 0 = not reported, gain stays 1.
+    float client_sdr_white_nits = 0.0f;
+    float hlg_peak_nits_value = 0.0f;
+    float hlg_system_gamma_value = 1.2f;
+    float hlg_sdr_band_gain_value = 1.0f;
+    float hlg_sdr_band_top_value = 0.0f;
 
     blend_t blend_disable;
     sampler_state_t sampler_linear;
@@ -2546,6 +2609,7 @@ namespace platf::dxgi {
       };
       const UINT cbuf_count = write_hdr_analysis_snapshot ? 3 : 2;
       device_ctx->CSSetConstantBuffers(0, cbuf_count, cbufs);
+      update_sdr_band_gain();
       if (hlg_display_cbuf) {
         ID3D11Buffer *hlg_cbuf = hlg_display_cbuf.get();
         device_ctx->CSSetConstantBuffers(3, 1, &hlg_cbuf);
@@ -2730,6 +2794,7 @@ namespace platf::dxgi {
       if (!nvenc_d3d->create_encoder(config::video.nv, client_config, colorspace, buffer_format)) return false;
 
       base.apply_colorspace(colorspace);
+      base.set_client_sdr_white(client_config.hdr_capabilities.sdr_white_nits);
       if (base.init_output(nvenc_d3d->get_input_texture(), client_config.width, client_config.height, colorspace, client_config.videoFormat, is_probe)) {
         return false;
       }
@@ -2846,6 +2911,7 @@ namespace platf::dxgi {
 
       base.apply_colorspace(colorspace);
       hdr_luminance_analysis_available = false;
+      base.set_client_sdr_white(client_config.hdr_capabilities.sdr_white_nits);
       if (base.init_output(static_cast<ID3D11Texture2D *>(amf_d3d->get_input_texture()), client_config.width, client_config.height, colorspace, client_config.videoFormat, is_probe) != 0) {
         return false;
       }
@@ -3352,6 +3418,14 @@ namespace platf::dxgi {
 
     cursor_white_multiplier = std::move(next_buffer);
     cursor_white_multiplier_value = next_multiplier;
+  }
+
+  std::optional<float>
+  display_vram_t::composed_sdr_white_nits() const {
+    if (!cursor_white_normalization_enabled) {
+      return std::nullopt;
+    }
+    return cursor_white_multiplier_value * 80.0f;
   }
 
   void

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -458,6 +458,14 @@ namespace platf::dxgi {
         auto draw = [&](auto &input, auto &y_or_yuv_viewports, auto &uv_viewport) {
           device_ctx->PSSetShaderResources(0, 1, &input);
 
+          // The SDR white gain buffer may be rebuilt at a frame boundary. Bind
+          // the current buffer here so the pixel-shader fallback sees updates
+          // just like the compute-shader path.
+          if (hlg_display_cbuf) {
+            ID3D11Buffer *hlg_cbuf = hlg_display_cbuf.get();
+            device_ctx->PSSetConstantBuffers(3, 1, &hlg_cbuf);
+          }
+
           // Select the correct pixel shader based on image gamma type:
           // - linear_gamma AND FP16 format: Use FP16 shader that applies transfer function
           //   (sRGB for SDR, PQ for HDR, HLG for HLG) to convert from linear light
@@ -508,6 +516,7 @@ namespace platf::dxgi {
           can_analyze_hdr_frame && should_dispatch_hdr_analysis();
         bool cs_used = false;
         bool hdr_analysis_snapshot_written = false;
+        update_sdr_band_gain();
         if (cs_path_active) {
           if (cs_for_p010) {
             // HDR P010: shader expects linear scRGB FP16 input.
@@ -694,7 +703,7 @@ namespace platf::dxgi {
     }
 
     // Re-anchor SDR-referenced content to the client's SDR reference white.
-    // Called per frame before the HLG conversion dispatch; cheap float compare,
+    // Called per frame before HLG conversion; cheap float compare,
     // the constant buffer is only rebuilt when the gain actually changes.
     void
     update_sdr_band_gain() {
@@ -2609,7 +2618,6 @@ namespace platf::dxgi {
       };
       const UINT cbuf_count = write_hdr_analysis_snapshot ? 3 : 2;
       device_ctx->CSSetConstantBuffers(0, cbuf_count, cbufs);
-      update_sdr_band_gain();
       if (hlg_display_cbuf) {
         ID3D11Buffer *hlg_cbuf = hlg_display_cbuf.get();
         device_ctx->CSSetConstantBuffers(3, 1, &hlg_cbuf);

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -2811,6 +2811,11 @@ namespace platf::dxgi {
       return result;
     }
 
+    void
+    set_client_sdr_white_nits(float nits) override {
+      base.set_client_sdr_white(nits);
+    }
+
   private:
     d3d_base_encode_device base;
     std::unique_ptr<nvenc::nvenc_d3d11> nvenc_d3d;
@@ -2925,6 +2930,11 @@ namespace platf::dxgi {
       int result = base.convert(img_base);
       hdr_luminance_stats = base.hdr_luminance_stats_out;
       return result;
+    }
+
+    void
+    set_client_sdr_white_nits(float nits) override {
+      base.set_client_sdr_white(nits);
     }
 
   private:

--- a/src/platform/windows/display_vram.cpp
+++ b/src/platform/windows/display_vram.cpp
@@ -698,8 +698,35 @@ namespace platf::dxgi {
     }
 
     void
+    reset_sdr_band_gain() {
+      if (!hlg_display_cbuf || hlg_peak_nits_value <= 0.0f ||
+          (std::abs(hlg_sdr_band_gain_value - 1.0f) < 0.01f &&
+           std::abs(hlg_sdr_band_top_value) < 0.01f)) {
+        return;
+      }
+
+      const HlgDisplayParams params {
+        hlg_peak_nits_value,
+        hlg_system_gamma_value,
+        1.0f,
+        0.0f,
+      };
+      auto next_buffer = make_buffer(device.get(), params);
+      if (!next_buffer) {
+        BOOST_LOG(warning) << "Failed to reset HLG SDR band gain; retaining previous value"sv;
+        return;
+      }
+      hlg_display_cbuf = std::move(next_buffer);
+      hlg_sdr_band_gain_value = 1.0f;
+      hlg_sdr_band_top_value = 0.0f;
+    }
+
+    void
     set_client_sdr_white(float nits) {
       client_sdr_white_nits = std::isfinite(nits) && nits > 0.0f ? nits : 0.0f;
+      if (client_sdr_white_nits <= 0.0f) {
+        reset_sdr_band_gain();
+      }
     }
 
     // Re-anchor SDR-referenced content to the client's SDR reference white.
@@ -707,7 +734,11 @@ namespace platf::dxgi {
     // the constant buffer is only rebuilt when the gain actually changes.
     void
     update_sdr_band_gain() {
-      if (client_sdr_white_nits <= 0.0f || !hlg_display_cbuf || hlg_peak_nits_value <= 0.0f) {
+      if (client_sdr_white_nits <= 0.0f) {
+        reset_sdr_band_gain();
+        return;
+      }
+      if (!hlg_display_cbuf || hlg_peak_nits_value <= 0.0f) {
         return;
       }
       auto vram_display = std::dynamic_pointer_cast<platf::dxgi::display_vram_t>(display);

--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -2559,10 +2559,6 @@ namespace platf {
   get_capabilities() {
     platform_caps::caps_t caps = 0;
 
-    // The control protocol accepts runtime SDR reference white updates. HLG
-    // converters that support them apply the value at a video frame boundary.
-    caps |= platform_caps::dynamic_sdr_white;
-
     // We support controller touchpad input as long as we're not emulating X360
     if (effective_gamepad_mode() != 2) {
       caps |= platform_caps::controller_touch;

--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -2559,6 +2559,10 @@ namespace platf {
   get_capabilities() {
     platform_caps::caps_t caps = 0;
 
+    // The control protocol accepts runtime SDR reference white updates. HLG
+    // converters that support them apply the value at a video frame boundary.
+    caps |= platform_caps::dynamic_sdr_white;
+
     // We support controller touchpad input as long as we're not emulating X360
     if (effective_gamepad_mode() != 2) {
       caps |= platform_caps::controller_touch;

--- a/src/rtsp.cpp
+++ b/src/rtsp.cpp
@@ -1121,6 +1121,9 @@ namespace rtsp_stream {
       if (cursor_channel::producer_available()) {
         caps |= platf::platform_caps::cursor_shape;
       }
+      if (video::active_encoder_supports_dynamic_sdr_white()) {
+        caps |= platf::platform_caps::dynamic_sdr_white;
+      }
       ss << "a=x-ss-general.featureFlags:" << caps << std::endl;
     }
 

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -5,6 +5,7 @@
 #include "process.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
 #include <future>
 #include <iomanip>
@@ -1970,7 +1971,7 @@ namespace stream {
 
     // 统一动态参数更新协议 (IDX_DYNAMIC_PARAM_CHANGE)
     // Payload 格式：
-    // - 参数类型 (int, 4字节): 0=分辨率, 1=FPS, 2=码率, 3=QP, 4=FEC, 5=预设, 6=自适应量化, 7=多遍编码, 8=VBV缓冲区
+    // - 参数类型 (int, 4字节): 0=分辨率, 1=FPS, 2=码率, 3=QP, 4=FEC, 5=预设, 6=自适应量化, 7=多遍编码, 8=VBV缓冲区, 9=客户端SDR白位
     // - 参数值：
     //   * 分辨率 (类型0): 2个int (8字节, width和height)
     //   * FPS (类型1): 1个float (4字节)
@@ -1985,7 +1986,8 @@ namespace stream {
         return;
       }
 
-      const int param_type = *reinterpret_cast<const int *>(payload.data());
+      int param_type;
+      std::memcpy(&param_type, payload.data(), sizeof(param_type));
       
       if (param_type < 0 || param_type >= static_cast<int>(video::dynamic_param_type_e::MAX_PARAM_TYPE)) {
         BOOST_LOG(warning) << "Invalid parameter type: " << param_type;
@@ -2039,6 +2041,41 @@ namespace stream {
         session->video.dynamic_param_change_events->raise(param);
         
         BOOST_LOG(info) << "Dynamic FPS change: " << new_fps << " fps";
+        return;
+      }
+
+      // This is an HLG conversion parameter, not part of the display/VDD HDR
+      // capability tuple. Apply it on the video thread without rebuilding the
+      // display or encoder.
+      if (param_type_enum == video::dynamic_param_type_e::CLIENT_SDR_WHITE_NITS) {
+        constexpr size_t SDR_WHITE_PAYLOAD_SIZE = sizeof(int) + sizeof(float);
+        if (payload.size() != SDR_WHITE_PAYLOAD_SIZE) {
+          BOOST_LOG(warning) << "Invalid payload size for client SDR white. Expected "
+                             << SDR_WHITE_PAYLOAD_SIZE << " bytes, got " << payload.size();
+          return;
+        }
+        if (session->config.controlProtocolType != 13 || session->config.monitor.dynamicRange != 2) {
+          BOOST_LOG(warning) << "Ignoring client SDR white update outside an encrypted HLG session";
+          return;
+        }
+
+        float sdr_white_nits;
+        std::memcpy(&sdr_white_nits, payload.data() + sizeof(int), sizeof(sdr_white_nits));
+        if (!std::isfinite(sdr_white_nits) || sdr_white_nits < 1.0f || sdr_white_nits > 10000.0f) {
+          BOOST_LOG(warning) << "Invalid client SDR white value: " << sdr_white_nits;
+          return;
+        }
+
+        session->config.monitor.hdr_capabilities.sdr_white_nits = sdr_white_nits;
+        session->hdr_capabilities.sdr_white_nits = sdr_white_nits;
+
+        video::dynamic_param_t param {};
+        param.type = video::dynamic_param_type_e::CLIENT_SDR_WHITE_NITS;
+        param.value.float_value = sdr_white_nits;
+        param.valid = true;
+        session->video.dynamic_param_change_events->raise(param);
+
+        BOOST_LOG(info) << "Dynamic client SDR white change: " << sdr_white_nits << " nits";
         return;
       }
 

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -2061,13 +2061,10 @@ namespace stream {
 
         float sdr_white_nits;
         std::memcpy(&sdr_white_nits, payload.data() + sizeof(int), sizeof(sdr_white_nits));
-        if (!std::isfinite(sdr_white_nits) || sdr_white_nits < 1.0f || sdr_white_nits > 10000.0f) {
+        if (!video::is_valid_client_sdr_white_nits(sdr_white_nits)) {
           BOOST_LOG(warning) << "Invalid client SDR white value: " << sdr_white_nits;
           return;
         }
-
-        session->config.monitor.hdr_capabilities.sdr_white_nits = sdr_white_nits;
-        session->hdr_capabilities.sdr_white_nits = sdr_white_nits;
 
         video::dynamic_param_t param {};
         param.type = video::dynamic_param_type_e::CLIENT_SDR_WHITE_NITS;

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -679,6 +679,9 @@ namespace stream {
     bool enable_hdr { false };
     hdr::client_display_capabilities_t hdr_capabilities;
     hdr::client_display_capabilities_t reported_hdr_capabilities;
+    // Runtime SDR white updates are consumed by the video thread and may also
+    // be needed by a control-thread display reconfiguration.
+    std::atomic<float> dynamic_sdr_white_nits { 0.0f };
     hdr::target_source_e hdr_target_source { hdr::target_source_e::safe_defaults };
 
     safe::mail_raw_t::event_t<bool> shutdown_event;
@@ -1926,6 +1929,9 @@ namespace stream {
       temp_launch_session.custom_screen_mode = session->custom_screen_mode;
       temp_launch_session.hdr_capabilities = session->hdr_capabilities;
       temp_launch_session.reported_hdr_capabilities = session->reported_hdr_capabilities;
+      const auto dynamic_sdr_white_nits = session->dynamic_sdr_white_nits.load(std::memory_order_acquire);
+      temp_launch_session.hdr_capabilities.sdr_white_nits = dynamic_sdr_white_nits;
+      temp_launch_session.reported_hdr_capabilities.sdr_white_nits = dynamic_sdr_white_nits;
       temp_launch_session.hdr_target_source = session->hdr_target_source;
 
       bool active_display_resolved = true;
@@ -2094,6 +2100,7 @@ namespace stream {
         param.type = video::dynamic_param_type_e::CLIENT_SDR_WHITE_NITS;
         param.value.float_value = sdr_white_nits;
         param.valid = true;
+        session->dynamic_sdr_white_nits.store(sdr_white_nits, std::memory_order_release);
         session->video.dynamic_param_change_events->raise(param);
 
         BOOST_LOG(info) << "Dynamic client SDR white change: " << sdr_white_nits << " nits";
@@ -4246,6 +4253,9 @@ namespace stream {
       session->enable_hdr = launch_session.enable_hdr;
       session->hdr_capabilities = launch_session.hdr_capabilities;
       session->reported_hdr_capabilities = launch_session.reported_hdr_capabilities;
+      session->dynamic_sdr_white_nits.store(
+        launch_session.hdr_capabilities.sdr_white_nits,
+        std::memory_order_release);
       session->hdr_target_source = launch_session.hdr_target_source;
 
       session->config = config;

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -5,8 +5,10 @@
 #include "process.h"
 
 #include <algorithm>
+#include <bit>
 #include <cmath>
 #include <cstdint>
+#include <cstring>
 #include <future>
 #include <iomanip>
 #include <optional>
@@ -134,6 +136,28 @@ namespace stream {
   }
 
   namespace {
+    std::uint32_t
+    read_dynamic_param_u32(std::string_view payload, std::size_t offset) {
+      return static_cast<std::uint32_t>(static_cast<unsigned char>(payload[offset])) |
+             (static_cast<std::uint32_t>(static_cast<unsigned char>(payload[offset + 1])) << 8) |
+             (static_cast<std::uint32_t>(static_cast<unsigned char>(payload[offset + 2])) << 16) |
+             (static_cast<std::uint32_t>(static_cast<unsigned char>(payload[offset + 3])) << 24);
+    }
+
+    std::int32_t
+    read_dynamic_param_i32(std::string_view payload, std::size_t offset) {
+      const auto value = read_dynamic_param_u32(payload, offset);
+      const auto signed_value = (value & 0x80000000u) != 0
+                                  ? static_cast<std::int64_t>(value) - (1LL << 32)
+                                  : static_cast<std::int64_t>(value);
+      return static_cast<std::int32_t>(signed_value);
+    }
+
+    float
+    read_dynamic_param_f32(std::string_view payload, std::size_t offset) {
+      return std::bit_cast<float>(read_dynamic_param_u32(payload, offset));
+    }
+
     std::int64_t
     steady_now_ms() {
       return std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -1979,15 +2003,15 @@ namespace stream {
     server->map(packetTypes[IDX_DYNAMIC_PARAM_CHANGE], [&, handle_resolution_change](session_t *session, const std::string_view &payload) {
       BOOST_LOG(debug) << "type [IDX_DYNAMIC_PARAM_CHANGE]"sv;
 
-      constexpr size_t MIN_PAYLOAD_SIZE = sizeof(int);
+      constexpr size_t WIRE_WORD_SIZE = sizeof(std::uint32_t);
+      constexpr size_t MIN_PAYLOAD_SIZE = WIRE_WORD_SIZE;
       if (payload.size() < MIN_PAYLOAD_SIZE) {
         BOOST_LOG(warning) << "Invalid payload size for dynamic param change. Expected at least " 
                            << MIN_PAYLOAD_SIZE << " bytes, got " << payload.size();
         return;
       }
 
-      int param_type;
-      std::memcpy(&param_type, payload.data(), sizeof(param_type));
+      const auto param_type = read_dynamic_param_i32(payload, 0);
       
       if (param_type < 0 || param_type >= static_cast<int>(video::dynamic_param_type_e::MAX_PARAM_TYPE)) {
         BOOST_LOG(warning) << "Invalid parameter type: " << param_type;
@@ -1998,28 +2022,29 @@ namespace stream {
       
       // 处理分辨率变更（需要两个int值）
       if (param_type_enum == video::dynamic_param_type_e::RESOLUTION) {
-        constexpr size_t RESOLUTION_PAYLOAD_SIZE = sizeof(int) * 3;  // 类型 + width + height
+        constexpr size_t RESOLUTION_PAYLOAD_SIZE = WIRE_WORD_SIZE * 3;  // 类型 + width + height
         if (payload.size() < RESOLUTION_PAYLOAD_SIZE) {
           BOOST_LOG(warning) << "Invalid payload size for resolution change. Expected " 
                              << RESOLUTION_PAYLOAD_SIZE << " bytes, got " << payload.size();
           return;
         }
 
-        const auto *resolution_data = reinterpret_cast<const int *>(payload.data());
-        handle_resolution_change(session, resolution_data[1], resolution_data[2]);
+        const auto width = read_dynamic_param_i32(payload, WIRE_WORD_SIZE);
+        const auto height = read_dynamic_param_i32(payload, WIRE_WORD_SIZE * 2);
+        handle_resolution_change(session, width, height);
         return;
       }
 
       // 处理FPS变更（需要float值）
       if (param_type_enum == video::dynamic_param_type_e::FPS) {
-        constexpr size_t FPS_PAYLOAD_SIZE = sizeof(int) + sizeof(float);
+        constexpr size_t FPS_PAYLOAD_SIZE = WIRE_WORD_SIZE * 2;
         if (payload.size() < FPS_PAYLOAD_SIZE) {
           BOOST_LOG(warning) << "Invalid payload size for FPS change. Expected " 
                              << FPS_PAYLOAD_SIZE << " bytes, got " << payload.size();
           return;
         }
 
-        const float new_fps = *reinterpret_cast<const float *>(payload.data() + sizeof(int));
+        const float new_fps = read_dynamic_param_f32(payload, WIRE_WORD_SIZE);
         
         if (new_fps <= 0.0f || new_fps > 1000.0f) {
           BOOST_LOG(warning) << "Invalid FPS value: " << new_fps;
@@ -2048,7 +2073,7 @@ namespace stream {
       // capability tuple. Apply it on the video thread without rebuilding the
       // display or encoder.
       if (param_type_enum == video::dynamic_param_type_e::CLIENT_SDR_WHITE_NITS) {
-        constexpr size_t SDR_WHITE_PAYLOAD_SIZE = sizeof(int) + sizeof(float);
+        constexpr size_t SDR_WHITE_PAYLOAD_SIZE = WIRE_WORD_SIZE * 2;
         if (payload.size() != SDR_WHITE_PAYLOAD_SIZE) {
           BOOST_LOG(warning) << "Invalid payload size for client SDR white. Expected "
                              << SDR_WHITE_PAYLOAD_SIZE << " bytes, got " << payload.size();
@@ -2059,8 +2084,7 @@ namespace stream {
           return;
         }
 
-        float sdr_white_nits;
-        std::memcpy(&sdr_white_nits, payload.data() + sizeof(int), sizeof(sdr_white_nits));
+        const float sdr_white_nits = read_dynamic_param_f32(payload, WIRE_WORD_SIZE);
         if (!video::is_valid_client_sdr_white_nits(sdr_white_nits)) {
           BOOST_LOG(warning) << "Invalid client SDR white value: " << sdr_white_nits;
           return;
@@ -2077,14 +2101,14 @@ namespace stream {
       }
 
       // 处理其他单值参数（码率、QP等，使用int值）
-      constexpr size_t INT_PARAM_PAYLOAD_SIZE = sizeof(int) * 2;
+      constexpr size_t INT_PARAM_PAYLOAD_SIZE = WIRE_WORD_SIZE * 2;
       if (payload.size() < INT_PARAM_PAYLOAD_SIZE) {
         BOOST_LOG(warning) << "Invalid payload size for dynamic param change. Expected at least " 
                            << INT_PARAM_PAYLOAD_SIZE << " bytes, got " << payload.size();
         return;
       }
 
-      const int param_value = reinterpret_cast<const int *>(payload.data())[1];
+      const auto param_value = read_dynamic_param_i32(payload, WIRE_WORD_SIZE);
 
       video::dynamic_param_t param;
       param.type = param_type_enum;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -654,6 +654,9 @@ namespace video {
           }
           break;
         }
+        case dynamic_param_type_e::CLIENT_SDR_WHITE_NITS:
+          device->set_client_sdr_white_nits(param.value.float_value);
+          break;
         default:
           BOOST_LOG(warning) << "AVCodec encoder: Unsupported dynamic parameter type: " << (int) param.type;
           break;
@@ -820,6 +823,9 @@ namespace video {
           BOOST_LOG(info) << "NVENC encoder VBV buffer size change requested: " << param.value.int_value << " Kbps";
           break;
         }
+        case dynamic_param_type_e::CLIENT_SDR_WHITE_NITS:
+          device->set_client_sdr_white_nits(param.value.float_value);
+          break;
         default:
           BOOST_LOG(warning) << "NVENC encoder: Unsupported dynamic parameter type: " << (int) param.type;
           break;
@@ -945,6 +951,9 @@ namespace video {
       switch (param.type) {
         case dynamic_param_type_e::BITRATE:
           set_bitrate(param.value.int_value);
+          break;
+        case dynamic_param_type_e::CLIENT_SDR_WHITE_NITS:
+          device->set_client_sdr_white_nits(param.value.float_value);
           break;
         default:
           break;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1623,6 +1623,22 @@ namespace video {
     return encoder ? std::string { encoder->name } : std::string {};
   }
 
+  bool
+  active_encoder_supports_dynamic_sdr_white() {
+    const auto *encoder = active_encoder_for_status.load(std::memory_order_acquire);
+    if (!encoder) {
+      return false;
+    }
+
+    return dynamic_cast<const encoder_platform_formats_nvenc *>(encoder->platform_formats.get()) != nullptr ||
+           dynamic_cast<const encoder_platform_formats_amf *>(encoder->platform_formats.get()) != nullptr;
+  }
+
+  bool
+  is_valid_client_sdr_white_nits(float nits) {
+    return std::isfinite(nits) && nits >= 50.0f && nits <= 1000.0f;
+  }
+
   void
   reset_display(std::shared_ptr<platf::display_t> &disp, const platf::mem_type_e &type, const std::string &display_name, const config_t &config) {
     // We try this twice, in case we still get an error on reinitialization
@@ -3070,7 +3086,7 @@ namespace video {
     int &frame_nr,  // Store progress of the frame number
     safe::mail_t mail,
     captured_frame_event_t images,
-    config_t config,
+    config_t &config,
     std::shared_ptr<platf::display_t> disp,
     std::unique_ptr<platf::encode_device_t> encode_device,
     safe::signal_t &reinit_event,
@@ -3209,6 +3225,12 @@ namespace video {
       while (dynamic_param_events_ptr->peek()) {
         if (auto param = dynamic_param_events_ptr->pop(0ms)) {
           BOOST_LOG(info) << "Applying dynamic parameter change: type=" << (int) param->type;
+          if (param->type == dynamic_param_type_e::CLIENT_SDR_WHITE_NITS) {
+            // Keep the latest value in the video-thread-owned config. If the
+            // encoder is recreated after a display/capture reinit, device
+            // construction will apply this value again.
+            config.hdr_capabilities.sdr_white_nits = param->value.float_value;
+          }
           session->set_dynamic_param(*param);
         }
       }

--- a/src/video.h
+++ b/src/video.h
@@ -66,6 +66,7 @@ namespace video {
     ADAPTIVE_QUANTIZATION, // 自适应量化 - 值：1个bool
     MULTI_PASS,        // 多遍编码 - 值：1个int
     VBV_BUFFER_SIZE,   // VBV缓冲区大小 - 值：1个int
+    CLIENT_SDR_WHITE_NITS, // 客户端 SDR reference white - 值：1个float (nits)
     MAX_PARAM_TYPE
   };
 

--- a/src/video.h
+++ b/src/video.h
@@ -66,9 +66,13 @@ namespace video {
     ADAPTIVE_QUANTIZATION, // 自适应量化 - 值：1个bool
     MULTI_PASS,        // 多遍编码 - 值：1个int
     VBV_BUFFER_SIZE,   // VBV缓冲区大小 - 值：1个int
-    CLIENT_SDR_WHITE_NITS, // 客户端 SDR reference white - 值：1个float (nits)
+    // Wire value 9; keep this explicit because the enum ordinal is part of the
+    // Sunshine dynamic-parameter control protocol.
+    CLIENT_SDR_WHITE_NITS = 9, // 客户端 SDR reference white - 值：1个float (nits)
     MAX_PARAM_TYPE
   };
+
+  static_assert(static_cast<int>(dynamic_param_type_e::CLIENT_SDR_WHITE_NITS) == 9);
 
   // 动态参数值联合体
   union dynamic_param_value_t {

--- a/src/video.h
+++ b/src/video.h
@@ -547,6 +547,18 @@ namespace video {
   std::string
   active_encoder_name();
 
+  /**
+   * @brief Whether the selected encoder path can apply runtime SDR white updates.
+   */
+  bool
+  active_encoder_supports_dynamic_sdr_white();
+
+  /**
+   * @brief Validate a client SDR reference white value from the control stream.
+   */
+  bool
+  is_valid_client_sdr_white_nits(float nits);
+
   void
   capture(
     safe::mail_t mail,

--- a/src_assets/windows/assets/shaders/directx/include/convert_hybrid_log_gamma_base.hlsl
+++ b/src_assets/windows/assets/shaders/directx/include/convert_hybrid_log_gamma_base.hlsl
@@ -3,11 +3,21 @@
 cbuffer hlg_display_cbuffer : register(b3) {
     float hlg_peak_nits;
     float hlg_system_gamma;
-    float2 hlg_display_pad;
+    float hlg_sdr_band_gain;
+    float hlg_sdr_band_top;
 };
 
 float3 ConvertScRGBTo2100HLG(float3 rgb)
 {
+    // Re-anchor SDR-referenced content (composed at the Windows SDR white) to
+    // the client's SDR reference white. Full gain at or below the band top,
+    // fading back to 1.0 by 2x so HDR highlights keep their absolute values.
+    // band top <= 0 or gain == 1 leaves the signal untouched.
+    if (hlg_sdr_band_top > 0.0 && hlg_sdr_band_gain != 1.0) {
+        float level = max(rgb.r, max(rgb.g, rgb.b));
+        float t = saturate((level - hlg_sdr_band_top) / max(hlg_sdr_band_top, 1e-4));
+        rgb *= lerp(hlg_sdr_band_gain, 1.0, smoothstep(0.0, 1.0, t));
+    }
     return scRGBTo2100HLG(rgb, hlg_peak_nits, hlg_system_gamma);
 }
 

--- a/tests/unit/test_video.cpp
+++ b/tests/unit/test_video.cpp
@@ -123,6 +123,15 @@ TEST(HlgSystemGamma, FallsBackToReferencePeakForInvalidValues) {
   EXPECT_NEAR(video::hlg_system_gamma(std::numeric_limits<float>::quiet_NaN()), 1.2f, 0.00001f);
 }
 
+TEST(DynamicSdrWhite, AcceptsOnlyFiniteValuesWithinProtocolRange) {
+  EXPECT_FALSE(video::is_valid_client_sdr_white_nits(49.0f));
+  EXPECT_TRUE(video::is_valid_client_sdr_white_nits(50.0f));
+  EXPECT_TRUE(video::is_valid_client_sdr_white_nits(1000.0f));
+  EXPECT_FALSE(video::is_valid_client_sdr_white_nits(1001.0f));
+  EXPECT_FALSE(video::is_valid_client_sdr_white_nits(std::numeric_limits<float>::quiet_NaN()));
+  EXPECT_FALSE(video::is_valid_client_sdr_white_nits(std::numeric_limits<float>::infinity()));
+}
+
 TEST(VideoBitrate, ConvertsTotalBitrateToEncoderBitrate) {
   EXPECT_EQ(video::encoder_bitrate_from_total_bitrate(50000, 10), 45000);
   EXPECT_EQ(video::encoder_bitrate_from_total_bitrate(50000, 80), 10000);


### PR DESCRIPTION
## Summary
- **`sdrBrightness` 解析**:moonlight-harmony 客户端(PR AlkaidLab/moonlight-harmony#113)上报实测 SDR 参考白;独立于三参数原子校验解析,范围 [50,1000] 越界忽略;per-client manual override 只覆盖亮度三元组,保留实测 sdr 白
- **HLG 转换 SDR 波段增益**:b3 常量缓冲的 pad 扩为 `sdrBandGain/sdrBandTop`;逐帧 `update_sdr_band_gain()` 以光标归一化路径跟踪的 Windows 实时 SDR 白位为分母,`gain = clamp(phoneSdr/windowsSdr, 0.5, 2.5)`,波段上沿 2× 处平滑过渡回 1.0(HDR 高光保持绝对值)。客户端未携带参数时恒等,与旧行为逐字节一致;仅 NVENC/AMF 注入(avcodec 路径无 client_config)
- **VDD 重建容差**:`hdr_brightness_t::nearly_equal`(每字段 ±max(25 nits, 5%))取代精确比较——实测上报逐会话存在几 nits 抖动,精确比较会导致每次重连重建 VDD

### 背景
HDR Vivid 过曝的宿主侧根因:游戏 SDR UI/中灰按 Windows 滑条白位(~200 nits)合成进 PQ,手机按绝对值显示,而手机自己 UI 的 SDR 白位在 ~450 nits。契约见 moonlight-harmony `docs/HDR_BRIGHTNESS_REPORTING.md`。

## Test plan
- [ ] `cmake --preset dev-win && cmake --build --preset dev` 编译通过
- [ ] 携带 sdrBrightness 的 HDR 会话:日志出现一次 `SDR band gain: phone=X, windows=Y, gain=Z`,数值合理
- [ ] 同客户端连续两次连接:日志不出现 `Rebuilding VDD`(容差生效)
- [ ] 不携带 sdrBrightness 的旧客户端:行为与 master 一致(增益恒 1)
- [ ] 真机:游戏 UI 白与手机状态栏白目视接近;HDR Vivid 过曝观感改善
- [ ] 回归:PQ/HDR10 模式、SDR 串流不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)