### PR TITLE
fix(ds5): guard virtual haptics audio capture

### DIFF
--- a/src/platform/windows/ds5/ds5_sidecar_client.cpp
+++ b/src/platform/windows/ds5/ds5_sidecar_client.cpp
@@ -58,6 +58,7 @@ namespace platf::ds5 {
       adaptive_triggers = 102,
       led = 103,
       haptics_pcm = 104,
+      audio_policy_violation = 105,
       error = 255,
     };
 
@@ -274,6 +275,7 @@ namespace platf::ds5 {
     std::atomic_int global_index { -1 };
     std::uint8_t client_index = 0;
     bool audio_haptics_requested = false;
+    bool force_hid_fallback = false;
     feedback_queue_t feedback_queue;
     std::uint32_t next_request_id = 1;
 
@@ -359,6 +361,18 @@ namespace platf::ds5 {
                 p[1], p[2], frames, read_u32(p.data() + 8), read_u64(p.data() + 12),
                 p.data() + 24, pcm_size));
             }
+          }
+          break;
+        case message_e::audio_policy_violation:
+          if (p.size() == 4 && p[0] == owned_index) {
+            static constexpr std::array<std::string_view, 3> role_names {
+              "console", "multimedia", "communications"
+            };
+            const auto role = p[2] < role_names.size() ? role_names[p[2]] : "unknown"sv;
+            force_hid_fallback = true;
+            audio_haptics_requested = false;
+            BOOST_LOG(warning) << "The virtual DualSense audio endpoint became the Windows "sv
+                               << role << " default; falling back to HID-only DualSense"sv;
           }
           break;
         case message_e::error:
@@ -508,7 +522,7 @@ namespace platf::ds5 {
       }
 
       client_index = id.clientRelativeIndex;
-      audio_haptics_requested = audio_haptics;
+      audio_haptics_requested = audio_haptics && !force_hid_fallback;
       online = true;
       BOOST_LOG(info) << "DualSense sidecar attached controller "sv << id.globalIndex
                       << (reply.payload[1] ? " with native four-channel haptics" : " (HID only)");
