### PR TITLE
fix(hdr): recover Vivid after startup fallback

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -713,7 +713,20 @@ namespace video {
       case transition_e::timed_out:
         BOOST_LOG(warning) << encoder_name << ": HDR Vivid startup guard timed out after "
                            << hdr_metadata::vivid_startup_gate_t::PREROLL_TIMEOUT.count()
-                           << " ms; starting this session as pure HLG without dynamic metadata";
+                           << " ms; temporarily starting as plain HLG while analysis continues"
+                           << " (samples=" << gate.consecutive_samples()
+                           << '/' << hdr_metadata::vivid_startup_guard_t::REQUIRED_SAMPLES
+                           << ", sequence=" << stats.sample_sequence
+                           << ", valid=" << stats.valid << ')';
+        break;
+      case transition_e::recovered:
+        BOOST_LOG(info) << encoder_name << ": HDR Vivid startup guard recovered after plain-HLG fallback; "
+                        << "switching to Vivid at IDR"
+                        << " (samples=" << gate.consecutive_samples()
+                        << '/' << hdr_metadata::vivid_startup_guard_t::REQUIRED_SAMPLES
+                        << ", sequence=" << stats.sample_sequence
+                        << ", avg=" << stats.avg_maxrgb
+                        << " nits, max=" << stats.max_maxrgb << " nits)";
         break;
       case transition_e::none:
         break;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -717,7 +717,9 @@ namespace video {
                            << " (samples=" << gate.consecutive_samples()
                            << '/' << hdr_metadata::vivid_startup_guard_t::REQUIRED_SAMPLES
                            << ", sequence=" << stats.sample_sequence
-                           << ", valid=" << stats.valid << ')';
+                           << ", valid=" << stats.valid
+                           << ", avg=" << stats.avg_maxrgb
+                           << " nits, max=" << stats.max_maxrgb << " nits)";
         break;
       case transition_e::recovered:
         BOOST_LOG(info) << encoder_name << ": HDR Vivid startup guard recovered after plain-HLG fallback; "
@@ -725,6 +727,7 @@ namespace video {
                         << " (samples=" << gate.consecutive_samples()
                         << '/' << hdr_metadata::vivid_startup_guard_t::REQUIRED_SAMPLES
                         << ", sequence=" << stats.sample_sequence
+                        << ", valid=" << stats.valid
                         << ", avg=" << stats.avg_maxrgb
                         << " nits, max=" << stats.max_maxrgb << " nits)";
         break;

--- a/src/video_hdr_metadata.h
+++ b/src/video_hdr_metadata.h
@@ -652,11 +652,12 @@ namespace video::hdr_metadata {
    * The stream-startup policy wrapped around vivid_startup_guard_t.
    *
    * The guard decides whether analyzer output is trustworthy; this decides what a
-   * session does about it — hold frames back, give up after a wall-clock budget, or
-   * emit from the first frame. Both native encoder paths need the identical answer,
-   * so the state machine lives here rather than being written twice: NVENC and AMF
-   * disagreeing about when HLG starts carrying Vivid would be a bug nobody notices
-   * until it is reported as "HDR looks different on my AMD box".
+    * session does about it — hold frames back, start temporarily as plain HLG after
+    * a wall-clock budget, recover Vivid at an IDR boundary, or emit from the first
+    * frame. Both native encoder paths need the identical answer, so the state machine
+    * lives here rather than being written twice: NVENC and AMF disagreeing about when
+    * HLG starts carrying Vivid would be a bug nobody notices until it is reported as
+    * "HDR looks different on my AMD box".
    *
    * The caller owns logging and force-IDR, which is why a transition is reported
    * rather than acted on. A session must feed every capture frame through
@@ -668,13 +669,15 @@ namespace video::hdr_metadata {
     enum class decision_e {
       emit,  ///< Hand this frame's stats to the encoder.
       hold,  ///< Encode nothing yet; keep converting so the analyzer can converge.
-      disabled,  ///< This session never emits dynamic metadata.
+      plain_hlg,  ///< Encode without Vivid while a starved analyzer catches up.
+      disabled,  ///< This stream cannot emit Vivid at all.
     };
 
     enum class transition_e {
       none,
       ready,  ///< The guard just converged; the next encoded frame should be an IDR.
-      timed_out,  ///< The preroll budget just expired; start as plain HLG.
+      timed_out,  ///< The preroll budget expired; temporarily start as plain HLG.
+      recovered,  ///< A timed-out guard converged; switch to Vivid at an IDR.
     };
 
     struct result_t {
@@ -724,12 +727,16 @@ namespace video::hdr_metadata {
       }
 
       if (guard_.observe(stats)) {
+        const bool recovered = state_ == state_e::fallback;
         state_ = state_e::enabled;
-        return { decision_e::emit, transition_e::ready };
+        return { decision_e::emit, recovered ? transition_e::recovered : transition_e::ready };
+      }
+      if (state_ == state_e::fallback) {
+        return { decision_e::plain_hlg, transition_e::none };
       }
       if (now - *preroll_started_ >= PREROLL_TIMEOUT) {
-        state_ = state_e::disabled;
-        return { decision_e::disabled, transition_e::timed_out };
+        state_ = state_e::fallback;
+        return { decision_e::plain_hlg, transition_e::timed_out };
       }
       return { decision_e::hold, transition_e::none };
     }
@@ -749,6 +756,7 @@ namespace video::hdr_metadata {
     enum class state_e {
       enabled,
       preroll,
+      fallback,
       disabled,
     };
 

--- a/tests/unit/test_video_hdr_metadata.cpp
+++ b/tests/unit/test_video_hdr_metadata.cpp
@@ -769,7 +769,8 @@ namespace {
 }  // namespace
 
 TEST(HdrDynamicMetadata, VividStartupGateEmitsImmediatelyForPq) {
-  // PQ has no plain-HDR10 fallback problem, so there is nothing to wait for.
+  // PQ carries HDR10+ independently of the HLG/Vivid startup policy, so an
+  // unavailable analyzer must never route it through plain-HLG fallback.
   gate_t gate { PQ, HEVC, true };
   EXPECT_FALSE(gate.prerolling());
 
@@ -777,6 +778,11 @@ TEST(HdrDynamicMetadata, VividStartupGateEmitsImmediatelyForPq) {
   const auto first = gate.observe(stable_hlg_stats(1), now);
   EXPECT_EQ(first.decision, gate_t::decision_e::emit);
   EXPECT_EQ(first.transition, gate_t::transition_e::none);
+
+  gate_t without_analysis { PQ, HEVC, false };
+  const auto still_emitted = without_analysis.observe({}, now + gate_t::PREROLL_TIMEOUT * 2);
+  EXPECT_EQ(still_emitted.decision, gate_t::decision_e::emit);
+  EXPECT_EQ(still_emitted.transition, gate_t::transition_e::none);
 }
 
 TEST(HdrDynamicMetadata, VividStartupGateHoldsHlgUntilTheGuardConverges) {
@@ -811,8 +817,8 @@ TEST(HdrDynamicMetadata, VividStartupGateAllowsAnalyzerColdStart) {
   auto invalid = stable_hlg_stats(1);
   invalid.valid = false;
 
-  // A slow first analyzer readback must not force this session into permanent
-  // HLG fallback before the GPU has had a chance to produce valid samples.
+  // A slow first analyzer readback must not force this session into plain-HLG
+  // fallback before the GPU has had a chance to produce valid samples.
   EXPECT_EQ(gate.observe(invalid, start).decision, gate_t::decision_e::hold);
   EXPECT_EQ(gate.observe(invalid, start + std::chrono::seconds { 1 }).decision,
     gate_t::decision_e::hold);
@@ -826,7 +832,7 @@ TEST(HdrDynamicMetadata, VividStartupGateAllowsAnalyzerColdStart) {
   EXPECT_EQ(ready.transition, gate_t::transition_e::ready);
 }
 
-TEST(HdrDynamicMetadata, VividStartupGateGivesUpAfterTheTimeout) {
+TEST(HdrDynamicMetadata, VividStartupGateFallsBackAndRecoversAfterTheTimeout) {
   gate_t gate { HLG, HEVC, true };
 
   const auto start = std::chrono::steady_clock::now();
@@ -838,14 +844,47 @@ TEST(HdrDynamicMetadata, VividStartupGateGivesUpAfterTheTimeout) {
     gate_t::decision_e::hold);
 
   const auto expired = gate.observe(invalid, start + gate_t::PREROLL_TIMEOUT);
-  EXPECT_EQ(expired.decision, gate_t::decision_e::disabled);
+  EXPECT_EQ(expired.decision, gate_t::decision_e::plain_hlg);
   EXPECT_EQ(expired.transition, gate_t::transition_e::timed_out);
 
-  // Stays disabled, and does not report the transition again: a stream that starts
-  // as plain HLG must not switch into Vivid later.
-  const auto after = gate.observe(stable_hlg_stats(2), start + gate_t::PREROLL_TIMEOUT * 2);
-  EXPECT_EQ(after.decision, gate_t::decision_e::disabled);
+  // Replayed encoder frames must not fabricate analyzer progress during fallback.
+  const auto first = stable_hlg_stats(2);
+  EXPECT_EQ(gate.observe(first, start + gate_t::PREROLL_TIMEOUT * 2).decision,
+    gate_t::decision_e::plain_hlg);
+  EXPECT_EQ(gate.observe(first, start + gate_t::PREROLL_TIMEOUT * 3).decision,
+    gate_t::decision_e::plain_hlg);
+  EXPECT_EQ(gate.consecutive_samples(), 1U);
+
+  EXPECT_EQ(gate.observe(stable_hlg_stats(3), start + gate_t::PREROLL_TIMEOUT * 4).decision,
+    gate_t::decision_e::plain_hlg);
+  const auto recovered = gate.observe(
+    stable_hlg_stats(4), start + gate_t::PREROLL_TIMEOUT * 5);
+  EXPECT_EQ(recovered.decision, gate_t::decision_e::emit);
+  EXPECT_EQ(recovered.transition, gate_t::transition_e::recovered);
+
+  // Recovery is a one-shot transition; the gate remains enabled afterward.
+  const auto after = gate.observe(stable_hlg_stats(5), start + gate_t::PREROLL_TIMEOUT * 6);
+  EXPECT_EQ(after.decision, gate_t::decision_e::emit);
   EXPECT_EQ(after.transition, gate_t::transition_e::none);
+}
+
+TEST(HdrDynamicMetadata, VividStartupGateKeepsSamplesAcrossFallback) {
+  gate_t gate { HLG, HEVC, true };
+
+  const auto start = std::chrono::steady_clock::now();
+  EXPECT_EQ(gate.observe(stable_hlg_stats(1), start).decision, gate_t::decision_e::hold);
+
+  // The sample that arrives exactly at the deadline still counts before the gate
+  // temporarily opens as plain HLG.
+  const auto expired = gate.observe(stable_hlg_stats(2), start + gate_t::PREROLL_TIMEOUT);
+  EXPECT_EQ(expired.decision, gate_t::decision_e::plain_hlg);
+  EXPECT_EQ(expired.transition, gate_t::transition_e::timed_out);
+  EXPECT_EQ(gate.consecutive_samples(), 2U);
+
+  const auto recovered = gate.observe(
+    stable_hlg_stats(3), start + gate_t::PREROLL_TIMEOUT + std::chrono::milliseconds { 1 });
+  EXPECT_EQ(recovered.decision, gate_t::decision_e::emit);
+  EXPECT_EQ(recovered.transition, gate_t::transition_e::recovered);
 }
 
 TEST(HdrDynamicMetadata, VividStartupGateDisablesHlgWithNothingToWaitFor) {


### PR DESCRIPTION
## 改了啥

- 将 HLG/Vivid 启动门禁超时后的永久 `disabled` 改为临时 `plain_hlg` fallback，继续编码普通 HLG，同时继续观察 analyzer 输出。
- analyzer 后续取得 3 个独立稳定样本时发出一次 `recovered` transition，并复用现有 transition 机制在 IDR 边界恢复 Vivid。
- 为 NVENC/AMF 补充 timeout/recovery 诊断日志，记录样本数、sequence、valid 和亮度统计。
- 增加回归测试，覆盖超时恢复、重复序列不推进、跨 fallback 保留样本，以及 PQ/HDR10+ 在 analyzer 不可用时仍直接 emit。

## 为什么

编码器原地重建且画面静止时，capture/analysis 可能没有新样本。墙钟超时只能限制首帧等待，不能解决样本饥饿；原状态机一旦超时就永久关闭动态元数据，导致整场会话只能使用普通 HLG。

本修改保留 1500 ms 首帧等待上限，但允许后续真实分析样本收敛后安全恢复 Vivid。

Fixes #970

## 边界

- 不修改 `minimum_fps_target`，避免改变其最低编码节奏等其他职责。
- 不缓存或重复转换 borrowed capture frame。
- HDR10+ 保持 PQ 独立直通，不进入 HLG/Vivid startup fallback。
- analyzer/编码格式确实不支持 Vivid 时仍使用永久 `disabled`。

## 验证

- UCRT64 GCC 成功编译 `tests/unit/test_video_hdr_metadata.cpp`。
- 头文件级运行时断言通过：HLG timeout → plain-HLG fallback → Vivid recovery、重复样本去重、PQ/HDR10+ 直通。
- 三个修改文件无编辑器诊断。
- CRLF-aware `git diff --check` 通过。