### PR TITLE
fix(ds5): preserve controller ownership during sidecar recovery

### DIFF
--- a/src/platform/windows/ds5/ds5_sidecar_client.cpp
+++ b/src/platform/windows/ds5/ds5_sidecar_client.cpp
@@ -620,7 +620,7 @@ namespace platf::ds5 {
   bool sidecar_client_t::owns(int global_index) const {
     // Ownership survives a temporary transport outage so the input layer can
     // still release the controller while the reader thread is recovering it.
-    return _impl->global_index == global_index;
+    return global_index >= 0 && _impl->global_index == global_index;
   }
 
   int sidecar_client_t::alloc(const gamepad_id_t &id, feedback_queue_t feedback_queue, bool audio_haptics) {

--- a/src/platform/windows/ds5/ds5_sidecar_client.cpp
+++ b/src/platform/windows/ds5/ds5_sidecar_client.cpp
@@ -458,6 +458,9 @@ namespace platf::ds5 {
 
       const auto deadline = std::chrono::steady_clock::now() + 10s;
       do {
+        if (stopping || WaitForSingleObject(stop_event, 0) == WAIT_OBJECT_0) {
+          return false;
+        }
         const auto connected_pipe = CreateFileW(pipe_path.c_str(), GENERIC_READ | GENERIC_WRITE,
                                                 0, nullptr, OPEN_EXISTING,
                                                 FILE_FLAG_OVERLAPPED, nullptr);
@@ -473,6 +476,9 @@ namespace platf::ds5 {
         WaitNamedPipeW(pipe_path.c_str(), 100);
       } while (std::chrono::steady_clock::now() < deadline);
 
+      if (stopping || WaitForSingleObject(stop_event, 0) == WAIT_OBJECT_0) {
+        return false;
+      }
       BOOST_LOG(error) << "Timed out connecting to DualSense sidecar pipe"sv;
       return false;
     }
@@ -612,7 +618,9 @@ namespace platf::ds5 {
   }
 
   bool sidecar_client_t::owns(int global_index) const {
-    return _impl->online && _impl->global_index == global_index;
+    // Ownership survives a temporary transport outage so the input layer can
+    // still release the controller while the reader thread is recovering it.
+    return _impl->global_index == global_index;
   }
 
   int sidecar_client_t::alloc(const gamepad_id_t &id, feedback_queue_t feedback_queue, bool audio_haptics) {
@@ -635,7 +643,7 @@ namespace platf::ds5 {
   }
 
   void sidecar_client_t::submit_input(int global_index, const gamepad_state_t &state) {
-    if (!owns(global_index)) return;
+    if (!owns(global_index) || !_impl->online) return;
     std::array<std::uint8_t, 20> payload {};
     payload[0] = static_cast<std::uint8_t>(global_index);
     write_u32(payload.data() + 4, state.buttonFlags);
@@ -649,7 +657,7 @@ namespace platf::ds5 {
   }
 
   void sidecar_client_t::submit_touch(const gamepad_touch_t &touch) {
-    if (!owns(touch.id.globalIndex)) return;
+    if (!owns(touch.id.globalIndex) || !_impl->online) return;
     std::array<std::uint8_t, 20> payload {};
     payload[0] = static_cast<std::uint8_t>(touch.id.globalIndex);
     payload[1] = touch.eventType;
@@ -661,7 +669,7 @@ namespace platf::ds5 {
   }
 
   void sidecar_client_t::submit_motion(const gamepad_motion_t &motion) {
-    if (!owns(motion.id.globalIndex)) return;
+    if (!owns(motion.id.globalIndex) || !_impl->online) return;
     std::array<std::uint8_t, 16> payload {};
     payload[0] = static_cast<std::uint8_t>(motion.id.globalIndex);
     payload[1] = motion.motionType;
@@ -672,7 +680,7 @@ namespace platf::ds5 {
   }
 
   void sidecar_client_t::submit_battery(const gamepad_battery_t &battery) {
-    if (!owns(battery.id.globalIndex)) return;
+    if (!owns(battery.id.globalIndex) || !_impl->online) return;
     std::array<std::uint8_t, 4> payload {
       static_cast<std::uint8_t>(battery.id.globalIndex), battery.state, battery.percentage, 0
     };

--- a/tests/tools/ds5_fake_sidecar.cpp
+++ b/tests/tools/ds5_fake_sidecar.cpp
@@ -88,8 +88,23 @@ int main(int argc, char **argv) {
                                              crash_always_name.c_str());
   const auto recovered_name = L"Local\\sunshine-ds5-test-recovered-" + event_suffix;
   const auto recovered_event = OpenEventW(EVENT_MODIFY_STATE, FALSE, recovered_name.c_str());
+  const auto recovery_started_name = L"Local\\sunshine-ds5-test-recovery-started-" + event_suffix;
+  const auto recovery_started_event = OpenEventW(EVENT_MODIFY_STATE, FALSE,
+                                                  recovery_started_name.c_str());
+  const auto recovery_wait_name = L"Local\\sunshine-ds5-test-recovery-wait-" + event_suffix;
+  const auto recovery_wait_event = OpenEventW(SYNCHRONIZE, FALSE,
+                                               recovery_wait_name.c_str());
   const auto marker_name = L"Local\\sunshine-ds5-test-marker-" + event_suffix;
   const auto marker_event = OpenEventW(EVENT_MODIFY_STATE, FALSE, marker_name.c_str());
+
+  // A crash-once test can hold the replacement process before it creates its
+  // pipe, exposing the Core client's assigned-but-offline recovery window.
+  if (crash_once_event && recovery_wait_event &&
+      WaitForSingleObject(crash_once_event, 0) == WAIT_OBJECT_0) {
+    if (recovery_started_event) SetEvent(recovery_started_event);
+    if (WaitForSingleObject(recovery_wait_event, 5000) != WAIT_OBJECT_0) return 5;
+  }
+
   const auto path = L"\\\\.\\pipe\\" + std::wstring(pipe_name.begin(), pipe_name.end());
   const auto pipe = CreateNamedPipeW(path.c_str(), PIPE_ACCESS_DUPLEX,
                                      PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
@@ -148,6 +163,8 @@ int main(int argc, char **argv) {
   }
 
   if (marker_event) CloseHandle(marker_event);
+  if (recovery_wait_event) CloseHandle(recovery_wait_event);
+  if (recovery_started_event) CloseHandle(recovery_started_event);
   if (recovered_event) CloseHandle(recovered_event);
   if (crash_always_event) CloseHandle(crash_always_event);
   if (crash_once_event) CloseHandle(crash_once_event);

--- a/tests/unit/platform/windows/test_ds5_sidecar_client.cpp
+++ b/tests/unit/platform/windows/test_ds5_sidecar_client.cpp
@@ -171,6 +171,41 @@ TEST(Ds5SidecarClientTests, RelaunchesOnceAfterUnexpectedExit) {
   client.free(0);
 }
 
+TEST(Ds5SidecarClientTests, FreeCancelsPendingRecovery) {
+  config_scope_t restore_config;
+  config::input.ds5_enabled = true;
+  config::input.ds5_sidecar_path = SUNSHINE_DS5_FAKE_SIDECAR_PATH;
+
+  event_namespace_scope_t events(L"cancel-recovery");
+  const auto continue_name = L"Local\\sunshine-ds5-test-continue-" + events.suffix;
+  const auto crash_name = L"Local\\sunshine-ds5-test-crash-once-" + events.suffix;
+  const auto recovery_started_name = L"Local\\sunshine-ds5-test-recovery-started-" + events.suffix;
+  const auto recovery_wait_name = L"Local\\sunshine-ds5-test-recovery-wait-" + events.suffix;
+  handle_scope_t continue_event(CreateEventW(nullptr, FALSE, FALSE, continue_name.c_str()));
+  handle_scope_t crash_event(CreateEventW(nullptr, TRUE, FALSE, crash_name.c_str()));
+  handle_scope_t recovery_started_event(CreateEventW(nullptr, FALSE, FALSE, recovery_started_name.c_str()));
+  handle_scope_t recovery_wait_event(CreateEventW(nullptr, TRUE, FALSE, recovery_wait_name.c_str()));
+  ASSERT_NE(continue_event.handle, nullptr);
+  ASSERT_NE(crash_event.handle, nullptr);
+  ASSERT_NE(recovery_started_event.handle, nullptr);
+  ASSERT_NE(recovery_wait_event.handle, nullptr);
+
+  auto mail = std::make_shared<safe::mail_raw_t>();
+  auto feedback = mail->queue<platf::gamepad_feedback_msg_t>("ds5-cancel-recovery-test");
+  platf::ds5::sidecar_client_t client;
+  ASSERT_EQ(client.alloc({ 0, 0 }, std::move(feedback), false), 0);
+  ASSERT_EQ(WaitForSingleObject(recovery_started_event.handle, 5000), WAIT_OBJECT_0);
+
+  // The transport is offline, but the sidecar still owns the controller id.
+  // The input layer relies on owns() to route release to sidecar_client_t::free().
+  EXPECT_TRUE(client.owns(0));
+  const auto started = std::chrono::steady_clock::now();
+  client.free(0);
+  const auto elapsed = std::chrono::steady_clock::now() - started;
+  EXPECT_LT(elapsed, std::chrono::seconds(3));
+  EXPECT_FALSE(client.owns(0));
+}
+
 TEST(Ds5SidecarClientTests, ReallocatesAfterRecoveryFailure) {
   config_scope_t restore_config;
   config::input.ds5_enabled = true;

--- a/tests/unit/platform/windows/test_ds5_sidecar_client.cpp
+++ b/tests/unit/platform/windows/test_ds5_sidecar_client.cpp
@@ -51,6 +51,11 @@ namespace {
   };
 }  // namespace
 
+TEST(Ds5SidecarClientTests, UnassignedIndexIsNotOwned) {
+  platf::ds5::sidecar_client_t client;
+  EXPECT_FALSE(client.owns(-1));
+}
+
 TEST(Ds5SidecarClientTests, AllocThenFreeCancelsBlockedReader) {
   config_scope_t restore_config;
   config::input.ds5_enabled = true;


### PR DESCRIPTION
## Problem

When the DS5 sidecar disconnects, the reader marks the transport offline before attempting one relaunch. `owns()` also depended on `online`, so a controller release in that window skipped `sidecar_client_t::free()`. The recovery thread could then restore a controller that the input session had already released.

The recovery connection loop also ignored the stop event while waiting up to 10 seconds for the replacement pipe.

## Fix

- keep `owns()` tied to the assigned global controller id across temporary transport outages
- keep data-plane submissions gated on `online`
- make the pipe connection loop cancelable through the persistent stop event
- add a deterministic regression test that frees the controller while the replacement sidecar is held before pipe creation

## Validation

- reconstructed base files were verified byte-for-byte against their Git blob SHAs
- added `Ds5SidecarClientTests.FreeCancelsPendingRecovery`
- confirmed the branch is one commit ahead of `master` with only the three intended files changed
- the Windows-only test target is not runnable in the current Linux environment; GitHub CI is expected to run it
