### PR TITLE
fix(ds5): lift legacy rumble above motor floor

### DIFF
--- a/src/haptics/authored_ir.cpp
+++ b/src/haptics/authored_ir.cpp
@@ -22,7 +22,7 @@ namespace haptics {
     constexpr float legacy_gate_open = 0.020f;
     constexpr float legacy_gate_close = 0.010f;
     constexpr float legacy_gate_hold_seconds = 0.060f;
-    constexpr float legacy_output_floor = 0.004f;
+    constexpr float legacy_output_floor = 0.030f;
     constexpr float legacy_low_band_trim = 1.15f;
     constexpr float legacy_high_band_trim = 1.20f;
     constexpr float legacy_transient_trim = 1.15f;
@@ -78,7 +78,12 @@ namespace haptics {
 
       const auto gated = std::clamp(
         (value - legacy_gate_close) / (1.0f - legacy_gate_close), 0.0f, 1.0f);
-      return std::tanh(makeup_gain * gated) / std::tanh(makeup_gain);
+      // ERM motors have a substantial startup threshold, while Android and HID
+      // clients commonly quantize the 16-bit protocol value to 8 bits. Lift
+      // quiet-but-valid authored content into the usable motor range without
+      // changing the noise gate or compressing full-scale output.
+      const auto perceptual = std::sqrt(gated);
+      return std::tanh(makeup_gain * perceptual) / std::tanh(makeup_gain);
     }
 
     std::uint16_t

--- a/src/haptics/authored_ir.cpp
+++ b/src/haptics/authored_ir.cpp
@@ -242,6 +242,9 @@ namespace haptics {
       _low_gate = {};
       _high_gate = {};
       _last_emit = {};
+      _active_since = {};
+      _last_nonzero_low = 0;
+      _last_nonzero_high = 0;
     }
 
     const bool must_stop = (frame->flags & AH_AUTHORED_FRAME_STREAM_END) != 0;

--- a/src/haptics/authored_ir.cpp
+++ b/src/haptics/authored_ir.cpp
@@ -18,6 +18,10 @@ namespace haptics {
     constexpr std::uint8_t source_stream_end = 0x02;
     constexpr std::uint8_t source_discontinuity = 0x04;
     constexpr auto legacy_emit_period = std::chrono::milliseconds(20);
+    // Some clients dispatch rumble on a slower timer and keep only the newest
+    // queued packet. Hold short synthesized pulses long enough that a stop
+    // packet cannot replace the only nonzero dispatch.
+    constexpr auto legacy_min_active_hold = std::chrono::milliseconds(80);
     constexpr auto legacy_watchdog_timeout = std::chrono::milliseconds(100);
     constexpr float legacy_gate_open = 0.020f;
     constexpr float legacy_gate_close = 0.010f;
@@ -282,8 +286,23 @@ namespace haptics {
     if (low_target <= 0.0f && _smoothed_low < legacy_output_floor) _smoothed_low = 0.0f;
     if (high_target <= 0.0f && _smoothed_high < legacy_output_floor) _smoothed_high = 0.0f;
 
-    const auto low = rumble_u16(_smoothed_low);
-    const auto high = rumble_u16(_smoothed_high);
+    auto low = rumble_u16(_smoothed_low);
+    auto high = rumble_u16(_smoothed_high);
+    if (low != 0 || high != 0) {
+      if (_active_since == std::chrono::steady_clock::time_point {}) _active_since = now;
+      _last_nonzero_low = low;
+      _last_nonzero_high = high;
+    }
+    else if (!must_stop && _active_since != std::chrono::steady_clock::time_point {} &&
+             now - _active_since < legacy_min_active_hold) {
+      low = _last_nonzero_low;
+      high = _last_nonzero_high;
+    }
+    else if (must_stop || _active_since != std::chrono::steady_clock::time_point {}) {
+      _active_since = {};
+      _last_nonzero_low = 0;
+      _last_nonzero_high = 0;
+    }
     // The 20 ms rate limit is the only emission gate. Held silence additionally
     // stays quiet instead of re-sending zero rumble at 50 Hz.
     const bool silent_hold = low == 0 && high == 0 && _last_low == 0 && _last_high == 0;
@@ -312,6 +331,9 @@ namespace haptics {
     _high_gate = {};
     _last_low = 0;
     _last_high = 0;
+    _active_since = {};
+    _last_nonzero_low = 0;
+    _last_nonzero_high = 0;
     if (!had_output) return std::nullopt;
     _last_emit = now;
     return legacy_rumble_t {_controller_id, 0, 0};

--- a/src/haptics/authored_ir.h
+++ b/src/haptics/authored_ir.h
@@ -101,9 +101,12 @@ namespace haptics {
     authored_ir_session_t _analyzer;
     std::chrono::steady_clock::time_point _last_input {};
     std::chrono::steady_clock::time_point _last_emit {};
+    std::chrono::steady_clock::time_point _active_since {};
     std::uint16_t _controller_id = 0;
     std::uint16_t _last_low = 0;
     std::uint16_t _last_high = 0;
+    std::uint16_t _last_nonzero_low = 0;
+    std::uint16_t _last_nonzero_high = 0;
     float _smoothed_low = 0.0f;
     float _smoothed_high = 0.0f;
     gate_state_t _low_gate;

--- a/tests/unit/test_authored_ir.cpp
+++ b/tests/unit/test_authored_ir.cpp
@@ -167,18 +167,64 @@ TEST(AuthoredDualSenseIr, LegacyFallbackHoldsShortPulseBeforeStop) {
   ASSERT_GT(first->low_frequency, 0);
 
   const std::vector<std::uint8_t> silence(240 * 4);
-  const auto held = session.process(0, 0, 240, 2, 25000, silence, start + 25ms);
+  std::optional<haptics::legacy_rumble_t> held;
+  for (std::uint32_t chunk = 1; chunk <= 5; ++chunk) {
+    const auto output = session.process(
+      0, 0, 240, chunk, chunk * 5000, silence,
+      start + std::chrono::milliseconds(chunk * 5));
+    if (output) held = output;
+  }
   ASSERT_TRUE(held.has_value());
-  // The hold preserves a nonzero dispatch, while the analyzer's release
-  // smoothing may legitimately update its level between packets.
+  // The hold preserves a nonzero dispatch, while release smoothing may
+  // legitimately update its level between packets.
   EXPECT_GT(held->low_frequency, 0);
   EXPECT_GT(held->high_frequency, 0);
 
-  const std::span<const std::uint8_t> empty_pcm;
-  const auto stopped = session.process(0, 0x02, 0, 3, 90000, empty_pcm, start + 90ms);
+  const auto stopped = session.poll(start + 125ms);
   ASSERT_TRUE(stopped.has_value());
   EXPECT_EQ(stopped->low_frequency, 0);
   EXPECT_EQ(stopped->high_frequency, 0);
+}
+
+TEST(AuthoredDualSenseIr, LegacyFallbackClearsFloorAfterRelease) {
+  using namespace std::chrono_literals;
+  haptics::legacy_rumble_session_t session;
+  ASSERT_TRUE(session.ready());
+  const auto start = std::chrono::steady_clock::time_point {1s};
+  const auto burst = sine_pcm(120.0, 32000.0);
+  ASSERT_TRUE(session.process(0, 0x01, 240, 0, 0, burst, start).has_value());
+
+  const std::vector<std::uint8_t> silence(240 * 4);
+  std::optional<haptics::legacy_rumble_t> at_release_start;
+  std::optional<haptics::legacy_rumble_t> latest;
+  for (std::uint32_t chunk = 1; chunk <= 80; ++chunk) {
+    const auto output = session.process(
+      0, 0, 240, chunk, chunk * 5000, silence,
+      start + std::chrono::milliseconds(chunk * 5));
+    if (output) latest = output;
+    if (chunk == 4) at_release_start = latest;
+  }
+  ASSERT_TRUE(at_release_start.has_value());
+  EXPECT_GT(at_release_start->low_frequency, 0);
+  ASSERT_TRUE(latest.has_value());
+  EXPECT_EQ(latest->low_frequency, 0u);
+  EXPECT_EQ(latest->high_frequency, 0u);
+}
+
+TEST(AuthoredDualSenseIr, LegacyFallbackDiscontinuityDoesNotReuseHold) {
+  using namespace std::chrono_literals;
+  haptics::legacy_rumble_session_t session;
+  ASSERT_TRUE(session.ready());
+  const auto start = std::chrono::steady_clock::time_point {1s};
+  const auto burst = sine_pcm(120.0, 32000.0);
+  ASSERT_TRUE(session.process(0, 0x01, 240, 0, 0, burst, start).has_value());
+
+  const std::vector<std::uint8_t> silence(240 * 4);
+  const auto restarted = session.process(
+    0, 0x05, 240, 1, 5000, silence, start + 5ms);
+  ASSERT_TRUE(restarted.has_value());
+  EXPECT_EQ(restarted->low_frequency, 0u);
+  EXPECT_EQ(restarted->high_frequency, 0u);
 }
 
 TEST(AuthoredDualSenseIr, LegacyFallbackSeparatesTactileBandsAndRejectsHiss) {

--- a/tests/unit/test_authored_ir.cpp
+++ b/tests/unit/test_authored_ir.cpp
@@ -169,10 +169,13 @@ TEST(AuthoredDualSenseIr, LegacyFallbackHoldsShortPulseBeforeStop) {
   const std::vector<std::uint8_t> silence(240 * 4);
   const auto held = session.process(0, 0, 240, 2, 25000, silence, start + 25ms);
   ASSERT_TRUE(held.has_value());
-  EXPECT_EQ(held->low_frequency, first->low_frequency);
-  EXPECT_EQ(held->high_frequency, first->high_frequency);
+  // The hold preserves a nonzero dispatch, while the analyzer's release
+  // smoothing may legitimately update its level between packets.
+  EXPECT_GT(held->low_frequency, 0);
+  EXPECT_GT(held->high_frequency, 0);
 
-  const auto stopped = session.process(0, 0, 240, 3, 90000, silence, start + 90ms);
+  const std::span<const std::uint8_t> empty_pcm;
+  const auto stopped = session.process(0, 0x02, 0, 3, 90000, empty_pcm, start + 90ms);
   ASSERT_TRUE(stopped.has_value());
   EXPECT_EQ(stopped->low_frequency, 0);
   EXPECT_EQ(stopped->high_frequency, 0);

--- a/tests/unit/test_authored_ir.cpp
+++ b/tests/unit/test_authored_ir.cpp
@@ -134,6 +134,28 @@ TEST(AuthoredDualSenseIr, LegacyFallbackProducesAndStopsRumble) {
   EXPECT_FALSE(session.process(2, 0, 240, 6, 60000, silence, start + 60ms).has_value());
 }
 
+TEST(AuthoredDualSenseIr, LegacyFallbackLiftsLowLevelContentAboveMotorFloor) {
+  using namespace std::chrono_literals;
+  haptics::legacy_rumble_session_t session;
+  ASSERT_TRUE(session.ready());
+  const auto start = std::chrono::steady_clock::time_point {1s};
+
+  std::optional<haptics::legacy_rumble_t> latest;
+  for (std::uint32_t chunk = 0; chunk <= 8; ++chunk) {
+    const auto pcm = sine_pcm(120.0, 1400.0, chunk * 240U);
+    const auto output = session.process(
+      0, chunk == 0 ? 0x01 : 0, 240, chunk,
+      static_cast<std::uint64_t>(chunk) * 5000U, pcm,
+      start + std::chrono::milliseconds(chunk * 5U));
+    if (output) latest = output;
+  }
+
+  ASSERT_TRUE(latest.has_value());
+  // Client renderers typically keep only the high byte. Preserve enough
+  // amplitude to clear real motor startup thresholds after that quantization.
+  EXPECT_GE(latest->low_frequency, 0x1800u);
+}
+
 TEST(AuthoredDualSenseIr, LegacyFallbackSeparatesTactileBandsAndRejectsHiss) {
   using namespace std::chrono_literals;
   const auto measure = [](double frequency_hz, std::uint32_t chunks) {

--- a/tests/unit/test_authored_ir.cpp
+++ b/tests/unit/test_authored_ir.cpp
@@ -156,6 +156,28 @@ TEST(AuthoredDualSenseIr, LegacyFallbackLiftsLowLevelContentAboveMotorFloor) {
   EXPECT_GE(latest->low_frequency, 0x1800u);
 }
 
+TEST(AuthoredDualSenseIr, LegacyFallbackHoldsShortPulseBeforeStop) {
+  using namespace std::chrono_literals;
+  haptics::legacy_rumble_session_t session;
+  ASSERT_TRUE(session.ready());
+  const auto start = std::chrono::steady_clock::time_point {1s};
+  const auto pcm = sine_pcm(120.0, 24000.0);
+  const auto first = session.process(0, 0x01, 240, 1, 0, pcm, start);
+  ASSERT_TRUE(first.has_value());
+  ASSERT_GT(first->low_frequency, 0);
+
+  const std::vector<std::uint8_t> silence(240 * 4);
+  const auto held = session.process(0, 0, 240, 2, 25000, silence, start + 25ms);
+  ASSERT_TRUE(held.has_value());
+  EXPECT_EQ(held->low_frequency, first->low_frequency);
+  EXPECT_EQ(held->high_frequency, first->high_frequency);
+
+  const auto stopped = session.process(0, 0, 240, 3, 90000, silence, start + 90ms);
+  ASSERT_TRUE(stopped.has_value());
+  EXPECT_EQ(stopped->low_frequency, 0);
+  EXPECT_EQ(stopped->high_frequency, 0);
+}
+
 TEST(AuthoredDualSenseIr, LegacyFallbackSeparatesTactileBandsAndRejectsHiss) {
   using namespace std::chrono_literals;
   const auto measure = [](double frequency_hz, std::uint32_t chunks) {

--- a/tests/unit/test_authored_ir.cpp
+++ b/tests/unit/test_authored_ir.cpp
@@ -205,7 +205,7 @@ TEST(AuthoredDualSenseIr, LegacyFallbackClearsFloorAfterRelease) {
     if (chunk == 4) at_release_start = latest;
   }
   ASSERT_TRUE(at_release_start.has_value());
-  EXPECT_GT(at_release_start->low_frequency, 0);
+  EXPECT_GE(at_release_start->low_frequency, 0x07AEu);
   ASSERT_TRUE(latest.has_value());
   EXPECT_EQ(latest->low_frequency, 0u);
   EXPECT_EQ(latest->high_frequency, 0u);

--- a/tests/unit/test_authored_ir.cpp
+++ b/tests/unit/test_authored_ir.cpp
@@ -196,6 +196,7 @@ TEST(AuthoredDualSenseIr, LegacyFallbackClearsFloorAfterRelease) {
 
   const std::vector<std::uint8_t> silence(240 * 4);
   std::optional<haptics::legacy_rumble_t> at_release_start;
+  std::optional<haptics::legacy_rumble_t> at_hold_expiry;
   std::optional<haptics::legacy_rumble_t> latest;
   for (std::uint32_t chunk = 1; chunk <= 80; ++chunk) {
     const auto output = session.process(
@@ -203,9 +204,13 @@ TEST(AuthoredDualSenseIr, LegacyFallbackClearsFloorAfterRelease) {
       start + std::chrono::milliseconds(chunk * 5));
     if (output) latest = output;
     if (chunk == 4) at_release_start = latest;
+    if (chunk == 16) at_hold_expiry = output;
   }
   ASSERT_TRUE(at_release_start.has_value());
   EXPECT_GE(at_release_start->low_frequency, 0x07AEu);
+  ASSERT_TRUE(at_hold_expiry.has_value());
+  EXPECT_EQ(at_hold_expiry->low_frequency, 0u);
+  EXPECT_EQ(at_hold_expiry->high_frequency, 0u);
   ASSERT_TRUE(latest.has_value());
   EXPECT_EQ(latest->low_frequency, 0u);
   EXPECT_EQ(latest->high_frequency, 0u);

--- a/tools/sunshine-ds5-sidecar/ControllerSession.cs
+++ b/tools/sunshine-ds5-sidecar/ControllerSession.cs
@@ -117,7 +117,7 @@ internal sealed class ControllerSession : IDisposable
                     SetTouch(slot, false, 0, 0, 0);
                 _touchSlots.Clear();
             }
-            else if (eventType is 0 or 1 or 3) // hover/down/move claim or update a slot
+            else if (eventType is 1 or 3) // down/move claim or update a slot
             {
                 if (!_touchSlots.TryGetValue(pointerId, out var slot))
                 {
@@ -127,6 +127,14 @@ internal sealed class ControllerSession : IDisposable
                     _touchSlots[pointerId] = slot;
                 }
                 SetTouch(slot, true, pointerId, x, y);
+            }
+            else if (eventType is 0 or 6) // hover/hover-leave are not contacts
+            {
+                // A hover packet must never claim a finger slot. HID touchpads
+                // use hover while the contact is up, and exposing it as active
+                // makes Windows interpret ordinary pointer movement as a
+                // precision-touchpad gesture (for example, menu scrolling).
+                return;
             }
             else if (eventType is 2 or 4 or 6 && _touchSlots.Remove(pointerId, out var slot))
             {


### PR DESCRIPTION
## 改了啥呀

- 保留现有 DS5 legacy 噪声门、频带分离、平滑和停止语义，只把门后的线性响应改成感知型平方根响应
- 将目标关闭后的输出截断地板提高到 3%，避免放大后的无效尾振赖着不走
- 增加低幅 120 Hz authored PCM 回归测试，确保 16 位 rumble 被客户端量化到 8 位后仍能越过真实马达启动门限

## 为啥要改

Pocket EVO 的实测日志已经证明 legacy 回退全链路都有走通，但最大输出只有 `low=0x0241`、`high=0x09A3`。到了 Android/HID 客户端右移 8 位后只剩 `2/255` 和 `9/255`，这点杂鱼强度连马达启动门限都摸不到，所以 Xbox 模式能振、DS5 legacy 模式却完全无感。

这次不降低噪声门，也不硬塞一个固定最小振幅。只有已经通过门限的有效 authored 内容会获得低幅增强，满幅输出仍保持满幅；目标关闭后则更快归零，避免把高频 onset 尾巴误当成持续触觉。

## 验证

- 使用 Sunshine 锁定的 `moonlight-audio-haptics` 提交 `0a76e71` 构建隔离测试二进制
- `/tmp/foundation-sunshine-authored-ir-tests-pinned --gtest_filter='AuthoredDualSenseIr.*'`：8/8 通过
- 覆盖低幅增强、频带分离、高频 hiss 抑制、门释放、stream end 和 watchdog 停振
- `git diff --check`：通过

完整 macOS CMake 配置受仓库缺失的预编译 FFmpeg bundle 阻断；Windows CI 负责最终平台构建验证。
