### PR TITLE
fix(ds5): bound force clear to short pulses

### DIFF
--- a/src/haptics/authored_ir.cpp
+++ b/src/haptics/authored_ir.cpp
@@ -245,6 +245,8 @@ namespace haptics {
       _active_since = {};
       _last_nonzero_low = 0;
       _last_nonzero_high = 0;
+      _short_release_low = false;
+      _short_release_high = false;
     }
 
     const bool must_stop = (frame->flags & AH_AUTHORED_FRAME_STREAM_END) != 0;
@@ -270,11 +272,32 @@ namespace haptics {
     if (must_stop) {
       _low_gate = {};
       _high_gate = {};
+      _short_release_low = false;
+      _short_release_high = false;
     }
     const auto low_target = must_stop ? 0.0f : shaped(
       low_energy, legacy_low_makeup_gain, _low_gate, duration_seconds);
     const auto high_target = must_stop ? 0.0f : shaped(
       high_energy, legacy_high_makeup_gain, _high_gate, duration_seconds);
+
+    // A force clear is only appropriate when a target drops out during the
+    // minimum hold window. Effects that were already active beyond that
+    // window must use the configured release tail instead.
+    const bool within_min_hold =
+      _active_since != std::chrono::steady_clock::time_point {} &&
+      now - _active_since < legacy_min_active_hold;
+    if (must_stop || low_target > 0.0f) {
+      _short_release_low = false;
+    }
+    else if (within_min_hold) {
+      _short_release_low = true;
+    }
+    if (must_stop || high_target > 0.0f) {
+      _short_release_high = false;
+    }
+    else if (within_min_hold) {
+      _short_release_high = true;
+    }
 
     const auto smooth = [duration_seconds](float previous, float target,
                                            float attack, float release) {
@@ -286,14 +309,11 @@ namespace haptics {
       _smoothed_low, low_target, legacy_low_attack_seconds, legacy_low_release_seconds);
     _smoothed_high = must_stop ? 0.0f : smooth(
       _smoothed_high, high_target, legacy_high_attack_seconds, legacy_high_release_seconds);
-    // Once the short-pulse hold has elapsed, do not let the release tail keep
-    // the motors active indefinitely. The hold is for dispatch reliability,
-    // not an extension of the authored signal.
-    if (!must_stop && _active_since != std::chrono::steady_clock::time_point {} &&
-        now - _active_since >= legacy_min_active_hold) {
-      if (low_target <= 0.0f) _smoothed_low = 0.0f;
-      if (high_target <= 0.0f) _smoothed_high = 0.0f;
-    }
+    const bool hold_expired =
+      _active_since != std::chrono::steady_clock::time_point {} &&
+      now - _active_since >= legacy_min_active_hold;
+    if (hold_expired && _short_release_low && low_target <= 0.0f) _smoothed_low = 0.0f;
+    if (hold_expired && _short_release_high && high_target <= 0.0f) _smoothed_high = 0.0f;
     if (low_target <= 0.0f && _smoothed_low < legacy_output_floor) _smoothed_low = 0.0f;
     if (high_target <= 0.0f && _smoothed_high < legacy_output_floor) _smoothed_high = 0.0f;
 
@@ -313,6 +333,8 @@ namespace haptics {
       _active_since = {};
       _last_nonzero_low = 0;
       _last_nonzero_high = 0;
+      _short_release_low = false;
+      _short_release_high = false;
     }
     // The 20 ms rate limit is the only emission gate. Held silence additionally
     // stays quiet instead of re-sending zero rumble at 50 Hz.
@@ -345,6 +367,8 @@ namespace haptics {
     _active_since = {};
     _last_nonzero_low = 0;
     _last_nonzero_high = 0;
+    _short_release_low = false;
+    _short_release_high = false;
     if (!had_output) return std::nullopt;
     _last_emit = now;
     return legacy_rumble_t {_controller_id, 0, 0};

--- a/src/haptics/authored_ir.h
+++ b/src/haptics/authored_ir.h
@@ -111,6 +111,11 @@ namespace haptics {
     float _smoothed_high = 0.0f;
     gate_state_t _low_gate;
     gate_state_t _high_gate;
+    // Set only when a motor starts releasing before the short-pulse hold
+    // expires. Such pulses are force-cleared at the boundary; long effects
+    // retain their normal release tail.
+    bool _short_release_low = false;
+    bool _short_release_high = false;
     bool _have_input = false;
   };
 }  // namespace haptics

--- a/tests/unit/test_authored_ir.cpp
+++ b/tests/unit/test_authored_ir.cpp
@@ -216,6 +216,46 @@ TEST(AuthoredDualSenseIr, LegacyFallbackClearsFloorAfterRelease) {
   EXPECT_EQ(latest->high_frequency, 0u);
 }
 
+TEST(AuthoredDualSenseIr, LegacyFallbackKeepsReleaseTailForLongEffect) {
+  using namespace std::chrono_literals;
+  haptics::legacy_rumble_session_t session;
+  ASSERT_TRUE(session.ready());
+  const auto start = std::chrono::steady_clock::time_point {1s};
+  const auto burst = sine_pcm(120.0, 32000.0);
+  const std::vector<std::uint8_t> silence(240 * 4);
+
+  // Keep the authored signal active beyond the short-pulse hold window.
+  bool saw_output = false;
+  for (std::uint32_t chunk = 0; chunk <= 20; ++chunk) {
+    const auto output = session.process(
+      0, chunk == 0 ? 0x01 : 0, 240, chunk, chunk * 5000,
+      burst, start + std::chrono::milliseconds(chunk * 5));
+    saw_output = saw_output || output.has_value();
+  }
+  ASSERT_TRUE(saw_output);
+
+  std::optional<haptics::legacy_rumble_t> release_start;
+  std::optional<haptics::legacy_rumble_t> latest;
+  for (std::uint32_t chunk = 21; chunk <= 80; ++chunk) {
+    const auto output = session.process(
+      0, 0, 240, chunk, chunk * 5000, silence,
+      start + std::chrono::milliseconds(chunk * 5));
+    if (output) {
+      if (!release_start) release_start = output;
+      latest = output;
+    }
+  }
+
+  ASSERT_TRUE(release_start.has_value());
+  // A long effect releases through the configured tail instead of being hard
+  // cut at the 80 ms short-pulse boundary.
+  EXPECT_GT(release_start->low_frequency, 0u);
+  EXPECT_GT(release_start->high_frequency, 0u);
+  ASSERT_TRUE(latest.has_value());
+  EXPECT_EQ(latest->low_frequency, 0u);
+  EXPECT_EQ(latest->high_frequency, 0u);
+}
+
 TEST(AuthoredDualSenseIr, LegacyFallbackDiscontinuityDoesNotReuseHold) {
   using namespace std::chrono_literals;
   haptics::legacy_rumble_session_t session;


### PR DESCRIPTION
## 背景

`5e49cde0` 在 hold 到期后无条件把 release tail 清零。它能满足短脉冲边界测试，但会让已经持续超过 80 ms 的振动在释放时被硬切断，绕过可调 release 参数。

## 修改

- 撤回无条件的 hold-expiry force clear。
- 仅当某个电机在 80 ms 最小保持窗口内开始释放时，记录短脉冲 force-clear 状态。
- 短脉冲在 hold 到期时清零，避免慢客户端丢失有效振动。
- 已经持续超过 hold 窗口的振动继续使用正常 release tail，自然归零。
- 流断、显式停止和 watchdog 清理 force-clear 状态。
- 增加长振动释放回归测试，确保不会在 80 ms 边界硬切断。

## 验证

- `clang++ -std=c++20 -fsyntax-only`：`src/haptics/authored_ir.cpp` 通过。
- `clang++ -std=c++20 -fsyntax-only`：`tests/unit/test_authored_ir.cpp` 通过。
- `git diff --check` 通过。
- 完整 CMake/Windows 构建交由 PR CI 验证。