@@ -523,6 +537,9 @@ namespace platf::ds5 {
       if (reader.joinable()) {
         reader.join();
       }
+      // A new allocation is an explicit user/session request. Only the
+      // automatic recovery of the current allocation inherits the fallback.
+      force_hid_fallback = false;
       if (!connect_and_attach(id, audio_haptics)) {
         return false;
       }

--- a/tests/tools/ds5_fake_sidecar.cpp
+++ b/tests/tools/ds5_fake_sidecar.cpp
@@ -80,6 +80,14 @@ int main(int argc, char **argv) {
   // The test process opts this peer into emitting async feedback ahead of the
   // attach reply, exercising the Core client's transaction multiplexing.
   const auto interleave = GetEnvironmentVariableW(L"SUNSHINE_DS5_TEST_INTERLEAVE", nullptr, 0) > 0;
+  const auto audio_policy_fallback =
+    GetEnvironmentVariableW(L"SUNSHINE_DS5_TEST_AUDIO_POLICY_FALLBACK", nullptr, 0) > 0;
+  const auto policy_once_name = L"Local\\sunshine-ds5-test-policy-once-" + event_suffix;
+  const auto policy_once_event = OpenEventW(SYNCHRONIZE | EVENT_MODIFY_STATE, FALSE,
+                                            policy_once_name.c_str());
+  const auto hid_fallback_name = L"Local\\sunshine-ds5-test-hid-fallback-" + event_suffix;
+  const auto hid_fallback_event = OpenEventW(EVENT_MODIFY_STATE, FALSE,
+                                             hid_fallback_name.c_str());
   const auto crash_once_name = L"Local\\sunshine-ds5-test-crash-once-" + event_suffix;
   const auto crash_once_event = OpenEventW(SYNCHRONIZE | EVENT_MODIFY_STATE, FALSE,
                                            crash_once_name.c_str());
@@ -118,7 +126,24 @@ int main(int argc, char **argv) {
       }
       std::vector<std::uint8_t> response(8);
       response[0] = payload[0];
+      if (audio_policy_fallback && payload[2] == 1) {
+        response[1] = 1;
+      }
       if (!reply(pipe, 4, request_id, response)) break;
+      if (audio_policy_fallback && policy_once_event &&
+          WaitForSingleObject(policy_once_event, 0) == WAIT_TIMEOUT) {
+        // The first process accepts the composite attach, then reports the
+        // same asynchronous violation as the real endpoint guard and exits.
+        FlushFileBuffers(pipe);
+        SetEvent(policy_once_event);
+        if (!reply(pipe, 105, 0, { payload[0], payload[1], 0, 0 })) break;
+        FlushFileBuffers(pipe);
+        break;
+      }
+      if (audio_policy_fallback && policy_once_event && hid_fallback_event &&
+          WaitForSingleObject(policy_once_event, 0) == WAIT_OBJECT_0 && payload[2] == 0) {
+        SetEvent(hid_fallback_event);
+      }
       if (crash_always_event) {
         // Ensure Core has consumed the attach reply before simulating the
         // post-attach crash; otherwise the test races pipe teardown.
@@ -148,6 +173,8 @@ int main(int argc, char **argv) {
   }
 
   if (marker_event) CloseHandle(marker_event);
+  if (hid_fallback_event) CloseHandle(hid_fallback_event);
+  if (policy_once_event) CloseHandle(policy_once_event);
   if (recovered_event) CloseHandle(recovered_event);
   if (crash_always_event) CloseHandle(crash_always_event);
   if (crash_once_event) CloseHandle(crash_once_event);

--- a/tests/unit/platform/windows/test_ds5_sidecar_client.cpp
+++ b/tests/unit/platform/windows/test_ds5_sidecar_client.cpp
@@ -49,6 +49,18 @@ namespace {
 
     std::wstring suffix;
   };
+
+  struct environment_scope_t {
+    environment_scope_t(const wchar_t *variable, const wchar_t *value): variable(variable) {
+      SetEnvironmentVariableW(variable, value);
+    }
+
+    ~environment_scope_t() {
+      SetEnvironmentVariableW(variable.c_str(), nullptr);
+    }
+
+    std::wstring variable;
+  };
 }  // namespace
 
 TEST(Ds5SidecarClientTests, AllocThenFreeCancelsBlockedReader) {
@@ -168,6 +180,40 @@ TEST(Ds5SidecarClientTests, RelaunchesOnceAfterUnexpectedExit) {
   ASSERT_TRUE(marker);
   ASSERT_EQ(marker->type, platf::gamepad_feedback_e::rumble);
   EXPECT_TRUE(client.owns(0));
+  client.free(0);
+}
+
+TEST(Ds5SidecarClientTests, FallsBackToHidOnlyWhenVirtualAudioBecomesDefault) {
+  config_scope_t restore_config;
+  config::input.ds5_enabled = true;
+  config::input.ds5_sidecar_path = SUNSHINE_DS5_FAKE_SIDECAR_PATH;
+
+  event_namespace_scope_t events(L"audio-policy-fallback");
+  environment_scope_t enable_policy_fallback(L"SUNSHINE_DS5_TEST_AUDIO_POLICY_FALLBACK", L"1");
+  const auto continue_name = L"Local\\sunshine-ds5-test-continue-" + events.suffix;
+  const auto policy_once_name = L"Local\\sunshine-ds5-test-policy-once-" + events.suffix;
+  const auto hid_fallback_name = L"Local\\sunshine-ds5-test-hid-fallback-" + events.suffix;
+  handle_scope_t continue_event(CreateEventW(nullptr, FALSE, FALSE, continue_name.c_str()));
+  handle_scope_t policy_once_event(CreateEventW(nullptr, TRUE, FALSE, policy_once_name.c_str()));
+  handle_scope_t hid_fallback_event(CreateEventW(nullptr, FALSE, FALSE, hid_fallback_name.c_str()));
+  ASSERT_NE(continue_event.handle, nullptr);
+  ASSERT_NE(policy_once_event.handle, nullptr);
+  ASSERT_NE(hid_fallback_event.handle, nullptr);
+
+  auto mail = std::make_shared<safe::mail_raw_t>();
+  auto feedback = mail->queue<platf::gamepad_feedback_msg_t>("ds5-audio-policy-fallback-test");
+  platf::ds5::sidecar_client_t client;
+  ASSERT_EQ(client.alloc({ 0, 0 }, std::move(feedback), true), 0);
+  ASSERT_EQ(WaitForSingleObject(hid_fallback_event.handle, 5000), WAIT_OBJECT_0);
+  // The fake peer signals after observing the HID-only ATTACH payload, just
+  // before connect_and_attach() publishes online=true. Wait for that final
+  // local state transition instead of racing it.
+  const auto online_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (!client.owns(0) && std::chrono::steady_clock::now() < online_deadline) {
+    Sleep(1);
+  }
+  EXPECT_TRUE(client.owns(0));
+  ASSERT_TRUE(SetEvent(continue_event.handle));
   client.free(0);
 }
 

--- a/tests/unit/platform/windows/test_ds5_sidecar_client.cpp
+++ b/tests/unit/platform/windows/test_ds5_sidecar_client.cpp
@@ -11,9 +11,13 @@
 
   #include "src/config.h"
   #include "src/platform/windows/ds5/ds5_sidecar_client.h"
+  #include <gtest/gtest-spi.h>
   #include <gtest/gtest.h>
 
 namespace {
+  using get_environment_fn_t = DWORD(WINAPI *)(LPCWSTR, LPWSTR, DWORD);
+  using set_environment_fn_t = BOOL(WINAPI *)(LPCWSTR, LPCWSTR);
+
   struct config_scope_t {
     config_scope_t():
         enabled(config::input.ds5_enabled),
@@ -51,31 +55,157 @@ namespace {
   };
 
   struct environment_scope_t {
-    environment_scope_t(const wchar_t *variable, const wchar_t *value): variable(variable) {
+    enum class original_state_e {
+      unknown,
+      undefined,
+      defined,
+    };
+
+    environment_scope_t(const wchar_t *variable, const wchar_t *value,
+                        get_environment_fn_t get_environment = GetEnvironmentVariableW,
+                        set_environment_fn_t set_environment = SetEnvironmentVariableW):
+        variable(variable),
+        set_environment(set_environment) {
       SetLastError(ERROR_SUCCESS);
-      auto required = GetEnvironmentVariableW(variable, nullptr, 0);
-      was_defined = required != 0 || GetLastError() != ERROR_ENVVAR_NOT_FOUND;
+      auto required = get_environment(variable, nullptr, 0);
+      if (required == 0) {
+        const auto error = GetLastError();
+        if (error == ERROR_ENVVAR_NOT_FOUND) {
+          original_state = original_state_e::undefined;
+        }
+        else if (error == ERROR_SUCCESS) {
+          original_state = original_state_e::defined;
+        }
+        else {
+          ADD_FAILURE() << "GetEnvironmentVariableW size query failed: " << error;
+          return;
+        }
+      }
+      else {
+        original_state = original_state_e::defined;
+      }
+
       while (required != 0) {
         original_value.resize(required);
-        const auto copied = GetEnvironmentVariableW(variable, original_value.data(), required);
+        SetLastError(ERROR_SUCCESS);
+        const auto copied = get_environment(variable, original_value.data(), required);
+        if (copied == 0 && GetLastError() != ERROR_SUCCESS) {
+          ADD_FAILURE() << "GetEnvironmentVariableW value read failed: " << GetLastError();
+          original_state = original_state_e::unknown;
+          original_value.clear();
+          return;
+        }
         if (copied < required) {
           original_value.resize(copied);
           break;
         }
-        required = copied + 1;
+        required = copied;
       }
-      SetEnvironmentVariableW(variable, value);
+
+      if (!set_environment(variable, value)) {
+        ADD_FAILURE() << "SetEnvironmentVariableW scoped write failed: " << GetLastError();
+        original_state = original_state_e::unknown;
+        return;
+      }
+      restore_required = true;
     }
 
     ~environment_scope_t() {
-      SetEnvironmentVariableW(variable.c_str(), was_defined ? original_value.c_str() : nullptr);
+      if (!restore_required)
+        return;
+      const auto *value = original_state == original_state_e::defined ? original_value.c_str() : nullptr;
+      if (!set_environment(variable.c_str(), value)) {
+        ADD_FAILURE() << "SetEnvironmentVariableW restore failed: " << GetLastError();
+      }
     }
 
     std::wstring variable;
     std::wstring original_value;
-    bool was_defined;
+    set_environment_fn_t set_environment;
+    original_state_e original_state = original_state_e::unknown;
+    bool restore_required = false;
   };
+
+  DWORD WINAPI fail_environment_read(LPCWSTR, LPWSTR, DWORD) {
+    SetLastError(ERROR_ACCESS_DENIED);
+    return 0;
+  }
+
+  DWORD WINAPI fail_environment_value_read(LPCWSTR, LPWSTR value, DWORD) {
+    if (!value) {
+      SetLastError(ERROR_SUCCESS);
+      return 2;
+    }
+    SetLastError(ERROR_ACCESS_DENIED);
+    return 0;
+  }
+
+  BOOL WINAPI fail_environment_write(LPCWSTR, LPCWSTR) {
+    SetLastError(ERROR_ACCESS_DENIED);
+    return FALSE;
+  }
+
+  int environment_write_calls;
+
+  BOOL WINAPI fail_environment_restore(LPCWSTR, LPCWSTR) {
+    if (environment_write_calls++ == 0)
+      return TRUE;
+    SetLastError(ERROR_ACCESS_DENIED);
+    return FALSE;
+  }
 }  // namespace
+
+TEST(Ds5SidecarClientTests, EnvironmentScopeRestoresPreviousValues) {
+  const auto variable = L"SUNSHINE_DS5_TEST_ENVIRONMENT_SCOPE_" + std::to_wstring(GetCurrentProcessId());
+  EXPECT_TRUE(SetEnvironmentVariableW(variable.c_str(), nullptr));
+  {
+    environment_scope_t scoped(variable.c_str(), L"temporary");
+  }
+  SetLastError(ERROR_SUCCESS);
+  EXPECT_EQ(GetEnvironmentVariableW(variable.c_str(), nullptr, 0), 0u);
+  EXPECT_EQ(GetLastError(), ERROR_ENVVAR_NOT_FOUND);
+
+  EXPECT_TRUE(SetEnvironmentVariableW(variable.c_str(), L""));
+  {
+    environment_scope_t scoped(variable.c_str(), L"temporary");
+  }
+  SetLastError(ERROR_SUCCESS);
+  EXPECT_EQ(GetEnvironmentVariableW(variable.c_str(), nullptr, 0), 1u);
+  EXPECT_EQ(GetLastError(), ERROR_SUCCESS);
+
+  EXPECT_TRUE(SetEnvironmentVariableW(variable.c_str(), L"original"));
+  {
+    environment_scope_t scoped(variable.c_str(), L"temporary");
+  }
+  std::array<wchar_t, 16> restored {};
+  EXPECT_EQ(GetEnvironmentVariableW(
+              variable.c_str(), restored.data(), static_cast<DWORD>(restored.size())),
+            8u);
+  EXPECT_STREQ(restored.data(), L"original");
+  EXPECT_TRUE(SetEnvironmentVariableW(variable.c_str(), nullptr));
+}
+
+TEST(Ds5SidecarClientTests, EnvironmentScopeReportsApiFailures) {
+  EXPECT_NONFATAL_FAILURE(
+    { environment_scope_t scoped(L"SUNSHINE_DS5_TEST_READ_FAILURE", L"temporary",
+                                 fail_environment_read, fail_environment_write); },
+    "GetEnvironmentVariableW size query failed");
+  EXPECT_NONFATAL_FAILURE(
+    { environment_scope_t scoped(L"SUNSHINE_DS5_TEST_VALUE_READ_FAILURE", L"temporary",
+                                 fail_environment_value_read, fail_environment_write); },
+    "GetEnvironmentVariableW value read failed");
+  EXPECT_NONFATAL_FAILURE(
+    { environment_scope_t scoped(L"SUNSHINE_DS5_TEST_SET_FAILURE", L"temporary",
+                                 GetEnvironmentVariableW, fail_environment_write); },
+    "SetEnvironmentVariableW scoped write failed");
+  EXPECT_NONFATAL_FAILURE(
+    {
+      environment_write_calls = 0;
+      environment_scope_t scoped(L"SUNSHINE_DS5_TEST_RESTORE_FAILURE", L"temporary",
+                                 GetEnvironmentVariableW, fail_environment_restore);
+    },
+    "SetEnvironmentVariableW restore failed");
+}
 
 TEST(Ds5SidecarClientTests, UnassignedIndexIsNotOwned) {
   platf::ds5::sidecar_client_t client;

--- a/tests/unit/platform/windows/test_ds5_sidecar_client.cpp
+++ b/tests/unit/platform/windows/test_ds5_sidecar_client.cpp
@@ -52,14 +52,28 @@ namespace {
 
   struct environment_scope_t {
     environment_scope_t(const wchar_t *variable, const wchar_t *value): variable(variable) {
+      SetLastError(ERROR_SUCCESS);
+      auto required = GetEnvironmentVariableW(variable, nullptr, 0);
+      was_defined = required != 0 || GetLastError() != ERROR_ENVVAR_NOT_FOUND;
+      while (required != 0) {
+        original_value.resize(required);
+        const auto copied = GetEnvironmentVariableW(variable, original_value.data(), required);
+        if (copied < required) {
+          original_value.resize(copied);
+          break;
+        }
+        required = copied + 1;
+      }
       SetEnvironmentVariableW(variable, value);
     }
 
     ~environment_scope_t() {
-      SetEnvironmentVariableW(variable.c_str(), nullptr);
+      SetEnvironmentVariableW(variable.c_str(), was_defined ? original_value.c_str() : nullptr);
     }
 
     std::wstring variable;
+    std::wstring original_value;
+    bool was_defined;
   };
 }  // namespace
 

--- a/tools/sunshine-ds5-sidecar/ControllerSession.cs
+++ b/tools/sunshine-ds5-sidecar/ControllerSession.cs
@@ -24,16 +24,15 @@ internal sealed class ControllerSession : IDisposable
     private const uint Y = 0x8000;
     private const uint Touchpad = 0x100000;
     private const uint Misc = 0x200000;
-    private const int AudioInputChannels = 4;
-    private const int HapticsOutputChannels = 2;
-    private const int BytesPerSample = 2;
     private const int HapticsFramesPerPacket = 240;
 
     private readonly object _stateLock = new();
     private readonly object _outputLock = new();
     private readonly HMController _controller;
     private readonly HMProfile _profile;
+    private readonly HMAudioOutput? _audioOutput;
     private readonly Action<Protocol.Message> _emit;
+    private DefaultAudioEndpointGuard? _audioEndpointGuard;
     private readonly AdaptiveTriggerState _adaptiveTriggers = new();
     private HMGamepadState _state;
     private readonly Dictionary<uint, int> _touchSlots = new();
@@ -63,10 +62,13 @@ internal sealed class ControllerSession : IDisposable
         };
 
         _controller.OutputDecoded += OnOutputDecoded;
-        if (_controller.UsbAudio is not null)
+        if (profile.Id == DualSenseHapticsAudio.CompositeProfileId)
         {
-            _controller.UsbAudio.Output.FramesReceived += OnAudioFrames;
-            _controller.UsbAudio.Output.StreamingChanged += OnAudioStreamingChanged;
+            _audioOutput = _controller.UsbAudio?.Output
+                ?? throw new InvalidDataException("Composite DualSense did not expose its audio output");
+            DualSenseHapticsAudio.ValidateRuntimeOutput(_audioOutput);
+            _audioOutput.FramesReceived += OnAudioFrames;
+            _audioOutput.StreamingChanged += OnAudioStreamingChanged;
         }
         // Emit a centered, untouched idle frame immediately: without it the
         // device reports an all-zero buffer until the first client input,
@@ -76,7 +78,22 @@ internal sealed class ControllerSession : IDisposable
 
     internal byte DeviceId { get; }
     internal byte ClientControllerNumber { get; }
-    internal bool HasAudio => _controller.UsbAudio is not null;
+    internal bool HasAudio => _audioOutput is not null;
+
+    internal void StartDefaultAudioEndpointGuard()
+    {
+        if (_audioOutput is null || _audioEndpointGuard is not null)
+            return;
+        _audioEndpointGuard = new DefaultAudioEndpointGuard(role =>
+        {
+            if (Volatile.Read(ref _disposed) != 0)
+                return;
+            _emit(new Protocol.Message(
+                Protocol.MessageType.AudioPolicyViolation,
+                0,
+                new[] { DeviceId, ClientControllerNumber, (byte)role, (byte)0 }));
+        });
+    }
 
     internal void SubmitInput(ReadOnlySpan<byte> payload)
     {
@@ -281,7 +298,7 @@ internal sealed class ControllerSession : IDisposable
             _audioResidual.AsSpan().CopyTo(combined);
             pcm.Span.CopyTo(combined.AsSpan(_audioResidual.Length));
         }
-        var sourceFrameBytes = AudioInputChannels * BytesPerSample;
+        var sourceFrameBytes = DualSenseHapticsAudio.InputFrameBytes;
         var usableBytes = combined.Length - combined.Length % sourceFrameBytes;
         _audioResidual = usableBytes == combined.Length ? Array.Empty<byte>() : combined[usableBytes..];
 
@@ -291,13 +308,8 @@ internal sealed class ControllerSession : IDisposable
         while (offsetFrames < frameCount)
         {
             var frames = Math.Min(HapticsFramesPerPacket, frameCount - offsetFrames);
-            var haptics = new byte[frames * HapticsOutputChannels * BytesPerSample];
-            for (var frame = 0; frame < frames; frame++)
-            {
-                var sourceOffset = (offsetFrames + frame) * sourceFrameBytes + 4;
-                var targetOffset = frame * 4;
-                source.Slice(sourceOffset, 4).CopyTo(haptics.AsSpan(targetOffset, 4));
-            }
+            var haptics = DualSenseHapticsAudio.Extract(
+                source.Slice(offsetFrames * sourceFrameBytes, frames * sourceFrameBytes));
             var flags = Volatile.Read(ref _hapticsStreaming) != 0 &&
                         Interlocked.Exchange(ref _hapticsNeedsStart, 0) != 0
                 ? Protocol.HapticsFlags.StreamStart
@@ -315,14 +327,14 @@ internal sealed class ControllerSession : IDisposable
         payload[0] = DeviceId;
         payload[1] = ClientControllerNumber;
         payload[2] = (byte)flags;
-        payload[3] = HapticsOutputChannels;
+        payload[3] = DualSenseHapticsAudio.OutputChannels;
         BinaryPrimitives.WriteUInt16LittleEndian(payload.AsSpan(4, 2), frameCount);
-        payload[6] = 16;
+        payload[6] = DualSenseHapticsAudio.BitsPerSample;
         BinaryPrimitives.WriteUInt32LittleEndian(payload.AsSpan(8, 4),
             unchecked((uint)Interlocked.Increment(ref _hapticsSequence)));
         BinaryPrimitives.WriteUInt64LittleEndian(payload.AsSpan(12, 8),
             (ulong)ElapsedMicroseconds());
-        BinaryPrimitives.WriteUInt32LittleEndian(payload.AsSpan(20, 4), 48000);
+        BinaryPrimitives.WriteUInt32LittleEndian(payload.AsSpan(20, 4), DualSenseHapticsAudio.SampleRateHz);
         pcm.CopyTo(payload.AsSpan(24));
         _emit(new Protocol.Message(Protocol.MessageType.HapticsPcm, 0, payload));
     }
@@ -424,16 +436,18 @@ internal sealed class ControllerSession : IDisposable
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
+        _audioEndpointGuard?.Dispose();
+        _audioEndpointGuard = null;
         _controller.OutputDecoded -= OnOutputDecoded;
         lock (_outputLock)
         {
             if (_adaptiveTriggers.TryReset(DeviceId, ClientControllerNumber, out var adaptiveTriggers))
                 _emit(adaptiveTriggers);
         }
-        if (_controller.UsbAudio is not null)
+        if (_audioOutput is not null)
         {
-            _controller.UsbAudio.Output.FramesReceived -= OnAudioFrames;
-            _controller.UsbAudio.Output.StreamingChanged -= OnAudioStreamingChanged;
+            _audioOutput.FramesReceived -= OnAudioFrames;
+            _audioOutput.StreamingChanged -= OnAudioStreamingChanged;
         }
         _controller.Dispose();
     }

--- a/tools/sunshine-ds5-sidecar/DefaultAudioEndpointGuard.cs
+++ b/tools/sunshine-ds5-sidecar/DefaultAudioEndpointGuard.cs
@@ -1,0 +1,230 @@
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Win32;
+
+namespace Sunshine.Ds5Sidecar;
+
+/// <summary>
+/// Fails closed when Windows selects the virtual HIDMaestro DualSense speaker
+/// as a default render endpoint. This is intentionally read-only: changing
+/// Windows audio policy relies on undocumented APIs and would make the helper
+/// responsible for restoring user preferences after crashes or upgrades.
+/// </summary>
+internal sealed class DefaultAudioEndpointGuard : IDisposable
+{
+    internal enum AudioRole : byte
+    {
+        Console = 0,
+        Multimedia = 1,
+        Communications = 2,
+    }
+
+    internal readonly record struct DeviceNodeIdentity(string InstanceId, IReadOnlyList<string> HardwareIds);
+
+    private static readonly Guid MmDeviceEnumeratorClass =
+        new("BCDE0395-E52F-467C-8E3D-C4579291692E");
+    private readonly CancellationTokenSource _stopping = new();
+    private readonly Action<AudioRole> _onViolation;
+    private readonly Task _worker;
+    private int _reported;
+
+    internal DefaultAudioEndpointGuard(Action<AudioRole> onViolation)
+    {
+        _onViolation = onViolation;
+        _worker = Task.Run(MonitorAsync);
+    }
+
+    private async Task MonitorAsync()
+    {
+        IMMDeviceEnumerator? enumerator = null;
+        try
+        {
+            var type = Type.GetTypeFromCLSID(MmDeviceEnumeratorClass, throwOnError: true)!;
+            enumerator = (IMMDeviceEnumerator)Activator.CreateInstance(type)!;
+            using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(400));
+            do
+            {
+                foreach (var role in Enum.GetValues<AudioRole>())
+                {
+                    if (IsDefaultVirtualDualSense(enumerator, role) &&
+                        Interlocked.Exchange(ref _reported, 1) == 0)
+                    {
+                        _onViolation(role);
+                        return;
+                    }
+                }
+            }
+            while (await timer.WaitForNextTickAsync(_stopping.Token));
+        }
+        catch (OperationCanceledException) when (_stopping.IsCancellationRequested)
+        {
+            // Normal session teardown.
+        }
+        catch (Exception error)
+        {
+            // Endpoint policy monitoring is defensive. A transient Core Audio
+            // failure must not take down controller input.
+            Console.Error.WriteLine($"Unable to monitor the default audio endpoint: {error.Message}");
+        }
+        finally
+        {
+            if (enumerator is not null && Marshal.IsComObject(enumerator))
+                Marshal.FinalReleaseComObject(enumerator);
+        }
+    }
+
+    private static bool IsDefaultVirtualDualSense(IMMDeviceEnumerator enumerator, AudioRole role)
+    {
+        IMMDevice? endpoint = null;
+        try
+        {
+            // AUDCLNT_E_DEVICE_INVALIDATED and E_NOTFOUND are normal while an
+            // endpoint is being created or removed, so treat any failed lookup
+            // as "not currently default" and retry on the next poll.
+            if (enumerator.GetDefaultAudioEndpoint(DataFlow.Render, role, out endpoint) < 0 || endpoint is null ||
+                endpoint.GetId(out var endpointId) < 0)
+                return false;
+            return IsVirtualDualSenseEndpoint(endpointId);
+        }
+        finally
+        {
+            if (endpoint is not null && Marshal.IsComObject(endpoint))
+                Marshal.FinalReleaseComObject(endpoint);
+        }
+    }
+
+    internal static bool IsVirtualDualSenseEndpoint(string endpointId)
+    {
+        var instanceId = endpointId.StartsWith("SWD\\MMDEVAPI\\", StringComparison.OrdinalIgnoreCase)
+            ? endpointId
+            : "SWD\\MMDEVAPI\\" + endpointId;
+        if (CM_Locate_DevNodeW(out var node, instanceId, 0) != 0)
+            return false;
+
+        var chain = new List<DeviceNodeIdentity>();
+        for (var depth = 0; depth < 12; ++depth)
+        {
+            var currentId = GetDeviceId(node);
+            if (currentId is null)
+                break;
+            chain.Add(new DeviceNodeIdentity(currentId, ReadHardwareIds(currentId)));
+            if (CM_Get_Parent(out node, node, 0) != 0)
+                break;
+        }
+        return IsVirtualDualSenseChain(chain);
+    }
+
+    internal static bool IsVirtualDualSenseChain(IEnumerable<DeviceNodeIdentity> chain)
+    {
+        var sonyDualSense = false;
+        var hidMaestro = false;
+        foreach (var node in chain)
+        {
+            sonyDualSense |= Contains(node.InstanceId, "VID_054C&PID_0CE6") ||
+                             node.HardwareIds.Any(id => Contains(id, "VID_054C&PID_0CE6"));
+            hidMaestro |= node.HardwareIds.Any(id =>
+                id.Equals("ROOT\\HIDMAESTRO_UDE", StringComparison.OrdinalIgnoreCase) ||
+                id.StartsWith("ROOT\\HIDMAESTRO_UDE\\", StringComparison.OrdinalIgnoreCase));
+        }
+        // Checking both properties avoids rejecting a physical Sony controller
+        // or some unrelated HIDMaestro virtual device.
+        return sonyDualSense && hidMaestro;
+    }
+
+    private static bool Contains(string value, string needle) =>
+        value.Contains(needle, StringComparison.OrdinalIgnoreCase);
+
+    private static string? GetDeviceId(uint node)
+    {
+        if (CM_Get_Device_ID_Size(out var length, node, 0) != 0)
+            return null;
+        var buffer = new StringBuilder(checked((int)length + 1));
+        return CM_Get_Device_IDW(node, buffer, length + 1, 0) == 0 ? buffer.ToString() : null;
+    }
+
+    private static IReadOnlyList<string> ReadHardwareIds(string instanceId)
+    {
+        try
+        {
+            using var key = Registry.LocalMachine.OpenSubKey(
+                @"SYSTEM\CurrentControlSet\Enum\" + instanceId, writable: false);
+            return key?.GetValue("HardwareID") switch
+            {
+                string[] values => values,
+                string value => new[] { value },
+                _ => Array.Empty<string>(),
+            };
+        }
+        catch (Exception error) when (error is IOException or UnauthorizedAccessException or System.Security.SecurityException)
+        {
+            return Array.Empty<string>();
+        }
+    }
+
+    public void Dispose()
+    {
+        _stopping.Cancel();
+        try { _worker.GetAwaiter().GetResult(); }
+        catch (OperationCanceledException) { }
+        _stopping.Dispose();
+    }
+
+    private enum DataFlow
+    {
+        Render = 0,
+    }
+
+    [ComImport]
+    [Guid("A95664D2-9614-4F35-A746-DE8DB63617E6")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IMMDeviceEnumerator
+    {
+        [PreserveSig]
+        int EnumAudioEndpoints(DataFlow dataFlow, uint stateMask, out IntPtr devices);
+        [PreserveSig]
+        int GetDefaultAudioEndpoint(DataFlow dataFlow, AudioRole role, out IMMDevice endpoint);
+        [PreserveSig]
+        int GetDevice([MarshalAs(UnmanagedType.LPWStr)] string id, out IMMDevice endpoint);
+        [PreserveSig]
+        int RegisterEndpointNotificationCallback(IntPtr callback);
+        [PreserveSig]
+        int UnregisterEndpointNotificationCallback(IntPtr callback);
+    }
+
+    [ComImport]
+    [Guid("D666063F-1587-4E43-81F1-B948E807363F")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IMMDevice
+    {
+        [PreserveSig]
+        int Activate(ref Guid interfaceId, uint classContext, IntPtr activationParameters,
+                     [MarshalAs(UnmanagedType.IUnknown)] out object instance);
+        [PreserveSig]
+        int OpenPropertyStore(uint access, out IntPtr properties);
+        [PreserveSig]
+        int GetId([MarshalAs(UnmanagedType.LPWStr)] out string id);
+        [PreserveSig]
+        int GetState(out uint state);
+    }
+
+    [DllImport("cfgmgr32.dll", CharSet = CharSet.Unicode)]
+    private static extern uint CM_Locate_DevNodeW(out uint deviceInstance,
+                                                  string deviceId,
+                                                  uint flags);
+
+    [DllImport("cfgmgr32.dll")]
+    private static extern uint CM_Get_Parent(out uint parentDeviceInstance,
+                                             uint deviceInstance,
+                                             uint flags);
+
+    [DllImport("cfgmgr32.dll")]
+    private static extern uint CM_Get_Device_ID_Size(out uint length,
+                                                     uint deviceInstance,
+                                                     uint flags);
+
+    [DllImport("cfgmgr32.dll", CharSet = CharSet.Unicode)]
+    private static extern uint CM_Get_Device_IDW(uint deviceInstance,
+                                                 StringBuilder buffer,
+                                                 uint bufferLength,
+                                                 uint flags);
+}

--- a/tools/sunshine-ds5-sidecar/DualSenseHapticsAudio.cs
+++ b/tools/sunshine-ds5-sidecar/DualSenseHapticsAudio.cs
@@ -1,0 +1,132 @@
+using System.Text.Json;
+using HIDMaestro;
+
+namespace Sunshine.Ds5Sidecar;
+
+internal static class DualSenseHapticsAudio
+{
+    internal const string CompositeProfileId = "dualsense-composite";
+    internal const int InputChannels = 4;
+    internal const int OutputChannels = 2;
+    internal const int BitsPerSample = 16;
+    internal const int BytesPerSample = BitsPerSample / 8;
+    internal const int SampleRateHz = 48000;
+    internal const int ChannelConfig = 0x0033;
+    internal const int InputFrameBytes = InputChannels * BytesPerSample;
+    internal const int OutputFrameBytes = OutputChannels * BytesPerSample;
+
+    private static readonly string[] ExpectedRoles =
+    [
+        "speakerLeft",
+        "speakerRight",
+        "hapticLeft",
+        "hapticRight",
+    ];
+
+    internal static void ValidateCompositeProfile(ReadOnlyMemory<byte> json)
+    {
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+        RequireString(root, "id", CompositeProfileId);
+        RequireString(root, "backend", "usbip");
+
+        if (!root.TryGetProperty("usbConfiguration", out var configuration) ||
+            !configuration.TryGetProperty("interfaces", out var interfaces) ||
+            interfaces.ValueKind != JsonValueKind.Array)
+        {
+            throw new InvalidDataException("Composite profile has no USB interface list");
+        }
+
+        JsonElement? outputStream = null;
+        foreach (var usbInterface in interfaces.EnumerateArray())
+        {
+            if (!usbInterface.TryGetProperty("function", out var function) ||
+                function.GetString() != "audioStreamingOut" ||
+                !usbInterface.TryGetProperty("altSettings", out var altSettings) ||
+                altSettings.ValueKind != JsonValueKind.Array)
+            {
+                continue;
+            }
+
+            foreach (var altSetting in altSettings.EnumerateArray())
+            {
+                if (!altSetting.TryGetProperty("audioStream", out var candidate))
+                    continue;
+                if (outputStream is not null)
+                    throw new InvalidDataException("Composite profile has multiple output audio streams");
+                outputStream = candidate;
+            }
+        }
+
+        if (outputStream is null)
+            throw new InvalidDataException("Composite profile has no output audio stream");
+        ValidateFormat(outputStream.Value);
+    }
+
+    internal static void ValidateRuntimeOutput(HMAudioOutput output)
+    {
+        if (output.Channels != InputChannels ||
+            output.BitsPerSample != BitsPerSample ||
+            output.SampleRateHz != SampleRateHz ||
+            !output.ChannelRoles.SequenceEqual(ExpectedRoles, StringComparer.Ordinal))
+        {
+            throw new InvalidDataException(
+                $"Unexpected DualSense audio layout: {output.Channels}ch/{output.BitsPerSample}-bit/" +
+                $"{output.SampleRateHz}Hz [{string.Join(", ", output.ChannelRoles)}]");
+        }
+    }
+
+    internal static byte[] Extract(ReadOnlySpan<byte> interleavedFrames)
+    {
+        if (interleavedFrames.Length % InputFrameBytes != 0)
+            throw new InvalidDataException("DualSense audio data does not contain complete four-channel frames");
+
+        var frameCount = interleavedFrames.Length / InputFrameBytes;
+        var haptics = new byte[frameCount * OutputFrameBytes];
+        for (var frame = 0; frame < frameCount; frame++)
+        {
+            var sourceOffset = frame * InputFrameBytes + 2 * BytesPerSample;
+            interleavedFrames.Slice(sourceOffset, OutputFrameBytes)
+                .CopyTo(haptics.AsSpan(frame * OutputFrameBytes, OutputFrameBytes));
+        }
+        return haptics;
+    }
+
+    private static void ValidateFormat(JsonElement stream)
+    {
+        RequireInt(stream, "channels", InputChannels);
+        RequireInt(stream, "bitsPerSample", BitsPerSample);
+        RequireInt(stream, "sampleRateHz", SampleRateHz);
+        RequireInt(stream, "channelConfig", ChannelConfig);
+
+        if (!stream.TryGetProperty("channelRoles", out var roles) ||
+            roles.ValueKind != JsonValueKind.Array ||
+            roles.GetArrayLength() != ExpectedRoles.Length)
+        {
+            throw new InvalidDataException("Composite profile has an invalid channel role list");
+        }
+
+        var index = 0;
+        foreach (var role in roles.EnumerateArray())
+        {
+            if (role.GetString() != ExpectedRoles[index])
+                throw new InvalidDataException($"Composite profile channel {index + 1} must be '{ExpectedRoles[index]}'");
+            index++;
+        }
+    }
+
+    private static void RequireString(JsonElement element, string property, string expected)
+    {
+        if (!element.TryGetProperty(property, out var value) || value.GetString() != expected)
+            throw new InvalidDataException($"Composite profile '{property}' must be '{expected}'");
+    }
+
+    private static void RequireInt(JsonElement element, string property, int expected)
+    {
+        if (!element.TryGetProperty(property, out var value) ||
+            !value.TryGetInt32(out var actual) || actual != expected)
+        {
+            throw new InvalidDataException($"Composite profile '{property}' must be {expected}");
+        }
+    }
+}

--- a/tools/sunshine-ds5-sidecar/Program.cs
+++ b/tools/sunshine-ds5-sidecar/Program.cs
@@ -6,6 +6,7 @@ using Sunshine.Ds5Sidecar;
 
 var pipeName = "sunshine-ds5-v1";
 var probe = false;
+var selfCheck = false;
 string? selfTestProfile = null;
 string? resultPath = null;
 string? audioWriterPath = null;
@@ -15,6 +16,8 @@ for (var i = 0; i < args.Length; i++)
         pipeName = args[++i];
     else if (args[i] == "--probe")
         probe = true;
+    else if (args[i] == "--self-check")
+        selfCheck = true;
     else if (args[i] == "--self-test" && i + 1 < args.Length)
         selfTestProfile = args[++i];
     else if (args[i] == "--result" && i + 1 < args.Length)
@@ -23,6 +26,18 @@ for (var i = 0; i < args.Length; i++)
         audioWriterPath = args[++i];
     else
         return Fail($"Unknown argument: {args[i]}");
+}
+
+if (selfCheck)
+{
+    ProtocolSelfTest.RunDeterministicChecks();
+    Console.WriteLine(JsonSerializer.Serialize(new
+    {
+        audio_layout = true,
+        channel_isolation = true,
+        default_endpoint_classification = true,
+    }));
+    return 0;
 }
 
 if (probe)

--- a/tools/sunshine-ds5-sidecar/Protocol.cs
+++ b/tools/sunshine-ds5-sidecar/Protocol.cs
@@ -40,6 +40,7 @@ internal static class Protocol
         AdaptiveTriggers = 102,
         Led = 103,
         HapticsPcm = 104,
+        AudioPolicyViolation = 105,
         Error = 255,
     }
 

--- a/tools/sunshine-ds5-sidecar/ProtocolSelfTest.cs
+++ b/tools/sunshine-ds5-sidecar/ProtocolSelfTest.cs
@@ -8,6 +8,7 @@ internal static class ProtocolSelfTest
 {
     internal static async Task<int> RunAsync(bool composite, string? resultPath, string? audioWriterPath)
     {
+        RunDeterministicChecks();
         VerifyAdaptiveTriggerEncoding();
         var pipeName = $"sunshine-ds5-self-test-{Environment.ProcessId}-{Guid.NewGuid():N}";
         using var stopping = new CancellationTokenSource(TimeSpan.FromSeconds(30));
@@ -143,6 +144,107 @@ internal static class ProtocolSelfTest
             await File.WriteAllTextAsync(resultPath, result, stopping.Token);
         return 0;
     }
+
+    internal static void RunDeterministicChecks()
+    {
+        VerifyBundledCompositeProfile();
+        VerifyHapticsChannelIsolation();
+        VerifyDefaultAudioEndpointClassification();
+    }
+
+    private static void VerifyDefaultAudioEndpointClassification()
+    {
+        var virtualDualSense = new[]
+        {
+            new DefaultAudioEndpointGuard.DeviceNodeIdentity(
+                @"SWD\MMDEVAPI\{0.0.0.00000000}.fixture", Array.Empty<string>()),
+            new DefaultAudioEndpointGuard.DeviceNodeIdentity(
+                @"USB\VID_054C&PID_0CE6&MI_00\fixture",
+                new[] { @"USB\VID_054C&PID_0CE6&MI_00" }),
+            new DefaultAudioEndpointGuard.DeviceNodeIdentity(
+                @"ROOT\USB\0000", new[] { @"ROOT\HIDMAESTRO_UDE" }),
+        };
+        Require(DefaultAudioEndpointGuard.IsVirtualDualSenseChain(virtualDualSense),
+            "virtual HIDMaestro DualSense endpoint classification");
+
+        Require(!DefaultAudioEndpointGuard.IsVirtualDualSenseChain(virtualDualSense[..2]),
+            "physical DualSense endpoint exclusion");
+        Require(!DefaultAudioEndpointGuard.IsVirtualDualSenseChain(new[]
+        {
+            new DefaultAudioEndpointGuard.DeviceNodeIdentity(
+                @"ROOT\USB\0000", new[] { @"ROOT\HIDMAESTRO_UDE" }),
+        }), "unrelated HIDMaestro endpoint exclusion");
+    }
+
+    private static void VerifyBundledCompositeProfile()
+    {
+        using var stream = typeof(ProtocolSelfTest).Assembly.GetManifestResourceStream(
+            "Sunshine.Ds5Sidecar.profiles.dualsense-composite.json")
+            ?? throw new InvalidOperationException("Bundled composite profile is missing");
+        using var memory = new MemoryStream();
+        stream.CopyTo(memory);
+        var profileJson = memory.ToArray();
+        DualSenseHapticsAudio.ValidateCompositeProfile(profileJson);
+
+        var profileText = System.Text.Encoding.UTF8.GetString(profileJson);
+        RequireProfileRejected(profileText.Replace("\"channels\":4", "\"channels\":2", StringComparison.Ordinal),
+            "stereo composite profile rejection");
+        RequireProfileRejected(profileText.Replace(
+                "\"hapticLeft\",\"hapticRight\"",
+                "\"hapticRight\",\"hapticLeft\"",
+                StringComparison.Ordinal),
+            "swapped haptics role rejection");
+    }
+
+    private static void RequireProfileRejected(string profileJson, string operation)
+    {
+        try
+        {
+            DualSenseHapticsAudio.ValidateCompositeProfile(System.Text.Encoding.UTF8.GetBytes(profileJson));
+            Require(false, operation);
+        }
+        catch (InvalidDataException)
+        {
+            // Expected.
+        }
+    }
+
+    private static void VerifyHapticsChannelIsolation()
+    {
+        var frames = new byte[DualSenseHapticsAudio.InputFrameBytes * 2];
+        WriteSample(frames, 0, 1234);
+        WriteSample(frames, 1, -2345);
+        WriteSample(frames, 4, short.MaxValue);
+        WriteSample(frames, 5, short.MinValue);
+        var speakerOnly = DualSenseHapticsAudio.Extract(frames);
+        Require(speakerOnly.AsSpan().IndexOfAnyExcept((byte)0) == -1,
+            "speaker channels cannot leak into haptics");
+
+        WriteSample(frames, 2, 3456);
+        WriteSample(frames, 3, -4567);
+        WriteSample(frames, 6, 5678);
+        WriteSample(frames, 7, -6789);
+        var haptics = DualSenseHapticsAudio.Extract(frames);
+        Require(BinaryPrimitives.ReadInt16LittleEndian(haptics.AsSpan(0, 2)) == 3456 &&
+                BinaryPrimitives.ReadInt16LittleEndian(haptics.AsSpan(2, 2)) == -4567 &&
+                BinaryPrimitives.ReadInt16LittleEndian(haptics.AsSpan(4, 2)) == 5678 &&
+                BinaryPrimitives.ReadInt16LittleEndian(haptics.AsSpan(6, 2)) == -6789,
+            "haptics channels preserve exact samples");
+
+        try
+        {
+            DualSenseHapticsAudio.Extract(frames.AsSpan(0, frames.Length - 1));
+            Require(false, "incomplete four-channel frame rejection");
+        }
+        catch (InvalidDataException)
+        {
+            // Expected: arbitrary callback fragmentation is reassembled by
+            // ControllerSession before complete frames reach the extractor.
+        }
+    }
+
+    private static void WriteSample(Span<byte> frames, int sample, short value) =>
+        BinaryPrimitives.WriteInt16LittleEndian(frames.Slice(sample * 2, 2), value);
 
     private static async Task SendAsync(Stream stream, Protocol.Message message, CancellationToken cancellationToken)
     {

--- a/tools/sunshine-ds5-sidecar/README.md
+++ b/tools/sunshine-ds5-sidecar/README.md
@@ -17,6 +17,13 @@ Read-only capability probe:
 dotnet Sunshine.Ds5Sidecar.dll --probe
 ```
 
+Deterministic four-channel layout and channel-isolation check (no elevation
+or virtual device required):
+
+```powershell
+dotnet Sunshine.Ds5Sidecar.dll --self-check
+```
+
 The production process must be launched elevated and placed in the Sunshine
 Job Object. The pipe accepts a single elevated client of the creating user;
 non-elevated callers are rejected at connect time and dropped without
@@ -24,3 +31,8 @@ ending the sidecar.
 Disconnecting the owning pipe disposes every device created by
 that connection. Standard `dualsense` uses UMDF2; `dualsense-composite`
 enables the USB composite HID/audio profile and authored haptics PCM.
+The composite session monitors the three Windows default render roles. If
+Windows selects the HIDMaestro-backed virtual DualSense speaker as a default,
+the helper reports the policy violation and exits; Sunshine then performs its
+single recovery attach in HID-only DS5 mode. This read-only fail-closed guard
+avoids undocumented audio-policy writes and never changes a user's defaults.

--- a/tools/sunshine-ds5-sidecar/SidecarServer.cs
+++ b/tools/sunshine-ds5-sidecar/SidecarServer.cs
@@ -20,9 +20,10 @@ internal sealed class SidecarServer : IAsyncDisposable
     internal SidecarServer(string pipeName)
     {
         _pipeName = pipeName;
-        LoadPatchedProfiles();
+        var compositeProfileValidated = LoadPatchedProfiles();
         _context.LoadDefaultProfiles();
-        _authoredHapticsAvailable = _context.GetProfile("dualsense-composite") is not null &&
+        _authoredHapticsAvailable = compositeProfileValidated &&
+                                    _context.GetProfile(DualSenseHapticsAudio.CompositeProfileId) is not null &&
                                     HMContext.IsUsbipBackendAvailable;
         _controlOutgoing = Channel.CreateUnbounded<Protocol.Message>(new UnboundedChannelOptions
         {
@@ -196,7 +197,8 @@ internal sealed class SidecarServer : IAsyncDisposable
         var profileId = payload[2] switch
         {
             0 => "dualsense",
-            1 => "dualsense-composite",
+            1 when _authoredHapticsAvailable => DualSenseHapticsAudio.CompositeProfileId,
+            1 => throw new InvalidOperationException("Validated DualSense four-channel audio is unavailable"),
             _ => throw new InvalidDataException("Unsupported DS5 profile mode"),
         };
         var profile = _context.GetProfile(profileId)
@@ -230,6 +232,10 @@ internal sealed class SidecarServer : IAsyncDisposable
                        ? Protocol.Capability.AudioFourChannel | Protocol.Capability.AuthoredHapticsPcm
                        : 0)));
         Emit(new Protocol.Message(Protocol.MessageType.AttachReply, requestId, reply));
+        // Queue the successful attach reply before monitoring starts. If the
+        // endpoint is already default, Core can finish attaching and enter its
+        // normal one-shot recovery path before we close this composite session.
+        session.StartDefaultAudioEndpointGuard();
     }
 
     private void Detach(uint requestId, ReadOnlySpan<byte> payload)
@@ -241,7 +247,7 @@ internal sealed class SidecarServer : IAsyncDisposable
         Emit(new Protocol.Message(Protocol.MessageType.DetachReply, requestId, new[] { payload[0] }));
     }
 
-    private void LoadPatchedProfiles()
+    private bool LoadPatchedProfiles()
     {
         // Upstream v1.6.1 USB DualSense profiles leave extendedReport unarmed,
         // so the vendor-blob encoder never runs and the Sony tail of report
@@ -262,15 +268,21 @@ internal sealed class SidecarServer : IAsyncDisposable
                 var resourceName = $"Sunshine.Ds5Sidecar.profiles.{id}.json";
                 using var stream = assembly.GetManifestResourceStream(resourceName)
                     ?? throw new InvalidOperationException($"Embedded profile '{resourceName}' is missing");
-                using var file = File.Create(Path.Combine(directory, id + ".json"));
-                stream.CopyTo(file);
+                using var memory = new MemoryStream();
+                stream.CopyTo(memory);
+                var profileBytes = memory.ToArray();
+                if (id == DualSenseHapticsAudio.CompositeProfileId)
+                    DualSenseHapticsAudio.ValidateCompositeProfile(profileBytes);
+                File.WriteAllBytes(Path.Combine(directory, id + ".json"), profileBytes);
             }
             if (_context.LoadProfilesFromDirectory(directory) < 2)
-                Console.Error.WriteLine("Patched DualSense profiles did not fully register");
+                throw new InvalidOperationException("Patched DualSense profiles did not fully register");
+            return true;
         }
         catch (Exception error)
         {
             Console.Error.WriteLine($"Unable to load patched DualSense profiles: {error.Message}");
+            return false;
         }
     }
 
@@ -317,6 +329,14 @@ internal sealed class SidecarServer : IAsyncDisposable
                 var frame = Protocol.Encode(message);
                 await pipe.WriteAsync(frame, cancellationToken);
                 await pipe.FlushAsync(cancellationToken);
+                if (message.Type == Protocol.MessageType.AudioPolicyViolation)
+                {
+                    // Flush the reason before ending the owner session. Core
+                    // consumes it and relaunches this controller in HID-only
+                    // mode, so input survives while suspect PCM is disabled.
+                    _sessionCancellation?.Cancel();
+                    return;
+                }
             }
         }
     }


### PR DESCRIPTION
## 改了啥呀

- 给 `dualsense-composite` 增加严格的 4ch/16-bit/48 kHz 与声道角色校验，只允许 3/4 声道进入触觉 PCM，普通扬声器声道别想偷偷混进来呀。
- 只读监控 Windows 的 Console、Multimedia、Communications 三种默认播放角色，同时校验 Sony DS5 VID/PID 与 HIDMaestro 父节点，避免把实体 DS5 认错。
- 虚拟 DS5 音频端点一旦成为系统默认输出，sidecar 会先发出异步策略事件再有序退出；Sunshine 复用现有单次恢复流程，以 HID-only DS5 重连，不会掉成 Xbox 360。
- 增加无提权确定性自检、假 sidecar 端到端回退测试，以及运行期行为说明。

- 测试环境变量 scope 会区分未定义、空值和非空值，并显式覆盖 Win32 读取、写入与恢复失败。

## 为啥要改

把 `NeverSetAsDefaultEndpoint` 一类策略写进注册表或调用未公开的 Audio Policy 接口，既不稳定，也很难在崩溃、升级和卸载时可靠恢复用户设置。近期方案改成 read-only + fail-closed：不碰用户默认设备，发现可能把普通游戏声音送进触觉通道时就短暂热插拔一次并降级，杂鱼污染 PCM 休想蒙混过关。

## 验证

- `dotnet build tools/sunshine-ds5-sidecar/Sunshine.Ds5Sidecar.csproj -c Release -p:HIDMaestroCorePath=...`：0 warning / 0 error
- `Sunshine.Ds5Sidecar.exe --self-check`：音频布局、声道隔离、端点归属分类通过
- 提权运行 `--self-test standard`：创建、输入、触摸、运动、电量、扳机、卸载与 owner 断开清理通过
- 提权运行 `--self-test composite`：上述链路及四声道能力通过
- UCRT 构建并运行 `ds5_sidecar_client_unit_tests.exe`：10/10 passed，包含 composite → 策略事件 → HID-only 自动恢复
- `dotnet format ... --verify-no-changes`：通过
- `git diff --check`：通过

